### PR TITLE
fix(il): preserve type through object coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   bindings, extending existing string and array specialization to captured
   strings and other safe reference values instead of widening them to
   `object`.
+- compiler: preserve known reference types through
+  `RequireObjectCoercible`, eliminating redundant casts before typed member
+  calls such as `String.Trim`.
 
 ## v0.12.1 - 2026-08-02
 

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.Helpers.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.Helpers.cs
@@ -36,13 +36,23 @@ public sealed partial class HIRToLIRLowerer
 
     private TempVariable RequireObjectCoercible(TempVariable receiverTemp)
     {
+        var objectReceiver = EnsureObject(receiverTemp);
+        var receiverStorage = GetTempStorage(objectReceiver);
+        var preservesKnownReferenceType = receiverStorage.Kind == ValueStorageKind.Reference
+            && receiverStorage.ClrType != null
+            && receiverStorage.ClrType != typeof(object);
         var checkedReceiver = CreateTempVariable();
         _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStatic(
             nameof(JavaScriptRuntime.ObjectRuntime),
             nameof(JavaScriptRuntime.ObjectRuntime.RequireObjectCoercible),
-            new[] { EnsureObject(receiverTemp) },
-            checkedReceiver));
-        DefineTempStorage(checkedReceiver, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+            new[] { objectReceiver },
+            checkedReceiver,
+            preservesKnownReferenceType ? receiverStorage : null));
+        DefineTempStorage(
+            checkedReceiver,
+            preservesKnownReferenceType
+                ? receiverStorage
+                : new ValueStorage(ValueStorageKind.Reference, typeof(object)));
         return checkedReceiver;
     }
 

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5279
+				// Method begins at RVA 0x527d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5294
+						// Method begins at RVA 0x5298
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x529d
+						// Method begins at RVA 0x52a1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52a6
+						// Method begins at RVA 0x52aa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52af
+						// Method begins at RVA 0x52b3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52b8
+						// Method begins at RVA 0x52bc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -146,7 +146,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52c1
+						// Method begins at RVA 0x52c5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -164,7 +164,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x528b
+					// Method begins at RVA 0x528f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5282
+				// Method begins at RVA 0x5286
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -500,7 +500,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52ca
+				// Method begins at RVA 0x52ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -610,7 +610,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52d3
+				// Method begins at RVA 0x52d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -739,7 +739,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52e5
+					// Method begins at RVA 0x52e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -757,7 +757,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52dc
+				// Method begins at RVA 0x52e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -881,7 +881,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52ee
+				// Method begins at RVA 0x52f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -944,7 +944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52f7
+				// Method begins at RVA 0x52fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1041,7 +1041,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5309
+					// Method begins at RVA 0x530d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1059,7 +1059,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5300
+				// Method begins at RVA 0x5304
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1186,7 +1186,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x531b
+					// Method begins at RVA 0x531f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1204,7 +1204,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5312
+				// Method begins at RVA 0x5316
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1232,7 +1232,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5336
+						// Method begins at RVA 0x533a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1250,7 +1250,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x532d
+					// Method begins at RVA 0x5331
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1268,7 +1268,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5324
+				// Method begins at RVA 0x5328
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1513,7 +1513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x533f
+				// Method begins at RVA 0x5343
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1541,7 +1541,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x535a
+						// Method begins at RVA 0x535e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1559,7 +1559,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5351
+					// Method begins at RVA 0x5355
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1577,7 +1577,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5348
+				// Method begins at RVA 0x534c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1734,7 +1734,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x536c
+					// Method begins at RVA 0x5370
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1754,7 +1754,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5375
+					// Method begins at RVA 0x5379
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1774,7 +1774,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x537e
+					// Method begins at RVA 0x5382
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1792,7 +1792,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5363
+				// Method begins at RVA 0x5367
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1821,7 +1821,7 @@
 			)
 			// Method begins at RVA 0x3014
 			// Header size: 12
-			// Code size: 1268 (0x4f4)
+			// Code size: 1263 (0x4ef)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2298,47 +2298,46 @@
 			IL_0481: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_0486: stloc.s 13
 			IL_0488: ldloc.s 13
-			IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_048f: stloc.s 9
+			IL_048a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_048f: stloc.s 13
 			IL_0491: ldarg.2
 			IL_0492: ldstr "upstream"
 			IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_049c: stloc.s 12
-			IL_049e: ldloc.s 12
+			IL_049c: stloc.s 9
+			IL_049e: ldloc.s 9
 			IL_04a0: ldstr "commit"
 			IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04aa: stloc.s 12
-			IL_04ac: ldloc.s 9
-			IL_04ae: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-			IL_04b3: ldloc.s 12
-			IL_04b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_04ba: stloc.s 12
-			IL_04bc: ldloc.s 12
-			IL_04be: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_04c3: ldc.i4.0
-			IL_04c4: ceq
-			IL_04c6: stloc.3
-			IL_04c7: ldloc.3
-			IL_04c8: brfalse IL_04f2
+			IL_04aa: stloc.s 9
+			IL_04ac: ldloc.s 13
+			IL_04ae: ldloc.s 9
+			IL_04b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_04b5: stloc.s 9
+			IL_04b7: ldloc.s 9
+			IL_04b9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04be: ldc.i4.0
+			IL_04bf: ceq
+			IL_04c1: stloc.3
+			IL_04c2: ldloc.3
+			IL_04c3: brfalse IL_04ed
 
-			IL_04cd: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
-			IL_04d2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_04dc: stloc.2
-			IL_04dd: ldloc.2
-			IL_04de: isinst [System.Runtime]System.Exception
-			IL_04e3: dup
-			IL_04e4: brtrue IL_04f1
+			IL_04c8: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
+			IL_04cd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_04d7: stloc.2
+			IL_04d8: ldloc.2
+			IL_04d9: isinst [System.Runtime]System.Exception
+			IL_04de: dup
+			IL_04df: brtrue IL_04ec
 
-			IL_04e9: pop
-			IL_04ea: ldloc.2
-			IL_04eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_04f0: throw
+			IL_04e4: pop
+			IL_04e5: ldloc.2
+			IL_04e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_04eb: throw
 
-			IL_04f1: throw
+			IL_04ec: throw
 
-			IL_04f2: ldnull
-			IL_04f3: ret
+			IL_04ed: ldnull
+			IL_04ee: ret
 		} // end of method validatePin::__js_call__
 
 	} // end of class validatePin
@@ -2354,7 +2353,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5387
+				// Method begins at RVA 0x538b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2381,7 +2380,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3514
+			// Method begins at RVA 0x3510
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -2455,7 +2454,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5390
+				// Method begins at RVA 0x5394
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2483,7 +2482,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x358c
+			// Method begins at RVA 0x3588
 			// Header size: 12
 			// Code size: 139 (0x8b)
 			.maxstack 8
@@ -2575,7 +2574,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5399
+				// Method begins at RVA 0x539d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2602,7 +2601,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3624
+			// Method begins at RVA 0x3620
 			// Header size: 12
 			// Code size: 158 (0x9e)
 			.maxstack 8
@@ -2700,7 +2699,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53ab
+					// Method begins at RVA 0x53af
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2718,7 +2717,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53a2
+				// Method begins at RVA 0x53a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2746,7 +2745,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x36d0
+			// Method begins at RVA 0x36cc
 			// Header size: 12
 			// Code size: 242 (0xf2)
 			.maxstack 8
@@ -2880,7 +2879,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53bd
+					// Method begins at RVA 0x53c1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2898,7 +2897,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53b4
+				// Method begins at RVA 0x53b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2926,7 +2925,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x37d0
+			// Method begins at RVA 0x37cc
 			// Header size: 12
 			// Code size: 1135 (0x46f)
 			.maxstack 8
@@ -3342,7 +3341,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53c6
+				// Method begins at RVA 0x53ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3369,7 +3368,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3c4c
+			// Method begins at RVA 0x3c48
 			// Header size: 12
 			// Code size: 83 (0x53)
 			.maxstack 8
@@ -3435,7 +3434,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53d8
+					// Method begins at RVA 0x53dc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3453,7 +3452,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53cf
+				// Method begins at RVA 0x53d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3480,7 +3479,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3cac
+			// Method begins at RVA 0x3ca8
 			// Header size: 12
 			// Code size: 175 (0xaf)
 			.maxstack 8
@@ -3588,7 +3587,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53ea
+					// Method begins at RVA 0x53ee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3608,7 +3607,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53f3
+					// Method begins at RVA 0x53f7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3626,7 +3625,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53e1
+				// Method begins at RVA 0x53e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3654,7 +3653,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3d68
+			// Method begins at RVA 0x3d64
 			// Header size: 12
 			// Code size: 691 (0x2b3)
 			.maxstack 8
@@ -3939,7 +3938,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53fc
+				// Method begins at RVA 0x5400
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3963,7 +3962,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x540e
+					// Method begins at RVA 0x5412
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3981,7 +3980,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5405
+				// Method begins at RVA 0x5409
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4005,7 +4004,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5420
+					// Method begins at RVA 0x5424
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4023,7 +4022,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5417
+				// Method begins at RVA 0x541b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4050,7 +4049,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4028
+			// Method begins at RVA 0x4024
 			// Header size: 12
 			// Code size: 397 (0x18d)
 			.maxstack 11
@@ -4265,7 +4264,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5471
+						// Method begins at RVA 0x5475
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4285,7 +4284,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x547a
+						// Method begins at RVA 0x547e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4303,7 +4302,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5468
+					// Method begins at RVA 0x546c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4323,7 +4322,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5483
+					// Method begins at RVA 0x5487
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4341,7 +4340,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5429
+				// Method begins at RVA 0x542d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4369,7 +4368,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5444
+						// Method begins at RVA 0x5448
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4387,7 +4386,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x543b
+					// Method begins at RVA 0x543f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4405,7 +4404,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5432
+				// Method begins at RVA 0x5436
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4433,7 +4432,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x545f
+						// Method begins at RVA 0x5463
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4451,7 +4450,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5456
+					// Method begins at RVA 0x545a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4469,7 +4468,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x544d
+				// Method begins at RVA 0x5451
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4497,9 +4496,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x41e0
+			// Method begins at RVA 0x41dc
 			// Header size: 12
-			// Code size: 1828 (0x724)
+			// Code size: 1836 (0x72c)
 			.maxstack 11
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -4520,8 +4519,8 @@
 				[15] object,
 				[16] object,
 				[17] bool,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[19] object,
+				[18] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
+				[19] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[20] object[],
 				[21] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 				[22] object,
@@ -4532,7 +4531,7 @@
 				[27] object,
 				[28] string,
 				[29] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[30] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
+				[30] object,
 				[31] object,
 				[32] object,
 				[33] string
@@ -4565,7 +4564,7 @@
 					IL_0032: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_0037: stloc.s 17
 					IL_0039: ldloc.s 17
-					IL_003b: brtrue IL_01cb
+					IL_003b: brtrue IL_01cf
 
 					IL_0040: ldloc.s 16
 					IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -4574,664 +4573,668 @@
 					IL_004b: stloc.s 5
 					IL_004d: ldarg.0
 					IL_004e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0058: stloc.s 16
-					IL_005a: ldc.i4.1
-					IL_005b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_0060: dup
-					IL_0061: ldarg.2
-					IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_0067: stloc.s 18
-					IL_0069: ldarg.0
-					IL_006a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_006f: ldc.i4.1
-					IL_0070: newarr [System.Runtime]System.Object
-					IL_0075: dup
-					IL_0076: ldc.i4.0
-					IL_0077: ldarg.0
-					IL_0078: stelem.ref
-					IL_0079: ldloc.s 5
-					IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0080: stloc.s 19
-					IL_0082: ldloc.s 19
-					IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0089: ldstr "split"
-					IL_008e: ldstr "/"
-					IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0098: stloc.s 19
-					IL_009a: ldloc.s 18
-					IL_009c: ldloc.s 19
-					IL_009e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_00a3: ldloc.s 18
-					IL_00a5: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_00aa: stloc.s 20
-					IL_00ac: ldloc.s 16
-					IL_00ae: ldstr "join"
-					IL_00b3: ldloc.s 20
-					IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-					IL_00ba: stloc.s 6
-					IL_00bc: ldarg.0
-					IL_00bd: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_00c2: stloc.s 21
-					IL_00c4: ldloc.s 21
-					IL_00c6: ldstr "existsSync"
-					IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_00d0: brtrue IL_00ea
+					IL_0053: stloc.s 18
+					IL_0055: ldloc.s 18
+					IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(!!0)
+					IL_005c: stloc.s 18
+					IL_005e: ldc.i4.1
+					IL_005f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_0064: dup
+					IL_0065: ldarg.2
+					IL_0066: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_006b: stloc.s 19
+					IL_006d: ldarg.0
+					IL_006e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_0073: ldc.i4.1
+					IL_0074: newarr [System.Runtime]System.Object
+					IL_0079: dup
+					IL_007a: ldc.i4.0
+					IL_007b: ldarg.0
+					IL_007c: stelem.ref
+					IL_007d: ldloc.s 5
+					IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0084: stloc.s 16
+					IL_0086: ldloc.s 16
+					IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_008d: ldstr "split"
+					IL_0092: ldstr "/"
+					IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_009c: stloc.s 16
+					IL_009e: ldloc.s 19
+					IL_00a0: ldloc.s 16
+					IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_00a7: ldloc.s 19
+					IL_00a9: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_00ae: stloc.s 20
+					IL_00b0: ldloc.s 18
+					IL_00b2: ldstr "join"
+					IL_00b7: ldloc.s 20
+					IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+					IL_00be: stloc.s 6
+					IL_00c0: ldarg.0
+					IL_00c1: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_00c6: stloc.s 21
+					IL_00c8: ldloc.s 21
+					IL_00ca: ldstr "existsSync"
+					IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_00d4: brtrue IL_00ee
 
-					IL_00d5: ldloc.s 21
-					IL_00d7: ldloc.s 6
-					IL_00d9: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-					IL_00de: box [System.Runtime]System.Boolean
-					IL_00e3: stloc.s 16
-					IL_00e5: br IL_0103
+					IL_00d9: ldloc.s 21
+					IL_00db: ldloc.s 6
+					IL_00dd: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+					IL_00e2: box [System.Runtime]System.Boolean
+					IL_00e7: stloc.s 16
+					IL_00e9: br IL_0107
 
-					IL_00ea: ldloc.s 21
-					IL_00ec: ldstr "existsSync"
-					IL_00f1: ldc.i4.1
-					IL_00f2: newarr [System.Runtime]System.Object
-					IL_00f7: dup
-					IL_00f8: ldc.i4.0
-					IL_00f9: ldloc.s 6
-					IL_00fb: stelem.ref
-					IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_0101: stloc.s 16
+					IL_00ee: ldloc.s 21
+					IL_00f0: ldstr "existsSync"
+					IL_00f5: ldc.i4.1
+					IL_00f6: newarr [System.Runtime]System.Object
+					IL_00fb: dup
+					IL_00fc: ldc.i4.0
+					IL_00fd: ldloc.s 6
+					IL_00ff: stelem.ref
+					IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_0105: stloc.s 16
 
-					IL_0103: ldloc.s 16
-					IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_010a: ldc.i4.0
-					IL_010b: ceq
-					IL_010d: stloc.s 17
-					IL_010f: ldloc.s 17
-					IL_0111: box [System.Runtime]System.Boolean
-					IL_0116: stloc.s 22
-					IL_0118: ldloc.s 22
-					IL_011a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_011f: stloc.s 17
-					IL_0121: ldloc.s 17
-					IL_0123: brtrue IL_019b
+					IL_0107: ldloc.s 16
+					IL_0109: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_010e: ldc.i4.0
+					IL_010f: ceq
+					IL_0111: stloc.s 17
+					IL_0113: ldloc.s 17
+					IL_0115: box [System.Runtime]System.Boolean
+					IL_011a: stloc.s 22
+					IL_011c: ldloc.s 22
+					IL_011e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0123: stloc.s 17
+					IL_0125: ldloc.s 17
+					IL_0127: brtrue IL_019f
 
-					IL_0128: ldarg.0
-					IL_0129: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_012e: stloc.s 21
-					IL_0130: ldloc.s 21
-					IL_0132: ldstr "statSync"
-					IL_0137: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_013c: brtrue IL_0151
+					IL_012c: ldarg.0
+					IL_012d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_0132: stloc.s 21
+					IL_0134: ldloc.s 21
+					IL_0136: ldstr "statSync"
+					IL_013b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_0140: brtrue IL_0155
 
-					IL_0141: ldloc.s 21
-					IL_0143: ldloc.s 6
-					IL_0145: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
-					IL_014a: stloc.s 16
-					IL_014c: br IL_016a
+					IL_0145: ldloc.s 21
+					IL_0147: ldloc.s 6
+					IL_0149: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
+					IL_014e: stloc.s 16
+					IL_0150: br IL_016e
 
-					IL_0151: ldloc.s 21
-					IL_0153: ldstr "statSync"
-					IL_0158: ldc.i4.1
-					IL_0159: newarr [System.Runtime]System.Object
-					IL_015e: dup
-					IL_015f: ldc.i4.0
-					IL_0160: ldloc.s 6
-					IL_0162: stelem.ref
-					IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_0168: stloc.s 16
+					IL_0155: ldloc.s 21
+					IL_0157: ldstr "statSync"
+					IL_015c: ldc.i4.1
+					IL_015d: newarr [System.Runtime]System.Object
+					IL_0162: dup
+					IL_0163: ldc.i4.0
+					IL_0164: ldloc.s 6
+					IL_0166: stelem.ref
+					IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_016c: stloc.s 16
 
-					IL_016a: ldloc.s 16
-					IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0171: ldstr "isFile"
-					IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_017b: stloc.s 16
-					IL_017d: ldloc.s 16
-					IL_017f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0184: ldc.i4.0
-					IL_0185: ceq
-					IL_0187: stloc.s 17
-					IL_0189: ldloc.s 17
-					IL_018b: box [System.Runtime]System.Boolean
-					IL_0190: stloc.s 23
-					IL_0192: ldloc.s 23
-					IL_0194: stloc.s 25
-					IL_0196: br IL_019f
+					IL_016e: ldloc.s 16
+					IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0175: ldstr "isFile"
+					IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_017f: stloc.s 16
+					IL_0181: ldloc.s 16
+					IL_0183: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0188: ldc.i4.0
+					IL_0189: ceq
+					IL_018b: stloc.s 17
+					IL_018d: ldloc.s 17
+					IL_018f: box [System.Runtime]System.Boolean
+					IL_0194: stloc.s 23
+					IL_0196: ldloc.s 23
+					IL_0198: stloc.s 25
+					IL_019a: br IL_01a3
 
-					IL_019b: ldloc.s 22
-					IL_019d: stloc.s 25
+					IL_019f: ldloc.s 22
+					IL_01a1: stloc.s 25
 
-					IL_019f: ldloc.s 25
-					IL_01a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01a6: stloc.s 17
-					IL_01a8: ldloc.s 17
-					IL_01aa: brfalse IL_01b8
+					IL_01a3: ldloc.s 25
+					IL_01a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_01aa: stloc.s 17
+					IL_01ac: ldloc.s 17
+					IL_01ae: brfalse IL_01bc
 
-					IL_01af: ldloc.0
-					IL_01b0: ldloc.s 5
-					IL_01b2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01b7: pop
+					IL_01b3: ldloc.0
+					IL_01b4: ldloc.s 5
+					IL_01b6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01bb: pop
 
-					IL_01b8: br IL_0028
+					IL_01bc: br IL_0028
 				// end loop
-				IL_01bd: ldloc.2
-				IL_01be: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_01c3: ldc.i4.1
-				IL_01c4: stloc.s 4
-				IL_01c6: leave IL_01e6
+				IL_01c1: ldloc.2
+				IL_01c2: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_01c7: ldc.i4.1
+				IL_01c8: stloc.s 4
+				IL_01ca: leave IL_01ea
 
-				IL_01cb: ldc.i4.1
-				IL_01cc: stloc.3
-				IL_01cd: leave IL_01e6
+				IL_01cf: ldc.i4.1
+				IL_01d0: stloc.3
+				IL_01d1: leave IL_01ea
 			} // end .try
 			finally
 			{
-				IL_01d2: ldloc.3
-				IL_01d3: brtrue IL_01e5
+				IL_01d6: ldloc.3
+				IL_01d7: brtrue IL_01e9
 
-				IL_01d8: ldloc.s 4
-				IL_01da: brtrue IL_01e5
+				IL_01dc: ldloc.s 4
+				IL_01de: brtrue IL_01e9
 
-				IL_01df: ldloc.2
-				IL_01e0: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_01e3: ldloc.2
+				IL_01e4: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_01e5: endfinally
+				IL_01e9: endfinally
 			} // end handler
 
-			IL_01e6: ldarg.3
-			IL_01e7: ldstr "requiredDirectories"
-			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f1: stloc.s 16
-			IL_01f3: ldloc.s 16
-			IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_01fa: stloc.s 7
-			IL_01fc: ldc.i4.0
-			IL_01fd: stloc.s 8
-			IL_01ff: ldc.i4.0
-			IL_0200: stloc.s 9
+			IL_01ea: ldarg.3
+			IL_01eb: ldstr "requiredDirectories"
+			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f5: stloc.s 16
+			IL_01f7: ldloc.s 16
+			IL_01f9: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_01fe: stloc.s 7
+			IL_0200: ldc.i4.0
+			IL_0201: stloc.s 8
+			IL_0203: ldc.i4.0
+			IL_0204: stloc.s 9
 			.try
 			{
-				// loop start (head: IL_0202)
-					IL_0202: ldloc.s 7
-					IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_0209: stloc.s 16
-					IL_020b: ldloc.s 16
-					IL_020d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_0212: stloc.s 17
-					IL_0214: ldloc.s 17
-					IL_0216: brtrue IL_03a7
+				// loop start (head: IL_0206)
+					IL_0206: ldloc.s 7
+					IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_020d: stloc.s 16
+					IL_020f: ldloc.s 16
+					IL_0211: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_0216: stloc.s 17
+					IL_0218: ldloc.s 17
+					IL_021a: brtrue IL_03af
 
-					IL_021b: ldloc.s 16
-					IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_0222: stloc.s 16
-					IL_0224: ldloc.s 16
-					IL_0226: stloc.s 10
-					IL_0228: ldarg.0
-					IL_0229: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0233: stloc.s 16
-					IL_0235: ldc.i4.1
-					IL_0236: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_023b: dup
-					IL_023c: ldarg.2
-					IL_023d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_0242: stloc.s 18
-					IL_0244: ldarg.0
-					IL_0245: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_024a: ldc.i4.1
-					IL_024b: newarr [System.Runtime]System.Object
-					IL_0250: dup
-					IL_0251: ldc.i4.0
-					IL_0252: ldarg.0
-					IL_0253: stelem.ref
-					IL_0254: ldloc.s 10
-					IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_025b: stloc.s 19
-					IL_025d: ldloc.s 19
-					IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0264: ldstr "split"
-					IL_0269: ldstr "/"
-					IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0273: stloc.s 19
-					IL_0275: ldloc.s 18
-					IL_0277: ldloc.s 19
-					IL_0279: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_027e: ldloc.s 18
-					IL_0280: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_0285: stloc.s 20
-					IL_0287: ldloc.s 16
-					IL_0289: ldstr "join"
-					IL_028e: ldloc.s 20
-					IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-					IL_0295: stloc.s 11
-					IL_0297: ldarg.0
-					IL_0298: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_029d: stloc.s 21
-					IL_029f: ldloc.s 21
-					IL_02a1: ldstr "existsSync"
-					IL_02a6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_02ab: brtrue IL_02c5
+					IL_021f: ldloc.s 16
+					IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_0226: stloc.s 16
+					IL_0228: ldloc.s 16
+					IL_022a: stloc.s 10
+					IL_022c: ldarg.0
+					IL_022d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_0232: stloc.s 18
+					IL_0234: ldloc.s 18
+					IL_0236: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(!!0)
+					IL_023b: stloc.s 18
+					IL_023d: ldc.i4.1
+					IL_023e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_0243: dup
+					IL_0244: ldarg.2
+					IL_0245: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_024a: stloc.s 19
+					IL_024c: ldarg.0
+					IL_024d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_0252: ldc.i4.1
+					IL_0253: newarr [System.Runtime]System.Object
+					IL_0258: dup
+					IL_0259: ldc.i4.0
+					IL_025a: ldarg.0
+					IL_025b: stelem.ref
+					IL_025c: ldloc.s 10
+					IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0263: stloc.s 16
+					IL_0265: ldloc.s 16
+					IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_026c: ldstr "split"
+					IL_0271: ldstr "/"
+					IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_027b: stloc.s 16
+					IL_027d: ldloc.s 19
+					IL_027f: ldloc.s 16
+					IL_0281: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_0286: ldloc.s 19
+					IL_0288: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_028d: stloc.s 20
+					IL_028f: ldloc.s 18
+					IL_0291: ldstr "join"
+					IL_0296: ldloc.s 20
+					IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+					IL_029d: stloc.s 11
+					IL_029f: ldarg.0
+					IL_02a0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_02a5: stloc.s 21
+					IL_02a7: ldloc.s 21
+					IL_02a9: ldstr "existsSync"
+					IL_02ae: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_02b3: brtrue IL_02cd
 
-					IL_02b0: ldloc.s 21
-					IL_02b2: ldloc.s 11
-					IL_02b4: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-					IL_02b9: box [System.Runtime]System.Boolean
-					IL_02be: stloc.s 16
-					IL_02c0: br IL_02de
+					IL_02b8: ldloc.s 21
+					IL_02ba: ldloc.s 11
+					IL_02bc: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+					IL_02c1: box [System.Runtime]System.Boolean
+					IL_02c6: stloc.s 16
+					IL_02c8: br IL_02e6
 
-					IL_02c5: ldloc.s 21
-					IL_02c7: ldstr "existsSync"
-					IL_02cc: ldc.i4.1
-					IL_02cd: newarr [System.Runtime]System.Object
-					IL_02d2: dup
-					IL_02d3: ldc.i4.0
-					IL_02d4: ldloc.s 11
-					IL_02d6: stelem.ref
-					IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_02dc: stloc.s 16
+					IL_02cd: ldloc.s 21
+					IL_02cf: ldstr "existsSync"
+					IL_02d4: ldc.i4.1
+					IL_02d5: newarr [System.Runtime]System.Object
+					IL_02da: dup
+					IL_02db: ldc.i4.0
+					IL_02dc: ldloc.s 11
+					IL_02de: stelem.ref
+					IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_02e4: stloc.s 16
 
-					IL_02de: ldloc.s 16
-					IL_02e0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_02e5: ldc.i4.0
-					IL_02e6: ceq
-					IL_02e8: stloc.s 17
-					IL_02ea: ldloc.s 17
-					IL_02ec: box [System.Runtime]System.Boolean
-					IL_02f1: stloc.s 22
-					IL_02f3: ldloc.s 22
-					IL_02f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02fa: stloc.s 17
-					IL_02fc: ldloc.s 17
-					IL_02fe: brtrue IL_0376
+					IL_02e6: ldloc.s 16
+					IL_02e8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_02ed: ldc.i4.0
+					IL_02ee: ceq
+					IL_02f0: stloc.s 17
+					IL_02f2: ldloc.s 17
+					IL_02f4: box [System.Runtime]System.Boolean
+					IL_02f9: stloc.s 22
+					IL_02fb: ldloc.s 22
+					IL_02fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0302: stloc.s 17
+					IL_0304: ldloc.s 17
+					IL_0306: brtrue IL_037e
 
-					IL_0303: ldarg.0
-					IL_0304: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_0309: stloc.s 21
-					IL_030b: ldloc.s 21
-					IL_030d: ldstr "statSync"
-					IL_0312: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_0317: brtrue IL_032c
+					IL_030b: ldarg.0
+					IL_030c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_0311: stloc.s 21
+					IL_0313: ldloc.s 21
+					IL_0315: ldstr "statSync"
+					IL_031a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_031f: brtrue IL_0334
 
-					IL_031c: ldloc.s 21
-					IL_031e: ldloc.s 11
-					IL_0320: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
-					IL_0325: stloc.s 16
-					IL_0327: br IL_0345
+					IL_0324: ldloc.s 21
+					IL_0326: ldloc.s 11
+					IL_0328: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
+					IL_032d: stloc.s 16
+					IL_032f: br IL_034d
 
-					IL_032c: ldloc.s 21
-					IL_032e: ldstr "statSync"
-					IL_0333: ldc.i4.1
-					IL_0334: newarr [System.Runtime]System.Object
-					IL_0339: dup
-					IL_033a: ldc.i4.0
-					IL_033b: ldloc.s 11
-					IL_033d: stelem.ref
-					IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_0343: stloc.s 16
+					IL_0334: ldloc.s 21
+					IL_0336: ldstr "statSync"
+					IL_033b: ldc.i4.1
+					IL_033c: newarr [System.Runtime]System.Object
+					IL_0341: dup
+					IL_0342: ldc.i4.0
+					IL_0343: ldloc.s 11
+					IL_0345: stelem.ref
+					IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_034b: stloc.s 16
 
-					IL_0345: ldloc.s 16
-					IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_034c: ldstr "isDirectory"
-					IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_0356: stloc.s 16
-					IL_0358: ldloc.s 16
-					IL_035a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_035f: ldc.i4.0
-					IL_0360: ceq
-					IL_0362: stloc.s 17
-					IL_0364: ldloc.s 17
-					IL_0366: box [System.Runtime]System.Boolean
-					IL_036b: stloc.s 23
-					IL_036d: ldloc.s 23
-					IL_036f: stloc.s 26
-					IL_0371: br IL_037a
+					IL_034d: ldloc.s 16
+					IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0354: ldstr "isDirectory"
+					IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_035e: stloc.s 16
+					IL_0360: ldloc.s 16
+					IL_0362: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0367: ldc.i4.0
+					IL_0368: ceq
+					IL_036a: stloc.s 17
+					IL_036c: ldloc.s 17
+					IL_036e: box [System.Runtime]System.Boolean
+					IL_0373: stloc.s 23
+					IL_0375: ldloc.s 23
+					IL_0377: stloc.s 26
+					IL_0379: br IL_0382
 
-					IL_0376: ldloc.s 22
-					IL_0378: stloc.s 26
+					IL_037e: ldloc.s 22
+					IL_0380: stloc.s 26
 
-					IL_037a: ldloc.s 26
-					IL_037c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0381: stloc.s 17
-					IL_0383: ldloc.s 17
-					IL_0385: brfalse IL_0393
+					IL_0382: ldloc.s 26
+					IL_0384: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0389: stloc.s 17
+					IL_038b: ldloc.s 17
+					IL_038d: brfalse IL_039b
 
-					IL_038a: ldloc.1
-					IL_038b: ldloc.s 10
-					IL_038d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0392: pop
+					IL_0392: ldloc.1
+					IL_0393: ldloc.s 10
+					IL_0395: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_039a: pop
 
-					IL_0393: br IL_0202
+					IL_039b: br IL_0206
 				// end loop
-				IL_0398: ldloc.s 7
-				IL_039a: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_039f: ldc.i4.1
-				IL_03a0: stloc.s 9
-				IL_03a2: leave IL_03c5
-
+				IL_03a0: ldloc.s 7
+				IL_03a2: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
 				IL_03a7: ldc.i4.1
-				IL_03a8: stloc.s 8
-				IL_03aa: leave IL_03c5
+				IL_03a8: stloc.s 9
+				IL_03aa: leave IL_03cd
+
+				IL_03af: ldc.i4.1
+				IL_03b0: stloc.s 8
+				IL_03b2: leave IL_03cd
 			} // end .try
 			finally
 			{
-				IL_03af: ldloc.s 8
-				IL_03b1: brtrue IL_03c4
+				IL_03b7: ldloc.s 8
+				IL_03b9: brtrue IL_03cc
 
-				IL_03b6: ldloc.s 9
-				IL_03b8: brtrue IL_03c4
+				IL_03be: ldloc.s 9
+				IL_03c0: brtrue IL_03cc
 
-				IL_03bd: ldloc.s 7
-				IL_03bf: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_03c5: ldloc.s 7
+				IL_03c7: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_03c4: endfinally
+				IL_03cc: endfinally
 			} // end handler
 
-			IL_03c5: ldloc.0
-			IL_03c6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_03cb: ldc.r8 0.0
-			IL_03d4: cgt
-			IL_03d6: stloc.s 17
-			IL_03d8: ldloc.s 17
-			IL_03da: box [System.Runtime]System.Boolean
-			IL_03df: stloc.s 22
-			IL_03e1: ldloc.s 22
-			IL_03e3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03e8: stloc.s 17
-			IL_03ea: ldloc.s 17
-			IL_03ec: brtrue IL_0416
+			IL_03cd: ldloc.0
+			IL_03ce: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_03d3: ldc.r8 0.0
+			IL_03dc: cgt
+			IL_03de: stloc.s 17
+			IL_03e0: ldloc.s 17
+			IL_03e2: box [System.Runtime]System.Boolean
+			IL_03e7: stloc.s 22
+			IL_03e9: ldloc.s 22
+			IL_03eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03f0: stloc.s 17
+			IL_03f2: ldloc.s 17
+			IL_03f4: brtrue IL_041e
 
-			IL_03f1: ldloc.1
-			IL_03f2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_03f7: ldc.r8 0.0
-			IL_0400: cgt
-			IL_0402: stloc.s 17
-			IL_0404: ldloc.s 17
-			IL_0406: box [System.Runtime]System.Boolean
-			IL_040b: stloc.s 23
-			IL_040d: ldloc.s 23
-			IL_040f: stloc.s 27
-			IL_0411: br IL_041a
+			IL_03f9: ldloc.1
+			IL_03fa: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_03ff: ldc.r8 0.0
+			IL_0408: cgt
+			IL_040a: stloc.s 17
+			IL_040c: ldloc.s 17
+			IL_040e: box [System.Runtime]System.Boolean
+			IL_0413: stloc.s 23
+			IL_0415: ldloc.s 23
+			IL_0417: stloc.s 27
+			IL_0419: br IL_0422
 
-			IL_0416: ldloc.s 22
-			IL_0418: stloc.s 27
+			IL_041e: ldloc.s 22
+			IL_0420: stloc.s 27
 
-			IL_041a: ldloc.s 27
-			IL_041c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0421: stloc.s 17
-			IL_0423: ldloc.s 17
-			IL_0425: brfalse IL_0506
+			IL_0422: ldloc.s 27
+			IL_0424: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0429: stloc.s 17
+			IL_042b: ldloc.s 17
+			IL_042d: brfalse IL_050e
 
-			IL_042a: ldc.i4.0
-			IL_042b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0430: stloc.s 12
-			IL_0432: ldloc.0
-			IL_0433: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0438: ldc.r8 0.0
-			IL_0441: cgt
-			IL_0443: brfalse IL_047f
+			IL_0432: ldc.i4.0
+			IL_0433: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0438: stloc.s 12
+			IL_043a: ldloc.0
+			IL_043b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0440: ldc.r8 0.0
+			IL_0449: cgt
+			IL_044b: brfalse IL_0487
 
-			IL_0448: ldloc.0
-			IL_0449: ldc.i4.1
-			IL_044a: newarr [System.Runtime]System.Object
-			IL_044f: dup
-			IL_0450: ldc.i4.0
-			IL_0451: ldstr ", "
-			IL_0456: stelem.ref
-			IL_0457: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_045c: stloc.s 28
-			IL_045e: ldloc.s 28
-			IL_0460: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0465: stloc.s 28
-			IL_0467: ldstr "missing files: "
-			IL_046c: ldloc.s 28
-			IL_046e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0473: stloc.s 28
-			IL_0475: ldloc.s 12
-			IL_0477: ldloc.s 28
-			IL_0479: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_047e: pop
+			IL_0450: ldloc.0
+			IL_0451: ldc.i4.1
+			IL_0452: newarr [System.Runtime]System.Object
+			IL_0457: dup
+			IL_0458: ldc.i4.0
+			IL_0459: ldstr ", "
+			IL_045e: stelem.ref
+			IL_045f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0464: stloc.s 28
+			IL_0466: ldloc.s 28
+			IL_0468: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_046d: stloc.s 28
+			IL_046f: ldstr "missing files: "
+			IL_0474: ldloc.s 28
+			IL_0476: call string [System.Runtime]System.String::Concat(string, string)
+			IL_047b: stloc.s 28
+			IL_047d: ldloc.s 12
+			IL_047f: ldloc.s 28
+			IL_0481: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0486: pop
 
-			IL_047f: ldloc.1
-			IL_0480: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0485: ldc.r8 0.0
-			IL_048e: cgt
-			IL_0490: brfalse IL_04cc
+			IL_0487: ldloc.1
+			IL_0488: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_048d: ldc.r8 0.0
+			IL_0496: cgt
+			IL_0498: brfalse IL_04d4
 
-			IL_0495: ldloc.1
-			IL_0496: ldc.i4.1
-			IL_0497: newarr [System.Runtime]System.Object
-			IL_049c: dup
-			IL_049d: ldc.i4.0
-			IL_049e: ldstr ", "
-			IL_04a3: stelem.ref
-			IL_04a4: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_04a9: stloc.s 28
-			IL_04ab: ldloc.s 28
-			IL_04ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04b2: stloc.s 28
-			IL_04b4: ldstr "missing directories: "
-			IL_04b9: ldloc.s 28
-			IL_04bb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04c0: stloc.s 28
-			IL_04c2: ldloc.s 12
-			IL_04c4: ldloc.s 28
-			IL_04c6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_04cb: pop
+			IL_049d: ldloc.1
+			IL_049e: ldc.i4.1
+			IL_049f: newarr [System.Runtime]System.Object
+			IL_04a4: dup
+			IL_04a5: ldc.i4.0
+			IL_04a6: ldstr ", "
+			IL_04ab: stelem.ref
+			IL_04ac: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_04b1: stloc.s 28
+			IL_04b3: ldloc.s 28
+			IL_04b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04ba: stloc.s 28
+			IL_04bc: ldstr "missing directories: "
+			IL_04c1: ldloc.s 28
+			IL_04c3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04c8: stloc.s 28
+			IL_04ca: ldloc.s 12
+			IL_04cc: ldloc.s 28
+			IL_04ce: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_04d3: pop
 
-			IL_04cc: ldloc.s 12
-			IL_04ce: ldc.i4.1
-			IL_04cf: newarr [System.Runtime]System.Object
-			IL_04d4: dup
-			IL_04d5: ldc.i4.0
-			IL_04d6: ldstr "; "
-			IL_04db: stelem.ref
-			IL_04dc: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_04e1: stloc.s 28
-			IL_04e3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04e8: dup
-			IL_04e9: ldstr "ok"
-			IL_04ee: ldc.i4.0
-			IL_04ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_04f4: dup
-			IL_04f5: ldstr "message"
-			IL_04fa: ldloc.s 28
-			IL_04fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0501: stloc.s 29
-			IL_0503: ldloc.s 29
-			IL_0505: ret
+			IL_04d4: ldloc.s 12
+			IL_04d6: ldc.i4.1
+			IL_04d7: newarr [System.Runtime]System.Object
+			IL_04dc: dup
+			IL_04dd: ldc.i4.0
+			IL_04de: ldstr "; "
+			IL_04e3: stelem.ref
+			IL_04e4: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_04e9: stloc.s 28
+			IL_04eb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_04f0: dup
+			IL_04f1: ldstr "ok"
+			IL_04f6: ldc.i4.0
+			IL_04f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_04fc: dup
+			IL_04fd: ldstr "message"
+			IL_0502: ldloc.s 28
+			IL_0504: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0509: stloc.s 29
+			IL_050b: ldloc.s 29
+			IL_050d: ret
 
-			IL_0506: ldarg.0
-			IL_0507: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_050c: stloc.s 30
-			IL_050e: ldloc.s 30
-			IL_0510: ldstr "join"
-			IL_0515: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_051a: brtrue IL_053f
+			IL_050e: ldarg.0
+			IL_050f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0514: stloc.s 18
+			IL_0516: ldloc.s 18
+			IL_0518: ldstr "join"
+			IL_051d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0522: brtrue IL_0547
 
-			IL_051f: ldloc.s 30
-			IL_0521: ldc.i4.2
-			IL_0522: newarr [System.Runtime]System.Object
-			IL_0527: dup
-			IL_0528: ldc.i4.0
-			IL_0529: ldarg.2
-			IL_052a: stelem.ref
-			IL_052b: dup
-			IL_052c: ldc.i4.1
-			IL_052d: ldstr "package.json"
+			IL_0527: ldloc.s 18
+			IL_0529: ldc.i4.2
+			IL_052a: newarr [System.Runtime]System.Object
+			IL_052f: dup
+			IL_0530: ldc.i4.0
+			IL_0531: ldarg.2
 			IL_0532: stelem.ref
-			IL_0533: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0538: stloc.s 13
-			IL_053a: br IL_055f
+			IL_0533: dup
+			IL_0534: ldc.i4.1
+			IL_0535: ldstr "package.json"
+			IL_053a: stelem.ref
+			IL_053b: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0540: stloc.s 13
+			IL_0542: br IL_0567
 
-			IL_053f: ldloc.s 30
-			IL_0541: ldstr "join"
-			IL_0546: ldc.i4.2
-			IL_0547: newarr [System.Runtime]System.Object
-			IL_054c: dup
-			IL_054d: ldc.i4.0
-			IL_054e: ldarg.2
-			IL_054f: stelem.ref
-			IL_0550: dup
-			IL_0551: ldc.i4.1
-			IL_0552: ldstr "package.json"
+			IL_0547: ldloc.s 18
+			IL_0549: ldstr "join"
+			IL_054e: ldc.i4.2
+			IL_054f: newarr [System.Runtime]System.Object
+			IL_0554: dup
+			IL_0555: ldc.i4.0
+			IL_0556: ldarg.2
 			IL_0557: stelem.ref
-			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_055d: stloc.s 13
+			IL_0558: dup
+			IL_0559: ldc.i4.1
+			IL_055a: ldstr "package.json"
+			IL_055f: stelem.ref
+			IL_0560: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0565: stloc.s 13
 
-			IL_055f: ldarg.0
-			IL_0560: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0565: stloc.s 21
-			IL_0567: ldloc.s 21
-			IL_0569: ldstr "readFileSync"
-			IL_056e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0573: brtrue IL_058d
+			IL_0567: ldarg.0
+			IL_0568: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_056d: stloc.s 21
+			IL_056f: ldloc.s 21
+			IL_0571: ldstr "readFileSync"
+			IL_0576: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_057b: brtrue IL_0595
 
-			IL_0578: ldloc.s 21
-			IL_057a: ldloc.s 13
-			IL_057c: ldstr "utf8"
-			IL_0581: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0586: stloc.s 16
-			IL_0588: br IL_05ae
+			IL_0580: ldloc.s 21
+			IL_0582: ldloc.s 13
+			IL_0584: ldstr "utf8"
+			IL_0589: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_058e: stloc.s 16
+			IL_0590: br IL_05b6
 
-			IL_058d: ldloc.s 21
-			IL_058f: ldstr "readFileSync"
-			IL_0594: ldc.i4.2
-			IL_0595: newarr [System.Runtime]System.Object
-			IL_059a: dup
-			IL_059b: ldc.i4.0
-			IL_059c: ldloc.s 13
-			IL_059e: stelem.ref
-			IL_059f: dup
-			IL_05a0: ldc.i4.1
-			IL_05a1: ldstr "utf8"
+			IL_0595: ldloc.s 21
+			IL_0597: ldstr "readFileSync"
+			IL_059c: ldc.i4.2
+			IL_059d: newarr [System.Runtime]System.Object
+			IL_05a2: dup
+			IL_05a3: ldc.i4.0
+			IL_05a4: ldloc.s 13
 			IL_05a6: stelem.ref
-			IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_05ac: stloc.s 16
+			IL_05a7: dup
+			IL_05a8: ldc.i4.1
+			IL_05a9: ldstr "utf8"
+			IL_05ae: stelem.ref
+			IL_05af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_05b4: stloc.s 16
 
-			IL_05ae: ldloc.s 16
-			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_05b5: stloc.s 14
-			IL_05b7: ldloc.s 14
-			IL_05b9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_05be: ldc.i4.0
-			IL_05bf: ceq
-			IL_05c1: stloc.s 17
-			IL_05c3: ldloc.s 17
-			IL_05c5: box [System.Runtime]System.Boolean
-			IL_05ca: stloc.s 22
-			IL_05cc: ldloc.s 22
-			IL_05ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05d3: stloc.s 17
-			IL_05d5: ldloc.s 17
-			IL_05d7: brtrue IL_0622
+			IL_05b6: ldloc.s 16
+			IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_05bd: stloc.s 14
+			IL_05bf: ldloc.s 14
+			IL_05c1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05c6: ldc.i4.0
+			IL_05c7: ceq
+			IL_05c9: stloc.s 17
+			IL_05cb: ldloc.s 17
+			IL_05cd: box [System.Runtime]System.Boolean
+			IL_05d2: stloc.s 22
+			IL_05d4: ldloc.s 22
+			IL_05d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05db: stloc.s 17
+			IL_05dd: ldloc.s 17
+			IL_05df: brtrue IL_062a
 
-			IL_05dc: ldloc.s 14
-			IL_05de: ldstr "version"
-			IL_05e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05e8: stloc.s 16
-			IL_05ea: ldarg.3
-			IL_05eb: ldstr "upstream"
-			IL_05f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05f5: stloc.s 19
-			IL_05f7: ldloc.s 19
-			IL_05f9: ldstr "packageVersion"
-			IL_05fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0603: stloc.s 19
-			IL_0605: ldloc.s 16
-			IL_0607: ldloc.s 19
-			IL_0609: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_060e: stloc.s 17
-			IL_0610: ldloc.s 17
-			IL_0612: box [System.Runtime]System.Boolean
-			IL_0617: stloc.s 23
-			IL_0619: ldloc.s 23
-			IL_061b: stloc.s 31
-			IL_061d: br IL_0626
+			IL_05e4: ldloc.s 14
+			IL_05e6: ldstr "version"
+			IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05f0: stloc.s 16
+			IL_05f2: ldarg.3
+			IL_05f3: ldstr "upstream"
+			IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05fd: stloc.s 30
+			IL_05ff: ldloc.s 30
+			IL_0601: ldstr "packageVersion"
+			IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_060b: stloc.s 30
+			IL_060d: ldloc.s 16
+			IL_060f: ldloc.s 30
+			IL_0611: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0616: stloc.s 17
+			IL_0618: ldloc.s 17
+			IL_061a: box [System.Runtime]System.Boolean
+			IL_061f: stloc.s 23
+			IL_0621: ldloc.s 23
+			IL_0623: stloc.s 31
+			IL_0625: br IL_062e
 
-			IL_0622: ldloc.s 22
-			IL_0624: stloc.s 31
+			IL_062a: ldloc.s 22
+			IL_062c: stloc.s 31
 
-			IL_0626: ldloc.s 31
-			IL_0628: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_062d: stloc.s 17
-			IL_062f: ldloc.s 17
-			IL_0631: brfalse IL_0702
+			IL_062e: ldloc.s 31
+			IL_0630: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0635: stloc.s 17
+			IL_0637: ldloc.s 17
+			IL_0639: brfalse IL_070a
 
-			IL_0636: ldarg.3
-			IL_0637: ldstr "upstream"
-			IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0641: stloc.s 19
-			IL_0643: ldloc.s 19
-			IL_0645: ldstr "packageVersion"
-			IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_064f: stloc.s 19
-			IL_0651: ldloc.s 19
-			IL_0653: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0658: stloc.s 28
-			IL_065a: ldstr "package.json version mismatch: expected "
-			IL_065f: ldloc.s 28
-			IL_0661: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0666: ldstr ", got "
-			IL_066b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0670: stloc.s 28
-			IL_0672: ldloc.s 14
-			IL_0674: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0679: stloc.s 17
-			IL_067b: ldloc.s 17
-			IL_067d: brfalse IL_0699
+			IL_063e: ldarg.3
+			IL_063f: ldstr "upstream"
+			IL_0644: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0649: stloc.s 30
+			IL_064b: ldloc.s 30
+			IL_064d: ldstr "packageVersion"
+			IL_0652: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0657: stloc.s 30
+			IL_0659: ldloc.s 30
+			IL_065b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0660: stloc.s 28
+			IL_0662: ldstr "package.json version mismatch: expected "
+			IL_0667: ldloc.s 28
+			IL_0669: call string [System.Runtime]System.String::Concat(string, string)
+			IL_066e: ldstr ", got "
+			IL_0673: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0678: stloc.s 28
+			IL_067a: ldloc.s 14
+			IL_067c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0681: stloc.s 17
+			IL_0683: ldloc.s 17
+			IL_0685: brfalse IL_06a1
 
-			IL_0682: ldloc.s 14
-			IL_0684: ldstr "version"
-			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_068e: stloc.s 19
-			IL_0690: ldloc.s 19
-			IL_0692: stloc.s 32
-			IL_0694: br IL_069d
+			IL_068a: ldloc.s 14
+			IL_068c: ldstr "version"
+			IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0696: stloc.s 30
+			IL_0698: ldloc.s 30
+			IL_069a: stloc.s 32
+			IL_069c: br IL_06a5
 
-			IL_0699: ldloc.s 14
-			IL_069b: stloc.s 32
+			IL_06a1: ldloc.s 14
+			IL_06a3: stloc.s 32
 
-			IL_069d: ldloc.s 32
-			IL_069f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_06a4: stloc.s 17
-			IL_06a6: ldloc.s 17
-			IL_06a8: brfalse IL_06c4
+			IL_06a5: ldloc.s 32
+			IL_06a7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_06ac: stloc.s 17
+			IL_06ae: ldloc.s 17
+			IL_06b0: brfalse IL_06cc
 
-			IL_06ad: ldloc.s 14
-			IL_06af: ldstr "version"
-			IL_06b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06b9: stloc.s 19
-			IL_06bb: ldloc.s 19
-			IL_06bd: stloc.s 15
-			IL_06bf: br IL_06cb
+			IL_06b5: ldloc.s 14
+			IL_06b7: ldstr "version"
+			IL_06bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06c1: stloc.s 30
+			IL_06c3: ldloc.s 30
+			IL_06c5: stloc.s 15
+			IL_06c7: br IL_06d3
 
-			IL_06c4: ldstr "<missing>"
-			IL_06c9: stloc.s 15
+			IL_06cc: ldstr "<missing>"
+			IL_06d1: stloc.s 15
 
-			IL_06cb: ldloc.s 15
-			IL_06cd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06d2: stloc.s 33
-			IL_06d4: ldloc.s 28
-			IL_06d6: ldloc.s 33
-			IL_06d8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06dd: stloc.s 33
-			IL_06df: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_06e4: dup
-			IL_06e5: ldstr "ok"
-			IL_06ea: ldc.i4.0
-			IL_06eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_06f0: dup
-			IL_06f1: ldstr "message"
-			IL_06f6: ldloc.s 33
-			IL_06f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06fd: stloc.s 29
-			IL_06ff: ldloc.s 29
-			IL_0701: ret
+			IL_06d3: ldloc.s 15
+			IL_06d5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06da: stloc.s 33
+			IL_06dc: ldloc.s 28
+			IL_06de: ldloc.s 33
+			IL_06e0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06e5: stloc.s 33
+			IL_06e7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_06ec: dup
+			IL_06ed: ldstr "ok"
+			IL_06f2: ldc.i4.0
+			IL_06f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_06f8: dup
+			IL_06f9: ldstr "message"
+			IL_06fe: ldloc.s 33
+			IL_0700: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0705: stloc.s 29
+			IL_0707: ldloc.s 29
+			IL_0709: ret
 
-			IL_0702: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0707: dup
-			IL_0708: ldstr "ok"
-			IL_070d: ldc.i4.1
-			IL_070e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0713: dup
-			IL_0714: ldstr "message"
-			IL_0719: ldstr ""
-			IL_071e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0723: ret
+			IL_070a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_070f: dup
+			IL_0710: ldstr "ok"
+			IL_0715: ldc.i4.1
+			IL_0716: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_071b: dup
+			IL_071c: ldstr "message"
+			IL_0721: ldstr ""
+			IL_0726: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_072b: ret
 		} // end of method validateResolvedRoot::__js_call__
 
 	} // end of class validateResolvedRoot
@@ -5255,7 +5258,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x549e
+						// Method begins at RVA 0x54a2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5273,7 +5276,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5495
+					// Method begins at RVA 0x5499
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5293,7 +5296,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54a7
+					// Method begins at RVA 0x54ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5311,7 +5314,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x548c
+				// Method begins at RVA 0x5490
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5340,7 +5343,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4944
+			// Method begins at RVA 0x4948
 			// Header size: 12
 			// Code size: 1053 (0x41d)
 			.maxstack 8
@@ -5789,7 +5792,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x54c2
+						// Method begins at RVA 0x54c6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5807,7 +5810,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54b9
+					// Method begins at RVA 0x54bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5825,7 +5828,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54b0
+				// Method begins at RVA 0x54b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5854,7 +5857,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4d70
+			// Method begins at RVA 0x4d74
 			// Header size: 12
 			// Code size: 373 (0x175)
 			.maxstack 8
@@ -6041,7 +6044,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54d4
+					// Method begins at RVA 0x54d8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6059,7 +6062,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54cb
+				// Method begins at RVA 0x54cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6088,7 +6091,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4ef4
+			// Method begins at RVA 0x4ef8
 			// Header size: 12
 			// Code size: 419 (0x1a3)
 			.maxstack 8
@@ -6277,7 +6280,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54e6
+					// Method begins at RVA 0x54ea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6297,7 +6300,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54ef
+					// Method begins at RVA 0x54f3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6315,7 +6318,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54dd
+				// Method begins at RVA 0x54e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6341,7 +6344,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x50a4
+			// Method begins at RVA 0x50a8
 			// Header size: 12
 			// Code size: 448 (0x1c0)
 			.maxstack 9
@@ -6580,7 +6583,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5501
+					// Method begins at RVA 0x5505
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6600,7 +6603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x550a
+					// Method begins at RVA 0x550e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6618,7 +6621,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54f8
+				// Method begins at RVA 0x54fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6666,7 +6669,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5270
+			// Method begins at RVA 0x5274
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -7324,7 +7327,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x5513
+		// Method begins at RVA 0x5517
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65bf
+				// Method begins at RVA 0x65c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65d1
+					// Method begins at RVA 0x65d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -153,7 +153,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65da
+					// Method begins at RVA 0x65de
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -173,7 +173,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65e3
+					// Method begins at RVA 0x65e7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65c8
+				// Method begins at RVA 0x65cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -296,7 +296,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65f5
+					// Method begins at RVA 0x65f9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -314,7 +314,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65ec
+				// Method begins at RVA 0x65f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -434,7 +434,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6607
+					// Method begins at RVA 0x660b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -452,7 +452,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65fe
+				// Method begins at RVA 0x6602
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -593,7 +593,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6610
+				// Method begins at RVA 0x6614
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2459,7 +2459,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x65b6
+			// Method begins at RVA 0x65ba
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2759,7 +2759,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6622
+				// Method begins at RVA 0x6626
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2789,40 +2789,40 @@
 			.maxstack 8
 			.locals init (
 				[0] string,
-				[1] object,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[2] object
 			)
 
 			IL_0000: ldarg.1
 			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0006: stloc.0
 			IL_0007: ldloc.0
-			IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000d: stloc.1
+			IL_0008: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_000d: stloc.0
 			IL_000e: ldstr "\\r\\n"
 			IL_0013: ldstr "g"
 			IL_0018: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_001d: stloc.2
-			IL_001e: ldloc.1
+			IL_001d: stloc.1
+			IL_001e: ldloc.0
 			IL_001f: ldstr "replace"
-			IL_0024: ldloc.2
+			IL_0024: ldloc.1
 			IL_0025: ldstr "\n"
 			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_002f: stloc.1
-			IL_0030: ldloc.1
+			IL_002f: stloc.2
+			IL_0030: ldloc.2
 			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0036: stloc.1
+			IL_0036: stloc.2
 			IL_0037: ldstr "\\r"
 			IL_003c: ldstr "g"
 			IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0046: stloc.2
-			IL_0047: ldloc.1
+			IL_0046: stloc.1
+			IL_0047: ldloc.2
 			IL_0048: ldstr "replace"
-			IL_004d: ldloc.2
+			IL_004d: ldloc.1
 			IL_004e: ldstr "\n"
 			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0058: stloc.1
-			IL_0059: ldloc.1
+			IL_0058: stloc.2
+			IL_0059: ldloc.2
 			IL_005a: ret
 		} // end of method normalizeLineEndings::__js_call__
 
@@ -2847,7 +2847,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x663d
+						// Method begins at RVA 0x6641
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2865,7 +2865,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6634
+					// Method begins at RVA 0x6638
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2883,7 +2883,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x662b
+				// Method begins at RVA 0x662f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3012,7 +3012,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6658
+						// Method begins at RVA 0x665c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3030,7 +3030,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x664f
+					// Method begins at RVA 0x6653
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3048,7 +3048,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6646
+				// Method begins at RVA 0x664a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3240,7 +3240,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x666a
+					// Method begins at RVA 0x666e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3258,7 +3258,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6661
+				// Method begins at RVA 0x6665
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3286,7 +3286,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6685
+						// Method begins at RVA 0x6689
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3304,7 +3304,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x667c
+					// Method begins at RVA 0x6680
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3322,7 +3322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6673
+				// Method begins at RVA 0x6677
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3491,7 +3491,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6697
+					// Method begins at RVA 0x669b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3509,7 +3509,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x668e
+				// Method begins at RVA 0x6692
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3637,7 +3637,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66a0
+				// Method begins at RVA 0x66a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3665,7 +3665,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66bb
+						// Method begins at RVA 0x66bf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3685,7 +3685,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66c4
+						// Method begins at RVA 0x66c8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3705,7 +3705,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66cd
+						// Method begins at RVA 0x66d1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3725,7 +3725,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66d6
+						// Method begins at RVA 0x66da
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3743,7 +3743,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66b2
+					// Method begins at RVA 0x66b6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3761,7 +3761,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66a9
+				// Method begins at RVA 0x66ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3800,10 +3800,10 @@
 				[4] float64,
 				[5] float64,
 				[6] bool,
-				[7] object,
+				[7] string,
 				[8] object,
 				[9] object,
-				[10] string
+				[10] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -3861,7 +3861,7 @@
 				IL_0091: brfalse IL_00e4
 
 				IL_0096: ldstr "\n"
-				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_009b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 				IL_00a0: stloc.s 7
 				IL_00a2: ldloc.1
 				IL_00a3: stloc.s 5
@@ -3876,13 +3876,13 @@
 				IL_00be: ldstr "repeat"
 				IL_00c3: ldloc.s 8
 				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00ca: stloc.s 7
-				IL_00cc: ldloc.s 7
+				IL_00ca: stloc.s 9
+				IL_00cc: ldloc.s 9
 				IL_00ce: ldloc.3
 				IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00d4: stloc.s 9
+				IL_00d4: stloc.s 10
 				IL_00d6: ldloc.0
-				IL_00d7: ldloc.s 9
+				IL_00d7: ldloc.s 10
 				IL_00d9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 				IL_00de: pop
 				IL_00df: br IL_00fa
@@ -3890,9 +3890,9 @@
 				IL_00e4: ldstr " "
 				IL_00e9: ldloc.3
 				IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00ef: stloc.s 9
+				IL_00ef: stloc.s 10
 				IL_00f1: ldloc.0
-				IL_00f2: ldloc.s 9
+				IL_00f2: ldloc.s 10
 				IL_00f4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 				IL_00f9: pop
 
@@ -3914,8 +3914,8 @@
 			IL_011e: ldstr ""
 			IL_0123: stelem.ref
 			IL_0124: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0129: stloc.s 10
-			IL_012b: ldloc.s 10
+			IL_0129: stloc.s 7
+			IL_012b: ldloc.s 7
 			IL_012d: ret
 		} // end of method foldBlockLines::__js_call__
 
@@ -3940,7 +3940,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66f1
+						// Method begins at RVA 0x66f5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3960,7 +3960,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66fa
+						// Method begins at RVA 0x66fe
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3980,7 +3980,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6703
+						// Method begins at RVA 0x6707
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3998,7 +3998,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66e8
+					// Method begins at RVA 0x66ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4016,7 +4016,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66df
+				// Method begins at RVA 0x66e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4248,7 +4248,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6715
+					// Method begins at RVA 0x6719
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4268,7 +4268,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x671e
+					// Method begins at RVA 0x6722
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4288,7 +4288,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6727
+					// Method begins at RVA 0x672b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4306,7 +4306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x670c
+				// Method begins at RVA 0x6710
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4535,7 +4535,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6742
+						// Method begins at RVA 0x6746
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4555,7 +4555,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x674b
+						// Method begins at RVA 0x674f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4575,7 +4575,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6754
+						// Method begins at RVA 0x6758
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4595,7 +4595,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x675d
+						// Method begins at RVA 0x6761
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4615,7 +4615,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6766
+						// Method begins at RVA 0x676a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4635,7 +4635,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x676f
+						// Method begins at RVA 0x6773
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4655,7 +4655,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6778
+						// Method begins at RVA 0x677c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4673,7 +4673,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6739
+					// Method begins at RVA 0x673d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4691,7 +4691,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6730
+				// Method begins at RVA 0x6734
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4722,7 +4722,7 @@
 			)
 			// Method begins at RVA 0x4770
 			// Header size: 12
-			// Code size: 888 (0x378)
+			// Code size: 892 (0x37c)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -4765,7 +4765,7 @@
 				IL_0027: ldloc.s 11
 				IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_002e: clt
-				IL_0030: brfalse IL_0376
+				IL_0030: brfalse IL_037a
 
 				IL_0035: ldarg.3
 				IL_0036: ldstr "index"
@@ -4822,7 +4822,7 @@
 				IL_00c4: clt
 				IL_00c6: brfalse IL_00d0
 
-				IL_00cb: br IL_0376
+				IL_00cb: br IL_037a
 
 				IL_00d0: ldloc.2
 				IL_00d1: ldarg.s baseIndent
@@ -4876,206 +4876,208 @@
 				IL_0162: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 				IL_0167: stloc.s 17
 				IL_0169: ldloc.s 17
-				IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0170: ldstr "exec"
-				IL_0175: ldloc.s 4
-				IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_017c: stloc.s 5
-				IL_017e: ldloc.s 5
-				IL_0180: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0185: ldc.i4.0
-				IL_0186: ceq
-				IL_0188: stloc.s 12
-				IL_018a: ldloc.s 12
-				IL_018c: brfalse IL_0206
+				IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+				IL_0170: stloc.s 17
+				IL_0172: ldloc.s 17
+				IL_0174: ldstr "exec"
+				IL_0179: ldloc.s 4
+				IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0180: stloc.s 5
+				IL_0182: ldloc.s 5
+				IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0189: ldc.i4.0
+				IL_018a: ceq
+				IL_018c: stloc.s 12
+				IL_018e: ldloc.s 12
+				IL_0190: brfalse IL_020a
 
-				IL_0191: ldarg.3
-				IL_0192: ldstr "index"
-				IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_019c: stloc.s 11
-				IL_019e: ldloc.s 11
-				IL_01a0: ldc.r8 1
-				IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_01ae: stloc.s 14
-				IL_01b0: ldloc.s 14
-				IL_01b2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01b7: stloc.s 15
-				IL_01b9: ldstr "Invalid frontmatter line "
-				IL_01be: ldloc.s 15
-				IL_01c0: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01c5: ldstr ": "
-				IL_01ca: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01cf: ldloc.s 4
-				IL_01d1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01d6: stloc.s 15
-				IL_01d8: ldloc.s 15
-				IL_01da: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01df: stloc.s 15
-				IL_01e1: ldloc.s 15
-				IL_01e3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01e8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_01ed: stloc.s 6
-				IL_01ef: ldloc.s 6
-				IL_01f1: isinst [System.Runtime]System.Exception
-				IL_01f6: dup
-				IL_01f7: brtrue IL_0205
+				IL_0195: ldarg.3
+				IL_0196: ldstr "index"
+				IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01a0: stloc.s 11
+				IL_01a2: ldloc.s 11
+				IL_01a4: ldc.r8 1
+				IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_01b2: stloc.s 14
+				IL_01b4: ldloc.s 14
+				IL_01b6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01bb: stloc.s 15
+				IL_01bd: ldstr "Invalid frontmatter line "
+				IL_01c2: ldloc.s 15
+				IL_01c4: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01c9: ldstr ": "
+				IL_01ce: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01d3: ldloc.s 4
+				IL_01d5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01da: stloc.s 15
+				IL_01dc: ldloc.s 15
+				IL_01de: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01e3: stloc.s 15
+				IL_01e5: ldloc.s 15
+				IL_01e7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_01f1: stloc.s 6
+				IL_01f3: ldloc.s 6
+				IL_01f5: isinst [System.Runtime]System.Exception
+				IL_01fa: dup
+				IL_01fb: brtrue IL_0209
 
-				IL_01fc: pop
-				IL_01fd: ldloc.s 6
-				IL_01ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0204: throw
+				IL_0200: pop
+				IL_0201: ldloc.s 6
+				IL_0203: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0208: throw
 
-				IL_0205: throw
+				IL_0209: throw
 
-				IL_0206: ldloc.s 5
-				IL_0208: ldc.r8 1
-				IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0216: stloc.s 7
-				IL_0218: ldloc.s 5
-				IL_021a: ldc.r8 2
-				IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0228: stloc.s 11
-				IL_022a: ldloc.s 11
-				IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0231: ldstr "trim"
-				IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_023b: stloc.s 8
-				IL_023d: ldarg.3
-				IL_023e: ldstr "index"
-				IL_0243: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0248: stloc.s 13
-				IL_024a: ldloc.s 13
-				IL_024c: ldc.r8 1
-				IL_0255: add
-				IL_0256: stloc.s 13
-				IL_0258: ldarg.3
-				IL_0259: ldstr "index"
-				IL_025e: ldloc.s 13
-				IL_0260: ldc.i4.1
-				IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_0266: pop
-				IL_0267: ldnull
-				IL_0268: stloc.s 9
-				IL_026a: ldloc.s 8
-				IL_026c: ldstr "|"
-				IL_0271: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0276: stloc.s 12
-				IL_0278: ldloc.s 12
-				IL_027a: box [System.Runtime]System.Boolean
-				IL_027f: stloc.s 18
-				IL_0281: ldloc.s 18
-				IL_0283: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0288: stloc.s 12
-				IL_028a: ldloc.s 12
-				IL_028c: brtrue IL_02b1
+				IL_020a: ldloc.s 5
+				IL_020c: ldc.r8 1
+				IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_021a: stloc.s 7
+				IL_021c: ldloc.s 5
+				IL_021e: ldc.r8 2
+				IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_022c: stloc.s 11
+				IL_022e: ldloc.s 11
+				IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0235: ldstr "trim"
+				IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_023f: stloc.s 8
+				IL_0241: ldarg.3
+				IL_0242: ldstr "index"
+				IL_0247: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_024c: stloc.s 13
+				IL_024e: ldloc.s 13
+				IL_0250: ldc.r8 1
+				IL_0259: add
+				IL_025a: stloc.s 13
+				IL_025c: ldarg.3
+				IL_025d: ldstr "index"
+				IL_0262: ldloc.s 13
+				IL_0264: ldc.i4.1
+				IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_026a: pop
+				IL_026b: ldnull
+				IL_026c: stloc.s 9
+				IL_026e: ldloc.s 8
+				IL_0270: ldstr "|"
+				IL_0275: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_027a: stloc.s 12
+				IL_027c: ldloc.s 12
+				IL_027e: box [System.Runtime]System.Boolean
+				IL_0283: stloc.s 18
+				IL_0285: ldloc.s 18
+				IL_0287: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_028c: stloc.s 12
+				IL_028e: ldloc.s 12
+				IL_0290: brtrue IL_02b5
 
-				IL_0291: ldloc.s 8
-				IL_0293: ldstr ">"
-				IL_0298: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_029d: stloc.s 12
-				IL_029f: ldloc.s 12
-				IL_02a1: box [System.Runtime]System.Boolean
-				IL_02a6: stloc.s 19
-				IL_02a8: ldloc.s 19
-				IL_02aa: stloc.s 20
-				IL_02ac: br IL_02b5
+				IL_0295: ldloc.s 8
+				IL_0297: ldstr ">"
+				IL_029c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02a1: stloc.s 12
+				IL_02a3: ldloc.s 12
+				IL_02a5: box [System.Runtime]System.Boolean
+				IL_02aa: stloc.s 19
+				IL_02ac: ldloc.s 19
+				IL_02ae: stloc.s 20
+				IL_02b0: br IL_02b9
 
-				IL_02b1: ldloc.s 18
-				IL_02b3: stloc.s 20
+				IL_02b5: ldloc.s 18
+				IL_02b7: stloc.s 20
 
-				IL_02b5: ldloc.s 20
-				IL_02b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02bc: stloc.s 12
-				IL_02be: ldloc.s 12
-				IL_02c0: brfalse IL_0306
+				IL_02b9: ldloc.s 20
+				IL_02bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02c0: stloc.s 12
+				IL_02c2: ldloc.s 12
+				IL_02c4: brfalse IL_030a
 
-				IL_02c5: ldarg.0
-				IL_02c6: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
-				IL_02cb: ldc.i4.1
-				IL_02cc: newarr [System.Runtime]System.Object
-				IL_02d1: dup
-				IL_02d2: ldc.i4.0
-				IL_02d3: ldarg.0
-				IL_02d4: stelem.ref
-				IL_02d5: stloc.s 21
-				IL_02d7: ldloc.s 21
-				IL_02d9: ldc.i4.4
-				IL_02da: newarr [System.Runtime]System.Object
-				IL_02df: dup
-				IL_02e0: ldc.i4.0
-				IL_02e1: ldarg.2
-				IL_02e2: stelem.ref
+				IL_02c9: ldarg.0
+				IL_02ca: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
+				IL_02cf: ldc.i4.1
+				IL_02d0: newarr [System.Runtime]System.Object
+				IL_02d5: dup
+				IL_02d6: ldc.i4.0
+				IL_02d7: ldarg.0
+				IL_02d8: stelem.ref
+				IL_02d9: stloc.s 21
+				IL_02db: ldloc.s 21
+				IL_02dd: ldc.i4.4
+				IL_02de: newarr [System.Runtime]System.Object
 				IL_02e3: dup
-				IL_02e4: ldc.i4.1
-				IL_02e5: ldarg.3
+				IL_02e4: ldc.i4.0
+				IL_02e5: ldarg.2
 				IL_02e6: stelem.ref
 				IL_02e7: dup
-				IL_02e8: ldc.i4.2
-				IL_02e9: ldarg.s baseIndent
-				IL_02eb: box [System.Runtime]System.Double
-				IL_02f0: stelem.ref
-				IL_02f1: dup
-				IL_02f2: ldc.i4.3
-				IL_02f3: ldloc.s 8
-				IL_02f5: stelem.ref
-				IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_02fb: stloc.s 11
-				IL_02fd: ldloc.s 11
-				IL_02ff: stloc.s 9
-				IL_0301: br IL_0365
+				IL_02e8: ldc.i4.1
+				IL_02e9: ldarg.3
+				IL_02ea: stelem.ref
+				IL_02eb: dup
+				IL_02ec: ldc.i4.2
+				IL_02ed: ldarg.s baseIndent
+				IL_02ef: box [System.Runtime]System.Double
+				IL_02f4: stelem.ref
+				IL_02f5: dup
+				IL_02f6: ldc.i4.3
+				IL_02f7: ldloc.s 8
+				IL_02f9: stelem.ref
+				IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_02ff: stloc.s 11
+				IL_0301: ldloc.s 11
+				IL_0303: stloc.s 9
+				IL_0305: br IL_0369
 
-				IL_0306: ldloc.s 8
-				IL_0308: ldstr ""
-				IL_030d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0312: stloc.s 12
-				IL_0314: ldloc.s 12
-				IL_0316: brfalse IL_0348
+				IL_030a: ldloc.s 8
+				IL_030c: ldstr ""
+				IL_0311: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0316: stloc.s 12
+				IL_0318: ldloc.s 12
+				IL_031a: brfalse IL_034c
 
-				IL_031b: ldarg.0
-				IL_031c: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
-				IL_0321: ldc.i4.1
-				IL_0322: newarr [System.Runtime]System.Object
-				IL_0327: dup
-				IL_0328: ldc.i4.0
-				IL_0329: ldarg.0
-				IL_032a: stelem.ref
-				IL_032b: stloc.s 21
-				IL_032d: ldloc.s 21
-				IL_032f: ldarg.2
-				IL_0330: ldarg.3
-				IL_0331: ldarg.s baseIndent
-				IL_0333: box [System.Runtime]System.Double
-				IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_033d: stloc.s 11
-				IL_033f: ldloc.s 11
-				IL_0341: stloc.s 9
-				IL_0343: br IL_0365
+				IL_031f: ldarg.0
+				IL_0320: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
+				IL_0325: ldc.i4.1
+				IL_0326: newarr [System.Runtime]System.Object
+				IL_032b: dup
+				IL_032c: ldc.i4.0
+				IL_032d: ldarg.0
+				IL_032e: stelem.ref
+				IL_032f: stloc.s 21
+				IL_0331: ldloc.s 21
+				IL_0333: ldarg.2
+				IL_0334: ldarg.3
+				IL_0335: ldarg.s baseIndent
+				IL_0337: box [System.Runtime]System.Double
+				IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_0341: stloc.s 11
+				IL_0343: ldloc.s 11
+				IL_0345: stloc.s 9
+				IL_0347: br IL_0369
 
-				IL_0348: ldarg.0
-				IL_0349: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
-				IL_034e: ldc.i4.1
-				IL_034f: newarr [System.Runtime]System.Object
-				IL_0354: dup
-				IL_0355: ldc.i4.0
-				IL_0356: ldarg.0
-				IL_0357: stelem.ref
-				IL_0358: ldloc.s 8
-				IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_035f: stloc.s 11
-				IL_0361: ldloc.s 11
-				IL_0363: stloc.s 9
+				IL_034c: ldarg.0
+				IL_034d: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
+				IL_0352: ldc.i4.1
+				IL_0353: newarr [System.Runtime]System.Object
+				IL_0358: dup
+				IL_0359: ldc.i4.0
+				IL_035a: ldarg.0
+				IL_035b: stelem.ref
+				IL_035c: ldloc.s 8
+				IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0363: stloc.s 11
+				IL_0365: ldloc.s 11
+				IL_0367: stloc.s 9
 
-				IL_0365: ldloc.0
-				IL_0366: ldloc.s 7
-				IL_0368: ldloc.s 9
-				IL_036a: ldc.i4.1
-				IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_0370: pop
-				IL_0371: br IL_0006
+				IL_0369: ldloc.0
+				IL_036a: ldloc.s 7
+				IL_036c: ldloc.s 9
+				IL_036e: ldc.i4.1
+				IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_0374: pop
+				IL_0375: br IL_0006
 			// end loop
 
-			IL_0376: ldloc.0
-			IL_0377: ret
+			IL_037a: ldloc.0
+			IL_037b: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -5091,7 +5093,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6781
+				// Method begins at RVA 0x6785
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5118,7 +5120,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4af4
+			// Method begins at RVA 0x4af8
 			// Header size: 12
 			// Code size: 114 (0x72)
 			.maxstack 8
@@ -5194,7 +5196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6793
+					// Method begins at RVA 0x6797
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5214,7 +5216,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x679c
+					// Method begins at RVA 0x67a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5234,7 +5236,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67a5
+					// Method begins at RVA 0x67a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5252,7 +5254,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x678a
+				// Method begins at RVA 0x678e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5279,7 +5281,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4b74
+			// Method begins at RVA 0x4b78
 			// Header size: 12
 			// Code size: 304 (0x130)
 			.maxstack 8
@@ -5411,7 +5413,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67ae
+				// Method begins at RVA 0x67b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5435,7 +5437,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4cb0
+			// Method begins at RVA 0x4cb4
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -5494,7 +5496,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67c0
+					// Method begins at RVA 0x67c4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5512,7 +5514,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67b7
+				// Method begins at RVA 0x67bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5536,7 +5538,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4d04
+			// Method begins at RVA 0x4d08
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -5604,7 +5606,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67c9
+				// Method begins at RVA 0x67cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5629,7 +5631,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4d80
+			// Method begins at RVA 0x4d84
 			// Header size: 12
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -5666,7 +5668,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67d2
+				// Method begins at RVA 0x67d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5693,7 +5695,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4db8
+			// Method begins at RVA 0x4dbc
 			// Header size: 12
 			// Code size: 53 (0x35)
 			.maxstack 8
@@ -5740,7 +5742,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67e4
+					// Method begins at RVA 0x67e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5760,7 +5762,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67ed
+					// Method begins at RVA 0x67f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5778,7 +5780,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67db
+				// Method begins at RVA 0x67df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5806,7 +5808,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6808
+						// Method begins at RVA 0x680c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5824,7 +5826,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67ff
+					// Method begins at RVA 0x6803
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5842,7 +5844,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67f6
+				// Method begins at RVA 0x67fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5871,7 +5873,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4dfc
+			// Method begins at RVA 0x4e00
 			// Header size: 12
 			// Code size: 452 (0x1c4)
 			.maxstack 8
@@ -6114,7 +6116,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x681a
+					// Method begins at RVA 0x681e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6134,7 +6136,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6823
+					// Method begins at RVA 0x6827
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6152,7 +6154,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6811
+				// Method begins at RVA 0x6815
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6181,7 +6183,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4fcc
+			// Method begins at RVA 0x4fd0
 			// Header size: 12
 			// Code size: 247 (0xf7)
 			.maxstack 8
@@ -6328,7 +6330,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6835
+					// Method begins at RVA 0x6839
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6348,7 +6350,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x683e
+					// Method begins at RVA 0x6842
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6368,7 +6370,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6847
+					// Method begins at RVA 0x684b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6388,7 +6390,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x686b
+					// Method begins at RVA 0x686f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6406,7 +6408,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x682c
+				// Method begins at RVA 0x6830
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6434,7 +6436,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6862
+						// Method begins at RVA 0x6866
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6452,7 +6454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6859
+					// Method begins at RVA 0x685d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6470,7 +6472,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6850
+				// Method begins at RVA 0x6854
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6498,7 +6500,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x50d0
+			// Method begins at RVA 0x50d4
 			// Header size: 12
 			// Code size: 1063 (0x427)
 			.maxstack 8
@@ -6982,7 +6984,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68a1
+						// Method begins at RVA 0x68a5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7002,7 +7004,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68aa
+						// Method begins at RVA 0x68ae
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7022,7 +7024,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68b3
+						// Method begins at RVA 0x68b7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7040,7 +7042,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6898
+					// Method begins at RVA 0x689c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7060,7 +7062,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68bc
+					// Method begins at RVA 0x68c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7080,7 +7082,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68c5
+					// Method begins at RVA 0x68c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7098,7 +7100,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6874
+				// Method begins at RVA 0x6878
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7126,7 +7128,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x688f
+						// Method begins at RVA 0x6893
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7144,7 +7146,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6886
+					// Method begins at RVA 0x688a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7162,7 +7164,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x687d
+				// Method begins at RVA 0x6881
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7190,7 +7192,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68e0
+						// Method begins at RVA 0x68e4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7208,7 +7210,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68d7
+					// Method begins at RVA 0x68db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7226,7 +7228,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x68ce
+				// Method begins at RVA 0x68d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7255,7 +7257,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5504
+			// Method begins at RVA 0x5508
 			// Header size: 12
 			// Code size: 1583 (0x62f)
 			.maxstack 8
@@ -7914,7 +7916,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68f2
+					// Method begins at RVA 0x68f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7934,7 +7936,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68fb
+					// Method begins at RVA 0x68ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7954,7 +7956,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6904
+					// Method begins at RVA 0x6908
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7974,7 +7976,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x690d
+					// Method begins at RVA 0x6911
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7994,7 +7996,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6916
+					// Method begins at RVA 0x691a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8014,7 +8016,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x691f
+					// Method begins at RVA 0x6923
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8034,7 +8036,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6928
+					// Method begins at RVA 0x692c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8052,7 +8054,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x68e9
+				// Method begins at RVA 0x68ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8081,7 +8083,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5b40
+			// Method begins at RVA 0x5b44
 			// Header size: 12
 			// Code size: 769 (0x301)
 			.maxstack 8
@@ -8483,7 +8485,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6970
+					// Method begins at RVA 0x6974
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8501,7 +8503,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6931
+				// Method begins at RVA 0x6935
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8529,7 +8531,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x694c
+						// Method begins at RVA 0x6950
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8547,7 +8549,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6943
+					// Method begins at RVA 0x6947
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8565,7 +8567,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x693a
+				// Method begins at RVA 0x693e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8593,7 +8595,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6967
+						// Method begins at RVA 0x696b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8611,7 +8613,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x695e
+					// Method begins at RVA 0x6962
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8629,7 +8631,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6955
+				// Method begins at RVA 0x6959
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8657,7 +8659,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5e50
+			// Method begins at RVA 0x5e54
 			// Header size: 12
 			// Code size: 1799 (0x707)
 			.maxstack 8
@@ -9422,7 +9424,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6979
+				// Method begins at RVA 0x697d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -9449,7 +9451,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x6564
+			// Method begins at RVA 0x6568
 			// Header size: 12
 			// Code size: 70 (0x46)
 			.maxstack 8
@@ -9555,7 +9557,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x6619
+			// Method begins at RVA 0x661d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -10094,7 +10096,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x6982
+		// Method begins at RVA 0x6986
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_JsObject_NamedProperties.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_JsObject_NamedProperties.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x280c
+				// Method begins at RVA 0x2814
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2815
+				// Method begins at RVA 0x281d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -59,7 +59,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27c6
+			// Method begins at RVA 0x27ce
 			// Header size: 1
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -89,7 +89,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27f1
+			// Method begins at RVA 0x27f9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -113,7 +113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2803
+				// Method begins at RVA 0x280b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,7 +131,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27fa
+			// Method begins at RVA 0x2802
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -157,7 +157,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1898 (0x76a)
+		// Code size: 1906 (0x772)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Array_JsObject_NamedProperties/Scope,
@@ -182,8 +182,9 @@
 			[19] object,
 			[20] string,
 			[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[22] object[],
-			[23] class [System.Runtime]System.Type
+			[22] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
+			[23] object[],
+			[24] class [System.Runtime]System.Type
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -514,227 +515,231 @@
 		IL_0441: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakMap::.ctor()
 		IL_0446: stloc.s 8
 		IL_0448: ldloc.s 8
-		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_044f: ldstr "set"
-		IL_0454: ldloc.1
-		IL_0455: ldstr "identity"
-		IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_045f: pop
-		IL_0460: ldstr "console"
-		IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_046f: stloc.s 13
-		IL_0471: ldloc.s 8
-		IL_0473: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0478: ldstr "get"
-		IL_047d: ldloc.1
-		IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0483: stloc.s 19
-		IL_0485: ldloc.s 13
-		IL_0487: ldstr "log"
-		IL_048c: ldloc.s 19
-		IL_048e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0493: pop
-		IL_0494: ldstr "console"
-		IL_0499: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04a3: stloc.s 19
-		IL_04a5: ldloc.1
-		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_04ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b0: ldstr "join"
-		IL_04b5: ldstr ","
-		IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04bf: stloc.s 13
-		IL_04c1: ldloc.s 19
-		IL_04c3: ldstr "log"
-		IL_04c8: ldloc.s 13
-		IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04cf: pop
-		IL_04d0: ldloc.1
-		IL_04d1: ldstr "custom"
-		IL_04d6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
-		IL_04db: stloc.s 15
-		IL_04dd: ldstr "console"
-		IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04ec: stloc.s 13
-		IL_04ee: ldloc.1
-		IL_04ef: ldstr "custom"
-		IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04f9: stloc.s 19
-		IL_04fb: ldloc.s 13
-		IL_04fd: ldstr "log"
-		IL_0502: ldloc.s 19
-		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0509: pop
-		IL_050a: ldloc.1
-		IL_050b: ldc.r8 5
-		IL_0514: ldstr "sparse"
-		IL_0519: ldc.i4.0
-		IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_051f: pop
-		IL_0520: ldstr "console"
-		IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_052a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_052f: stloc.s 19
-		IL_0531: ldloc.1
-		IL_0532: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0537: box [System.Runtime]System.Double
-		IL_053c: stloc.s 14
-		IL_053e: ldloc.1
-		IL_053f: ldc.r8 5
-		IL_0548: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_054d: stloc.s 13
-		IL_054f: ldc.r8 4
-		IL_0558: box [System.Runtime]System.Double
-		IL_055d: ldloc.1
-		IL_055e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0563: stloc.s 15
-		IL_0565: ldloc.s 15
-		IL_0567: box [System.Runtime]System.Boolean
-		IL_056c: stloc.s 18
-		IL_056e: ldloc.s 19
-		IL_0570: ldstr "log"
-		IL_0575: ldloc.s 14
-		IL_0577: ldloc.s 13
-		IL_0579: ldloc.s 18
-		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0580: pop
-		IL_0581: ldloc.1
-		IL_0582: ldc.r8 2
-		IL_058b: ldc.i4.0
-		IL_058c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
-		IL_0591: ldstr "console"
-		IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05a0: stloc.s 13
-		IL_05a2: ldloc.1
-		IL_05a3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_05a8: box [System.Runtime]System.Double
-		IL_05ad: stloc.s 14
-		IL_05af: ldc.r8 2
-		IL_05b8: box [System.Runtime]System.Double
-		IL_05bd: ldloc.1
-		IL_05be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_05c3: stloc.s 15
-		IL_05c5: ldloc.s 15
-		IL_05c7: box [System.Runtime]System.Boolean
-		IL_05cc: stloc.s 18
-		IL_05ce: ldc.r8 5
-		IL_05d7: box [System.Runtime]System.Double
-		IL_05dc: ldloc.1
-		IL_05dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_05e2: stloc.s 15
-		IL_05e4: ldloc.s 15
-		IL_05e6: box [System.Runtime]System.Boolean
-		IL_05eb: stloc.s 17
-		IL_05ed: ldloc.s 13
-		IL_05ef: ldstr "log"
-		IL_05f4: ldloc.s 14
-		IL_05f6: ldloc.s 18
-		IL_05f8: ldloc.s 17
-		IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_05ff: pop
-		IL_0600: ldc.i4.1
-		IL_0601: newarr [System.Runtime]System.Object
-		IL_0606: dup
-		IL_0607: ldc.i4.0
-		IL_0608: ldloc.0
-		IL_0609: stelem.ref
-		IL_060a: stloc.s 22
-		IL_060c: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
-		IL_0611: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0616: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
-		IL_061b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0620: stloc.s 23
-		IL_0622: ldloc.s 23
-		IL_0624: ldloc.s 22
-		IL_0626: ldc.r8 0.0
-		IL_062f: box [System.Runtime]System.Double
-		IL_0634: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0639: stloc.s 13
-		IL_063b: ldstr "Array"
-		IL_0640: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0645: stloc.s 19
-		IL_0647: ldloc.s 13
-		IL_0649: ldloc.s 19
-		IL_064b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0650: stloc.s 19
-		IL_0652: ldloc.s 19
-		IL_0654: stloc.s 9
-		IL_0656: ldc.i4.0
-		IL_0657: newarr [System.Runtime]System.Object
-		IL_065c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0661: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0666: newobj instance void Modules.Array_JsObject_NamedProperties/DerivedArray::.ctor()
-		IL_066b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0670: stloc.s 10
-		IL_0672: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_067c: stloc.s 10
-		IL_067e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_0683: ldloc.s 10
-		IL_0685: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
-		IL_068a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_068f: ldstr "prototype"
-		IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0699: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_069e: ldloc.s 10
-		IL_06a0: ldc.r8 1
-		IL_06a9: ldc.r8 42
-		IL_06b2: ldc.i4.0
-		IL_06b3: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_06b8: ldstr "console"
-		IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06c7: stloc.s 19
-		IL_06c9: ldloc.s 10
-		IL_06cb: ldstr "length"
-		IL_06d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06d5: stloc.s 13
-		IL_06d7: ldloc.s 10
-		IL_06d9: ldc.r8 1
-		IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_06e7: stloc.s 12
-		IL_06e9: ldloc.s 19
-		IL_06eb: ldstr "log"
-		IL_06f0: ldloc.s 13
-		IL_06f2: ldloc.s 12
-		IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_06f9: pop
-		IL_06fa: ldstr "console"
-		IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0704: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0709: ldloc.1
-		IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_070f: stloc.s 12
-		IL_0711: ldstr "log"
-		IL_0716: ldloc.s 12
-		IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_071d: pop
-		IL_071e: ldstr "console"
-		IL_0723: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0728: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_072d: ldstr "log"
-		IL_0732: ldloc.1
-		IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0738: pop
-		IL_0739: ldloc.1
-		IL_073a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_073f: pop
-		IL_0740: ldstr "console"
-		IL_0745: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_074a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_074f: ldloc.1
-		IL_0750: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0755: box [System.Runtime]System.Boolean
-		IL_075a: stloc.s 17
-		IL_075c: ldstr "log"
-		IL_0761: ldloc.s 17
-		IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0768: pop
-		IL_0769: ret
+		IL_044a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_044f: stloc.s 22
+		IL_0451: ldloc.s 22
+		IL_0453: ldstr "set"
+		IL_0458: ldloc.1
+		IL_0459: ldstr "identity"
+		IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0463: pop
+		IL_0464: ldstr "console"
+		IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0473: stloc.s 13
+		IL_0475: ldloc.s 8
+		IL_0477: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_047c: stloc.s 22
+		IL_047e: ldloc.s 22
+		IL_0480: ldstr "get"
+		IL_0485: ldloc.1
+		IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_048b: stloc.s 19
+		IL_048d: ldloc.s 13
+		IL_048f: ldstr "log"
+		IL_0494: ldloc.s 19
+		IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_049b: pop
+		IL_049c: ldstr "console"
+		IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04ab: stloc.s 19
+		IL_04ad: ldloc.1
+		IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04b8: ldstr "join"
+		IL_04bd: ldstr ","
+		IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04c7: stloc.s 13
+		IL_04c9: ldloc.s 19
+		IL_04cb: ldstr "log"
+		IL_04d0: ldloc.s 13
+		IL_04d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04d7: pop
+		IL_04d8: ldloc.1
+		IL_04d9: ldstr "custom"
+		IL_04de: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
+		IL_04e3: stloc.s 15
+		IL_04e5: ldstr "console"
+		IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04f4: stloc.s 13
+		IL_04f6: ldloc.1
+		IL_04f7: ldstr "custom"
+		IL_04fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0501: stloc.s 19
+		IL_0503: ldloc.s 13
+		IL_0505: ldstr "log"
+		IL_050a: ldloc.s 19
+		IL_050c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0511: pop
+		IL_0512: ldloc.1
+		IL_0513: ldc.r8 5
+		IL_051c: ldstr "sparse"
+		IL_0521: ldc.i4.0
+		IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_0527: pop
+		IL_0528: ldstr "console"
+		IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0537: stloc.s 19
+		IL_0539: ldloc.1
+		IL_053a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_053f: box [System.Runtime]System.Double
+		IL_0544: stloc.s 14
+		IL_0546: ldloc.1
+		IL_0547: ldc.r8 5
+		IL_0550: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0555: stloc.s 13
+		IL_0557: ldc.r8 4
+		IL_0560: box [System.Runtime]System.Double
+		IL_0565: ldloc.1
+		IL_0566: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_056b: stloc.s 15
+		IL_056d: ldloc.s 15
+		IL_056f: box [System.Runtime]System.Boolean
+		IL_0574: stloc.s 18
+		IL_0576: ldloc.s 19
+		IL_0578: ldstr "log"
+		IL_057d: ldloc.s 14
+		IL_057f: ldloc.s 13
+		IL_0581: ldloc.s 18
+		IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0588: pop
+		IL_0589: ldloc.1
+		IL_058a: ldc.r8 2
+		IL_0593: ldc.i4.0
+		IL_0594: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+		IL_0599: ldstr "console"
+		IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05a8: stloc.s 13
+		IL_05aa: ldloc.1
+		IL_05ab: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_05b0: box [System.Runtime]System.Double
+		IL_05b5: stloc.s 14
+		IL_05b7: ldc.r8 2
+		IL_05c0: box [System.Runtime]System.Double
+		IL_05c5: ldloc.1
+		IL_05c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_05cb: stloc.s 15
+		IL_05cd: ldloc.s 15
+		IL_05cf: box [System.Runtime]System.Boolean
+		IL_05d4: stloc.s 18
+		IL_05d6: ldc.r8 5
+		IL_05df: box [System.Runtime]System.Double
+		IL_05e4: ldloc.1
+		IL_05e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_05ea: stloc.s 15
+		IL_05ec: ldloc.s 15
+		IL_05ee: box [System.Runtime]System.Boolean
+		IL_05f3: stloc.s 17
+		IL_05f5: ldloc.s 13
+		IL_05f7: ldstr "log"
+		IL_05fc: ldloc.s 14
+		IL_05fe: ldloc.s 18
+		IL_0600: ldloc.s 17
+		IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0607: pop
+		IL_0608: ldc.i4.1
+		IL_0609: newarr [System.Runtime]System.Object
+		IL_060e: dup
+		IL_060f: ldc.i4.0
+		IL_0610: ldloc.0
+		IL_0611: stelem.ref
+		IL_0612: stloc.s 23
+		IL_0614: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
+		IL_0619: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_061e: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
+		IL_0623: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0628: stloc.s 24
+		IL_062a: ldloc.s 24
+		IL_062c: ldloc.s 23
+		IL_062e: ldc.r8 0.0
+		IL_0637: box [System.Runtime]System.Double
+		IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0641: stloc.s 13
+		IL_0643: ldstr "Array"
+		IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_064d: stloc.s 19
+		IL_064f: ldloc.s 13
+		IL_0651: ldloc.s 19
+		IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_0658: stloc.s 19
+		IL_065a: ldloc.s 19
+		IL_065c: stloc.s 9
+		IL_065e: ldc.i4.0
+		IL_065f: newarr [System.Runtime]System.Object
+		IL_0664: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0669: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_066e: newobj instance void Modules.Array_JsObject_NamedProperties/DerivedArray::.ctor()
+		IL_0673: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0678: stloc.s 10
+		IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_067f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0684: stloc.s 10
+		IL_0686: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_068b: ldloc.s 10
+		IL_068d: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
+		IL_0692: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0697: ldstr "prototype"
+		IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_06a1: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_06a6: ldloc.s 10
+		IL_06a8: ldc.r8 1
+		IL_06b1: ldc.r8 42
+		IL_06ba: ldc.i4.0
+		IL_06bb: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_06c0: ldstr "console"
+		IL_06c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06cf: stloc.s 19
+		IL_06d1: ldloc.s 10
+		IL_06d3: ldstr "length"
+		IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06dd: stloc.s 13
+		IL_06df: ldloc.s 10
+		IL_06e1: ldc.r8 1
+		IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_06ef: stloc.s 12
+		IL_06f1: ldloc.s 19
+		IL_06f3: ldstr "log"
+		IL_06f8: ldloc.s 13
+		IL_06fa: ldloc.s 12
+		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0701: pop
+		IL_0702: ldstr "console"
+		IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_070c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0711: ldloc.1
+		IL_0712: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0717: stloc.s 12
+		IL_0719: ldstr "log"
+		IL_071e: ldloc.s 12
+		IL_0720: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0725: pop
+		IL_0726: ldstr "console"
+		IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0735: ldstr "log"
+		IL_073a: ldloc.1
+		IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0740: pop
+		IL_0741: ldloc.1
+		IL_0742: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_0747: pop
+		IL_0748: ldstr "console"
+		IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0752: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0757: ldloc.1
+		IL_0758: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_075d: box [System.Runtime]System.Boolean
+		IL_0762: stloc.s 17
+		IL_0764: ldstr "log"
+		IL_0769: ldloc.s 17
+		IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0770: pop
+		IL_0771: ret
 	} // end of method Array_JsObject_NamedProperties::__js_module_init__
 
 } // end of class Modules.Array_JsObject_NamedProperties
@@ -746,7 +751,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x281e
+		// Method begins at RVA 0x2826
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Prototype_CustomMethod_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Prototype_CustomMethod_Dispatch.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21e8
+					// Method begins at RVA 0x21ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21df
+				// Method begins at RVA 0x21e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2150
+			// Method begins at RVA 0x2154
 			// Header size: 12
 			// Code size: 122 (0x7a)
 			.maxstack 8
@@ -125,7 +125,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d6
+			// Method begins at RVA 0x21da
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -151,15 +151,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 243 (0xf3)
+		// Code size: 247 (0xf7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Prototype_CustomMethod_Dispatch/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[2] object,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
-			[4] object,
-			[5] string
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[5] object,
+			[6] string
 		)
 
 		IL_0000: newobj instance void Modules.Array_Prototype_CustomMethod_Dispatch/Scope::.ctor()
@@ -204,36 +205,38 @@
 		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_008d: stloc.2
 		IL_008e: ldloc.1
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0094: ldstr "removeGraphNode"
-		IL_0099: ldc.r8 2
-		IL_00a2: box [System.Runtime]System.Double
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ac: stloc.s 4
-		IL_00ae: ldloc.2
-		IL_00af: ldstr "log"
-		IL_00b4: ldloc.s 4
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bb: pop
-		IL_00bc: ldstr "console"
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cb: stloc.s 4
-		IL_00cd: ldloc.1
-		IL_00ce: ldc.i4.1
-		IL_00cf: newarr [System.Runtime]System.Object
-		IL_00d4: dup
-		IL_00d5: ldc.i4.0
-		IL_00d6: ldstr ","
-		IL_00db: stelem.ref
-		IL_00dc: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_00e1: stloc.s 5
-		IL_00e3: ldloc.s 4
-		IL_00e5: ldstr "log"
-		IL_00ea: ldloc.s 5
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f1: pop
-		IL_00f2: ret
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
+		IL_0094: stloc.s 4
+		IL_0096: ldloc.s 4
+		IL_0098: ldstr "removeGraphNode"
+		IL_009d: ldc.r8 2
+		IL_00a6: box [System.Runtime]System.Double
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b0: stloc.s 5
+		IL_00b2: ldloc.2
+		IL_00b3: ldstr "log"
+		IL_00b8: ldloc.s 5
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bf: pop
+		IL_00c0: ldstr "console"
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cf: stloc.s 5
+		IL_00d1: ldloc.1
+		IL_00d2: ldc.i4.1
+		IL_00d3: newarr [System.Runtime]System.Object
+		IL_00d8: dup
+		IL_00d9: ldc.i4.0
+		IL_00da: ldstr ","
+		IL_00df: stelem.ref
+		IL_00e0: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_00e5: stloc.s 6
+		IL_00e7: ldloc.s 5
+		IL_00e9: ldstr "log"
+		IL_00ee: ldloc.s 6
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f5: pop
+		IL_00f6: ret
 	} // end of method Array_Prototype_CustomMethod_Dispatch::__js_module_init__
 
 } // end of class Modules.Array_Prototype_CustomMethod_Dispatch
@@ -245,7 +248,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f1
+		// Method begins at RVA 0x21f5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ForOfIterableArrowCallback.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ForOfIterableArrowCallback.verified.txt
@@ -28,7 +28,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2258
+					// Method begins at RVA 0x2255
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -54,7 +54,7 @@
 				)
 				// Method begins at RVA 0x2204
 				// Header size: 12
-				// Code size: 36 (0x24)
+				// Code size: 33 (0x21)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -66,13 +66,14 @@
 				IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 				IL_000f: stloc.0
 				IL_0010: ldloc.0
-				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0016: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-				IL_001b: ldarg.1
-				IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-				IL_0021: stloc.1
-				IL_0022: ldloc.1
-				IL_0023: ret
+				IL_0011: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+				IL_0016: stloc.0
+				IL_0017: ldloc.0
+				IL_0018: ldarg.1
+				IL_0019: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_001e: stloc.1
+				IL_001f: ldloc.1
+				IL_0020: ret
 			} // end of method ArrowFunction_L2C48::__js_call__
 
 		} // end of class ArrowFunction_L2C48
@@ -91,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x223d
+				// Method begins at RVA 0x223a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -115,7 +116,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x224f
+					// Method begins at RVA 0x224c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -133,7 +134,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2246
+				// Method begins at RVA 0x2243
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -272,7 +273,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2234
+			// Method begins at RVA 0x2231
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -374,7 +375,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2261
+		// Method begins at RVA 0x225e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ConstructorAssigned.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ConstructorAssigned.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222a
+				// Method begins at RVA 0x222e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2196
+			// Method begins at RVA 0x219a
 			// Header size: 1
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2218
+				// Method begins at RVA 0x221c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2221
+				// Method begins at RVA 0x2225
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a8
+			// Method begins at RVA 0x21ac
 			// Header size: 12
 			// Code size: 91 (0x5b)
 			.maxstack 8
@@ -173,7 +173,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x220f
+			// Method begins at RVA 0x2213
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -199,7 +199,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 314 (0x13a)
+		// Code size: 318 (0x13e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Scope,
@@ -210,7 +210,8 @@
 			[5] class [System.Runtime]System.Type,
 			[6] object,
 			[7] class Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter,
-			[8] object
+			[8] object,
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Scope::.ctor()
@@ -297,16 +298,18 @@
 		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0116: stloc.s 8
 		IL_0118: ldloc.3
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011e: ldstr "getX"
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0128: stloc.s 6
-		IL_012a: ldloc.s 8
-		IL_012c: ldstr "log"
-		IL_0131: ldloc.s 6
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0138: pop
-		IL_0139: ret
+		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
+		IL_011e: stloc.s 9
+		IL_0120: ldloc.s 9
+		IL_0122: ldstr "getX"
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_012c: stloc.s 6
+		IL_012e: ldloc.s 8
+		IL_0130: ldstr "log"
+		IL_0135: ldloc.s 6
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013c: pop
+		IL_013d: ret
 	} // end of method ArrowFunction_LexicalThis_ConstructorAssigned::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalThis_ConstructorAssigned
@@ -318,7 +321,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2233
+		// Method begins at RVA 0x2237
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_CreatedInMethod.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_CreatedInMethod.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fc
+				// Method begins at RVA 0x2204
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2171
+			// Method begins at RVA 0x2179
 			// Header size: 1
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e1
+				// Method begins at RVA 0x21e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ea
+				// Method begins at RVA 0x21f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f3
+				// Method begins at RVA 0x21fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,7 +131,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2182
+			// Method begins at RVA 0x218a
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -150,7 +150,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2194
+			// Method begins at RVA 0x219c
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -189,7 +189,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21e0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -215,7 +215,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 277 (0x115)
+		// Code size: 285 (0x11d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_LexicalThis_CreatedInMethod/Scope,
@@ -225,7 +225,8 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] class Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter,
 			[6] object,
-			[7] object
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_LexicalThis_CreatedInMethod/Scope::.ctor()
@@ -281,30 +282,34 @@
 		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00be: stloc.s 6
 		IL_00c0: ldloc.3
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c6: ldstr "g"
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00d0: stloc.s 7
-		IL_00d2: ldloc.s 6
-		IL_00d4: ldstr "log"
-		IL_00d9: ldloc.s 7
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e0: pop
-		IL_00e1: ldstr "console"
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f0: stloc.s 7
-		IL_00f2: ldloc.s 4
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f9: ldstr "g"
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0103: stloc.s 6
-		IL_0105: ldloc.s 7
-		IL_0107: ldstr "log"
-		IL_010c: ldloc.s 6
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0113: pop
-		IL_0114: ret
+		IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
+		IL_00c6: stloc.s 7
+		IL_00c8: ldloc.s 7
+		IL_00ca: ldstr "g"
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00d4: stloc.s 8
+		IL_00d6: ldloc.s 6
+		IL_00d8: ldstr "log"
+		IL_00dd: ldloc.s 8
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e4: pop
+		IL_00e5: ldstr "console"
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f4: stloc.s 8
+		IL_00f6: ldloc.s 4
+		IL_00f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
+		IL_00fd: stloc.s 7
+		IL_00ff: ldloc.s 7
+		IL_0101: ldstr "g"
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_010b: stloc.s 6
+		IL_010d: ldloc.s 8
+		IL_010f: ldstr "log"
+		IL_0114: ldloc.s 6
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011b: pop
+		IL_011c: ret
 	} // end of method ArrowFunction_LexicalThis_CreatedInMethod::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalThis_CreatedInMethod
@@ -316,7 +321,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2205
+		// Method begins at RVA 0x220d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2371
+				// Method begins at RVA 0x2375
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2168
+			// Method begins at RVA 0x216c
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -89,7 +89,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2368
+				// Method begins at RVA 0x236c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -113,7 +113,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x218c
+			// Method begins at RVA 0x2190
 			// Header size: 12
 			// Code size: 345 (0x159)
 			.maxstack 8
@@ -265,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x234d
+				// Method begins at RVA 0x2351
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -285,7 +285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2356
+				// Method begins at RVA 0x235a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -305,7 +305,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x235f
+				// Method begins at RVA 0x2363
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -331,7 +331,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22f1
+			// Method begins at RVA 0x22f5
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -350,7 +350,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2300
+			// Method begins at RVA 0x2304
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -389,7 +389,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2344
+			// Method begins at RVA 0x2348
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -415,7 +415,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 268 (0x10c)
+		// Code size: 272 (0x110)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ArrowFunction_LexicalThis/Scope,
@@ -423,8 +423,9 @@
 			[2] object,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] class Modules.Async_ArrowFunction_LexicalThis/Counter,
-			[5] object,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[6] object,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		)
 
 		IL_0000: newobj instance void Modules.Async_ArrowFunction_LexicalThis/Scope::.ctor()
@@ -466,46 +467,48 @@
 		IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_0087: stloc.3
 		IL_0088: ldloc.3
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008e: ldstr "g"
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0098: stloc.s 5
-		IL_009a: ldloc.s 5
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a1: stloc.s 5
-		IL_00a3: ldnull
-		IL_00a4: ldftn object Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L23C16::__js_call__(object, object)
-		IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00af: ldc.i4.1
-		IL_00b0: newarr [System.Runtime]System.Object
-		IL_00b5: dup
-		IL_00b6: ldc.i4.0
-		IL_00b7: ldloc.0
-		IL_00b8: stelem.ref
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00c3: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_00c8: ldc.i4.1
-		IL_00c9: conv.r8
-		IL_00ca: ldstr ""
-		IL_00cf: ldc.i4.0
-		IL_00d0: ldc.i4.0
-		IL_00d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_00db: stloc.s 6
-		IL_00dd: ldloc.s 5
-		IL_00df: ldstr "then"
-		IL_00e4: ldloc.s 6
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00eb: pop
-		IL_00ec: ldstr "console"
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fb: ldstr "log"
-		IL_0100: ldstr "After calling async getter"
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010a: pop
-		IL_010b: ret
+		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
+		IL_008e: stloc.s 5
+		IL_0090: ldloc.s 5
+		IL_0092: ldstr "g"
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_009c: stloc.s 6
+		IL_009e: ldloc.s 6
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a5: stloc.s 6
+		IL_00a7: ldnull
+		IL_00a8: ldftn object Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L23C16::__js_call__(object, object)
+		IL_00ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00b3: ldc.i4.1
+		IL_00b4: newarr [System.Runtime]System.Object
+		IL_00b9: dup
+		IL_00ba: ldc.i4.0
+		IL_00bb: ldloc.0
+		IL_00bc: stelem.ref
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00c7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_00cc: ldc.i4.1
+		IL_00cd: conv.r8
+		IL_00ce: ldstr ""
+		IL_00d3: ldc.i4.0
+		IL_00d4: ldc.i4.0
+		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_00df: stloc.s 7
+		IL_00e1: ldloc.s 6
+		IL_00e3: ldstr "then"
+		IL_00e8: ldloc.s 7
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ef: pop
+		IL_00f0: ldstr "console"
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ff: ldstr "log"
+		IL_0104: ldstr "After calling async getter"
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010e: pop
+		IL_010f: ret
 	} // end of method Async_ArrowFunction_LexicalThis::__js_module_init__
 
 } // end of class Modules.Async_ArrowFunction_LexicalThis
@@ -517,7 +520,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x237a
+		// Method begins at RVA 0x237e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
@@ -291,8 +291,8 @@
 				[0] class Modules.Async_RealSuspension_SetTimeout/run/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+				[4] object
 			)
 
 			IL_0000: newobj instance void Modules.Async_RealSuspension_SetTimeout/run/Scope::.ctor()
@@ -332,8 +332,8 @@
 			IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
 			IL_0068: stloc.2
 			IL_0069: ldloc.2
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006f: stloc.3
+			IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
+			IL_006f: stloc.2
 			IL_0070: ldnull
 			IL_0071: ldftn object Modules.Async_RealSuspension_SetTimeout/run/ArrowFunction_L13C13::__js_call__(object)
 			IL_0077: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
@@ -353,13 +353,13 @@
 			IL_009d: ldc.i4.0
 			IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
 			IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-			IL_00a8: stloc.s 4
-			IL_00aa: ldloc.3
-			IL_00ab: ldstr "then"
-			IL_00b0: ldloc.s 4
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00b7: stloc.3
-			IL_00b8: ldloc.3
+			IL_00a8: stloc.3
+			IL_00a9: ldloc.2
+			IL_00aa: ldstr "then"
+			IL_00af: ldloc.3
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00b5: stloc.s 4
+			IL_00b7: ldloc.s 4
 			IL_00b9: ret
 		} // end of method run::__js_call__
 

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x219f
+				// Method begins at RVA 0x21a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2180
+			// Method begins at RVA 0x2188
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a8
+				// Method begins at RVA 0x21b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b1
+				// Method begins at RVA 0x21b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -116,7 +116,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ba
+				// Method begins at RVA 0x21c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -136,7 +136,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c3
+				// Method begins at RVA 0x21cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -157,7 +157,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2196
+			// Method begins at RVA 0x219e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -183,13 +183,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 291 (0x123)
+		// Code size: 299 (0x12b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
 			[2] object,
-			[3] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/Scope::.ctor()
@@ -208,76 +209,78 @@
 		IL_0026: nop
 		IL_0027: nop
 		IL_0028: ldloc.1
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_002e: ldstr "bind"
-		IL_0033: ldc.i4.0
-		IL_0034: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0039: ldc.r8 1
-		IL_0042: box [System.Runtime]System.Double
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_004c: stloc.2
-		IL_004d: ldloc.2
-		IL_004e: isinst [System.Runtime]System.Delegate
-		IL_0053: brfalse IL_0077
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
+		IL_002e: stloc.3
+		IL_002f: ldloc.3
+		IL_0030: ldstr "bind"
+		IL_0035: ldc.i4.0
+		IL_0036: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_003b: ldc.r8 1
+		IL_0044: box [System.Runtime]System.Double
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_004e: stloc.2
+		IL_004f: ldloc.2
+		IL_0050: isinst [System.Runtime]System.Delegate
+		IL_0055: brfalse IL_0079
 
-		IL_0058: ldstr "console"
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0067: ldstr "log"
-		IL_006c: ldstr "bound function"
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0076: pop
+		IL_005a: ldstr "console"
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0069: ldstr "log"
+		IL_006e: ldstr "bound function"
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0078: pop
 
-		IL_0077: ldarg.1
-		IL_0078: isinst [System.Runtime]System.Delegate
-		IL_007d: brfalse IL_00a1
+		IL_0079: ldarg.1
+		IL_007a: isinst [System.Runtime]System.Delegate
+		IL_007f: brfalse IL_00a3
 
-		IL_0082: ldstr "console"
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0091: ldstr "log"
-		IL_0096: ldstr "require function"
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a0: pop
+		IL_0084: ldstr "console"
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0093: ldstr "log"
+		IL_0098: ldstr "require function"
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a2: pop
 
-		IL_00a1: ldarg.2
-		IL_00a2: ldstr "require"
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ac: stloc.3
-		IL_00ad: ldloc.3
-		IL_00ae: isinst [System.Runtime]System.Delegate
-		IL_00b3: brfalse IL_00d7
+		IL_00a3: ldarg.2
+		IL_00a4: ldstr "require"
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ae: stloc.s 4
+		IL_00b0: ldloc.s 4
+		IL_00b2: isinst [System.Runtime]System.Delegate
+		IL_00b7: brfalse IL_00db
 
-		IL_00b8: ldstr "console"
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c7: ldstr "log"
-		IL_00cc: ldstr "module.require function"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d6: pop
+		IL_00bc: ldstr "console"
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cb: ldstr "log"
+		IL_00d0: ldstr "module.require function"
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00da: pop
 
-		IL_00d7: ldstr "Function"
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e1: ldstr "prototype"
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00eb: stloc.3
-		IL_00ec: ldloc.3
-		IL_00ed: ldstr "bind"
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f7: stloc.3
-		IL_00f8: ldloc.3
-		IL_00f9: isinst [System.Runtime]System.Delegate
-		IL_00fe: brfalse IL_0122
+		IL_00db: ldstr "Function"
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e5: ldstr "prototype"
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ef: stloc.s 4
+		IL_00f1: ldloc.s 4
+		IL_00f3: ldstr "bind"
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00fd: stloc.s 4
+		IL_00ff: ldloc.s 4
+		IL_0101: isinst [System.Runtime]System.Delegate
+		IL_0106: brfalse IL_012a
 
-		IL_0103: ldstr "console"
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0112: ldstr "log"
-		IL_0117: ldstr "prototype bind function"
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0121: pop
+		IL_010b: ldstr "console"
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011a: ldstr "log"
+		IL_011f: ldstr "prototype bind function"
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0129: pop
 
-		IL_0122: ret
+		IL_012a: ret
 	} // end of method BinaryOperator_TypeofFunctionStrictEqual_CallableShapes::__js_module_init__
 
 } // end of class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes
@@ -289,7 +292,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21cc
+		// Method begins at RVA 0x21d4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x246b
+				// Method begins at RVA 0x2467
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2474
+				// Method begins at RVA 0x2470
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x247d
+				// Method begins at RVA 0x2479
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x248f
+					// Method begins at RVA 0x248b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2498
+					// Method begins at RVA 0x2494
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2486
+				// Method begins at RVA 0x2482
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -177,7 +177,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2458
+			// Method begins at RVA 0x2454
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -197,7 +197,7 @@
 			)
 			// Method begins at RVA 0x22ec
 			// Header size: 12
-			// Code size: 335 (0x14f)
+			// Code size: 330 (0x14a)
 			.maxstack 8
 			.locals init (
 				[0] class [System.Runtime]System.Exception,
@@ -230,7 +230,7 @@
 				IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
 				IL_0033: throw
 
-				IL_0034: leave IL_00ed
+				IL_0034: leave IL_00e8
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -282,50 +282,49 @@
 				IL_00b1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_00b6: stloc.s 5
 				IL_00b8: ldloc.s 5
-				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00bf: stloc.s 4
-				IL_00c1: ldloc.s 4
-				IL_00c3: castclass [System.Runtime]System.String
-				IL_00c8: ldstr "without a setter"
-				IL_00cd: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-				IL_00d2: stloc.s 7
-				IL_00d4: ldloc.s 6
-				IL_00d6: ldstr "log"
-				IL_00db: ldloc.s 7
-				IL_00dd: box [System.Runtime]System.Boolean
-				IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00e7: pop
-				IL_00e8: leave IL_00ed
+				IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_00bf: stloc.s 5
+				IL_00c1: ldloc.s 5
+				IL_00c3: ldstr "without a setter"
+				IL_00c8: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+				IL_00cd: stloc.s 7
+				IL_00cf: ldloc.s 6
+				IL_00d1: ldstr "log"
+				IL_00d6: ldloc.s 7
+				IL_00d8: box [System.Runtime]System.Boolean
+				IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00e2: pop
+				IL_00e3: leave IL_00e8
 			} // end handler
 
-			IL_00ed: ldarg.0
-			IL_00ee: ldc.r8 7
-			IL_00f7: box [System.Runtime]System.Double
-			IL_00fc: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_set_writeOnly(object)
-			IL_0101: pop
-			IL_0102: ldstr "console"
-			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0111: ldstr "log"
-			IL_0116: ldarg.0
-			IL_0117: ldfld object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::saved
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0121: pop
-			IL_0122: ldstr "console"
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0131: ldarg.0
-			IL_0132: callvirt instance float64 Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_get_readOnly()
-			IL_0137: box [System.Runtime]System.Double
-			IL_013c: stloc.s 8
-			IL_013e: ldstr "log"
-			IL_0143: ldloc.s 8
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_014a: pop
-			IL_014b: ldnull
-			IL_014c: stloc.3
-			IL_014d: ldloc.3
-			IL_014e: ret
+			IL_00e8: ldarg.0
+			IL_00e9: ldc.r8 7
+			IL_00f2: box [System.Runtime]System.Double
+			IL_00f7: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_set_writeOnly(object)
+			IL_00fc: pop
+			IL_00fd: ldstr "console"
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010c: ldstr "log"
+			IL_0111: ldarg.0
+			IL_0112: ldfld object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::saved
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_011c: pop
+			IL_011d: ldstr "console"
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_012c: ldarg.0
+			IL_012d: callvirt instance float64 Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_get_readOnly()
+			IL_0132: box [System.Runtime]System.Double
+			IL_0137: stloc.s 8
+			IL_0139: ldstr "log"
+			IL_013e: ldloc.s 8
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0145: pop
+			IL_0146: ldnull
+			IL_0147: stloc.3
+			IL_0148: ldloc.3
+			IL_0149: ret
 		} // end of method AccessorEdges::log
 
 	} // end of class AccessorEdges
@@ -337,7 +336,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2462
+			// Method begins at RVA 0x245e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -653,7 +652,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24a1
+		// Method begins at RVA 0x249d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LetClosureCapture.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LetClosureCapture.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2244
+				// Method begins at RVA 0x2250
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x221a
+			// Method begins at RVA 0x2226
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -64,7 +64,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2229
+			// Method begins at RVA 0x2235
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x223b
+				// Method begins at RVA 0x2247
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -113,7 +113,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2232
+			// Method begins at RVA 0x223e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -139,7 +139,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 446 (0x1be)
+		// Code size: 458 (0x1ca)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_LetClosureCapture/Scope,
@@ -150,7 +150,9 @@
 			[5] class Modules.ControlFlow_ForLoop_LetClosureCapture/Scope_For_L5C5,
 			[6] float64,
 			[7] object,
-			[8] object[]
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[9] object[],
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_LetClosureCapture/Scope::.ctor()
@@ -235,61 +237,67 @@
 		IL_00ee: ldstr "console"
 		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fd: ldloc.1
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0103: stloc.s 4
-		IL_0105: ldc.i4.0
-		IL_0106: newarr [System.Runtime]System.Object
-		IL_010b: stloc.s 8
-		IL_010d: ldloc.s 4
-		IL_010f: ldc.r8 0.0
-		IL_0118: box [System.Runtime]System.Double
-		IL_011d: ldloc.s 8
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0124: stloc.s 4
-		IL_0126: ldstr "log"
-		IL_012b: ldloc.s 4
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0132: pop
-		IL_0133: ldstr "console"
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0142: ldloc.1
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0148: stloc.s 4
-		IL_014a: ldc.i4.0
-		IL_014b: newarr [System.Runtime]System.Object
-		IL_0150: stloc.s 8
-		IL_0152: ldloc.s 4
-		IL_0154: ldc.r8 1
-		IL_015d: box [System.Runtime]System.Double
-		IL_0162: ldloc.s 8
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0169: stloc.s 4
-		IL_016b: ldstr "log"
-		IL_0170: ldloc.s 4
-		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0177: pop
-		IL_0178: ldstr "console"
-		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0187: ldloc.1
-		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018d: stloc.s 4
-		IL_018f: ldc.i4.0
-		IL_0190: newarr [System.Runtime]System.Object
-		IL_0195: stloc.s 8
-		IL_0197: ldloc.s 4
-		IL_0199: ldc.r8 2
-		IL_01a2: box [System.Runtime]System.Double
-		IL_01a7: ldloc.s 8
-		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_01ae: stloc.s 4
-		IL_01b0: ldstr "log"
-		IL_01b5: ldloc.s 4
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bc: pop
-		IL_01bd: ret
+		IL_00fd: stloc.s 4
+		IL_00ff: ldloc.1
+		IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
+		IL_0105: stloc.s 8
+		IL_0107: ldc.i4.0
+		IL_0108: newarr [System.Runtime]System.Object
+		IL_010d: stloc.s 9
+		IL_010f: ldloc.s 8
+		IL_0111: ldc.r8 0.0
+		IL_011a: box [System.Runtime]System.Double
+		IL_011f: ldloc.s 9
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0126: stloc.s 10
+		IL_0128: ldloc.s 4
+		IL_012a: ldstr "log"
+		IL_012f: ldloc.s 10
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0136: pop
+		IL_0137: ldstr "console"
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0146: stloc.s 10
+		IL_0148: ldloc.1
+		IL_0149: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
+		IL_014e: stloc.s 8
+		IL_0150: ldc.i4.0
+		IL_0151: newarr [System.Runtime]System.Object
+		IL_0156: stloc.s 9
+		IL_0158: ldloc.s 8
+		IL_015a: ldc.r8 1
+		IL_0163: box [System.Runtime]System.Double
+		IL_0168: ldloc.s 9
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_016f: stloc.s 4
+		IL_0171: ldloc.s 10
+		IL_0173: ldstr "log"
+		IL_0178: ldloc.s 4
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017f: pop
+		IL_0180: ldstr "console"
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018f: stloc.s 4
+		IL_0191: ldloc.1
+		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
+		IL_0197: stloc.s 8
+		IL_0199: ldc.i4.0
+		IL_019a: newarr [System.Runtime]System.Object
+		IL_019f: stloc.s 9
+		IL_01a1: ldloc.s 8
+		IL_01a3: ldc.r8 2
+		IL_01ac: box [System.Runtime]System.Double
+		IL_01b1: ldloc.s 9
+		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_01b8: stloc.s 10
+		IL_01ba: ldloc.s 4
+		IL_01bc: ldstr "log"
+		IL_01c1: ldloc.s 10
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c8: pop
+		IL_01c9: ret
 	} // end of method ControlFlow_ForLoop_LetClosureCapture::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_LetClosureCapture
@@ -301,7 +309,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x224d
+		// Method begins at RVA 0x2259
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LetClosureCapture_Continue.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LetClosureCapture_Continue.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2274
+				// Method begins at RVA 0x2280
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x224a
+			// Method begins at RVA 0x2256
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -64,7 +64,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2259
+			// Method begins at RVA 0x2265
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -96,7 +96,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x227d
+					// Method begins at RVA 0x2289
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -114,7 +114,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x226b
+				// Method begins at RVA 0x2277
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -135,7 +135,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2262
+			// Method begins at RVA 0x226e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -161,7 +161,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 494 (0x1ee)
+		// Code size: 506 (0x1fa)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope,
@@ -173,7 +173,9 @@
 			[6] class Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope_For_L5C5,
 			[7] float64,
 			[8] object,
-			[9] object[]
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[10] object[],
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope::.ctor()
@@ -272,61 +274,67 @@
 		IL_011e: ldstr "console"
 		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012d: ldloc.1
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0133: stloc.s 4
-		IL_0135: ldc.i4.0
-		IL_0136: newarr [System.Runtime]System.Object
-		IL_013b: stloc.s 9
-		IL_013d: ldloc.s 4
-		IL_013f: ldc.r8 0.0
-		IL_0148: box [System.Runtime]System.Double
-		IL_014d: ldloc.s 9
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0154: stloc.s 4
-		IL_0156: ldstr "log"
-		IL_015b: ldloc.s 4
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0162: pop
-		IL_0163: ldstr "console"
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0172: ldloc.1
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0178: stloc.s 4
-		IL_017a: ldc.i4.0
-		IL_017b: newarr [System.Runtime]System.Object
-		IL_0180: stloc.s 9
-		IL_0182: ldloc.s 4
-		IL_0184: ldc.r8 1
-		IL_018d: box [System.Runtime]System.Double
-		IL_0192: ldloc.s 9
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0199: stloc.s 4
-		IL_019b: ldstr "log"
-		IL_01a0: ldloc.s 4
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a7: pop
-		IL_01a8: ldstr "console"
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b7: ldloc.1
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bd: stloc.s 4
-		IL_01bf: ldc.i4.0
-		IL_01c0: newarr [System.Runtime]System.Object
-		IL_01c5: stloc.s 9
-		IL_01c7: ldloc.s 4
-		IL_01c9: ldc.r8 2
-		IL_01d2: box [System.Runtime]System.Double
-		IL_01d7: ldloc.s 9
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_01de: stloc.s 4
-		IL_01e0: ldstr "log"
-		IL_01e5: ldloc.s 4
-		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ec: pop
-		IL_01ed: ret
+		IL_012d: stloc.s 4
+		IL_012f: ldloc.1
+		IL_0130: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
+		IL_0135: stloc.s 9
+		IL_0137: ldc.i4.0
+		IL_0138: newarr [System.Runtime]System.Object
+		IL_013d: stloc.s 10
+		IL_013f: ldloc.s 9
+		IL_0141: ldc.r8 0.0
+		IL_014a: box [System.Runtime]System.Double
+		IL_014f: ldloc.s 10
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0156: stloc.s 11
+		IL_0158: ldloc.s 4
+		IL_015a: ldstr "log"
+		IL_015f: ldloc.s 11
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0166: pop
+		IL_0167: ldstr "console"
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0176: stloc.s 11
+		IL_0178: ldloc.1
+		IL_0179: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
+		IL_017e: stloc.s 9
+		IL_0180: ldc.i4.0
+		IL_0181: newarr [System.Runtime]System.Object
+		IL_0186: stloc.s 10
+		IL_0188: ldloc.s 9
+		IL_018a: ldc.r8 1
+		IL_0193: box [System.Runtime]System.Double
+		IL_0198: ldloc.s 10
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_019f: stloc.s 4
+		IL_01a1: ldloc.s 11
+		IL_01a3: ldstr "log"
+		IL_01a8: ldloc.s 4
+		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01af: pop
+		IL_01b0: ldstr "console"
+		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01bf: stloc.s 4
+		IL_01c1: ldloc.1
+		IL_01c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
+		IL_01c7: stloc.s 9
+		IL_01c9: ldc.i4.0
+		IL_01ca: newarr [System.Runtime]System.Object
+		IL_01cf: stloc.s 10
+		IL_01d1: ldloc.s 9
+		IL_01d3: ldc.r8 2
+		IL_01dc: box [System.Runtime]System.Double
+		IL_01e1: ldloc.s 10
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_01e8: stloc.s 11
+		IL_01ea: ldloc.s 4
+		IL_01ec: ldstr "log"
+		IL_01f1: ldloc.s 11
+		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f8: pop
+		IL_01f9: ret
 	} // end of method ControlFlow_ForLoop_LetClosureCapture_Continue::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_LetClosureCapture_Continue
@@ -338,7 +346,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2286
+		// Method begins at RVA 0x2292
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_VarClosureCapture.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_VarClosureCapture.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f4
+				// Method begins at RVA 0x2200
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x21da
+			// Method begins at RVA 0x21e6
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21eb
+				// Method begins at RVA 0x21f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -91,7 +91,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e2
+			// Method begins at RVA 0x21ee
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -117,7 +117,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 382 (0x17e)
+		// Code size: 394 (0x18a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_VarClosureCapture/Scope,
@@ -126,7 +126,9 @@
 			[3] float64,
 			[4] object,
 			[5] object,
-			[6] object[]
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[7] object[],
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_VarClosureCapture/Scope::.ctor()
@@ -190,61 +192,67 @@
 		IL_00ae: ldstr "console"
 		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bd: ldloc.1
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c3: stloc.s 5
-		IL_00c5: ldc.i4.0
-		IL_00c6: newarr [System.Runtime]System.Object
-		IL_00cb: stloc.s 6
-		IL_00cd: ldloc.s 5
-		IL_00cf: ldc.r8 0.0
-		IL_00d8: box [System.Runtime]System.Double
-		IL_00dd: ldloc.s 6
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_00e4: stloc.s 5
-		IL_00e6: ldstr "log"
-		IL_00eb: ldloc.s 5
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f2: pop
-		IL_00f3: ldstr "console"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0102: ldloc.1
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0108: stloc.s 5
-		IL_010a: ldc.i4.0
-		IL_010b: newarr [System.Runtime]System.Object
-		IL_0110: stloc.s 6
-		IL_0112: ldloc.s 5
-		IL_0114: ldc.r8 1
-		IL_011d: box [System.Runtime]System.Double
-		IL_0122: ldloc.s 6
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0129: stloc.s 5
-		IL_012b: ldstr "log"
-		IL_0130: ldloc.s 5
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0137: pop
-		IL_0138: ldstr "console"
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0147: ldloc.1
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014d: stloc.s 5
-		IL_014f: ldc.i4.0
-		IL_0150: newarr [System.Runtime]System.Object
-		IL_0155: stloc.s 6
-		IL_0157: ldloc.s 5
-		IL_0159: ldc.r8 2
-		IL_0162: box [System.Runtime]System.Double
-		IL_0167: ldloc.s 6
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_016e: stloc.s 5
-		IL_0170: ldstr "log"
-		IL_0175: ldloc.s 5
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017c: pop
-		IL_017d: ret
+		IL_00bd: stloc.s 5
+		IL_00bf: ldloc.1
+		IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
+		IL_00c5: stloc.s 6
+		IL_00c7: ldc.i4.0
+		IL_00c8: newarr [System.Runtime]System.Object
+		IL_00cd: stloc.s 7
+		IL_00cf: ldloc.s 6
+		IL_00d1: ldc.r8 0.0
+		IL_00da: box [System.Runtime]System.Double
+		IL_00df: ldloc.s 7
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_00e6: stloc.s 8
+		IL_00e8: ldloc.s 5
+		IL_00ea: ldstr "log"
+		IL_00ef: ldloc.s 8
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f6: pop
+		IL_00f7: ldstr "console"
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0106: stloc.s 8
+		IL_0108: ldloc.1
+		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
+		IL_010e: stloc.s 6
+		IL_0110: ldc.i4.0
+		IL_0111: newarr [System.Runtime]System.Object
+		IL_0116: stloc.s 7
+		IL_0118: ldloc.s 6
+		IL_011a: ldc.r8 1
+		IL_0123: box [System.Runtime]System.Double
+		IL_0128: ldloc.s 7
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_012f: stloc.s 5
+		IL_0131: ldloc.s 8
+		IL_0133: ldstr "log"
+		IL_0138: ldloc.s 5
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013f: pop
+		IL_0140: ldstr "console"
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014f: stloc.s 5
+		IL_0151: ldloc.1
+		IL_0152: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
+		IL_0157: stloc.s 6
+		IL_0159: ldc.i4.0
+		IL_015a: newarr [System.Runtime]System.Object
+		IL_015f: stloc.s 7
+		IL_0161: ldloc.s 6
+		IL_0163: ldc.r8 2
+		IL_016c: box [System.Runtime]System.Double
+		IL_0171: ldloc.s 7
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0178: stloc.s 8
+		IL_017a: ldloc.s 5
+		IL_017c: ldstr "log"
+		IL_0181: ldloc.s 8
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0188: pop
+		IL_0189: ret
 	} // end of method ControlFlow_ForLoop_VarClosureCapture::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_VarClosureCapture
@@ -256,7 +264,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21fd
+		// Method begins at RVA 0x2209
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Array_SymbolIterator_SparseLiteral.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Array_SymbolIterator_SparseLiteral.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x221d
+				// Method begins at RVA 0x222d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -36,7 +36,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2214
+			// Method begins at RVA 0x2224
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -62,7 +62,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 422 (0x1a6)
+		// Code size: 438 (0x1b6)
 		.maxstack 16
 		.locals init (
 			[0] class Modules.ControlFlow_ForOf_Array_SymbolIterator_SparseLiteral/Scope,
@@ -74,8 +74,9 @@
 			[6] object,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[8] object,
-			[9] bool,
-			[10] float64
+			[9] object[],
+			[10] bool,
+			[11] float64
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForOf_Array_SymbolIterator_SparseLiteral/Scope::.ctor()
@@ -137,84 +138,92 @@
 		IL_00d2: box [System.Runtime]System.Double
 		IL_00d7: stloc.2
 		IL_00d8: ldloc.1
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00de: ldstr "iterator"
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_00e8: ldc.i4.0
-		IL_00e9: newarr [System.Runtime]System.Object
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_00f3: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-		IL_00f8: stloc.3
-		IL_00f9: ldc.i4.0
-		IL_00fa: stloc.s 4
-		IL_00fc: ldc.i4.0
-		IL_00fd: stloc.s 5
+		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
+		IL_00de: stloc.s 7
+		IL_00e0: ldstr "iterator"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_00ea: stloc.s 8
+		IL_00ec: ldc.i4.0
+		IL_00ed: newarr [System.Runtime]System.Object
+		IL_00f2: stloc.s 9
+		IL_00f4: ldloc.s 7
+		IL_00f6: ldloc.s 8
+		IL_00f8: ldloc.s 9
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_00ff: stloc.s 8
+		IL_0101: ldloc.s 8
+		IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+		IL_0108: stloc.3
+		IL_0109: ldc.i4.0
+		IL_010a: stloc.s 4
+		IL_010c: ldc.i4.0
+		IL_010d: stloc.s 5
 		.try
 		{
-			// loop start (head: IL_00ff)
-				IL_00ff: ldloc.3
-				IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-				IL_0105: stloc.s 8
-				IL_0107: ldloc.s 8
-				IL_0109: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-				IL_010e: stloc.s 9
-				IL_0110: ldloc.s 9
-				IL_0112: brtrue IL_016d
-
+			// loop start (head: IL_010f)
+				IL_010f: ldloc.3
+				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+				IL_0115: stloc.s 8
 				IL_0117: ldloc.s 8
-				IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-				IL_011e: stloc.s 8
-				IL_0120: ldloc.s 8
-				IL_0122: stloc.s 6
-				IL_0124: ldstr "console"
-				IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0133: ldstr "log"
-				IL_0138: ldloc.s 6
-				IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_013f: pop
-				IL_0140: ldloc.2
-				IL_0141: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0146: ldc.r8 1
-				IL_014f: add
-				IL_0150: stloc.s 10
-				IL_0152: ldloc.s 10
-				IL_0154: box [System.Runtime]System.Double
-				IL_0159: stloc.2
-				IL_015a: br IL_00ff
-			// end loop
-			IL_015f: ldloc.3
-			IL_0160: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-			IL_0165: ldc.i4.1
-			IL_0166: stloc.s 5
-			IL_0168: leave IL_018a
+				IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+				IL_011e: stloc.s 10
+				IL_0120: ldloc.s 10
+				IL_0122: brtrue IL_017d
 
-			IL_016d: ldc.i4.1
-			IL_016e: stloc.s 4
-			IL_0170: leave IL_018a
+				IL_0127: ldloc.s 8
+				IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+				IL_012e: stloc.s 8
+				IL_0130: ldloc.s 8
+				IL_0132: stloc.s 6
+				IL_0134: ldstr "console"
+				IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0143: ldstr "log"
+				IL_0148: ldloc.s 6
+				IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_014f: pop
+				IL_0150: ldloc.2
+				IL_0151: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0156: ldc.r8 1
+				IL_015f: add
+				IL_0160: stloc.s 11
+				IL_0162: ldloc.s 11
+				IL_0164: box [System.Runtime]System.Double
+				IL_0169: stloc.2
+				IL_016a: br IL_010f
+			// end loop
+			IL_016f: ldloc.3
+			IL_0170: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+			IL_0175: ldc.i4.1
+			IL_0176: stloc.s 5
+			IL_0178: leave IL_019a
+
+			IL_017d: ldc.i4.1
+			IL_017e: stloc.s 4
+			IL_0180: leave IL_019a
 		} // end .try
 		finally
 		{
-			IL_0175: ldloc.s 4
-			IL_0177: brtrue IL_0189
+			IL_0185: ldloc.s 4
+			IL_0187: brtrue IL_0199
 
-			IL_017c: ldloc.s 5
-			IL_017e: brtrue IL_0189
+			IL_018c: ldloc.s 5
+			IL_018e: brtrue IL_0199
 
-			IL_0183: ldloc.3
-			IL_0184: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+			IL_0193: ldloc.3
+			IL_0194: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-			IL_0189: endfinally
+			IL_0199: endfinally
 		} // end handler
 
-		IL_018a: ldstr "console"
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0199: ldstr "log"
-		IL_019e: ldloc.2
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a4: pop
-		IL_01a5: ret
+		IL_019a: ldstr "console"
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a9: ldstr "log"
+		IL_01ae: ldloc.2
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b4: pop
+		IL_01b5: ret
 	} // end of method ControlFlow_ForOf_Array_SymbolIterator_SparseLiteral::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_Array_SymbolIterator_SparseLiteral
@@ -226,7 +235,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2226
+		// Method begins at RVA 0x2236
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Date/Snapshots/GeneratorTests.Date_Construct_FromMs_GetTime_ToISOString.verified.txt
+++ b/tests/Jroc.Tests/Date/Snapshots/GeneratorTests.Date_Construct_FromMs_GetTime_ToISOString.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20d4
+			// Method begins at RVA 0x20dc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 120 (0x78)
+		// Code size: 128 (0x80)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Date_Construct_FromMs_GetTime_ToISOString/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Date,
 			[2] object,
-			[3] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.Date,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Date_Construct_FromMs_GetTime_ToISOString/Scope::.ctor()
@@ -61,30 +62,34 @@
 		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_002a: stloc.2
 		IL_002b: ldloc.1
-		IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0031: ldstr "getTime"
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_003b: stloc.3
-		IL_003c: ldloc.2
-		IL_003d: ldstr "log"
-		IL_0042: ldloc.3
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0048: pop
-		IL_0049: ldstr "console"
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0058: stloc.3
-		IL_0059: ldloc.1
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005f: ldstr "toISOString"
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0069: stloc.2
-		IL_006a: ldloc.3
-		IL_006b: ldstr "log"
-		IL_0070: ldloc.2
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0076: pop
-		IL_0077: ret
+		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Date>(!!0)
+		IL_0031: stloc.3
+		IL_0032: ldloc.3
+		IL_0033: ldstr "getTime"
+		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_003d: stloc.s 4
+		IL_003f: ldloc.2
+		IL_0040: ldstr "log"
+		IL_0045: ldloc.s 4
+		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004c: pop
+		IL_004d: ldstr "console"
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005c: stloc.s 4
+		IL_005e: ldloc.1
+		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Date>(!!0)
+		IL_0064: stloc.3
+		IL_0065: ldloc.3
+		IL_0066: ldstr "toISOString"
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0070: stloc.2
+		IL_0071: ldloc.s 4
+		IL_0073: ldstr "log"
+		IL_0078: ldloc.2
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: pop
+		IL_007f: ret
 	} // end of method Date_Construct_FromMs_GetTime_ToISOString::__js_module_init__
 
 } // end of class Modules.Date_Construct_FromMs_GetTime_ToISOString
@@ -96,7 +101,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20dd
+		// Method begins at RVA 0x20e5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2459
+				// Method begins at RVA 0x2465
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2344
+			// Method begins at RVA 0x234c
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -89,7 +89,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2474
+				// Method begins at RVA 0x2480
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -115,12 +115,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2370
+			// Method begins at RVA 0x2378
 			// Header size: 12
-			// Code size: 57 (0x39)
+			// Code size: 61 (0x3d)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -132,14 +133,18 @@
 			IL_0016: ldarg.0
 			IL_0017: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
 			IL_001c: castclass [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0026: ldstr "register"
-			IL_002b: ldloc.0
-			IL_002c: ldstr "held"
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0036: pop
-			IL_0037: ldnull
-			IL_0038: ret
+			IL_0021: stloc.1
+			IL_0022: ldloc.1
+			IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry>(!!0)
+			IL_0028: stloc.1
+			IL_0029: ldloc.1
+			IL_002a: ldstr "register"
+			IL_002f: ldloc.0
+			IL_0030: ldstr "held"
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_003a: pop
+			IL_003b: ldnull
+			IL_003c: ret
 		} // end of method FunctionExpression_L19C1::__js_call__
 
 	} // end of class FunctionExpression_L19C1
@@ -162,7 +167,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x247d
+				// Method begins at RVA 0x2489
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -186,7 +191,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23b8
+			// Method begins at RVA 0x23c4
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -215,7 +220,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2486
+				// Method begins at RVA 0x2492
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -241,7 +246,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23d4
+			// Method begins at RVA 0x23e0
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -272,7 +277,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x248f
+				// Method begins at RVA 0x249b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -298,7 +303,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23f8
+			// Method begins at RVA 0x2404
 			// Header size: 12
 			// Code size: 76 (0x4c)
 			.maxstack 8
@@ -356,7 +361,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2462
+				// Method begins at RVA 0x246e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -376,7 +381,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x246b
+				// Method begins at RVA 0x2477
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -398,7 +403,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2450
+			// Method begins at RVA 0x245c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -424,7 +429,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 726 (0x2d6)
+		// Code size: 734 (0x2de)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FinalizationRegistry_Cleanup_Order/Scope,
@@ -517,177 +522,181 @@
 			IL_00d8: ldloc.0
 			IL_00d9: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
 			IL_00de: castclass [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e8: ldstr "register"
-			IL_00ed: ldloc.1
-			IL_00ee: ldloc.1
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00f4: pop
-			IL_00f5: ldstr "console"
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0104: ldstr "log"
-			IL_0109: ldstr "same target threw:"
-			IL_010e: ldc.i4.0
-			IL_010f: box [System.Runtime]System.Boolean
-			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0119: pop
-			IL_011a: leave IL_01a8
+			IL_00e3: stloc.s 8
+			IL_00e5: ldloc.s 8
+			IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry>(!!0)
+			IL_00ec: stloc.s 8
+			IL_00ee: ldloc.s 8
+			IL_00f0: ldstr "register"
+			IL_00f5: ldloc.1
+			IL_00f6: ldloc.1
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00fc: pop
+			IL_00fd: ldstr "console"
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010c: ldstr "log"
+			IL_0111: ldstr "same target threw:"
+			IL_0116: ldc.i4.0
+			IL_0117: box [System.Runtime]System.Boolean
+			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0121: pop
+			IL_0122: leave IL_01b0
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_011f: stloc.2
-			IL_0120: ldloc.2
-			IL_0121: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0126: dup
-			IL_0127: brtrue IL_013c
+			IL_0127: stloc.2
+			IL_0128: ldloc.2
+			IL_0129: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_012e: dup
+			IL_012f: brtrue IL_0144
 
-			IL_012c: pop
-			IL_012d: ldloc.2
-			IL_012e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0133: dup
-			IL_0134: brtrue IL_0147
+			IL_0134: pop
+			IL_0135: ldloc.2
+			IL_0136: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_013b: dup
+			IL_013c: brtrue IL_014f
 
-			IL_0139: pop
-			IL_013a: rethrow
+			IL_0141: pop
+			IL_0142: rethrow
 
-			IL_013c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0141: stloc.3
-			IL_0142: br IL_0148
+			IL_0144: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0149: stloc.3
+			IL_014a: br IL_0150
 
-			IL_0147: stloc.3
+			IL_014f: stloc.3
 
-			IL_0148: ldloc.3
-			IL_0149: stloc.s 4
-			IL_014b: ldstr "console"
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_015a: ldstr "log"
-			IL_015f: ldstr "same target threw:"
-			IL_0164: ldc.i4.1
-			IL_0165: box [System.Runtime]System.Boolean
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_016f: pop
-			IL_0170: ldstr "console"
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_017f: stloc.s 10
-			IL_0181: ldloc.s 4
-			IL_0183: ldstr "name"
-			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_018d: stloc.s 9
-			IL_018f: ldloc.s 10
-			IL_0191: ldstr "log"
-			IL_0196: ldstr "same target name:"
-			IL_019b: ldloc.s 9
-			IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01a2: pop
-			IL_01a3: leave IL_01a8
+			IL_0150: ldloc.3
+			IL_0151: stloc.s 4
+			IL_0153: ldstr "console"
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0162: ldstr "log"
+			IL_0167: ldstr "same target threw:"
+			IL_016c: ldc.i4.1
+			IL_016d: box [System.Runtime]System.Boolean
+			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0177: pop
+			IL_0178: ldstr "console"
+			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0187: stloc.s 10
+			IL_0189: ldloc.s 4
+			IL_018b: ldstr "name"
+			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0195: stloc.s 9
+			IL_0197: ldloc.s 10
+			IL_0199: ldstr "log"
+			IL_019e: ldstr "same target name:"
+			IL_01a3: ldloc.s 9
+			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01aa: pop
+			IL_01ab: leave IL_01b0
 		} // end handler
 
-		IL_01a8: ldloc.0
-		IL_01a9: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_01ae: ldftn object Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_01b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01b9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_01be: ldc.i4.0
-		IL_01bf: conv.r8
-		IL_01c0: ldstr ""
-		IL_01c5: ldc.i4.0
-		IL_01c6: ldc.i4.1
-		IL_01c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_01cc: stloc.s 11
-		IL_01ce: ldc.i4.0
-		IL_01cf: newarr [System.Runtime]System.Object
-		IL_01d4: stloc.s 12
-		IL_01d6: ldloc.s 11
-		IL_01d8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01dd: ldloc.s 12
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_01e4: pop
-		IL_01e5: ldnull
-		IL_01e6: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13::__js_call__(object, object)
-		IL_01ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01f1: ldc.i4.1
-		IL_01f2: newarr [System.Runtime]System.Object
-		IL_01f7: dup
-		IL_01f8: ldc.i4.0
-		IL_01f9: ldloc.0
-		IL_01fa: stelem.ref
-		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0205: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_020a: ldc.i4.1
-		IL_020b: conv.r8
-		IL_020c: ldstr ""
-		IL_0211: ldc.i4.0
-		IL_0212: ldc.i4.0
-		IL_0213: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0218: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_021d: stloc.s 7
-		IL_021f: ldloc.s 7
-		IL_0221: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
-		IL_0226: stloc.s 13
-		IL_0228: ldloc.s 13
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022f: stloc.s 9
-		IL_0231: ldloc.0
-		IL_0232: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_0237: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_023d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0242: ldc.i4.1
-		IL_0243: newarr [System.Runtime]System.Object
-		IL_0248: dup
-		IL_0249: ldc.i4.0
-		IL_024a: ldloc.0
-		IL_024b: stelem.ref
-		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0256: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_025b: ldc.i4.0
-		IL_025c: conv.r8
-		IL_025d: ldstr ""
-		IL_0262: ldc.i4.0
+		IL_01b0: ldloc.0
+		IL_01b1: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_01b6: ldftn object Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+		IL_01bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01c1: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_01c6: ldc.i4.0
+		IL_01c7: conv.r8
+		IL_01c8: ldstr ""
+		IL_01cd: ldc.i4.0
+		IL_01ce: ldc.i4.1
+		IL_01cf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_01d4: stloc.s 11
+		IL_01d6: ldc.i4.0
+		IL_01d7: newarr [System.Runtime]System.Object
+		IL_01dc: stloc.s 12
+		IL_01de: ldloc.s 11
+		IL_01e0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01e5: ldloc.s 12
+		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_01ec: pop
+		IL_01ed: ldnull
+		IL_01ee: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13::__js_call__(object, object)
+		IL_01f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01f9: ldc.i4.1
+		IL_01fa: newarr [System.Runtime]System.Object
+		IL_01ff: dup
+		IL_0200: ldc.i4.0
+		IL_0201: ldloc.0
+		IL_0202: stelem.ref
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_020d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0212: ldc.i4.1
+		IL_0213: conv.r8
+		IL_0214: ldstr ""
+		IL_0219: ldc.i4.0
+		IL_021a: ldc.i4.0
+		IL_021b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0220: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_0225: stloc.s 7
+		IL_0227: ldloc.s 7
+		IL_0229: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
+		IL_022e: stloc.s 13
+		IL_0230: ldloc.s 13
+		IL_0232: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
+		IL_0237: stloc.s 13
+		IL_0239: ldloc.0
+		IL_023a: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_023f: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+		IL_0245: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_024a: ldc.i4.1
+		IL_024b: newarr [System.Runtime]System.Object
+		IL_0250: dup
+		IL_0251: ldc.i4.0
+		IL_0252: ldloc.0
+		IL_0253: stelem.ref
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_025e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
 		IL_0263: ldc.i4.0
-		IL_0264: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0269: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_026e: stloc.s 11
-		IL_0270: ldloc.s 9
-		IL_0272: ldstr "then"
-		IL_0277: ldloc.s 11
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027e: pop
-		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
-		IL_0284: pop
-		IL_0285: ldloc.0
-		IL_0286: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_028b: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_0291: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0296: ldc.i4.1
-		IL_0297: newarr [System.Runtime]System.Object
-		IL_029c: dup
-		IL_029d: ldc.i4.0
-		IL_029e: ldloc.0
-		IL_029f: stelem.ref
-		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02aa: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_02af: ldc.i4.0
-		IL_02b0: conv.r8
-		IL_02b1: ldstr ""
-		IL_02b6: ldc.i4.0
+		IL_0264: conv.r8
+		IL_0265: ldstr ""
+		IL_026a: ldc.i4.0
+		IL_026b: ldc.i4.0
+		IL_026c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0271: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0276: stloc.s 11
+		IL_0278: ldloc.s 13
+		IL_027a: ldstr "then"
+		IL_027f: ldloc.s 11
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0286: pop
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
+		IL_028c: pop
+		IL_028d: ldloc.0
+		IL_028e: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_0293: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+		IL_0299: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_029e: ldc.i4.1
+		IL_029f: newarr [System.Runtime]System.Object
+		IL_02a4: dup
+		IL_02a5: ldc.i4.0
+		IL_02a6: ldloc.0
+		IL_02a7: stelem.ref
+		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02b2: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
 		IL_02b7: ldc.i4.0
-		IL_02b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_02bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_02c2: stloc.s 11
-		IL_02c4: ldloc.s 11
-		IL_02c6: ldc.i4.0
-		IL_02c7: newarr [System.Runtime]System.Object
-		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_02d1: pop
-		IL_02d2: ldnull
-		IL_02d3: stloc.s 5
-		IL_02d5: ret
+		IL_02b8: conv.r8
+		IL_02b9: ldstr ""
+		IL_02be: ldc.i4.0
+		IL_02bf: ldc.i4.0
+		IL_02c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_02c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_02ca: stloc.s 11
+		IL_02cc: ldloc.s 11
+		IL_02ce: ldc.i4.0
+		IL_02cf: newarr [System.Runtime]System.Object
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_02d9: pop
+		IL_02da: ldnull
+		IL_02db: stloc.s 5
+		IL_02dd: ret
 	} // end of method FinalizationRegistry_Cleanup_Order::__js_module_init__
 
 } // end of class Modules.FinalizationRegistry_Cleanup_Order
@@ -699,7 +708,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2498
+		// Method begins at RVA 0x24a4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2351
+				// Method begins at RVA 0x2361
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x229c
+			// Method begins at RVA 0x22a8
 			// Header size: 12
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -84,7 +84,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x235a
+				// Method begins at RVA 0x236a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -110,13 +110,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x22bc
+			// Method begins at RVA 0x22c8
 			// Header size: 12
-			// Code size: 67 (0x43)
+			// Code size: 69 (0x45)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[1] object,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry,
 				[2] object
 			)
 
@@ -129,20 +129,22 @@
 			IL_0016: ldarg.0
 			IL_0017: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
 			IL_001c: castclass [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0026: stloc.1
-			IL_0027: ldarg.0
-			IL_0028: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::token
-			IL_002d: stloc.2
-			IL_002e: ldloc.1
-			IL_002f: ldstr "register"
-			IL_0034: ldloc.0
-			IL_0035: ldstr "held"
-			IL_003a: ldloc.2
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0040: pop
-			IL_0041: ldnull
-			IL_0042: ret
+			IL_0021: stloc.1
+			IL_0022: ldloc.1
+			IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry>(!!0)
+			IL_0028: stloc.1
+			IL_0029: ldarg.0
+			IL_002a: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::token
+			IL_002f: stloc.2
+			IL_0030: ldloc.1
+			IL_0031: ldstr "register"
+			IL_0036: ldloc.0
+			IL_0037: ldstr "held"
+			IL_003c: ldloc.2
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0042: pop
+			IL_0043: ldnull
+			IL_0044: ret
 		} // end of method FunctionExpression_L9C1::__js_call__
 
 	} // end of class FunctionExpression_L9C1
@@ -158,7 +160,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2375
+				// Method begins at RVA 0x2385
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -184,7 +186,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x230c
+			// Method begins at RVA 0x231c
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -230,7 +232,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2363
+				// Method begins at RVA 0x2373
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +252,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x236c
+				// Method begins at RVA 0x237c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -273,7 +275,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2348
+			// Method begins at RVA 0x2358
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -299,7 +301,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 559 (0x22f)
+		// Code size: 571 (0x23b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FinalizationRegistry_Unregister_Basic/Scope,
@@ -314,8 +316,7 @@
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[10] object[],
 			[11] object,
-			[12] object,
-			[13] object
+			[12] object
 		)
 
 		IL_0000: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/Scope::.ctor()
@@ -386,126 +387,132 @@
 		IL_00c4: ldloc.0
 		IL_00c5: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
 		IL_00ca: castclass [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d4: stloc.s 12
-		IL_00d6: ldloc.0
-		IL_00d7: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::token
-		IL_00dc: stloc.s 13
-		IL_00de: ldloc.s 12
-		IL_00e0: ldstr "unregister"
-		IL_00e5: ldloc.s 13
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ec: stloc.s 13
-		IL_00ee: ldloc.s 11
-		IL_00f0: ldstr "log"
-		IL_00f5: ldloc.s 13
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fc: pop
+		IL_00cf: stloc.s 7
+		IL_00d1: ldloc.s 7
+		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry>(!!0)
+		IL_00d8: stloc.s 7
+		IL_00da: ldloc.0
+		IL_00db: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::token
+		IL_00e0: stloc.s 12
+		IL_00e2: ldloc.s 7
+		IL_00e4: ldstr "unregister"
+		IL_00e9: ldloc.s 12
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f0: stloc.s 12
+		IL_00f2: ldloc.s 11
+		IL_00f4: ldstr "log"
+		IL_00f9: ldloc.s 12
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0100: pop
 		.try
 		{
-			IL_00fd: nop
-			IL_00fe: ldloc.0
-			IL_00ff: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
-			IL_0104: castclass [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry
-			IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010e: ldstr "unregister"
-			IL_0113: ldc.r8 123
-			IL_011c: box [System.Runtime]System.Double
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0126: pop
-			IL_0127: ldstr "console"
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0136: ldstr "log"
-			IL_013b: ldstr "bad token threw:"
-			IL_0140: ldc.i4.0
-			IL_0141: box [System.Runtime]System.Boolean
-			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_014b: pop
-			IL_014c: leave IL_01d8
+			IL_0101: nop
+			IL_0102: ldloc.0
+			IL_0103: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
+			IL_0108: castclass [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry
+			IL_010d: stloc.s 7
+			IL_010f: ldloc.s 7
+			IL_0111: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry>(!!0)
+			IL_0116: stloc.s 7
+			IL_0118: ldloc.s 7
+			IL_011a: ldstr "unregister"
+			IL_011f: ldc.r8 123
+			IL_0128: box [System.Runtime]System.Double
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0132: pop
+			IL_0133: ldstr "console"
+			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0142: ldstr "log"
+			IL_0147: ldstr "bad token threw:"
+			IL_014c: ldc.i4.0
+			IL_014d: box [System.Runtime]System.Boolean
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0157: pop
+			IL_0158: leave IL_01e4
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0151: stloc.1
-			IL_0152: ldloc.1
-			IL_0153: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0158: dup
-			IL_0159: brtrue IL_016e
+			IL_015d: stloc.1
+			IL_015e: ldloc.1
+			IL_015f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0164: dup
+			IL_0165: brtrue IL_017a
 
-			IL_015e: pop
-			IL_015f: ldloc.1
-			IL_0160: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0165: dup
-			IL_0166: brtrue IL_0179
+			IL_016a: pop
+			IL_016b: ldloc.1
+			IL_016c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0171: dup
+			IL_0172: brtrue IL_0185
 
-			IL_016b: pop
-			IL_016c: rethrow
+			IL_0177: pop
+			IL_0178: rethrow
 
-			IL_016e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0173: stloc.2
-			IL_0174: br IL_017a
+			IL_017a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_017f: stloc.2
+			IL_0180: br IL_0186
 
-			IL_0179: stloc.2
+			IL_0185: stloc.2
 
-			IL_017a: ldloc.2
-			IL_017b: stloc.3
-			IL_017c: ldstr "console"
-			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018b: ldstr "log"
-			IL_0190: ldstr "bad token threw:"
-			IL_0195: ldc.i4.1
-			IL_0196: box [System.Runtime]System.Boolean
-			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01a0: pop
-			IL_01a1: ldstr "console"
-			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b0: stloc.s 13
-			IL_01b2: ldloc.3
-			IL_01b3: ldstr "name"
-			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01bd: stloc.s 11
-			IL_01bf: ldloc.s 13
-			IL_01c1: ldstr "log"
-			IL_01c6: ldstr "bad token name:"
-			IL_01cb: ldloc.s 11
-			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01d2: pop
-			IL_01d3: leave IL_01d8
+			IL_0186: ldloc.2
+			IL_0187: stloc.3
+			IL_0188: ldstr "console"
+			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0197: ldstr "log"
+			IL_019c: ldstr "bad token threw:"
+			IL_01a1: ldc.i4.1
+			IL_01a2: box [System.Runtime]System.Boolean
+			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01ac: pop
+			IL_01ad: ldstr "console"
+			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01bc: stloc.s 12
+			IL_01be: ldloc.3
+			IL_01bf: ldstr "name"
+			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01c9: stloc.s 11
+			IL_01cb: ldloc.s 12
+			IL_01cd: ldstr "log"
+			IL_01d2: ldstr "bad token name:"
+			IL_01d7: ldloc.s 11
+			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01de: pop
+			IL_01df: leave IL_01e4
 		} // end handler
 
-		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
-		IL_01dd: pop
-		IL_01de: ldloc.0
-		IL_01df: castclass Modules.FinalizationRegistry_Unregister_Basic/Scope
-		IL_01e4: ldftn object Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14::__js_call__(class Modules.FinalizationRegistry_Unregister_Basic/Scope, object)
-		IL_01ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01ef: ldc.i4.1
-		IL_01f0: newarr [System.Runtime]System.Object
-		IL_01f5: dup
-		IL_01f6: ldc.i4.0
-		IL_01f7: ldloc.0
-		IL_01f8: stelem.ref
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0203: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0208: ldc.i4.0
-		IL_0209: conv.r8
-		IL_020a: ldstr ""
-		IL_020f: ldc.i4.0
-		IL_0210: ldc.i4.0
-		IL_0211: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0216: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_021b: stloc.s 9
-		IL_021d: ldloc.s 9
-		IL_021f: ldc.i4.0
-		IL_0220: newarr [System.Runtime]System.Object
-		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_022a: pop
-		IL_022b: ldnull
-		IL_022c: stloc.s 4
-		IL_022e: ret
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
+		IL_01e9: pop
+		IL_01ea: ldloc.0
+		IL_01eb: castclass Modules.FinalizationRegistry_Unregister_Basic/Scope
+		IL_01f0: ldftn object Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14::__js_call__(class Modules.FinalizationRegistry_Unregister_Basic/Scope, object)
+		IL_01f6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01fb: ldc.i4.1
+		IL_01fc: newarr [System.Runtime]System.Object
+		IL_0201: dup
+		IL_0202: ldc.i4.0
+		IL_0203: ldloc.0
+		IL_0204: stelem.ref
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_020f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0214: ldc.i4.0
+		IL_0215: conv.r8
+		IL_0216: ldstr ""
+		IL_021b: ldc.i4.0
+		IL_021c: ldc.i4.0
+		IL_021d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0222: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0227: stloc.s 9
+		IL_0229: ldloc.s 9
+		IL_022b: ldc.i4.0
+		IL_022c: newarr [System.Runtime]System.Object
+		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_0236: pop
+		IL_0237: ldnull
+		IL_0238: stloc.s 4
+		IL_023a: ret
 	} // end of method FinalizationRegistry_Unregister_Basic::__js_module_init__
 
 } // end of class Modules.FinalizationRegistry_Unregister_Basic
@@ -517,7 +524,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x237e
+		// Method begins at RVA 0x238e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2103
+				// Method begins at RVA 0x2107
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e4
+			// Method begins at RVA 0x20e8
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -75,7 +75,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20fa
+			// Method begins at RVA 0x20fe
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -101,14 +101,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 133 (0x85)
+		// Code size: 137 (0x89)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Apply_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
 			[2] object,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[4] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Apply_Basic/Scope::.ctor()
@@ -131,28 +132,30 @@
 		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0037: stloc.2
 		IL_0038: ldloc.1
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003e: ldc.i4.2
-		IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0044: dup
-		IL_0045: ldc.r8 1
-		IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0053: dup
-		IL_0054: ldc.r8 2
-		IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0062: stloc.3
-		IL_0063: ldstr "apply"
-		IL_0068: ldc.i4.0
-		IL_0069: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_006e: ldloc.3
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0074: stloc.s 4
-		IL_0076: ldloc.2
-		IL_0077: ldstr "log"
-		IL_007c: ldloc.s 4
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0083: pop
-		IL_0084: ret
+		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
+		IL_003e: stloc.3
+		IL_003f: ldc.i4.2
+		IL_0040: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0045: dup
+		IL_0046: ldc.r8 1
+		IL_004f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0054: dup
+		IL_0055: ldc.r8 2
+		IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0063: stloc.s 4
+		IL_0065: ldloc.3
+		IL_0066: ldstr "apply"
+		IL_006b: ldc.i4.0
+		IL_006c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0071: ldloc.s 4
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0078: stloc.s 5
+		IL_007a: ldloc.2
+		IL_007b: ldstr "log"
+		IL_0080: ldloc.s 5
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0087: pop
+		IL_0088: ret
 	} // end of method Function_Apply_Basic::__js_module_init__
 
 } // end of class Modules.Function_Apply_Basic
@@ -164,7 +167,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x210c
+		// Method begins at RVA 0x2110
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_NullArgArray_TreatedAsEmpty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_NullArgArray_TreatedAsEmpty.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20fd
+				// Method begins at RVA 0x2101
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,7 +48,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20c0
+			// Method begins at RVA 0x20c4
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -91,7 +91,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f4
+			// Method begins at RVA 0x20f8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -117,13 +117,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 99 (0x63)
+		// Code size: 103 (0x67)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Apply_NullArgArray_TreatedAsEmpty/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[2] object,
-			[3] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Apply_NullArgArray_TreatedAsEmpty/Scope::.ctor()
@@ -146,20 +147,22 @@
 		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0037: stloc.2
 		IL_0038: ldloc.1
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003e: ldstr "apply"
-		IL_0043: ldc.i4.0
-		IL_0044: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0049: ldc.i4.0
-		IL_004a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0054: stloc.3
-		IL_0055: ldloc.2
-		IL_0056: ldstr "log"
-		IL_005b: ldloc.3
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0061: pop
-		IL_0062: ret
+		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_003e: stloc.3
+		IL_003f: ldloc.3
+		IL_0040: ldstr "apply"
+		IL_0045: ldc.i4.0
+		IL_0046: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_004b: ldc.i4.0
+		IL_004c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0056: stloc.s 4
+		IL_0058: ldloc.2
+		IL_0059: ldstr "log"
+		IL_005e: ldloc.s 4
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0065: pop
+		IL_0066: ret
 	} // end of method Function_Apply_NullArgArray_TreatedAsEmpty::__js_module_init__
 
 } // end of class Modules.Function_Apply_NullArgArray_TreatedAsEmpty
@@ -171,7 +174,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2106
+		// Method begins at RVA 0x210a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_ThisArg.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_ThisArg.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x211b
+				// Method begins at RVA 0x211f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20ec
+			// Method begins at RVA 0x20f0
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -79,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2112
+			// Method begins at RVA 0x2116
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -105,15 +105,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 141 (0x8d)
+		// Code size: 145 (0x91)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Apply_ThisArg/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Apply_ThisArg/Scope::.ctor()
@@ -142,24 +143,26 @@
 		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0051: stloc.3
 		IL_0052: ldloc.1
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0058: ldc.i4.1
-		IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_005e: dup
-		IL_005f: ldc.r8 5
-		IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_006d: stloc.s 4
-		IL_006f: ldstr "apply"
-		IL_0074: ldloc.2
-		IL_0075: ldloc.s 4
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_007c: stloc.s 5
-		IL_007e: ldloc.3
-		IL_007f: ldstr "log"
-		IL_0084: ldloc.s 5
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008b: pop
-		IL_008c: ret
+		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_0058: stloc.s 4
+		IL_005a: ldc.i4.1
+		IL_005b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0060: dup
+		IL_0061: ldc.r8 5
+		IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_006f: stloc.s 5
+		IL_0071: ldloc.s 4
+		IL_0073: ldstr "apply"
+		IL_0078: ldloc.2
+		IL_0079: ldloc.s 5
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0080: stloc.s 6
+		IL_0082: ldloc.3
+		IL_0083: ldstr "log"
+		IL_0088: ldloc.s 6
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008f: pop
+		IL_0090: ret
 	} // end of method Function_Apply_ThisArg::__js_module_init__
 
 } // end of class Modules.Function_Apply_ThisArg
@@ -171,7 +174,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2124
+		// Method begins at RVA 0x2128
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Basic_PartialApplication.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Basic_PartialApplication.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x211f
+				// Method begins at RVA 0x2123
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20f8
+			// Method begins at RVA 0x20fc
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -80,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2116
+			// Method begins at RVA 0x211a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -106,15 +106,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 153 (0x99)
+		// Code size: 157 (0x9d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_Basic_PartialApplication/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3,
 			[2] object,
-			[3] object,
-			[4] object[],
-			[5] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3,
+			[4] object,
+			[5] object[],
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Bind_Basic_PartialApplication/Scope::.ctor()
@@ -133,34 +134,36 @@
 		IL_0026: nop
 		IL_0027: nop
 		IL_0028: ldloc.1
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_002e: ldstr "bind"
-		IL_0033: ldc.i4.0
-		IL_0034: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0039: ldc.r8 1
-		IL_0042: box [System.Runtime]System.Double
-		IL_0047: ldc.r8 2
-		IL_0050: box [System.Runtime]System.Double
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_005a: stloc.2
-		IL_005b: ldstr "console"
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006a: stloc.3
-		IL_006b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0070: stloc.s 4
-		IL_0072: ldloc.2
-		IL_0073: ldloc.s 4
-		IL_0075: ldc.r8 3
-		IL_007e: box [System.Runtime]System.Double
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0088: stloc.s 5
-		IL_008a: ldloc.3
-		IL_008b: ldstr "log"
-		IL_0090: ldloc.s 5
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0097: pop
-		IL_0098: ret
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3>(!!0)
+		IL_002e: stloc.3
+		IL_002f: ldloc.3
+		IL_0030: ldstr "bind"
+		IL_0035: ldc.i4.0
+		IL_0036: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_003b: ldc.r8 1
+		IL_0044: box [System.Runtime]System.Double
+		IL_0049: ldc.r8 2
+		IL_0052: box [System.Runtime]System.Double
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_005c: stloc.2
+		IL_005d: ldstr "console"
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006c: stloc.s 4
+		IL_006e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0073: stloc.s 5
+		IL_0075: ldloc.2
+		IL_0076: ldloc.s 5
+		IL_0078: ldc.r8 3
+		IL_0081: box [System.Runtime]System.Double
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_008b: stloc.s 6
+		IL_008d: ldloc.s 4
+		IL_008f: ldstr "log"
+		IL_0094: ldloc.s 6
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009b: pop
+		IL_009c: ret
 	} // end of method Function_Bind_Basic_PartialApplication::__js_module_init__
 
 } // end of class Modules.Function_Bind_Basic_PartialApplication
@@ -172,7 +175,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2128
+		// Method begins at RVA 0x212c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Metadata_LengthNameAndPrototype.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Metadata_LengthNameAndPrototype.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x242b
+				// Method begins at RVA 0x242f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2404
+			// Method begins at RVA 0x2408
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -80,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2422
+			// Method begins at RVA 0x2426
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -106,7 +106,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 935 (0x3a7)
+		// Code size: 939 (0x3ab)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_Metadata_LengthNameAndPrototype/Scope,
@@ -115,11 +115,12 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[7] object,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[8] object,
 			[9] object,
-			[10] bool
+			[10] object,
+			[11] bool
 		)
 
 		IL_0000: newobj instance void Modules.Function_Bind_Metadata_LengthNameAndPrototype/Scope::.ctor()
@@ -138,256 +139,258 @@
 		IL_0026: nop
 		IL_0027: nop
 		IL_0028: ldloc.1
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0033: dup
-		IL_0034: ldstr "ignored"
-		IL_0039: ldc.i4.1
-		IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_003f: stloc.s 6
-		IL_0041: ldstr "bind"
-		IL_0046: ldloc.s 6
-		IL_0048: ldc.r8 1
-		IL_0051: box [System.Runtime]System.Double
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_005b: stloc.2
-		IL_005c: ldloc.2
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0067: dup
-		IL_0068: ldstr "ignoredAgain"
-		IL_006d: ldc.i4.1
-		IL_006e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0073: stloc.s 6
-		IL_0075: ldstr "bind"
-		IL_007a: ldloc.s 6
-		IL_007c: ldc.r8 2
-		IL_0085: box [System.Runtime]System.Double
-		IL_008a: ldc.r8 3
-		IL_0093: box [System.Runtime]System.Double
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_009d: stloc.3
-		IL_009e: ldloc.2
-		IL_009f: ldstr "length"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_00a9: stloc.s 4
-		IL_00ab: ldloc.2
-		IL_00ac: ldstr "name"
-		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_00b6: stloc.s 5
-		IL_00b8: ldstr "console"
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c7: stloc.s 7
-		IL_00c9: ldloc.2
-		IL_00ca: ldstr "length"
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d4: stloc.s 8
-		IL_00d6: ldloc.s 7
-		IL_00d8: ldstr "log"
-		IL_00dd: ldloc.s 8
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e4: pop
-		IL_00e5: ldstr "console"
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f4: stloc.s 8
-		IL_00f6: ldloc.2
-		IL_00f7: ldstr "name"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0101: stloc.s 7
-		IL_0103: ldloc.s 8
-		IL_0105: ldstr "log"
-		IL_010a: ldloc.s 7
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0111: pop
-		IL_0112: ldstr "console"
-		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0121: stloc.s 7
-		IL_0123: ldloc.s 4
-		IL_0125: ldstr "value"
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012f: stloc.s 8
-		IL_0131: ldloc.s 7
-		IL_0133: ldstr "log"
-		IL_0138: ldloc.s 8
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013f: pop
-		IL_0140: ldstr "console"
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014f: stloc.s 8
-		IL_0151: ldloc.s 4
-		IL_0153: ldstr "writable"
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015d: stloc.s 7
-		IL_015f: ldloc.s 8
-		IL_0161: ldstr "log"
-		IL_0166: ldloc.s 7
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016d: pop
-		IL_016e: ldstr "console"
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017d: stloc.s 7
-		IL_017f: ldloc.s 4
-		IL_0181: ldstr "enumerable"
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018b: stloc.s 8
-		IL_018d: ldloc.s 7
-		IL_018f: ldstr "log"
-		IL_0194: ldloc.s 8
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019b: pop
-		IL_019c: ldstr "console"
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ab: stloc.s 8
-		IL_01ad: ldloc.s 4
-		IL_01af: ldstr "configurable"
-		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b9: stloc.s 7
-		IL_01bb: ldloc.s 8
-		IL_01bd: ldstr "log"
-		IL_01c2: ldloc.s 7
-		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c9: pop
-		IL_01ca: ldstr "console"
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d9: stloc.s 7
-		IL_01db: ldloc.s 5
-		IL_01dd: ldstr "value"
-		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e7: stloc.s 8
-		IL_01e9: ldloc.s 7
-		IL_01eb: ldstr "log"
-		IL_01f0: ldloc.s 8
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f7: pop
-		IL_01f8: ldstr "console"
-		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0207: stloc.s 8
-		IL_0209: ldloc.s 5
-		IL_020b: ldstr "writable"
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0215: stloc.s 7
-		IL_0217: ldloc.s 8
-		IL_0219: ldstr "log"
-		IL_021e: ldloc.s 7
-		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0225: pop
-		IL_0226: ldstr "console"
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0235: stloc.s 7
-		IL_0237: ldloc.s 5
-		IL_0239: ldstr "enumerable"
-		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0243: stloc.s 8
-		IL_0245: ldloc.s 7
-		IL_0247: ldstr "log"
-		IL_024c: ldloc.s 8
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0253: pop
-		IL_0254: ldstr "console"
-		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0263: stloc.s 8
-		IL_0265: ldloc.s 5
-		IL_0267: ldstr "configurable"
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0271: stloc.s 7
-		IL_0273: ldloc.s 8
-		IL_0275: ldstr "log"
-		IL_027a: ldloc.s 7
-		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0281: pop
-		IL_0282: ldstr "console"
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0291: ldloc.2
-		IL_0292: ldstr "length"
-		IL_0297: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_029c: box [System.Runtime]System.Boolean
-		IL_02a1: stloc.s 9
-		IL_02a3: ldstr "log"
-		IL_02a8: ldloc.s 9
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02af: pop
-		IL_02b0: ldstr "console"
-		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02bf: ldloc.2
-		IL_02c0: ldstr "name"
-		IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_02ca: box [System.Runtime]System.Boolean
-		IL_02cf: stloc.s 9
-		IL_02d1: ldstr "log"
-		IL_02d6: ldloc.s 9
-		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02dd: pop
-		IL_02de: ldstr "console"
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ed: ldloc.2
-		IL_02ee: ldstr "prototype"
-		IL_02f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_02f8: box [System.Runtime]System.Boolean
-		IL_02fd: stloc.s 9
-		IL_02ff: ldstr "log"
-		IL_0304: ldloc.s 9
-		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_030b: pop
-		IL_030c: ldstr "console"
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_031b: stloc.s 7
-		IL_031d: ldloc.2
-		IL_031e: ldstr "prototype"
-		IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0328: stloc.s 8
-		IL_032a: ldloc.s 8
-		IL_032c: ldnull
-		IL_032d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0332: stloc.s 10
-		IL_0334: ldloc.s 10
-		IL_0336: box [System.Runtime]System.Boolean
-		IL_033b: stloc.s 9
-		IL_033d: ldloc.s 7
-		IL_033f: ldstr "log"
-		IL_0344: ldloc.s 9
-		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_034b: pop
-		IL_034c: ldstr "console"
-		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_035b: stloc.s 7
-		IL_035d: ldloc.3
-		IL_035e: ldstr "length"
-		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0368: stloc.s 8
-		IL_036a: ldloc.s 7
-		IL_036c: ldstr "log"
-		IL_0371: ldloc.s 8
-		IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0378: pop
-		IL_0379: ldstr "console"
-		IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0388: stloc.s 8
-		IL_038a: ldloc.3
-		IL_038b: ldstr "name"
-		IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0395: stloc.s 7
-		IL_0397: ldloc.s 8
-		IL_0399: ldstr "log"
-		IL_039e: ldloc.s 7
-		IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03a5: pop
-		IL_03a6: ret
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3>(!!0)
+		IL_002e: stloc.s 6
+		IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0035: dup
+		IL_0036: ldstr "ignored"
+		IL_003b: ldc.i4.1
+		IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0041: stloc.s 7
+		IL_0043: ldloc.s 6
+		IL_0045: ldstr "bind"
+		IL_004a: ldloc.s 7
+		IL_004c: ldc.r8 1
+		IL_0055: box [System.Runtime]System.Double
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_005f: stloc.2
+		IL_0060: ldloc.2
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_006b: dup
+		IL_006c: ldstr "ignoredAgain"
+		IL_0071: ldc.i4.1
+		IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0077: stloc.s 7
+		IL_0079: ldstr "bind"
+		IL_007e: ldloc.s 7
+		IL_0080: ldc.r8 2
+		IL_0089: box [System.Runtime]System.Double
+		IL_008e: ldc.r8 3
+		IL_0097: box [System.Runtime]System.Double
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00a1: stloc.3
+		IL_00a2: ldloc.2
+		IL_00a3: ldstr "length"
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_00ad: stloc.s 4
+		IL_00af: ldloc.2
+		IL_00b0: ldstr "name"
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_00ba: stloc.s 5
+		IL_00bc: ldstr "console"
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cb: stloc.s 8
+		IL_00cd: ldloc.2
+		IL_00ce: ldstr "length"
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d8: stloc.s 9
+		IL_00da: ldloc.s 8
+		IL_00dc: ldstr "log"
+		IL_00e1: ldloc.s 9
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e8: pop
+		IL_00e9: ldstr "console"
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f8: stloc.s 9
+		IL_00fa: ldloc.2
+		IL_00fb: ldstr "name"
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0105: stloc.s 8
+		IL_0107: ldloc.s 9
+		IL_0109: ldstr "log"
+		IL_010e: ldloc.s 8
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0115: pop
+		IL_0116: ldstr "console"
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0125: stloc.s 8
+		IL_0127: ldloc.s 4
+		IL_0129: ldstr "value"
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0133: stloc.s 9
+		IL_0135: ldloc.s 8
+		IL_0137: ldstr "log"
+		IL_013c: ldloc.s 9
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0143: pop
+		IL_0144: ldstr "console"
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0153: stloc.s 9
+		IL_0155: ldloc.s 4
+		IL_0157: ldstr "writable"
+		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0161: stloc.s 8
+		IL_0163: ldloc.s 9
+		IL_0165: ldstr "log"
+		IL_016a: ldloc.s 8
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0171: pop
+		IL_0172: ldstr "console"
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0181: stloc.s 8
+		IL_0183: ldloc.s 4
+		IL_0185: ldstr "enumerable"
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018f: stloc.s 9
+		IL_0191: ldloc.s 8
+		IL_0193: ldstr "log"
+		IL_0198: ldloc.s 9
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019f: pop
+		IL_01a0: ldstr "console"
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01af: stloc.s 9
+		IL_01b1: ldloc.s 4
+		IL_01b3: ldstr "configurable"
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01bd: stloc.s 8
+		IL_01bf: ldloc.s 9
+		IL_01c1: ldstr "log"
+		IL_01c6: ldloc.s 8
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01cd: pop
+		IL_01ce: ldstr "console"
+		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01dd: stloc.s 8
+		IL_01df: ldloc.s 5
+		IL_01e1: ldstr "value"
+		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01eb: stloc.s 9
+		IL_01ed: ldloc.s 8
+		IL_01ef: ldstr "log"
+		IL_01f4: ldloc.s 9
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01fb: pop
+		IL_01fc: ldstr "console"
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020b: stloc.s 9
+		IL_020d: ldloc.s 5
+		IL_020f: ldstr "writable"
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0219: stloc.s 8
+		IL_021b: ldloc.s 9
+		IL_021d: ldstr "log"
+		IL_0222: ldloc.s 8
+		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0229: pop
+		IL_022a: ldstr "console"
+		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0239: stloc.s 8
+		IL_023b: ldloc.s 5
+		IL_023d: ldstr "enumerable"
+		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0247: stloc.s 9
+		IL_0249: ldloc.s 8
+		IL_024b: ldstr "log"
+		IL_0250: ldloc.s 9
+		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0257: pop
+		IL_0258: ldstr "console"
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0267: stloc.s 9
+		IL_0269: ldloc.s 5
+		IL_026b: ldstr "configurable"
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0275: stloc.s 8
+		IL_0277: ldloc.s 9
+		IL_0279: ldstr "log"
+		IL_027e: ldloc.s 8
+		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0285: pop
+		IL_0286: ldstr "console"
+		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0295: ldloc.2
+		IL_0296: ldstr "length"
+		IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_02a0: box [System.Runtime]System.Boolean
+		IL_02a5: stloc.s 10
+		IL_02a7: ldstr "log"
+		IL_02ac: ldloc.s 10
+		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b3: pop
+		IL_02b4: ldstr "console"
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c3: ldloc.2
+		IL_02c4: ldstr "name"
+		IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_02ce: box [System.Runtime]System.Boolean
+		IL_02d3: stloc.s 10
+		IL_02d5: ldstr "log"
+		IL_02da: ldloc.s 10
+		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02e1: pop
+		IL_02e2: ldstr "console"
+		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f1: ldloc.2
+		IL_02f2: ldstr "prototype"
+		IL_02f7: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_02fc: box [System.Runtime]System.Boolean
+		IL_0301: stloc.s 10
+		IL_0303: ldstr "log"
+		IL_0308: ldloc.s 10
+		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_030f: pop
+		IL_0310: ldstr "console"
+		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_031f: stloc.s 8
+		IL_0321: ldloc.2
+		IL_0322: ldstr "prototype"
+		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_032c: stloc.s 9
+		IL_032e: ldloc.s 9
+		IL_0330: ldnull
+		IL_0331: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0336: stloc.s 11
+		IL_0338: ldloc.s 11
+		IL_033a: box [System.Runtime]System.Boolean
+		IL_033f: stloc.s 10
+		IL_0341: ldloc.s 8
+		IL_0343: ldstr "log"
+		IL_0348: ldloc.s 10
+		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_034f: pop
+		IL_0350: ldstr "console"
+		IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_035f: stloc.s 8
+		IL_0361: ldloc.3
+		IL_0362: ldstr "length"
+		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_036c: stloc.s 9
+		IL_036e: ldloc.s 8
+		IL_0370: ldstr "log"
+		IL_0375: ldloc.s 9
+		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_037c: pop
+		IL_037d: ldstr "console"
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_038c: stloc.s 9
+		IL_038e: ldloc.3
+		IL_038f: ldstr "name"
+		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0399: stloc.s 8
+		IL_039b: ldloc.s 9
+		IL_039d: ldstr "log"
+		IL_03a2: ldloc.s 8
+		IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a9: pop
+		IL_03aa: ret
 	} // end of method Function_Bind_Metadata_LengthNameAndPrototype::__js_module_init__
 
 } // end of class Modules.Function_Bind_Metadata_LengthNameAndPrototype
@@ -399,7 +402,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2434
+		// Method begins at RVA 0x2438
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_ThisBinding_IgnoresCallReceiver.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_ThisBinding_IgnoresCallReceiver.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x214b
+				// Method begins at RVA 0x2153
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x211c
+			// Method begins at RVA 0x2124
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -79,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2142
+			// Method begins at RVA 0x214a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -105,7 +105,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 189 (0xbd)
+		// Code size: 197 (0xc5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/Scope,
@@ -113,8 +113,10 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[5] object,
-			[6] object
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[6] object,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/Scope::.ctor()
@@ -139,38 +141,42 @@
 		IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_0041: stloc.2
 		IL_0042: ldloc.1
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0048: ldstr "bind"
-		IL_004d: ldloc.2
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0053: stloc.3
-		IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0059: dup
-		IL_005a: ldstr "base"
-		IL_005f: ldc.r8 100
-		IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_006d: dup
-		IL_006e: ldstr "m"
-		IL_0073: ldloc.3
-		IL_0074: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0079: stloc.s 4
-		IL_007b: ldstr "console"
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008a: stloc.s 5
-		IL_008c: ldloc.s 4
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0093: ldstr "m"
-		IL_0098: ldc.r8 5
-		IL_00a1: box [System.Runtime]System.Double
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ab: stloc.s 6
-		IL_00ad: ldloc.s 5
-		IL_00af: ldstr "log"
-		IL_00b4: ldloc.s 6
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bb: pop
-		IL_00bc: ret
+		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_0048: stloc.s 5
+		IL_004a: ldloc.s 5
+		IL_004c: ldstr "bind"
+		IL_0051: ldloc.2
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0057: stloc.3
+		IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_005d: dup
+		IL_005e: ldstr "base"
+		IL_0063: ldc.r8 100
+		IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0071: dup
+		IL_0072: ldstr "m"
+		IL_0077: ldloc.3
+		IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_007d: stloc.s 4
+		IL_007f: ldstr "console"
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008e: stloc.s 6
+		IL_0090: ldloc.s 4
+		IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
+		IL_0097: stloc.s 7
+		IL_0099: ldloc.s 7
+		IL_009b: ldstr "m"
+		IL_00a0: ldc.r8 5
+		IL_00a9: box [System.Runtime]System.Double
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b3: stloc.s 8
+		IL_00b5: ldloc.s 6
+		IL_00b7: ldstr "log"
+		IL_00bc: ldloc.s 8
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c3: pop
+		IL_00c4: ret
 	} // end of method Function_Bind_ThisBinding_IgnoresCallReceiver::__js_module_init__
 
 } // end of class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver
@@ -182,7 +188,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2154
+		// Method begins at RVA 0x215c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2127
+				// Method begins at RVA 0x212b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20d8
+			// Method begins at RVA 0x20dc
 			// Header size: 12
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -91,7 +91,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211e
+			// Method begins at RVA 0x2122
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -117,14 +117,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 122 (0x7a)
+		// Code size: 126 (0x7e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object,
-			[4] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Call_Basic/Scope::.ctor()
@@ -153,19 +154,21 @@
 		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_004d: stloc.3
 		IL_004e: ldloc.1
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0054: ldstr "call"
-		IL_0059: ldloc.2
-		IL_005a: ldstr "A"
-		IL_005f: ldstr "B"
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0069: stloc.s 4
-		IL_006b: ldloc.3
-		IL_006c: ldstr "log"
-		IL_0071: ldloc.s 4
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0078: pop
-		IL_0079: ret
+		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
+		IL_0054: stloc.s 4
+		IL_0056: ldloc.s 4
+		IL_0058: ldstr "call"
+		IL_005d: ldloc.2
+		IL_005e: ldstr "A"
+		IL_0063: ldstr "B"
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_006d: stloc.s 5
+		IL_006f: ldloc.3
+		IL_0070: ldstr "log"
+		IL_0075: ldloc.s 5
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007c: pop
+		IL_007d: ret
 	} // end of method Function_Call_Basic::__js_module_init__
 
 } // end of class Modules.Function_Call_Basic
@@ -177,7 +180,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2130
+		// Method begins at RVA 0x2134
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a94
+				// Method begins at RVA 0x2a98
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2916
+			// Method begins at RVA 0x291a
 			// Header size: 1
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -77,7 +77,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a9d
+				// Method begins at RVA 0x2aa1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -100,7 +100,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2940
+			// Method begins at RVA 0x2944
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -139,7 +139,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa6
+				// Method begins at RVA 0x2aaa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2976
+			// Method begins at RVA 0x297a
 			// Header size: 1
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -198,7 +198,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aaf
+				// Method begins at RVA 0x2ab3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -221,7 +221,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29a4
+			// Method begins at RVA 0x29a8
 			// Header size: 1
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -253,7 +253,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ac1
+					// Method begins at RVA 0x2ac5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -278,7 +278,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a2c
+				// Method begins at RVA 0x2a30
 				// Header size: 12
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -323,7 +323,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab8
+				// Method begins at RVA 0x2abc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -350,7 +350,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x29c8
+			// Method begins at RVA 0x29cc
 			// Header size: 12
 			// Code size: 60 (0x3c)
 			.maxstack 8
@@ -401,7 +401,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aca
+				// Method begins at RVA 0x2ace
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -425,7 +425,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a10
+			// Method begins at RVA 0x2a14
 			// Header size: 1
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -453,7 +453,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad3
+				// Method begins at RVA 0x2ad7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -476,7 +476,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a25
+			// Method begins at RVA 0x2a29
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -498,7 +498,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2adc
+				// Method begins at RVA 0x2ae0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -521,7 +521,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a28
+			// Method begins at RVA 0x2a2c
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -543,7 +543,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae5
+				// Method begins at RVA 0x2ae9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -563,7 +563,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aee
+				// Method begins at RVA 0x2af2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -584,7 +584,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a62
+			// Method begins at RVA 0x2a66
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -602,7 +602,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a6c
+			// Method begins at RVA 0x2a70
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -651,7 +651,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a8b
+			// Method begins at RVA 0x2a8f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -677,7 +677,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2234 (0x8ba)
+		// Code size: 2238 (0x8be)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Function_ConstructedInstance_ObjectSemantics/Scope,
@@ -705,7 +705,8 @@
 			[22] object,
 			[23] object,
 			[24] object[],
-			[25] class [System.Runtime]System.Type
+			[25] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
+			[26] class [System.Runtime]System.Type
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -1135,284 +1136,286 @@
 		IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0566: pop
 		IL_0567: ldloc.1
-		IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_056d: ldstr "bind"
-		IL_0572: ldc.i4.0
-		IL_0573: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0578: ldc.r8 10
-		IL_0581: box [System.Runtime]System.Double
-		IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_058b: stloc.s 11
-		IL_058d: ldloc.s 11
-		IL_058f: ldc.i4.1
-		IL_0590: newarr [System.Runtime]System.Object
-		IL_0595: dup
-		IL_0596: ldc.i4.0
-		IL_0597: ldc.r8 5
-		IL_05a0: box [System.Runtime]System.Double
-		IL_05a5: stelem.ref
-		IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_05ab: stloc.s 12
-		IL_05ad: ldstr "console"
-		IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05bc: stloc.s 23
-		IL_05be: ldloc.s 12
-		IL_05c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05c5: ldstr "sum"
-		IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_05cf: stloc.s 22
-		IL_05d1: ldloc.s 23
-		IL_05d3: ldstr "log"
-		IL_05d8: ldloc.s 22
-		IL_05da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05df: pop
-		IL_05e0: ldstr "console"
-		IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05ef: stloc.s 22
-		IL_05f1: ldloc.s 12
-		IL_05f3: ldloc.1
-		IL_05f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_05f9: stloc.s 19
-		IL_05fb: ldloc.s 19
-		IL_05fd: box [System.Runtime]System.Boolean
-		IL_0602: stloc.s 20
-		IL_0604: ldloc.s 22
-		IL_0606: ldstr "log"
-		IL_060b: ldloc.s 20
-		IL_060d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0612: pop
-		IL_0613: ldnull
-		IL_0614: ldftn object Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'::__js_call__(object, object)
-		IL_061a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_061f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0624: ldc.i4.1
-		IL_0625: conv.r8
-		IL_0626: ldstr ""
-		IL_062b: ldc.i4.0
-		IL_062c: ldc.i4.0
-		IL_062d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0632: stloc.s 13
-		IL_0634: ldloc.s 13
-		IL_0636: ldc.i4.1
-		IL_0637: newarr [System.Runtime]System.Object
-		IL_063c: dup
-		IL_063d: ldc.i4.0
-		IL_063e: ldc.r8 9
-		IL_0647: box [System.Runtime]System.Double
-		IL_064c: stelem.ref
-		IL_064d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_0652: stloc.s 14
-		IL_0654: ldstr "console"
-		IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0663: stloc.s 22
-		IL_0665: ldloc.s 14
-		IL_0667: ldstr "value"
-		IL_066c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0671: stloc.s 23
-		IL_0673: ldloc.s 22
-		IL_0675: ldstr "log"
-		IL_067a: ldloc.s 23
-		IL_067c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0681: pop
-		IL_0682: ldstr "console"
-		IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_068c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0691: stloc.s 23
-		IL_0693: ldloc.s 14
-		IL_0695: ldloc.s 13
-		IL_0697: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_069c: stloc.s 19
-		IL_069e: ldloc.s 19
-		IL_06a0: box [System.Runtime]System.Boolean
-		IL_06a5: stloc.s 20
-		IL_06a7: ldloc.s 23
-		IL_06a9: ldstr "log"
-		IL_06ae: ldloc.s 20
-		IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06b5: pop
-		IL_06b6: nop
-		IL_06b7: ldloc.s 5
-		IL_06b9: ldstr "prototype"
-		IL_06be: ldc.r8 3
-		IL_06c7: ldc.i4.1
-		IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_06cd: pop
-		IL_06ce: ldstr "console"
-		IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06dd: stloc.s 23
-		IL_06df: ldloc.s 5
-		IL_06e1: ldc.i4.0
-		IL_06e2: newarr [System.Runtime]System.Object
-		IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_06ec: stloc.s 22
-		IL_06ee: ldloc.s 22
-		IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_06f5: stloc.s 22
-		IL_06f7: ldstr "Object"
-		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0701: ldstr "prototype"
-		IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_070b: stloc.s 18
-		IL_070d: ldloc.s 22
-		IL_070f: ldloc.s 18
-		IL_0711: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0716: stloc.s 19
-		IL_0718: ldloc.s 19
-		IL_071a: box [System.Runtime]System.Boolean
-		IL_071f: stloc.s 20
-		IL_0721: ldloc.s 23
-		IL_0723: ldstr "log"
-		IL_0728: ldloc.s 20
-		IL_072a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_072f: pop
-		IL_0730: nop
-		IL_0731: ldloc.s 6
-		IL_0733: ldstr "prototype"
-		IL_0738: ldc.i4.0
-		IL_0739: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_073e: ldc.i4.1
-		IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0744: pop
-		IL_0745: ldstr "console"
-		IL_074a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_074f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0754: stloc.s 23
-		IL_0756: ldloc.s 6
-		IL_0758: ldc.i4.0
-		IL_0759: newarr [System.Runtime]System.Object
-		IL_075e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_0763: stloc.s 18
-		IL_0765: ldloc.s 18
-		IL_0767: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_076c: stloc.s 18
-		IL_076e: ldstr "Object"
-		IL_0773: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0778: ldstr "prototype"
-		IL_077d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0782: stloc.s 22
-		IL_0784: ldloc.s 18
-		IL_0786: ldloc.s 22
-		IL_0788: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_078d: stloc.s 19
-		IL_078f: ldloc.s 19
-		IL_0791: box [System.Runtime]System.Boolean
-		IL_0796: stloc.s 20
-		IL_0798: ldloc.s 23
-		IL_079a: ldstr "log"
-		IL_079f: ldloc.s 20
-		IL_07a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07a6: pop
-		IL_07a7: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
-		IL_07ac: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_07b1: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
-		IL_07b6: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_07bb: stloc.s 25
-		IL_07bd: ldc.i4.1
-		IL_07be: newarr [System.Runtime]System.Object
-		IL_07c3: dup
-		IL_07c4: ldc.i4.0
-		IL_07c5: ldloc.0
-		IL_07c6: stelem.ref
-		IL_07c7: stloc.s 24
-		IL_07c9: ldc.i4.s 10
-		IL_07cb: newarr [System.Runtime]System.Object
-		IL_07d0: dup
-		IL_07d1: ldc.i4.0
-		IL_07d2: ldloc.s 25
-		IL_07d4: stelem.ref
-		IL_07d5: dup
-		IL_07d6: ldc.i4.1
-		IL_07d7: ldstr "read"
-		IL_07dc: stelem.ref
-		IL_07dd: dup
-		IL_07de: ldc.i4.2
-		IL_07df: ldstr "read"
-		IL_07e4: stelem.ref
-		IL_07e5: dup
-		IL_07e6: ldc.i4.3
-		IL_07e7: ldc.r8 1
-		IL_07f0: box [System.Runtime]System.Double
-		IL_07f5: stelem.ref
-		IL_07f6: dup
-		IL_07f7: ldc.i4.4
-		IL_07f8: ldstr "read"
-		IL_07fd: stelem.ref
-		IL_07fe: dup
-		IL_07ff: ldc.i4.5
-		IL_0800: ldc.i4.1
-		IL_0801: box [System.Runtime]System.Boolean
-		IL_0806: stelem.ref
-		IL_0807: dup
-		IL_0808: ldc.i4.6
-		IL_0809: ldc.i4.0
-		IL_080a: box [System.Runtime]System.Boolean
-		IL_080f: stelem.ref
-		IL_0810: dup
-		IL_0811: ldc.i4.7
-		IL_0812: ldc.i4.0
-		IL_0813: box [System.Runtime]System.Boolean
-		IL_0818: stelem.ref
-		IL_0819: dup
-		IL_081a: ldc.i4.8
-		IL_081b: ldc.i4.0
-		IL_081c: box [System.Runtime]System.Boolean
-		IL_0821: stelem.ref
-		IL_0822: dup
-		IL_0823: ldc.i4.s 9
-		IL_0825: ldloc.s 24
-		IL_0827: stelem.ref
-		IL_0828: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_082d: pop
-		IL_082e: ldc.i4.1
-		IL_082f: newarr [System.Runtime]System.Object
-		IL_0834: dup
-		IL_0835: ldc.i4.0
-		IL_0836: ldloc.0
-		IL_0837: stelem.ref
-		IL_0838: stloc.s 24
-		IL_083a: ldloc.s 25
-		IL_083c: ldloc.s 24
-		IL_083e: ldc.r8 0.0
-		IL_0847: box [System.Runtime]System.Double
-		IL_084c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0851: stloc.s 23
-		IL_0853: ldloc.s 23
-		IL_0855: stloc.s 15
-		IL_0857: ldstr "console"
-		IL_085c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0861: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0866: stloc.s 23
-		IL_0868: ldloc.1
-		IL_0869: ldc.i4.2
-		IL_086a: newarr [System.Runtime]System.Object
-		IL_086f: dup
-		IL_0870: ldc.i4.0
-		IL_0871: ldc.r8 6
-		IL_087a: box [System.Runtime]System.Double
-		IL_087f: stelem.ref
-		IL_0880: dup
-		IL_0881: ldc.i4.1
-		IL_0882: ldc.r8 1
-		IL_088b: box [System.Runtime]System.Double
-		IL_0890: stelem.ref
-		IL_0891: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_0896: stloc.s 22
-		IL_0898: ldloc.s 15
-		IL_089a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_089f: stloc.s 18
-		IL_08a1: ldloc.s 22
-		IL_08a3: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
-		IL_08a8: stloc.s 22
-		IL_08aa: ldloc.s 23
-		IL_08ac: ldstr "log"
-		IL_08b1: ldloc.s 22
-		IL_08b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_08b8: pop
-		IL_08b9: ret
+		IL_0568: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
+		IL_056d: stloc.s 25
+		IL_056f: ldloc.s 25
+		IL_0571: ldstr "bind"
+		IL_0576: ldc.i4.0
+		IL_0577: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_057c: ldc.r8 10
+		IL_0585: box [System.Runtime]System.Double
+		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_058f: stloc.s 11
+		IL_0591: ldloc.s 11
+		IL_0593: ldc.i4.1
+		IL_0594: newarr [System.Runtime]System.Object
+		IL_0599: dup
+		IL_059a: ldc.i4.0
+		IL_059b: ldc.r8 5
+		IL_05a4: box [System.Runtime]System.Double
+		IL_05a9: stelem.ref
+		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_05af: stloc.s 12
+		IL_05b1: ldstr "console"
+		IL_05b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05c0: stloc.s 23
+		IL_05c2: ldloc.s 12
+		IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05c9: ldstr "sum"
+		IL_05ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_05d3: stloc.s 22
+		IL_05d5: ldloc.s 23
+		IL_05d7: ldstr "log"
+		IL_05dc: ldloc.s 22
+		IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05e3: pop
+		IL_05e4: ldstr "console"
+		IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05f3: stloc.s 22
+		IL_05f5: ldloc.s 12
+		IL_05f7: ldloc.1
+		IL_05f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_05fd: stloc.s 19
+		IL_05ff: ldloc.s 19
+		IL_0601: box [System.Runtime]System.Boolean
+		IL_0606: stloc.s 20
+		IL_0608: ldloc.s 22
+		IL_060a: ldstr "log"
+		IL_060f: ldloc.s 20
+		IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0616: pop
+		IL_0617: ldnull
+		IL_0618: ldftn object Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'::__js_call__(object, object)
+		IL_061e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0623: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0628: ldc.i4.1
+		IL_0629: conv.r8
+		IL_062a: ldstr ""
+		IL_062f: ldc.i4.0
+		IL_0630: ldc.i4.0
+		IL_0631: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0636: stloc.s 13
+		IL_0638: ldloc.s 13
+		IL_063a: ldc.i4.1
+		IL_063b: newarr [System.Runtime]System.Object
+		IL_0640: dup
+		IL_0641: ldc.i4.0
+		IL_0642: ldc.r8 9
+		IL_064b: box [System.Runtime]System.Double
+		IL_0650: stelem.ref
+		IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_0656: stloc.s 14
+		IL_0658: ldstr "console"
+		IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0662: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0667: stloc.s 22
+		IL_0669: ldloc.s 14
+		IL_066b: ldstr "value"
+		IL_0670: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0675: stloc.s 23
+		IL_0677: ldloc.s 22
+		IL_0679: ldstr "log"
+		IL_067e: ldloc.s 23
+		IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0685: pop
+		IL_0686: ldstr "console"
+		IL_068b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0695: stloc.s 23
+		IL_0697: ldloc.s 14
+		IL_0699: ldloc.s 13
+		IL_069b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_06a0: stloc.s 19
+		IL_06a2: ldloc.s 19
+		IL_06a4: box [System.Runtime]System.Boolean
+		IL_06a9: stloc.s 20
+		IL_06ab: ldloc.s 23
+		IL_06ad: ldstr "log"
+		IL_06b2: ldloc.s 20
+		IL_06b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06b9: pop
+		IL_06ba: nop
+		IL_06bb: ldloc.s 5
+		IL_06bd: ldstr "prototype"
+		IL_06c2: ldc.r8 3
+		IL_06cb: ldc.i4.1
+		IL_06cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_06d1: pop
+		IL_06d2: ldstr "console"
+		IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06e1: stloc.s 23
+		IL_06e3: ldloc.s 5
+		IL_06e5: ldc.i4.0
+		IL_06e6: newarr [System.Runtime]System.Object
+		IL_06eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_06f0: stloc.s 22
+		IL_06f2: ldloc.s 22
+		IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_06f9: stloc.s 22
+		IL_06fb: ldstr "Object"
+		IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0705: ldstr "prototype"
+		IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_070f: stloc.s 18
+		IL_0711: ldloc.s 22
+		IL_0713: ldloc.s 18
+		IL_0715: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_071a: stloc.s 19
+		IL_071c: ldloc.s 19
+		IL_071e: box [System.Runtime]System.Boolean
+		IL_0723: stloc.s 20
+		IL_0725: ldloc.s 23
+		IL_0727: ldstr "log"
+		IL_072c: ldloc.s 20
+		IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0733: pop
+		IL_0734: nop
+		IL_0735: ldloc.s 6
+		IL_0737: ldstr "prototype"
+		IL_073c: ldc.i4.0
+		IL_073d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0742: ldc.i4.1
+		IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0748: pop
+		IL_0749: ldstr "console"
+		IL_074e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0758: stloc.s 23
+		IL_075a: ldloc.s 6
+		IL_075c: ldc.i4.0
+		IL_075d: newarr [System.Runtime]System.Object
+		IL_0762: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_0767: stloc.s 18
+		IL_0769: ldloc.s 18
+		IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0770: stloc.s 18
+		IL_0772: ldstr "Object"
+		IL_0777: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_077c: ldstr "prototype"
+		IL_0781: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0786: stloc.s 22
+		IL_0788: ldloc.s 18
+		IL_078a: ldloc.s 22
+		IL_078c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0791: stloc.s 19
+		IL_0793: ldloc.s 19
+		IL_0795: box [System.Runtime]System.Boolean
+		IL_079a: stloc.s 20
+		IL_079c: ldloc.s 23
+		IL_079e: ldstr "log"
+		IL_07a3: ldloc.s 20
+		IL_07a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07aa: pop
+		IL_07ab: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
+		IL_07b0: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_07b5: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
+		IL_07ba: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_07bf: stloc.s 26
+		IL_07c1: ldc.i4.1
+		IL_07c2: newarr [System.Runtime]System.Object
+		IL_07c7: dup
+		IL_07c8: ldc.i4.0
+		IL_07c9: ldloc.0
+		IL_07ca: stelem.ref
+		IL_07cb: stloc.s 24
+		IL_07cd: ldc.i4.s 10
+		IL_07cf: newarr [System.Runtime]System.Object
+		IL_07d4: dup
+		IL_07d5: ldc.i4.0
+		IL_07d6: ldloc.s 26
+		IL_07d8: stelem.ref
+		IL_07d9: dup
+		IL_07da: ldc.i4.1
+		IL_07db: ldstr "read"
+		IL_07e0: stelem.ref
+		IL_07e1: dup
+		IL_07e2: ldc.i4.2
+		IL_07e3: ldstr "read"
+		IL_07e8: stelem.ref
+		IL_07e9: dup
+		IL_07ea: ldc.i4.3
+		IL_07eb: ldc.r8 1
+		IL_07f4: box [System.Runtime]System.Double
+		IL_07f9: stelem.ref
+		IL_07fa: dup
+		IL_07fb: ldc.i4.4
+		IL_07fc: ldstr "read"
+		IL_0801: stelem.ref
+		IL_0802: dup
+		IL_0803: ldc.i4.5
+		IL_0804: ldc.i4.1
+		IL_0805: box [System.Runtime]System.Boolean
+		IL_080a: stelem.ref
+		IL_080b: dup
+		IL_080c: ldc.i4.6
+		IL_080d: ldc.i4.0
+		IL_080e: box [System.Runtime]System.Boolean
+		IL_0813: stelem.ref
+		IL_0814: dup
+		IL_0815: ldc.i4.7
+		IL_0816: ldc.i4.0
+		IL_0817: box [System.Runtime]System.Boolean
+		IL_081c: stelem.ref
+		IL_081d: dup
+		IL_081e: ldc.i4.8
+		IL_081f: ldc.i4.0
+		IL_0820: box [System.Runtime]System.Boolean
+		IL_0825: stelem.ref
+		IL_0826: dup
+		IL_0827: ldc.i4.s 9
+		IL_0829: ldloc.s 24
+		IL_082b: stelem.ref
+		IL_082c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0831: pop
+		IL_0832: ldc.i4.1
+		IL_0833: newarr [System.Runtime]System.Object
+		IL_0838: dup
+		IL_0839: ldc.i4.0
+		IL_083a: ldloc.0
+		IL_083b: stelem.ref
+		IL_083c: stloc.s 24
+		IL_083e: ldloc.s 26
+		IL_0840: ldloc.s 24
+		IL_0842: ldc.r8 0.0
+		IL_084b: box [System.Runtime]System.Double
+		IL_0850: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0855: stloc.s 23
+		IL_0857: ldloc.s 23
+		IL_0859: stloc.s 15
+		IL_085b: ldstr "console"
+		IL_0860: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_086a: stloc.s 23
+		IL_086c: ldloc.1
+		IL_086d: ldc.i4.2
+		IL_086e: newarr [System.Runtime]System.Object
+		IL_0873: dup
+		IL_0874: ldc.i4.0
+		IL_0875: ldc.r8 6
+		IL_087e: box [System.Runtime]System.Double
+		IL_0883: stelem.ref
+		IL_0884: dup
+		IL_0885: ldc.i4.1
+		IL_0886: ldc.r8 1
+		IL_088f: box [System.Runtime]System.Double
+		IL_0894: stelem.ref
+		IL_0895: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_089a: stloc.s 22
+		IL_089c: ldloc.s 15
+		IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_08a3: stloc.s 18
+		IL_08a5: ldloc.s 22
+		IL_08a7: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
+		IL_08ac: stloc.s 22
+		IL_08ae: ldloc.s 23
+		IL_08b0: ldstr "log"
+		IL_08b5: ldloc.s 22
+		IL_08b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_08bc: pop
+		IL_08bd: ret
 	} // end of method Function_ConstructedInstance_ObjectSemantics::__js_module_init__
 
 } // end of class Modules.Function_ConstructedInstance_ObjectSemantics
@@ -1424,7 +1427,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2af7
+		// Method begins at RVA 0x2afb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_NonLiteral_RuntimeError.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_NonLiteral_RuntimeError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x220d
+				// Method begins at RVA 0x2205
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2216
+				// Method begins at RVA 0x220e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x221f
+				// Method begins at RVA 0x2217
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2228
+				// Method begins at RVA 0x2220
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2204
+			// Method begins at RVA 0x21fc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 395 (0x18b)
+		// Code size: 385 (0x181)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_NonLiteral_RuntimeError/Scope,
@@ -136,8 +136,7 @@
 			[8] object,
 			[9] object,
 			[10] string,
-			[11] object,
-			[12] bool
+			[11] bool
 		)
 
 		IL_0000: newobj instance void Modules.Function_Constructor_NonLiteral_RuntimeError/Scope::.ctor()
@@ -161,7 +160,7 @@
 			IL_0038: ldstr "call-no-error"
 			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_0042: pop
-			IL_0043: leave IL_00c3
+			IL_0043: leave IL_00be
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -196,97 +195,95 @@
 			IL_0087: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_008c: stloc.s 10
 			IL_008e: ldloc.s 10
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0095: stloc.s 11
-			IL_0097: ldloc.s 11
-			IL_0099: castclass [System.Runtime]System.String
-			IL_009e: ldstr "string literal arguments"
-			IL_00a3: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_00a8: stloc.s 12
-			IL_00aa: ldloc.s 9
-			IL_00ac: ldstr "log"
-			IL_00b1: ldloc.s 12
-			IL_00b3: box [System.Runtime]System.Boolean
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00bd: pop
-			IL_00be: leave IL_00c3
+			IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0095: stloc.s 10
+			IL_0097: ldloc.s 10
+			IL_0099: ldstr "string literal arguments"
+			IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_00a3: stloc.s 11
+			IL_00a5: ldloc.s 9
+			IL_00a7: ldstr "log"
+			IL_00ac: ldloc.s 11
+			IL_00ae: box [System.Runtime]System.Boolean
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00b8: pop
+			IL_00b9: leave IL_00be
 		} // end handler
 		.try
 		{
-			IL_00c3: nop
-			IL_00c4: ldstr "Function"
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ce: stloc.s 9
-			IL_00d0: ldloc.s 9
-			IL_00d2: ldc.i4.1
-			IL_00d3: newarr [System.Runtime]System.Object
-			IL_00d8: dup
-			IL_00d9: ldc.i4.0
-			IL_00da: ldloc.1
-			IL_00db: stelem.ref
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-			IL_00e1: pop
-			IL_00e2: ldstr "console"
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f1: ldstr "log"
-			IL_00f6: ldstr "new-no-error"
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0100: pop
-			IL_0101: leave IL_0187
+			IL_00be: nop
+			IL_00bf: ldstr "Function"
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c9: stloc.s 9
+			IL_00cb: ldloc.s 9
+			IL_00cd: ldc.i4.1
+			IL_00ce: newarr [System.Runtime]System.Object
+			IL_00d3: dup
+			IL_00d4: ldc.i4.0
+			IL_00d5: ldloc.1
+			IL_00d6: stelem.ref
+			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+			IL_00dc: pop
+			IL_00dd: ldstr "console"
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ec: ldstr "log"
+			IL_00f1: ldstr "new-no-error"
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00fb: pop
+			IL_00fc: leave IL_017d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0106: stloc.s 5
-			IL_0108: ldloc.s 5
-			IL_010a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_010f: dup
-			IL_0110: brtrue IL_0126
+			IL_0101: stloc.s 5
+			IL_0103: ldloc.s 5
+			IL_0105: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_010a: dup
+			IL_010b: brtrue IL_0121
 
-			IL_0115: pop
-			IL_0116: ldloc.s 5
-			IL_0118: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_011d: dup
-			IL_011e: brtrue IL_0132
+			IL_0110: pop
+			IL_0111: ldloc.s 5
+			IL_0113: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0118: dup
+			IL_0119: brtrue IL_012d
 
-			IL_0123: pop
-			IL_0124: rethrow
+			IL_011e: pop
+			IL_011f: rethrow
 
-			IL_0126: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_012b: stloc.s 6
-			IL_012d: br IL_0134
+			IL_0121: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0126: stloc.s 6
+			IL_0128: br IL_012f
 
-			IL_0132: stloc.s 6
+			IL_012d: stloc.s 6
 
-			IL_0134: ldloc.s 6
-			IL_0136: stloc.s 7
-			IL_0138: ldstr "console"
-			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0147: stloc.s 9
-			IL_0149: ldloc.s 7
-			IL_014b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0150: stloc.s 10
-			IL_0152: ldloc.s 10
-			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0159: stloc.s 11
-			IL_015b: ldloc.s 11
-			IL_015d: castclass [System.Runtime]System.String
-			IL_0162: ldstr "string literal arguments"
-			IL_0167: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_016c: stloc.s 12
-			IL_016e: ldloc.s 9
-			IL_0170: ldstr "log"
-			IL_0175: ldloc.s 12
-			IL_0177: box [System.Runtime]System.Boolean
-			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0181: pop
-			IL_0182: leave IL_0187
+			IL_012f: ldloc.s 6
+			IL_0131: stloc.s 7
+			IL_0133: ldstr "console"
+			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0142: stloc.s 9
+			IL_0144: ldloc.s 7
+			IL_0146: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_014b: stloc.s 10
+			IL_014d: ldloc.s 10
+			IL_014f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0154: stloc.s 10
+			IL_0156: ldloc.s 10
+			IL_0158: ldstr "string literal arguments"
+			IL_015d: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_0162: stloc.s 11
+			IL_0164: ldloc.s 9
+			IL_0166: ldstr "log"
+			IL_016b: ldloc.s 11
+			IL_016d: box [System.Runtime]System.Boolean
+			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0177: pop
+			IL_0178: leave IL_017d
 		} // end handler
 
-		IL_0187: ldnull
-		IL_0188: stloc.s 8
-		IL_018a: ret
+		IL_017d: ldnull
+		IL_017e: stloc.s 8
+		IL_0180: ret
 	} // end of method Function_Constructor_NonLiteral_RuntimeError::__js_module_init__
 
 } // end of class Modules.Function_Constructor_NonLiteral_RuntimeError
@@ -298,7 +295,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2231
+		// Method begins at RVA 0x2229
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_SyntaxError.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_SyntaxError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2179
+				// Method begins at RVA 0x217d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2182
+				// Method begins at RVA 0x2186
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2170
+			// Method begins at RVA 0x2174
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 259 (0x103)
+		// Code size: 262 (0x106)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_SyntaxError/Scope,
@@ -92,8 +92,9 @@
 			[4] string,
 			[5] object,
 			[6] object,
-			[7] bool,
-			[8] object
+			[7] string,
+			[8] bool,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Constructor_SyntaxError/Scope::.ctor()
@@ -125,7 +126,7 @@
 			IL_0044: ldstr "no-error"
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_004e: pop
-			IL_004f: leave IL_00ff
+			IL_004f: leave IL_0102
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -158,39 +159,42 @@
 			IL_0087: ldstr "console"
 			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0096: ldloc.s 4
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009d: castclass [System.Runtime]System.String
-			IL_00a2: ldstr "SyntaxError"
-			IL_00a7: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_00ac: stloc.s 7
-			IL_00ae: ldstr "log"
-			IL_00b3: ldloc.s 7
-			IL_00b5: box [System.Runtime]System.Boolean
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00bf: pop
-			IL_00c0: ldstr "console"
-			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00cf: ldloc.s 4
-			IL_00d1: callvirt instance int32 [System.Runtime]System.String::get_Length()
-			IL_00d6: conv.r8
-			IL_00d7: ldc.r8 0.0
-			IL_00e0: cgt
-			IL_00e2: stloc.s 7
-			IL_00e4: ldloc.s 7
-			IL_00e6: box [System.Runtime]System.Boolean
-			IL_00eb: stloc.s 8
-			IL_00ed: ldstr "log"
-			IL_00f2: ldloc.s 8
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00f9: pop
-			IL_00fa: leave IL_00ff
+			IL_0096: stloc.s 6
+			IL_0098: ldloc.s 4
+			IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_009f: stloc.s 7
+			IL_00a1: ldloc.s 7
+			IL_00a3: ldstr "SyntaxError"
+			IL_00a8: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_00ad: stloc.s 8
+			IL_00af: ldloc.s 6
+			IL_00b1: ldstr "log"
+			IL_00b6: ldloc.s 8
+			IL_00b8: box [System.Runtime]System.Boolean
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00c2: pop
+			IL_00c3: ldstr "console"
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d2: ldloc.s 4
+			IL_00d4: callvirt instance int32 [System.Runtime]System.String::get_Length()
+			IL_00d9: conv.r8
+			IL_00da: ldc.r8 0.0
+			IL_00e3: cgt
+			IL_00e5: stloc.s 8
+			IL_00e7: ldloc.s 8
+			IL_00e9: box [System.Runtime]System.Boolean
+			IL_00ee: stloc.s 9
+			IL_00f0: ldstr "log"
+			IL_00f5: ldloc.s 9
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00fc: pop
+			IL_00fd: leave IL_0102
 		} // end handler
 
-		IL_00ff: ldnull
-		IL_0100: stloc.s 5
-		IL_0102: ret
+		IL_0102: ldnull
+		IL_0103: stloc.s 5
+		IL_0105: ret
 	} // end of method Function_Constructor_SyntaxError::__js_module_init__
 
 } // end of class Modules.Function_Constructor_SyntaxError
@@ -202,7 +206,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218b
+		// Method begins at RVA 0x218f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2126
+				// Method begins at RVA 0x212a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2112
+			// Method begins at RVA 0x2116
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -68,7 +68,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211d
+			// Method begins at RVA 0x2121
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -94,15 +94,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 182 (0xb6)
+		// Code size: 186 (0xba)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0,
 			[2] object,
 			[3] object,
-			[4] bool,
-			[5] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0,
+			[5] bool,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/Scope::.ctor()
@@ -138,32 +139,34 @@
 		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0060: stloc.3
 		IL_0061: ldloc.1
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0067: ldstr "toString"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0071: stloc.2
-		IL_0072: ldloc.2
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0078: ldstr "indexOf"
-		IL_007d: ldstr "DynamicFunction_L12C34"
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0087: stloc.2
-		IL_0088: ldloc.2
-		IL_0089: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_008e: ldc.r8 0.0
-		IL_0097: clt
-		IL_0099: ldc.i4.0
-		IL_009a: ceq
-		IL_009c: stloc.s 4
-		IL_009e: ldloc.s 4
-		IL_00a0: box [System.Runtime]System.Boolean
-		IL_00a5: stloc.s 5
-		IL_00a7: ldloc.3
-		IL_00a8: ldstr "log"
-		IL_00ad: ldloc.s 5
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b4: pop
-		IL_00b5: ret
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0>(!!0)
+		IL_0067: stloc.s 4
+		IL_0069: ldloc.s 4
+		IL_006b: ldstr "toString"
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0075: stloc.2
+		IL_0076: ldloc.2
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007c: ldstr "indexOf"
+		IL_0081: ldstr "DynamicFunction_L12C34"
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008b: stloc.2
+		IL_008c: ldloc.2
+		IL_008d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0092: ldc.r8 0.0
+		IL_009b: clt
+		IL_009d: ldc.i4.0
+		IL_009e: ceq
+		IL_00a0: stloc.s 5
+		IL_00a2: ldloc.s 5
+		IL_00a4: box [System.Runtime]System.Boolean
+		IL_00a9: stloc.s 6
+		IL_00ab: ldloc.3
+		IL_00ac: ldstr "log"
+		IL_00b1: ldloc.s 6
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b8: pop
+		IL_00b9: ret
 	} // end of method Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous::__js_module_init__
 
 } // end of class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous
@@ -175,7 +178,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212f
+		// Method begins at RVA 0x2133
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralMethod_ThisBinding.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralMethod_ThisBinding.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2113
+				// Method begins at RVA 0x2117
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e4
+			// Method begins at RVA 0x20e8
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -72,7 +72,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x210a
+			// Method begins at RVA 0x210e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -98,14 +98,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 136 (0x88)
+		// Code size: 140 (0x8c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ObjectLiteralMethod_ThisBinding/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
 			[3] object,
-			[4] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_ObjectLiteralMethod_ThisBinding/Scope::.ctor()
@@ -137,18 +138,20 @@
 		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0058: stloc.3
 		IL_0059: ldloc.1
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005f: ldstr "format"
-		IL_0064: ldc.r8 42
-		IL_006d: box [System.Runtime]System.Double
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0077: stloc.s 4
-		IL_0079: ldloc.3
-		IL_007a: ldstr "log"
-		IL_007f: ldloc.s 4
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0086: pop
-		IL_0087: ret
+		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
+		IL_005f: stloc.s 4
+		IL_0061: ldloc.s 4
+		IL_0063: ldstr "format"
+		IL_0068: ldc.r8 42
+		IL_0071: box [System.Runtime]System.Double
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007b: stloc.s 5
+		IL_007d: ldloc.3
+		IL_007e: ldstr "log"
+		IL_0083: ldloc.s 5
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008a: pop
+		IL_008b: ret
 	} // end of method Function_ObjectLiteralMethod_ThisBinding::__js_module_init__
 
 } // end of class Modules.Function_ObjectLiteralMethod_ThisBinding
@@ -160,7 +163,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x211c
+		// Method begins at RVA 0x2120
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b26
+				// Method begins at RVA 0x2b2e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b2f
+				// Method begins at RVA 0x2b37
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +140,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b38
+				// Method begins at RVA 0x2b40
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -202,7 +202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b41
+				// Method begins at RVA 0x2b49
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -271,7 +271,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b4a
+				// Method begins at RVA 0x2b52
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -345,7 +345,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b53
+				// Method begins at RVA 0x2b5b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -408,7 +408,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b5c
+				// Method begins at RVA 0x2b64
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -551,7 +551,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b65
+				// Method begins at RVA 0x2b6d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -680,7 +680,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b6e
+				// Method begins at RVA 0x2b76
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -708,11 +708,13 @@
 			)
 			// Method begins at RVA 0x2900
 			// Header size: 12
-			// Code size: 74 (0x4a)
+			// Code size: 82 (0x52)
 			.maxstack 9
 			.locals init (
 				[0] object,
-				[1] object
+				[1] object,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[3] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -730,13 +732,21 @@
 			IL_0020: dup
 			IL_0021: ldc.r8 1
 			IL_002a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0034: ldstr "iterator"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-			IL_003e: ldc.i4.0
-			IL_003f: newarr [System.Runtime]System.Object
-			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-			IL_0049: ret
+			IL_002f: stloc.2
+			IL_0030: ldloc.2
+			IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
+			IL_0036: stloc.2
+			IL_0037: ldstr "iterator"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+			IL_0041: stloc.0
+			IL_0042: ldc.i4.0
+			IL_0043: newarr [System.Runtime]System.Object
+			IL_0048: stloc.3
+			IL_0049: ldloc.2
+			IL_004a: ldloc.0
+			IL_004b: ldloc.3
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+			IL_0051: ret
 		} // end of method FunctionExpression_spread::__js_call__
 
 	} // end of class FunctionExpression_spread
@@ -752,7 +762,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b77
+				// Method begins at RVA 0x2b7f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -778,7 +788,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2958
+			// Method begins at RVA 0x2960
 			// Header size: 12
 			// Code size: 162 (0xa2)
 			.maxstack 8
@@ -878,7 +888,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b89
+					// Method begins at RVA 0x2b91
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -898,7 +908,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b92
+					// Method begins at RVA 0x2b9a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -916,7 +926,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b80
+				// Method begins at RVA 0x2b88
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -942,7 +952,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2a08
+			// Method begins at RVA 0x2a10
 			// Header size: 12
 			// Code size: 177 (0xb1)
 			.maxstack 8
@@ -1056,7 +1066,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b9b
+				// Method begins at RVA 0x2ba3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1083,7 +1093,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2ad8
+			// Method begins at RVA 0x2ae0
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -1160,7 +1170,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b1d
+			// Method begins at RVA 0x2b25
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1642,7 +1652,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2ba4
+		// Method begins at RVA 0x2bac
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4edc
+				// Method begins at RVA 0x4f44
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ee5
+				// Method begins at RVA 0x4f4d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ef7
+					// Method begins at RVA 0x4f5f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4eee
+				// Method begins at RVA 0x4f56
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -191,7 +191,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f09
+					// Method begins at RVA 0x4f71
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -209,7 +209,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f00
+				// Method begins at RVA 0x4f68
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -265,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f12
+				// Method begins at RVA 0x4f7a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -324,7 +324,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f2d
+						// Method begins at RVA 0x4f95
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -344,7 +344,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f36
+						// Method begins at RVA 0x4f9e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -362,7 +362,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f24
+					// Method begins at RVA 0x4f8c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -380,7 +380,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f1b
+				// Method begins at RVA 0x4f83
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -642,7 +642,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f3f
+				// Method begins at RVA 0x4fa7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -720,7 +720,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f48
+				// Method begins at RVA 0x4fb0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -748,12 +748,12 @@
 			)
 			// Method begins at RVA 0x34f0
 			// Header size: 12
-			// Code size: 103 (0x67)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -765,7 +765,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 30
 				IL_0016: clt
-				IL_0018: brfalse IL_0065
+				IL_0018: brfalse IL_0067
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -773,28 +773,30 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "split"
-				IL_0046: ldloc.3
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: ldc.r8 1
-				IL_005e: add
-				IL_005f: stloc.0
-				IL_0060: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "split"
+				IL_0048: ldloc.3
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_004e: stloc.3
+				IL_004f: ldarg.0
+				IL_0050: ldloc.3
+				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_000a
 			// end loop
 
-			IL_0065: ldnull
-			IL_0066: ret
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method FunctionExpression_L56C36::__js_call__
 
 	} // end of class FunctionExpression_L56C36
@@ -810,7 +812,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f51
+				// Method begins at RVA 0x4fb9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -836,7 +838,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3564
+			// Method begins at RVA 0x3568
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -888,7 +890,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f5a
+				// Method begins at RVA 0x4fc2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -914,14 +916,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x35bc
+			// Method begins at RVA 0x35c0
 			// Header size: 12
-			// Code size: 103 (0x67)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -933,7 +935,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 30
 				IL_0016: clt
-				IL_0018: brfalse IL_0065
+				IL_0018: brfalse IL_0067
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -941,28 +943,30 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "split"
-				IL_0046: ldloc.3
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: ldc.r8 1
-				IL_005e: add
-				IL_005f: stloc.0
-				IL_0060: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "split"
+				IL_0048: ldloc.3
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_004e: stloc.3
+				IL_004f: ldarg.0
+				IL_0050: ldloc.3
+				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_000a
 			// end loop
 
-			IL_0065: ldnull
-			IL_0066: ret
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method FunctionExpression_L66C35::__js_call__
 
 	} // end of class FunctionExpression_L66C35
@@ -978,7 +982,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f63
+				// Method begins at RVA 0x4fcb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1004,7 +1008,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3630
+			// Method begins at RVA 0x3638
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -1056,7 +1060,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f6c
+				// Method begins at RVA 0x4fd4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1082,14 +1086,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3688
+			// Method begins at RVA 0x3690
 			// Header size: 12
-			// Code size: 103 (0x67)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -1101,7 +1105,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0065
+				IL_0018: brfalse IL_0067
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -1109,28 +1113,30 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "split"
-				IL_0046: ldloc.3
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: ldc.r8 1
-				IL_005e: add
-				IL_005f: stloc.0
-				IL_0060: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "split"
+				IL_0048: ldloc.3
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_004e: stloc.3
+				IL_004f: ldarg.0
+				IL_0050: ldloc.3
+				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_000a
 			// end loop
 
-			IL_0065: ldnull
-			IL_0066: ret
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method FunctionExpression_L76C39::__js_call__
 
 	} // end of class FunctionExpression_L76C39
@@ -1146,7 +1152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f75
+				// Method begins at RVA 0x4fdd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1172,7 +1178,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x36fc
+			// Method begins at RVA 0x3708
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -1224,7 +1230,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f7e
+				// Method begins at RVA 0x4fe6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1250,14 +1256,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3754
+			// Method begins at RVA 0x3760
 			// Header size: 12
-			// Code size: 103 (0x67)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -1269,7 +1275,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0065
+				IL_0018: brfalse IL_0067
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -1277,28 +1283,30 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "match"
-				IL_0046: ldloc.3
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: ldc.r8 1
-				IL_005e: add
-				IL_005f: stloc.0
-				IL_0060: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "match"
+				IL_0048: ldloc.3
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_004e: stloc.3
+				IL_004f: ldarg.0
+				IL_0050: ldloc.3
+				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_000a
 			// end loop
 
-			IL_0065: ldnull
-			IL_0066: ret
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method FunctionExpression_L88C23::__js_call__
 
 	} // end of class FunctionExpression_L88C23
@@ -1314,7 +1322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f87
+				// Method begins at RVA 0x4fef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1340,7 +1348,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x37c8
+			// Method begins at RVA 0x37d8
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -1384,7 +1392,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f90
+				// Method begins at RVA 0x4ff8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1410,7 +1418,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3808
+			// Method begins at RVA 0x3818
 			// Header size: 12
 			// Code size: 103 (0x67)
 			.maxstack 8
@@ -1474,7 +1482,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f99
+				// Method begins at RVA 0x5001
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1500,7 +1508,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x387c
+			// Method begins at RVA 0x388c
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -1544,7 +1552,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fa2
+				// Method begins at RVA 0x500a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1570,14 +1578,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x38bc
+			// Method begins at RVA 0x38cc
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -1589,7 +1597,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_006a
+				IL_0018: brfalse IL_006c
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -1597,29 +1605,31 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "replace"
-				IL_0046: ldloc.3
-				IL_0047: ldstr ""
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0051: stloc.3
-				IL_0052: ldarg.0
-				IL_0053: ldloc.3
-				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0059: ldloc.0
-				IL_005a: ldc.r8 1
-				IL_0063: add
-				IL_0064: stloc.0
-				IL_0065: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "replace"
+				IL_0048: ldloc.3
+				IL_0049: ldstr ""
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0053: stloc.3
+				IL_0054: ldarg.0
+				IL_0055: ldloc.3
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
 			// end loop
 
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method FunctionExpression_L106C31::__js_call__
 
 	} // end of class FunctionExpression_L106C31
@@ -1635,7 +1645,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fab
+				// Method begins at RVA 0x5013
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1661,7 +1671,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3934
+			// Method begins at RVA 0x3948
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -1705,7 +1715,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fb4
+				// Method begins at RVA 0x501c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1731,14 +1741,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3974
+			// Method begins at RVA 0x3988
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -1750,7 +1760,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_006a
+				IL_0018: brfalse IL_006c
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -1758,29 +1768,31 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "replace"
-				IL_0046: ldloc.3
-				IL_0047: ldstr "asdfasdfasdf"
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0051: stloc.3
-				IL_0052: ldarg.0
-				IL_0053: ldloc.3
-				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0059: ldloc.0
-				IL_005a: ldc.r8 1
-				IL_0063: add
-				IL_0064: stloc.0
-				IL_0065: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "replace"
+				IL_0048: ldloc.3
+				IL_0049: ldstr "asdfasdfasdf"
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0053: stloc.3
+				IL_0054: ldarg.0
+				IL_0055: ldloc.3
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
 			// end loop
 
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method FunctionExpression_L115C33::__js_call__
 
 	} // end of class FunctionExpression_L115C33
@@ -1796,7 +1808,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fbd
+				// Method begins at RVA 0x5025
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1822,7 +1834,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x39ec
+			// Method begins at RVA 0x3a04
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -1874,7 +1886,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fc6
+				// Method begins at RVA 0x502e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1900,14 +1912,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3a44
+			// Method begins at RVA 0x3a5c
 			// Header size: 12
-			// Code size: 103 (0x67)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -1919,7 +1931,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0065
+				IL_0018: brfalse IL_0067
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -1927,28 +1939,30 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "match"
-				IL_0046: ldloc.3
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: ldc.r8 1
-				IL_005e: add
-				IL_005f: stloc.0
-				IL_0060: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "match"
+				IL_0048: ldloc.3
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_004e: stloc.3
+				IL_004f: ldarg.0
+				IL_0050: ldloc.3
+				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_000a
 			// end loop
 
-			IL_0065: ldnull
-			IL_0066: ret
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method FunctionExpression_L125C30::__js_call__
 
 	} // end of class FunctionExpression_L125C30
@@ -1964,7 +1978,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fcf
+				// Method begins at RVA 0x5037
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1990,7 +2004,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3ab8
+			// Method begins at RVA 0x3ad4
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -2034,7 +2048,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fd8
+				// Method begins at RVA 0x5040
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2060,7 +2074,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3af8
+			// Method begins at RVA 0x3b14
 			// Header size: 12
 			// Code size: 103 (0x67)
 			.maxstack 8
@@ -2124,7 +2138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fe1
+				// Method begins at RVA 0x5049
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2150,7 +2164,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3b6c
+			// Method begins at RVA 0x3b88
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -2194,7 +2208,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fea
+				// Method begins at RVA 0x5052
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2220,14 +2234,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3bac
+			// Method begins at RVA 0x3bc8
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -2239,7 +2253,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_006a
+				IL_0018: brfalse IL_006c
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -2247,29 +2261,31 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "replace"
-				IL_0046: ldloc.3
-				IL_0047: ldstr ""
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0051: stloc.3
-				IL_0052: ldarg.0
-				IL_0053: ldloc.3
-				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0059: ldloc.0
-				IL_005a: ldc.r8 1
-				IL_0063: add
-				IL_0064: stloc.0
-				IL_0065: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "replace"
+				IL_0048: ldloc.3
+				IL_0049: ldstr ""
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0053: stloc.3
+				IL_0054: ldarg.0
+				IL_0055: ldloc.3
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
 			// end loop
 
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method FunctionExpression_L143C38::__js_call__
 
 	} // end of class FunctionExpression_L143C38
@@ -2285,7 +2301,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ff3
+				// Method begins at RVA 0x505b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2311,7 +2327,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3c24
+			// Method begins at RVA 0x3c44
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -2355,7 +2371,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ffc
+				// Method begins at RVA 0x5064
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2381,14 +2397,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3c64
+			// Method begins at RVA 0x3c84
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -2400,7 +2416,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_006a
+				IL_0018: brfalse IL_006c
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -2408,29 +2424,31 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "replace"
-				IL_0046: ldloc.3
-				IL_0047: ldstr "asdfasdfasdf"
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0051: stloc.3
-				IL_0052: ldarg.0
-				IL_0053: ldloc.3
-				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0059: ldloc.0
-				IL_005a: ldc.r8 1
-				IL_0063: add
-				IL_0064: stloc.0
-				IL_0065: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "replace"
+				IL_0048: ldloc.3
+				IL_0049: ldstr "asdfasdfasdf"
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0053: stloc.3
+				IL_0054: ldarg.0
+				IL_0055: ldloc.3
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
 			// end loop
 
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method FunctionExpression_L152C40::__js_call__
 
 	} // end of class FunctionExpression_L152C40
@@ -2446,7 +2464,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5005
+				// Method begins at RVA 0x506d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2472,7 +2490,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3cdc
+			// Method begins at RVA 0x3d00
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -2520,7 +2538,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5017
+					// Method begins at RVA 0x507f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2544,7 +2562,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4e7d
+				// Method begins at RVA 0x4ee5
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -2562,7 +2580,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x500e
+				// Method begins at RVA 0x5076
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2588,15 +2606,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3d1c
+			// Method begins at RVA 0x3d40
 			// Header size: 12
-			// Code size: 148 (0x94)
+			// Code size: 150 (0x96)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/Scope,
 				[1] float64,
 				[2] float64,
-				[3] object,
+				[3] string,
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 			)
@@ -2611,7 +2629,7 @@
 				IL_0012: ldloc.2
 				IL_0013: ldc.r8 50
 				IL_001c: clt
-				IL_001e: brfalse IL_0092
+				IL_001e: brfalse IL_0094
 
 				IL_0023: ldarg.0
 				IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -2619,40 +2637,42 @@
 				IL_002e: ldloc.1
 				IL_002f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_0034: castclass [System.Runtime]System.String
-				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003e: stloc.3
-				IL_003f: ldarg.0
-				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0045: stloc.s 4
-				IL_0047: ldnull
-				IL_0048: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
-				IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-				IL_0053: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-				IL_0058: ldc.i4.1
-				IL_0059: conv.r8
-				IL_005a: ldstr ""
-				IL_005f: ldc.i4.0
-				IL_0060: ldc.i4.1
-				IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-				IL_0066: stloc.s 5
-				IL_0068: ldloc.3
-				IL_0069: ldstr "replace"
-				IL_006e: ldloc.s 4
-				IL_0070: ldloc.s 5
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0077: stloc.s 4
-				IL_0079: ldarg.0
-				IL_007a: ldloc.s 4
-				IL_007c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0081: ldloc.1
-				IL_0082: ldc.r8 1
-				IL_008b: add
-				IL_008c: stloc.1
-				IL_008d: br IL_0010
+				IL_0039: stloc.3
+				IL_003a: ldloc.3
+				IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_0040: stloc.3
+				IL_0041: ldarg.0
+				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0047: stloc.s 4
+				IL_0049: ldnull
+				IL_004a: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
+				IL_0050: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+				IL_0055: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+				IL_005a: ldc.i4.1
+				IL_005b: conv.r8
+				IL_005c: ldstr ""
+				IL_0061: ldc.i4.0
+				IL_0062: ldc.i4.1
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+				IL_0068: stloc.s 5
+				IL_006a: ldloc.3
+				IL_006b: ldstr "replace"
+				IL_0070: ldloc.s 4
+				IL_0072: ldloc.s 5
+				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0079: stloc.s 4
+				IL_007b: ldarg.0
+				IL_007c: ldloc.s 4
+				IL_007e: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0083: ldloc.1
+				IL_0084: ldc.r8 1
+				IL_008d: add
+				IL_008e: stloc.1
+				IL_008f: br IL_0010
 			// end loop
 
-			IL_0092: ldnull
-			IL_0093: ret
+			IL_0094: ldnull
+			IL_0095: ret
 		} // end of method FunctionExpression_L161C49::__js_call__
 
 	} // end of class FunctionExpression_L161C49
@@ -2668,7 +2688,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5020
+				// Method begins at RVA 0x5088
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2694,7 +2714,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3dbc
+			// Method begins at RVA 0x3de4
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -2746,7 +2766,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5029
+				// Method begins at RVA 0x5091
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2772,14 +2792,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3e14
+			// Method begins at RVA 0x3e3c
 			// Header size: 12
-			// Code size: 103 (0x67)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -2791,7 +2811,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0065
+				IL_0018: brfalse IL_0067
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -2799,28 +2819,30 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "match"
-				IL_0046: ldloc.3
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: ldc.r8 1
-				IL_005e: add
-				IL_005f: stloc.0
-				IL_0060: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "match"
+				IL_0048: ldloc.3
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_004e: stloc.3
+				IL_004f: ldarg.0
+				IL_0050: ldloc.3
+				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_000a
 			// end loop
 
-			IL_0065: ldnull
-			IL_0066: ret
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method FunctionExpression_L175C32::__js_call__
 
 	} // end of class FunctionExpression_L175C32
@@ -2836,7 +2858,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5032
+				// Method begins at RVA 0x509a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2862,7 +2884,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3e88
+			// Method begins at RVA 0x3eb4
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -2906,7 +2928,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x503b
+				// Method begins at RVA 0x50a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2932,7 +2954,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3ec8
+			// Method begins at RVA 0x3ef4
 			// Header size: 12
 			// Code size: 103 (0x67)
 			.maxstack 8
@@ -2996,7 +3018,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5044
+				// Method begins at RVA 0x50ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3022,7 +3044,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3f3c
+			// Method begins at RVA 0x3f68
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -3066,7 +3088,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x504d
+				// Method begins at RVA 0x50b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3092,14 +3114,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3f7c
+			// Method begins at RVA 0x3fa8
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -3111,7 +3133,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_006a
+				IL_0018: brfalse IL_006c
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -3119,29 +3141,31 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "replace"
-				IL_0046: ldloc.3
-				IL_0047: ldstr ""
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0051: stloc.3
-				IL_0052: ldarg.0
-				IL_0053: ldloc.3
-				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0059: ldloc.0
-				IL_005a: ldc.r8 1
-				IL_0063: add
-				IL_0064: stloc.0
-				IL_0065: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "replace"
+				IL_0048: ldloc.3
+				IL_0049: ldstr ""
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0053: stloc.3
+				IL_0054: ldarg.0
+				IL_0055: ldloc.3
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
 			// end loop
 
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method FunctionExpression_L193C40::__js_call__
 
 	} // end of class FunctionExpression_L193C40
@@ -3157,7 +3181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5056
+				// Method begins at RVA 0x50be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3183,7 +3207,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3ff4
+			// Method begins at RVA 0x4024
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -3227,7 +3251,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x505f
+				// Method begins at RVA 0x50c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3253,14 +3277,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4034
+			// Method begins at RVA 0x4064
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -3272,7 +3296,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_006a
+				IL_0018: brfalse IL_006c
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -3280,29 +3304,31 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "replace"
-				IL_0046: ldloc.3
-				IL_0047: ldstr "asdfasdfasdf"
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0051: stloc.3
-				IL_0052: ldarg.0
-				IL_0053: ldloc.3
-				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0059: ldloc.0
-				IL_005a: ldc.r8 1
-				IL_0063: add
-				IL_0064: stloc.0
-				IL_0065: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "replace"
+				IL_0048: ldloc.3
+				IL_0049: ldstr "asdfasdfasdf"
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0053: stloc.3
+				IL_0054: ldarg.0
+				IL_0055: ldloc.3
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
 			// end loop
 
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method FunctionExpression_L202C42::__js_call__
 
 	} // end of class FunctionExpression_L202C42
@@ -3318,7 +3344,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5068
+				// Method begins at RVA 0x50d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3344,7 +3370,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x40ac
+			// Method begins at RVA 0x40e0
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -3396,7 +3422,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5071
+				// Method begins at RVA 0x50d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3422,14 +3448,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4104
+			// Method begins at RVA 0x4138
 			// Header size: 12
-			// Code size: 103 (0x67)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -3441,7 +3467,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0065
+				IL_0018: brfalse IL_0067
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -3449,28 +3475,30 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "match"
-				IL_0046: ldloc.3
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: ldc.r8 1
-				IL_005e: add
-				IL_005f: stloc.0
-				IL_0060: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "match"
+				IL_0048: ldloc.3
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_004e: stloc.3
+				IL_004f: ldarg.0
+				IL_0050: ldloc.3
+				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_000a
 			// end loop
 
-			IL_0065: ldnull
-			IL_0066: ret
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method FunctionExpression_L212C39::__js_call__
 
 	} // end of class FunctionExpression_L212C39
@@ -3486,7 +3514,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x507a
+				// Method begins at RVA 0x50e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3512,7 +3540,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4178
+			// Method begins at RVA 0x41b0
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -3556,7 +3584,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5083
+				// Method begins at RVA 0x50eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3582,7 +3610,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x41b8
+			// Method begins at RVA 0x41f0
 			// Header size: 12
 			// Code size: 103 (0x67)
 			.maxstack 8
@@ -3646,7 +3674,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x508c
+				// Method begins at RVA 0x50f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3672,7 +3700,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x422c
+			// Method begins at RVA 0x4264
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -3716,7 +3744,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5095
+				// Method begins at RVA 0x50fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3742,14 +3770,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x426c
+			// Method begins at RVA 0x42a4
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -3761,7 +3789,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_006a
+				IL_0018: brfalse IL_006c
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -3769,29 +3797,31 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "replace"
-				IL_0046: ldloc.3
-				IL_0047: ldstr ""
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0051: stloc.3
-				IL_0052: ldarg.0
-				IL_0053: ldloc.3
-				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0059: ldloc.0
-				IL_005a: ldc.r8 1
-				IL_0063: add
-				IL_0064: stloc.0
-				IL_0065: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "replace"
+				IL_0048: ldloc.3
+				IL_0049: ldstr ""
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0053: stloc.3
+				IL_0054: ldarg.0
+				IL_0055: ldloc.3
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
 			// end loop
 
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method FunctionExpression_L230C47::__js_call__
 
 	} // end of class FunctionExpression_L230C47
@@ -3807,7 +3837,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x509e
+				// Method begins at RVA 0x5106
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3833,7 +3863,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x42e4
+			// Method begins at RVA 0x4320
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -3877,7 +3907,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50a7
+				// Method begins at RVA 0x510f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3903,14 +3933,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4324
+			// Method begins at RVA 0x4360
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -3922,7 +3952,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_006a
+				IL_0018: brfalse IL_006c
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -3930,29 +3960,31 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "replace"
-				IL_0046: ldloc.3
-				IL_0047: ldstr "asdfasdfasdf"
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0051: stloc.3
-				IL_0052: ldarg.0
-				IL_0053: ldloc.3
-				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0059: ldloc.0
-				IL_005a: ldc.r8 1
-				IL_0063: add
-				IL_0064: stloc.0
-				IL_0065: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "replace"
+				IL_0048: ldloc.3
+				IL_0049: ldstr "asdfasdfasdf"
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0053: stloc.3
+				IL_0054: ldarg.0
+				IL_0055: ldloc.3
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
 			// end loop
 
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method FunctionExpression_L239C49::__js_call__
 
 	} // end of class FunctionExpression_L239C49
@@ -3968,7 +4000,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50b0
+				// Method begins at RVA 0x5118
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3994,7 +4026,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x439c
+			// Method begins at RVA 0x43dc
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -4042,7 +4074,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50c2
+					// Method begins at RVA 0x512a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4066,7 +4098,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4e84
+				// Method begins at RVA 0x4eec
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -4084,7 +4116,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50b9
+				// Method begins at RVA 0x5121
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4110,15 +4142,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x43dc
+			// Method begins at RVA 0x441c
 			// Header size: 12
-			// Code size: 148 (0x94)
+			// Code size: 150 (0x96)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/Scope,
 				[1] float64,
 				[2] float64,
-				[3] object,
+				[3] string,
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 			)
@@ -4133,7 +4165,7 @@
 				IL_0012: ldloc.2
 				IL_0013: ldc.r8 50
 				IL_001c: clt
-				IL_001e: brfalse IL_0092
+				IL_001e: brfalse IL_0094
 
 				IL_0023: ldarg.0
 				IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -4141,40 +4173,42 @@
 				IL_002e: ldloc.1
 				IL_002f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_0034: castclass [System.Runtime]System.String
-				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003e: stloc.3
-				IL_003f: ldarg.0
-				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0045: stloc.s 4
-				IL_0047: ldnull
-				IL_0048: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
-				IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-				IL_0053: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-				IL_0058: ldc.i4.1
-				IL_0059: conv.r8
-				IL_005a: ldstr ""
-				IL_005f: ldc.i4.0
-				IL_0060: ldc.i4.1
-				IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-				IL_0066: stloc.s 5
-				IL_0068: ldloc.3
-				IL_0069: ldstr "replace"
-				IL_006e: ldloc.s 4
-				IL_0070: ldloc.s 5
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0077: stloc.s 4
-				IL_0079: ldarg.0
-				IL_007a: ldloc.s 4
-				IL_007c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0081: ldloc.1
-				IL_0082: ldc.r8 1
-				IL_008b: add
-				IL_008c: stloc.1
-				IL_008d: br IL_0010
+				IL_0039: stloc.3
+				IL_003a: ldloc.3
+				IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_0040: stloc.3
+				IL_0041: ldarg.0
+				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0047: stloc.s 4
+				IL_0049: ldnull
+				IL_004a: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
+				IL_0050: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+				IL_0055: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+				IL_005a: ldc.i4.1
+				IL_005b: conv.r8
+				IL_005c: ldstr ""
+				IL_0061: ldc.i4.0
+				IL_0062: ldc.i4.1
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+				IL_0068: stloc.s 5
+				IL_006a: ldloc.3
+				IL_006b: ldstr "replace"
+				IL_0070: ldloc.s 4
+				IL_0072: ldloc.s 5
+				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0079: stloc.s 4
+				IL_007b: ldarg.0
+				IL_007c: ldloc.s 4
+				IL_007e: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0083: ldloc.1
+				IL_0084: ldc.r8 1
+				IL_008d: add
+				IL_008e: stloc.1
+				IL_008f: br IL_0010
 			// end loop
 
-			IL_0092: ldnull
-			IL_0093: ret
+			IL_0094: ldnull
+			IL_0095: ret
 		} // end of method FunctionExpression_L248C58::__js_call__
 
 	} // end of class FunctionExpression_L248C58
@@ -4190,7 +4224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50cb
+				// Method begins at RVA 0x5133
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4216,7 +4250,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x447c
+			// Method begins at RVA 0x44c0
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -4268,7 +4302,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50d4
+				// Method begins at RVA 0x513c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4294,14 +4328,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x44d4
+			// Method begins at RVA 0x4518
 			// Header size: 12
-			// Code size: 103 (0x67)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -4313,7 +4347,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0065
+				IL_0018: brfalse IL_0067
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -4321,28 +4355,30 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "match"
-				IL_0046: ldloc.3
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: ldc.r8 1
-				IL_005e: add
-				IL_005f: stloc.0
-				IL_0060: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "match"
+				IL_0048: ldloc.3
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_004e: stloc.3
+				IL_004f: ldarg.0
+				IL_0050: ldloc.3
+				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_000a
 			// end loop
 
-			IL_0065: ldnull
-			IL_0066: ret
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method FunctionExpression_L262C31::__js_call__
 
 	} // end of class FunctionExpression_L262C31
@@ -4358,7 +4394,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50dd
+				// Method begins at RVA 0x5145
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4384,7 +4420,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4548
+			// Method begins at RVA 0x4590
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -4428,7 +4464,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50e6
+				// Method begins at RVA 0x514e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4454,14 +4490,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4588
+			// Method begins at RVA 0x45d0
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -4473,7 +4509,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_006a
+				IL_0018: brfalse IL_006c
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -4481,29 +4517,31 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "replace"
-				IL_0046: ldloc.3
-				IL_0047: ldstr "asdfasdfasdf"
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0051: stloc.3
-				IL_0052: ldarg.0
-				IL_0053: ldloc.3
-				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0059: ldloc.0
-				IL_005a: ldc.r8 1
-				IL_0063: add
-				IL_0064: stloc.0
-				IL_0065: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "replace"
+				IL_0048: ldloc.3
+				IL_0049: ldstr "asdfasdfasdf"
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0053: stloc.3
+				IL_0054: ldarg.0
+				IL_0055: ldloc.3
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
 			// end loop
 
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method FunctionExpression_L271C33::__js_call__
 
 	} // end of class FunctionExpression_L271C33
@@ -4519,7 +4557,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50ef
+				// Method begins at RVA 0x5157
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4545,7 +4583,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4600
+			// Method begins at RVA 0x464c
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -4589,7 +4627,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50f8
+				// Method begins at RVA 0x5160
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4615,14 +4653,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4640
+			// Method begins at RVA 0x468c
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
+				[2] string,
 				[3] object
 			)
 
@@ -4634,7 +4672,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_006a
+				IL_0018: brfalse IL_006c
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -4642,29 +4680,31 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldarg.0
-				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_003f: stloc.3
-				IL_0040: ldloc.2
-				IL_0041: ldstr "replace"
-				IL_0046: ldloc.3
-				IL_0047: ldstr "asdf\\1asdfasdf"
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0051: stloc.3
-				IL_0052: ldarg.0
-				IL_0053: ldloc.3
-				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0059: ldloc.0
-				IL_005a: ldc.r8 1
-				IL_0063: add
-				IL_0064: stloc.0
-				IL_0065: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.3
+				IL_0042: ldloc.2
+				IL_0043: ldstr "replace"
+				IL_0048: ldloc.3
+				IL_0049: ldstr "asdf\\1asdfasdf"
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0053: stloc.3
+				IL_0054: ldarg.0
+				IL_0055: ldloc.3
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
 			// end loop
 
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method FunctionExpression_L280C46::__js_call__
 
 	} // end of class FunctionExpression_L280C46
@@ -4680,7 +4720,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5101
+				// Method begins at RVA 0x5169
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4706,7 +4746,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x46b8
+			// Method begins at RVA 0x4708
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -4754,7 +4794,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5113
+					// Method begins at RVA 0x517b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4779,7 +4819,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4e8c
+				// Method begins at RVA 0x4ef4
 				// Header size: 12
 				// Code size: 26 (0x1a)
 				.maxstack 8
@@ -4808,7 +4848,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x510a
+				// Method begins at RVA 0x5172
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4834,15 +4874,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x46f8
+			// Method begins at RVA 0x4748
 			// Header size: 12
-			// Code size: 148 (0x94)
+			// Code size: 150 (0x96)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/Scope,
 				[1] float64,
 				[2] float64,
-				[3] object,
+				[3] string,
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
 			)
@@ -4857,7 +4897,7 @@
 				IL_0012: ldloc.2
 				IL_0013: ldc.r8 50
 				IL_001c: clt
-				IL_001e: brfalse IL_0092
+				IL_001e: brfalse IL_0094
 
 				IL_0023: ldarg.0
 				IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -4865,40 +4905,42 @@
 				IL_002e: ldloc.1
 				IL_002f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_0034: castclass [System.Runtime]System.String
-				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003e: stloc.3
-				IL_003f: ldarg.0
-				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0045: stloc.s 4
-				IL_0047: ldnull
-				IL_0048: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
-				IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-				IL_0053: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-				IL_0058: ldc.i4.2
-				IL_0059: conv.r8
-				IL_005a: ldstr ""
-				IL_005f: ldc.i4.0
-				IL_0060: ldc.i4.1
-				IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-				IL_0066: stloc.s 5
-				IL_0068: ldloc.3
-				IL_0069: ldstr "replace"
-				IL_006e: ldloc.s 4
-				IL_0070: ldloc.s 5
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0077: stloc.s 4
-				IL_0079: ldarg.0
-				IL_007a: ldloc.s 4
-				IL_007c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0081: ldloc.1
-				IL_0082: ldc.r8 1
-				IL_008b: add
-				IL_008c: stloc.1
-				IL_008d: br IL_0010
+				IL_0039: stloc.3
+				IL_003a: ldloc.3
+				IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_0040: stloc.3
+				IL_0041: ldarg.0
+				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0047: stloc.s 4
+				IL_0049: ldnull
+				IL_004a: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
+				IL_0050: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+				IL_0055: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+				IL_005a: ldc.i4.2
+				IL_005b: conv.r8
+				IL_005c: ldstr ""
+				IL_0061: ldc.i4.0
+				IL_0062: ldc.i4.1
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+				IL_0068: stloc.s 5
+				IL_006a: ldloc.3
+				IL_006b: ldstr "replace"
+				IL_0070: ldloc.s 4
+				IL_0072: ldloc.s 5
+				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0079: stloc.s 4
+				IL_007b: ldarg.0
+				IL_007c: ldloc.s 4
+				IL_007e: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0083: ldloc.1
+				IL_0084: ldc.r8 1
+				IL_008d: add
+				IL_008e: stloc.1
+				IL_008f: br IL_0010
 			// end loop
 
-			IL_0092: ldnull
-			IL_0093: ret
+			IL_0094: ldnull
+			IL_0095: ret
 		} // end of method FunctionExpression_L289C55::__js_call__
 
 	} // end of class FunctionExpression_L289C55
@@ -4914,7 +4956,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x511c
+				// Method begins at RVA 0x5184
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4940,7 +4982,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4798
+			// Method begins at RVA 0x47ec
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -4988,7 +5030,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x512e
+					// Method begins at RVA 0x5196
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5013,7 +5055,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4eb4
+				// Method begins at RVA 0x4f1c
 				// Header size: 12
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -5039,7 +5081,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5125
+				// Method begins at RVA 0x518d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5065,15 +5107,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x47d8
+			// Method begins at RVA 0x482c
 			// Header size: 12
-			// Code size: 148 (0x94)
+			// Code size: 150 (0x96)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/Scope,
 				[1] float64,
 				[2] float64,
-				[3] object,
+				[3] string,
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
 			)
@@ -5088,7 +5130,7 @@
 				IL_0012: ldloc.2
 				IL_0013: ldc.r8 50
 				IL_001c: clt
-				IL_001e: brfalse IL_0092
+				IL_001e: brfalse IL_0094
 
 				IL_0023: ldarg.0
 				IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -5096,40 +5138,42 @@
 				IL_002e: ldloc.1
 				IL_002f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_0034: castclass [System.Runtime]System.String
-				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003e: stloc.3
-				IL_003f: ldarg.0
-				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0045: stloc.s 4
-				IL_0047: ldnull
-				IL_0048: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
-				IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-				IL_0053: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-				IL_0058: ldc.i4.2
-				IL_0059: conv.r8
-				IL_005a: ldstr ""
-				IL_005f: ldc.i4.0
-				IL_0060: ldc.i4.1
-				IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-				IL_0066: stloc.s 5
-				IL_0068: ldloc.3
-				IL_0069: ldstr "replace"
-				IL_006e: ldloc.s 4
-				IL_0070: ldloc.s 5
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0077: stloc.s 4
-				IL_0079: ldarg.0
-				IL_007a: ldloc.s 4
-				IL_007c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0081: ldloc.1
-				IL_0082: ldc.r8 1
-				IL_008b: add
-				IL_008c: stloc.1
-				IL_008d: br IL_0010
+				IL_0039: stloc.3
+				IL_003a: ldloc.3
+				IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_0040: stloc.3
+				IL_0041: ldarg.0
+				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0047: stloc.s 4
+				IL_0049: ldnull
+				IL_004a: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
+				IL_0050: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+				IL_0055: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+				IL_005a: ldc.i4.2
+				IL_005b: conv.r8
+				IL_005c: ldstr ""
+				IL_0061: ldc.i4.0
+				IL_0062: ldc.i4.1
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+				IL_0068: stloc.s 5
+				IL_006a: ldloc.3
+				IL_006b: ldstr "replace"
+				IL_0070: ldloc.s 4
+				IL_0072: ldloc.s 5
+				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0079: stloc.s 4
+				IL_007b: ldarg.0
+				IL_007c: ldloc.s 4
+				IL_007e: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0083: ldloc.1
+				IL_0084: ldc.r8 1
+				IL_008d: add
+				IL_008e: stloc.1
+				IL_008f: br IL_0010
 			// end loop
 
-			IL_0092: ldnull
-			IL_0093: ret
+			IL_0094: ldnull
+			IL_0095: ret
 		} // end of method FunctionExpression_L300C64::__js_call__
 
 	} // end of class FunctionExpression_L300C64
@@ -5145,7 +5189,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5137
+				// Method begins at RVA 0x519f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5171,7 +5215,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4878
+			// Method begins at RVA 0x48d0
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -5215,7 +5259,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5140
+				// Method begins at RVA 0x51a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5241,15 +5285,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x48b8
+			// Method begins at RVA 0x4910
 			// Header size: 12
-			// Code size: 112 (0x70)
+			// Code size: 116 (0x74)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[2] string,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[4] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -5260,7 +5305,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_006e
+				IL_0018: brfalse IL_0072
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -5268,29 +5313,31 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldstr "aaaaaaaaaa"
-				IL_003e: ldstr "g"
-				IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0048: stloc.3
-				IL_0049: ldloc.2
-				IL_004a: ldstr "match"
-				IL_004f: ldloc.3
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0055: stloc.2
-				IL_0056: ldarg.0
-				IL_0057: ldloc.2
-				IL_0058: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005d: ldloc.0
-				IL_005e: ldc.r8 1
-				IL_0067: add
-				IL_0068: stloc.0
-				IL_0069: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldstr "aaaaaaaaaa"
+				IL_0040: ldstr "g"
+				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_004a: stloc.3
+				IL_004b: ldloc.2
+				IL_004c: ldstr "match"
+				IL_0051: ldloc.3
+				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0057: stloc.s 4
+				IL_0059: ldarg.0
+				IL_005a: ldloc.s 4
+				IL_005c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0061: ldloc.0
+				IL_0062: ldc.r8 1
+				IL_006b: add
+				IL_006c: stloc.0
+				IL_006d: br IL_000a
 			// end loop
 
-			IL_006e: ldnull
-			IL_006f: ret
+			IL_0072: ldnull
+			IL_0073: ret
 		} // end of method FunctionExpression_L313C25::__js_call__
 
 	} // end of class FunctionExpression_L313C25
@@ -5306,7 +5353,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5149
+				// Method begins at RVA 0x51b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5332,7 +5379,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4934
+			// Method begins at RVA 0x4990
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -5376,7 +5423,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5152
+				// Method begins at RVA 0x51ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5402,16 +5449,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4974
+			// Method begins at RVA 0x49d0
 			// Header size: 12
-			// Code size: 116 (0x74)
+			// Code size: 111 (0x6f)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[3] object,
-				[4] string
+				[3] string,
+				[4] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -5422,39 +5469,38 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0072
+				IL_0018: brfalse IL_006d
 
 				IL_001d: ldstr "aaaaaaaaaa"
 				IL_0022: ldstr "g"
 				IL_0027: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 				IL_002c: stloc.2
 				IL_002d: ldloc.2
-				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0033: stloc.3
+				IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+				IL_0033: stloc.2
 				IL_0034: ldarg.0
 				IL_0035: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
 				IL_003a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_003f: ldloc.0
 				IL_0040: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_0045: castclass [System.Runtime]System.String
-				IL_004a: stloc.s 4
+				IL_004a: stloc.3
+				IL_004b: ldloc.2
 				IL_004c: ldloc.3
-				IL_004d: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-				IL_0052: ldloc.s 4
-				IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-				IL_0059: stloc.3
-				IL_005a: ldarg.0
-				IL_005b: ldloc.3
-				IL_005c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0061: ldloc.0
-				IL_0062: ldc.r8 1
-				IL_006b: add
-				IL_006c: stloc.0
-				IL_006d: br IL_000a
+				IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_0052: stloc.s 4
+				IL_0054: ldarg.0
+				IL_0055: ldloc.s 4
+				IL_0057: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005c: ldloc.0
+				IL_005d: ldc.r8 1
+				IL_0066: add
+				IL_0067: stloc.0
+				IL_0068: br IL_000a
 			// end loop
 
-			IL_0072: ldnull
-			IL_0073: ret
+			IL_006d: ldnull
+			IL_006e: ret
 		} // end of method FunctionExpression_L322C24::__js_call__
 
 	} // end of class FunctionExpression_L322C24
@@ -5470,7 +5516,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x515b
+				// Method begins at RVA 0x51c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5496,7 +5542,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x49f4
+			// Method begins at RVA 0x4a4c
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -5540,7 +5586,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5164
+				// Method begins at RVA 0x51cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5566,15 +5612,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4a34
+			// Method begins at RVA 0x4a8c
 			// Header size: 12
-			// Code size: 117 (0x75)
+			// Code size: 121 (0x79)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[2] string,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[4] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -5585,7 +5632,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_0073
+				IL_0018: brfalse IL_0077
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -5593,30 +5640,32 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldstr "aaaaaaaaaa"
-				IL_003e: ldstr "g"
-				IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0048: stloc.3
-				IL_0049: ldloc.2
-				IL_004a: ldstr "replace"
-				IL_004f: ldloc.3
-				IL_0050: ldstr ""
-				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_005a: stloc.2
-				IL_005b: ldarg.0
-				IL_005c: ldloc.2
-				IL_005d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0062: ldloc.0
-				IL_0063: ldc.r8 1
-				IL_006c: add
-				IL_006d: stloc.0
-				IL_006e: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldstr "aaaaaaaaaa"
+				IL_0040: ldstr "g"
+				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_004a: stloc.3
+				IL_004b: ldloc.2
+				IL_004c: ldstr "replace"
+				IL_0051: ldloc.3
+				IL_0052: ldstr ""
+				IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_005c: stloc.s 4
+				IL_005e: ldarg.0
+				IL_005f: ldloc.s 4
+				IL_0061: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0066: ldloc.0
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.0
+				IL_0072: br IL_000a
 			// end loop
 
-			IL_0073: ldnull
-			IL_0074: ret
+			IL_0077: ldnull
+			IL_0078: ret
 		} // end of method FunctionExpression_L331C33::__js_call__
 
 	} // end of class FunctionExpression_L331C33
@@ -5632,7 +5681,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x516d
+				// Method begins at RVA 0x51d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5658,7 +5707,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4ab8
+			// Method begins at RVA 0x4b14
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -5702,7 +5751,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5176
+				// Method begins at RVA 0x51de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5728,15 +5777,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4af8
+			// Method begins at RVA 0x4b54
 			// Header size: 12
-			// Code size: 117 (0x75)
+			// Code size: 121 (0x79)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[2] string,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[4] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -5747,7 +5797,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_0073
+				IL_0018: brfalse IL_0077
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -5755,30 +5805,32 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldstr "aaaaaaaaaa"
-				IL_003e: ldstr "g"
-				IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0048: stloc.3
-				IL_0049: ldloc.2
-				IL_004a: ldstr "replace"
-				IL_004f: ldloc.3
-				IL_0050: ldstr "asdfasdfasdf"
-				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_005a: stloc.2
-				IL_005b: ldarg.0
-				IL_005c: ldloc.2
-				IL_005d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0062: ldloc.0
-				IL_0063: ldc.r8 1
-				IL_006c: add
-				IL_006d: stloc.0
-				IL_006e: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldstr "aaaaaaaaaa"
+				IL_0040: ldstr "g"
+				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_004a: stloc.3
+				IL_004b: ldloc.2
+				IL_004c: ldstr "replace"
+				IL_0051: ldloc.3
+				IL_0052: ldstr "asdfasdfasdf"
+				IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_005c: stloc.s 4
+				IL_005e: ldarg.0
+				IL_005f: ldloc.s 4
+				IL_0061: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0066: ldloc.0
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.0
+				IL_0072: br IL_000a
 			// end loop
 
-			IL_0073: ldnull
-			IL_0074: ret
+			IL_0077: ldnull
+			IL_0078: ret
 		} // end of method FunctionExpression_L340C35::__js_call__
 
 	} // end of class FunctionExpression_L340C35
@@ -5794,7 +5846,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x517f
+				// Method begins at RVA 0x51e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5820,7 +5872,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4b7c
+			// Method begins at RVA 0x4bdc
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -5864,7 +5916,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5188
+				// Method begins at RVA 0x51f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5890,15 +5942,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4bbc
+			// Method begins at RVA 0x4c1c
 			// Header size: 12
-			// Code size: 112 (0x70)
+			// Code size: 116 (0x74)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[2] string,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[4] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -5909,7 +5962,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_006e
+				IL_0018: brfalse IL_0072
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -5917,29 +5970,31 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldstr "aaaaaaaaaa"
-				IL_003e: ldstr "g"
-				IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0048: stloc.3
-				IL_0049: ldloc.2
-				IL_004a: ldstr "match"
-				IL_004f: ldloc.3
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0055: stloc.2
-				IL_0056: ldarg.0
-				IL_0057: ldloc.2
-				IL_0058: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005d: ldloc.0
-				IL_005e: ldc.r8 1
-				IL_0067: add
-				IL_0068: stloc.0
-				IL_0069: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldstr "aaaaaaaaaa"
+				IL_0040: ldstr "g"
+				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_004a: stloc.3
+				IL_004b: ldloc.2
+				IL_004c: ldstr "match"
+				IL_0051: ldloc.3
+				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0057: stloc.s 4
+				IL_0059: ldarg.0
+				IL_005a: ldloc.s 4
+				IL_005c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0061: ldloc.0
+				IL_0062: ldc.r8 1
+				IL_006b: add
+				IL_006c: stloc.0
+				IL_006d: br IL_000a
 			// end loop
 
-			IL_006e: ldnull
-			IL_006f: ret
+			IL_0072: ldnull
+			IL_0073: ret
 		} // end of method FunctionExpression_L349C32::__js_call__
 
 	} // end of class FunctionExpression_L349C32
@@ -5955,7 +6010,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5191
+				// Method begins at RVA 0x51f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5981,7 +6036,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4c38
+			// Method begins at RVA 0x4c9c
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -6025,7 +6080,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x519a
+				// Method begins at RVA 0x5202
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6051,16 +6106,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4c78
+			// Method begins at RVA 0x4cdc
 			// Header size: 12
-			// Code size: 116 (0x74)
+			// Code size: 111 (0x6f)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[3] object,
-				[4] string
+				[3] string,
+				[4] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -6071,39 +6126,38 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0072
+				IL_0018: brfalse IL_006d
 
 				IL_001d: ldstr "aaaaaaaaaa"
 				IL_0022: ldstr "g"
 				IL_0027: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 				IL_002c: stloc.2
 				IL_002d: ldloc.2
-				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0033: stloc.3
+				IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+				IL_0033: stloc.2
 				IL_0034: ldarg.0
 				IL_0035: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
 				IL_003a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_003f: ldloc.0
 				IL_0040: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_0045: castclass [System.Runtime]System.String
-				IL_004a: stloc.s 4
+				IL_004a: stloc.3
+				IL_004b: ldloc.2
 				IL_004c: ldloc.3
-				IL_004d: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-				IL_0052: ldloc.s 4
-				IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-				IL_0059: stloc.3
-				IL_005a: ldarg.0
-				IL_005b: ldloc.3
-				IL_005c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0061: ldloc.0
-				IL_0062: ldc.r8 1
-				IL_006b: add
-				IL_006c: stloc.0
-				IL_006d: br IL_000a
+				IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_0052: stloc.s 4
+				IL_0054: ldarg.0
+				IL_0055: ldloc.s 4
+				IL_0057: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005c: ldloc.0
+				IL_005d: ldc.r8 1
+				IL_0066: add
+				IL_0067: stloc.0
+				IL_0068: br IL_000a
 			// end loop
 
-			IL_0072: ldnull
-			IL_0073: ret
+			IL_006d: ldnull
+			IL_006e: ret
 		} // end of method FunctionExpression_L358C31::__js_call__
 
 	} // end of class FunctionExpression_L358C31
@@ -6119,7 +6173,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51a3
+				// Method begins at RVA 0x520b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6145,7 +6199,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4cf8
+			// Method begins at RVA 0x4d58
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -6189,7 +6243,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51ac
+				// Method begins at RVA 0x5214
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6215,15 +6269,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4d38
+			// Method begins at RVA 0x4d98
 			// Header size: 12
-			// Code size: 117 (0x75)
+			// Code size: 121 (0x79)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[2] string,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[4] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -6234,7 +6289,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_0073
+				IL_0018: brfalse IL_0077
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -6242,30 +6297,32 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldstr "aaaaaaaaaa"
-				IL_003e: ldstr "g"
-				IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0048: stloc.3
-				IL_0049: ldloc.2
-				IL_004a: ldstr "replace"
-				IL_004f: ldloc.3
-				IL_0050: ldstr ""
-				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_005a: stloc.2
-				IL_005b: ldarg.0
-				IL_005c: ldloc.2
-				IL_005d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0062: ldloc.0
-				IL_0063: ldc.r8 1
-				IL_006c: add
-				IL_006d: stloc.0
-				IL_006e: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldstr "aaaaaaaaaa"
+				IL_0040: ldstr "g"
+				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_004a: stloc.3
+				IL_004b: ldloc.2
+				IL_004c: ldstr "replace"
+				IL_0051: ldloc.3
+				IL_0052: ldstr ""
+				IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_005c: stloc.s 4
+				IL_005e: ldarg.0
+				IL_005f: ldloc.s 4
+				IL_0061: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0066: ldloc.0
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.0
+				IL_0072: br IL_000a
 			// end loop
 
-			IL_0073: ldnull
-			IL_0074: ret
+			IL_0077: ldnull
+			IL_0078: ret
 		} // end of method FunctionExpression_L367C40::__js_call__
 
 	} // end of class FunctionExpression_L367C40
@@ -6281,7 +6338,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51b5
+				// Method begins at RVA 0x521d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6307,7 +6364,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4dbc
+			// Method begins at RVA 0x4e20
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -6351,7 +6408,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51be
+				// Method begins at RVA 0x5226
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6377,15 +6434,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4dfc
+			// Method begins at RVA 0x4e60
 			// Header size: 12
-			// Code size: 117 (0x75)
+			// Code size: 121 (0x79)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[2] string,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[4] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -6396,7 +6454,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 50
 				IL_0016: clt
-				IL_0018: brfalse IL_0073
+				IL_0018: brfalse IL_0077
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -6404,30 +6462,32 @@
 				IL_0028: ldloc.0
 				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_002e: castclass [System.Runtime]System.String
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0038: stloc.2
-				IL_0039: ldstr "aaaaaaaaaa"
-				IL_003e: ldstr "g"
-				IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0048: stloc.3
-				IL_0049: ldloc.2
-				IL_004a: ldstr "replace"
-				IL_004f: ldloc.3
-				IL_0050: ldstr "asdfasdfasdf"
-				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_005a: stloc.2
-				IL_005b: ldarg.0
-				IL_005c: ldloc.2
-				IL_005d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0062: ldloc.0
-				IL_0063: ldc.r8 1
-				IL_006c: add
-				IL_006d: stloc.0
-				IL_006e: br IL_000a
+				IL_0033: stloc.2
+				IL_0034: ldloc.2
+				IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_003a: stloc.2
+				IL_003b: ldstr "aaaaaaaaaa"
+				IL_0040: ldstr "g"
+				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_004a: stloc.3
+				IL_004b: ldloc.2
+				IL_004c: ldstr "replace"
+				IL_0051: ldloc.3
+				IL_0052: ldstr "asdfasdfasdf"
+				IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_005c: stloc.s 4
+				IL_005e: ldarg.0
+				IL_005f: ldloc.s 4
+				IL_0061: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0066: ldloc.0
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.0
+				IL_0072: br IL_000a
 			// end loop
 
-			IL_0073: ldnull
-			IL_0074: ret
+			IL_0077: ldnull
+			IL_0078: ret
 		} // end of method FunctionExpression_L376C42::__js_call__
 
 	} // end of class FunctionExpression_L376C42
@@ -6462,7 +6522,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4ed3
+			// Method begins at RVA 0x4f3b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -8031,7 +8091,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x51c7
+		// Method begins at RVA 0x522f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37f2
+				// Method begins at RVA 0x37fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37fb
+				// Method begins at RVA 0x3803
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +140,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3804
+				// Method begins at RVA 0x380c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -248,7 +248,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3816
+					// Method begins at RVA 0x381e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -272,7 +272,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36b4
+				// Method begins at RVA 0x36bc
 				// Header size: 12
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -309,7 +309,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x381f
+					// Method begins at RVA 0x3827
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -333,7 +333,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36dc
+				// Method begins at RVA 0x36e4
 				// Header size: 1
 				// Code size: 12 (0xc)
 				.maxstack 8
@@ -357,7 +357,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3828
+					// Method begins at RVA 0x3830
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -375,7 +375,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x380d
+				// Method begins at RVA 0x3815
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -772,7 +772,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3831
+				// Method begins at RVA 0x3839
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -802,7 +802,7 @@
 			)
 			// Method begins at RVA 0x28c8
 			// Header size: 12
-			// Code size: 216 (0xd8)
+			// Code size: 210 (0xd2)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -842,67 +842,69 @@
 			IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_0044: stloc.3
 			IL_0045: ldloc.3
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004b: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-			IL_0050: ldarg.2
-			IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0056: stloc.s 4
-			IL_0058: ldloc.s 4
-			IL_005a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_005f: stloc.2
-			IL_0060: ldloc.2
-			IL_0061: brfalse IL_007d
+			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_004b: stloc.3
+			IL_004c: ldloc.3
+			IL_004d: ldarg.2
+			IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0053: stloc.s 4
+			IL_0055: ldloc.s 4
+			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_005c: stloc.2
+			IL_005d: ldloc.2
+			IL_005e: brfalse IL_007a
 
-			IL_0066: ldc.i4.1
-			IL_0067: newarr [System.Runtime]System.Object
-			IL_006c: dup
-			IL_006d: ldc.i4.0
-			IL_006e: ldarg.0
-			IL_006f: stelem.ref
-			IL_0070: stloc.s 5
-			IL_0072: ldnull
-			IL_0073: ldarg.3
-			IL_0074: ldarg.2
-			IL_0075: tail.
-			IL_0077: call object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
-			IL_007c: ret
+			IL_0063: ldc.i4.1
+			IL_0064: newarr [System.Runtime]System.Object
+			IL_0069: dup
+			IL_006a: ldc.i4.0
+			IL_006b: ldarg.0
+			IL_006c: stelem.ref
+			IL_006d: stloc.s 5
+			IL_006f: ldnull
+			IL_0070: ldarg.3
+			IL_0071: ldarg.2
+			IL_0072: tail.
+			IL_0074: call object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
+			IL_0079: ret
 
-			IL_007d: ldstr "^\\d+\\.\\d+\\.\\d+$"
-			IL_0082: ldstr ""
-			IL_0087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_008c: stloc.3
-			IL_008d: ldloc.3
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0093: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-			IL_0098: ldarg.2
-			IL_0099: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_009e: stloc.s 4
-			IL_00a0: ldloc.s 4
-			IL_00a2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00a7: ldc.i4.0
-			IL_00a8: ceq
-			IL_00aa: stloc.2
-			IL_00ab: ldloc.2
-			IL_00ac: brfalse IL_00d6
+			IL_007a: ldstr "^\\d+\\.\\d+\\.\\d+$"
+			IL_007f: ldstr ""
+			IL_0084: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0089: stloc.3
+			IL_008a: ldloc.3
+			IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_0090: stloc.3
+			IL_0091: ldloc.3
+			IL_0092: ldarg.2
+			IL_0093: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0098: stloc.s 4
+			IL_009a: ldloc.s 4
+			IL_009c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00a1: ldc.i4.0
+			IL_00a2: ceq
+			IL_00a4: stloc.2
+			IL_00a5: ldloc.2
+			IL_00a6: brfalse IL_00d0
 
-			IL_00b1: ldstr "Explicit version must be major.minor.patch"
-			IL_00b6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00c0: stloc.1
-			IL_00c1: ldloc.1
-			IL_00c2: isinst [System.Runtime]System.Exception
-			IL_00c7: dup
-			IL_00c8: brtrue IL_00d5
+			IL_00ab: ldstr "Explicit version must be major.minor.patch"
+			IL_00b0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00ba: stloc.1
+			IL_00bb: ldloc.1
+			IL_00bc: isinst [System.Runtime]System.Exception
+			IL_00c1: dup
+			IL_00c2: brtrue IL_00cf
 
-			IL_00cd: pop
-			IL_00ce: ldloc.1
-			IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00d4: throw
+			IL_00c7: pop
+			IL_00c8: ldloc.1
+			IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00ce: throw
 
-			IL_00d5: throw
+			IL_00cf: throw
 
-			IL_00d6: ldarg.2
-			IL_00d7: ret
+			IL_00d0: ldarg.2
+			IL_00d1: ret
 		} // end of method resolveTargetVersion::__js_call__
 
 	} // end of class resolveTargetVersion
@@ -922,7 +924,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3843
+					// Method begins at RVA 0x384b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -940,7 +942,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x383a
+				// Method begins at RVA 0x3842
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -965,7 +967,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29ac
+			// Method begins at RVA 0x29a8
 			// Header size: 12
 			// Code size: 171 (0xab)
 			.maxstack 8
@@ -1056,7 +1058,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3855
+					// Method begins at RVA 0x385d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1074,7 +1076,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x384c
+				// Method begins at RVA 0x3854
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1099,16 +1101,17 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a64
+			// Method begins at RVA 0x2a60
 			// Header size: 12
-			// Code size: 143 (0x8f)
+			// Code size: 142 (0x8e)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[1] object,
-				[2] object,
-				[3] bool,
-				[4] string
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[3] object,
+				[4] bool,
+				[5] string
 			)
 
 			IL_0000: ldstr "<JrocPackageVersion\\b([^>]*)>[^<]+<\\/JrocPackageVersion>"
@@ -1116,55 +1119,56 @@
 			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_000f: stloc.0
 			IL_0010: ldloc.0
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0016: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-			IL_001b: ldarg.1
-			IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0021: stloc.2
-			IL_0022: ldloc.2
-			IL_0023: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0028: ldc.i4.0
-			IL_0029: ceq
-			IL_002b: stloc.3
-			IL_002c: ldloc.3
-			IL_002d: brfalse IL_0057
+			IL_0011: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_0016: stloc.2
+			IL_0017: ldloc.2
+			IL_0018: ldarg.1
+			IL_0019: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_001e: stloc.3
+			IL_001f: ldloc.3
+			IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0025: ldc.i4.0
+			IL_0026: ceq
+			IL_0028: stloc.s 4
+			IL_002a: ldloc.s 4
+			IL_002c: brfalse IL_0056
 
-			IL_0032: ldstr "Could not find <JrocPackageVersion> in samples/Directory.Build.props"
-			IL_0037: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_003c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0041: stloc.1
-			IL_0042: ldloc.1
-			IL_0043: isinst [System.Runtime]System.Exception
-			IL_0048: dup
-			IL_0049: brtrue IL_0056
+			IL_0031: ldstr "Could not find <JrocPackageVersion> in samples/Directory.Build.props"
+			IL_0036: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_003b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0040: stloc.1
+			IL_0041: ldloc.1
+			IL_0042: isinst [System.Runtime]System.Exception
+			IL_0047: dup
+			IL_0048: brtrue IL_0055
 
-			IL_004e: pop
-			IL_004f: ldloc.1
-			IL_0050: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_004d: pop
+			IL_004e: ldloc.1
+			IL_004f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0054: throw
+
 			IL_0055: throw
 
-			IL_0056: throw
-
-			IL_0057: ldarg.1
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005d: stloc.2
-			IL_005e: ldarg.2
-			IL_005f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0064: stloc.s 4
-			IL_0066: ldstr "<JrocPackageVersion$1>"
-			IL_006b: ldloc.s 4
-			IL_006d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0072: ldstr "</JrocPackageVersion>"
-			IL_0077: call string [System.Runtime]System.String::Concat(string, string)
-			IL_007c: stloc.s 4
-			IL_007e: ldloc.2
-			IL_007f: ldstr "replace"
-			IL_0084: ldloc.0
-			IL_0085: ldloc.s 4
-			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_008c: stloc.2
-			IL_008d: ldloc.2
-			IL_008e: ret
+			IL_0056: ldarg.1
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005c: stloc.3
+			IL_005d: ldarg.2
+			IL_005e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0063: stloc.s 5
+			IL_0065: ldstr "<JrocPackageVersion$1>"
+			IL_006a: ldloc.s 5
+			IL_006c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0071: ldstr "</JrocPackageVersion>"
+			IL_0076: call string [System.Runtime]System.String::Concat(string, string)
+			IL_007b: stloc.s 5
+			IL_007d: ldloc.3
+			IL_007e: ldstr "replace"
+			IL_0083: ldloc.0
+			IL_0084: ldloc.s 5
+			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_008b: stloc.3
+			IL_008c: ldloc.3
+			IL_008d: ret
 		} // end of method updateSamplesPropsVersion::__js_call__
 
 	} // end of class updateSamplesPropsVersion
@@ -1184,7 +1188,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3867
+					// Method begins at RVA 0x386f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1202,7 +1206,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x385e
+				// Method begins at RVA 0x3866
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1229,7 +1233,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2b00
+			// Method begins at RVA 0x2afc
 			// Header size: 12
 			// Code size: 534 (0x216)
 			.maxstack 8
@@ -1439,7 +1443,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3870
+				// Method begins at RVA 0x3878
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1463,14 +1467,13 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d24
+			// Method begins at RVA 0x2d20
 			// Header size: 12
-			// Code size: 55 (0x37)
+			// Code size: 50 (0x32)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object,
-				[2] object
+				[1] object
 			)
 
 			IL_0000: ldstr "^_Nothing yet\\._"
@@ -1478,20 +1481,19 @@
 			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_000f: stloc.0
 			IL_0010: ldloc.0
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0016: stloc.1
+			IL_0011: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_0016: stloc.0
 			IL_0017: ldarg.1
 			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_001d: ldstr "trim"
 			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0027: stloc.2
-			IL_0028: ldloc.1
-			IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-			IL_002e: ldloc.2
-			IL_002f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0034: stloc.2
-			IL_0035: ldloc.2
-			IL_0036: ret
+			IL_0027: stloc.1
+			IL_0028: ldloc.0
+			IL_0029: ldloc.1
+			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_002f: stloc.1
+			IL_0030: ldloc.1
+			IL_0031: ret
 		} // end of method isPlaceholder::__js_call__
 
 	} // end of class isPlaceholder
@@ -1517,7 +1519,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3882
+					// Method begins at RVA 0x388a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1542,7 +1544,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36ec
+				// Method begins at RVA 0x36f4
 				// Header size: 12
 				// Code size: 126 (0x7e)
 				.maxstack 8
@@ -1622,7 +1624,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3879
+				// Method begins at RVA 0x3881
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1650,123 +1652,128 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2d68
+			// Method begins at RVA 0x2d60
 			// Header size: 12
-			// Code size: 324 (0x144)
+			// Code size: 338 (0x152)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/Scope,
 				[1] object,
 				[2] object,
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1,
-				[6] bool,
-				[7] string
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.Date,
+				[4] object,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1,
+				[7] bool,
+				[8] string
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Scripts_BumpVersion/generateReleaseSection/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Date::Construct()
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0010: ldstr "toISOString"
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_001a: stloc.3
-			IL_001b: ldloc.3
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0021: ldstr "slice"
-			IL_0026: ldc.r8 0.0
-			IL_002f: box [System.Runtime]System.Double
-			IL_0034: ldc.r8 10
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0047: stloc.1
-			IL_0048: ldarg.3
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004e: stloc.3
-			IL_004f: ldstr "\\r?\\n"
-			IL_0054: ldstr ""
-			IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_005e: stloc.s 4
-			IL_0060: ldloc.3
-			IL_0061: ldstr "split"
-			IL_0066: ldloc.s 4
-			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_006d: stloc.3
-			IL_006e: ldloc.3
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0074: stloc.3
-			IL_0075: ldnull
-			IL_0076: ldftn object Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44::__js_call__(object[], object, object)
-			IL_007c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0081: ldc.i4.2
-			IL_0082: newarr [System.Runtime]System.Object
-			IL_0087: dup
-			IL_0088: ldc.i4.0
-			IL_0089: ldarg.0
-			IL_008a: stelem.ref
-			IL_008b: dup
-			IL_008c: ldc.i4.1
-			IL_008d: ldloc.0
-			IL_008e: stelem.ref
-			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0099: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-			IL_009e: ldc.i4.1
-			IL_009f: conv.r8
-			IL_00a0: ldstr ""
-			IL_00a5: ldc.i4.0
-			IL_00a6: ldc.i4.0
-			IL_00a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-			IL_00ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-			IL_00b1: stloc.s 5
-			IL_00b3: ldloc.3
-			IL_00b4: ldstr "filter"
-			IL_00b9: ldloc.s 5
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00c0: stloc.3
-			IL_00c1: ldloc.3
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c7: ldstr "join"
-			IL_00cc: ldstr "\n"
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00d6: stloc.2
-			IL_00d7: ldloc.2
-			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00dd: ldc.i4.0
-			IL_00de: ceq
-			IL_00e0: stloc.s 6
-			IL_00e2: ldloc.s 6
-			IL_00e4: brfalse IL_00f3
-
-			IL_00e9: ldstr "\n"
+			IL_000b: stloc.3
+			IL_000c: ldloc.3
+			IL_000d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Date>(!!0)
+			IL_0012: stloc.3
+			IL_0013: ldloc.3
+			IL_0014: ldstr "toISOString"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_001e: stloc.s 4
+			IL_0020: ldloc.s 4
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0027: ldstr "slice"
+			IL_002c: ldc.r8 0.0
+			IL_0035: box [System.Runtime]System.Double
+			IL_003a: ldc.r8 10
+			IL_0043: box [System.Runtime]System.Double
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_004d: stloc.1
+			IL_004e: ldarg.3
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0054: stloc.s 4
+			IL_0056: ldstr "\\r?\\n"
+			IL_005b: ldstr ""
+			IL_0060: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0065: stloc.s 5
+			IL_0067: ldloc.s 4
+			IL_0069: ldstr "split"
+			IL_006e: ldloc.s 5
+			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0075: stloc.s 4
+			IL_0077: ldloc.s 4
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_007e: stloc.s 4
+			IL_0080: ldnull
+			IL_0081: ldftn object Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44::__js_call__(object[], object, object)
+			IL_0087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_008c: ldc.i4.2
+			IL_008d: newarr [System.Runtime]System.Object
+			IL_0092: dup
+			IL_0093: ldc.i4.0
+			IL_0094: ldarg.0
+			IL_0095: stelem.ref
+			IL_0096: dup
+			IL_0097: ldc.i4.1
+			IL_0098: ldloc.0
+			IL_0099: stelem.ref
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00a4: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+			IL_00a9: ldc.i4.1
+			IL_00aa: conv.r8
+			IL_00ab: ldstr ""
+			IL_00b0: ldc.i4.0
+			IL_00b1: ldc.i4.0
+			IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+			IL_00b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+			IL_00bc: stloc.s 6
+			IL_00be: ldloc.s 4
+			IL_00c0: ldstr "filter"
+			IL_00c5: ldloc.s 6
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00cc: stloc.s 4
+			IL_00ce: ldloc.s 4
+			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d5: ldstr "join"
+			IL_00da: ldstr "\n"
+			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00e4: stloc.2
+			IL_00e5: ldloc.2
+			IL_00e6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00eb: ldc.i4.0
+			IL_00ec: ceq
 			IL_00ee: stloc.s 7
 			IL_00f0: ldloc.s 7
-			IL_00f2: stloc.2
+			IL_00f2: brfalse IL_0101
 
-			IL_00f3: ldarg.2
-			IL_00f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00f9: stloc.s 7
-			IL_00fb: ldstr "## v"
-			IL_0100: ldloc.s 7
-			IL_0102: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0107: ldstr " - "
-			IL_010c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0111: ldloc.1
-			IL_0112: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0117: stloc.s 7
-			IL_0119: ldloc.s 7
-			IL_011b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0120: ldstr "\n\n"
-			IL_0125: call string [System.Runtime]System.String::Concat(string, string)
-			IL_012a: ldloc.2
-			IL_012b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0130: stloc.s 7
-			IL_0132: ldloc.s 7
-			IL_0134: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0139: ldstr "\n"
-			IL_013e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0143: ret
+			IL_00f7: ldstr "\n"
+			IL_00fc: stloc.s 8
+			IL_00fe: ldloc.s 8
+			IL_0100: stloc.2
+
+			IL_0101: ldarg.2
+			IL_0102: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0107: stloc.s 8
+			IL_0109: ldstr "## v"
+			IL_010e: ldloc.s 8
+			IL_0110: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0115: ldstr " - "
+			IL_011a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_011f: ldloc.1
+			IL_0120: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0125: stloc.s 8
+			IL_0127: ldloc.s 8
+			IL_0129: call string [System.Runtime]System.String::Concat(string, string)
+			IL_012e: ldstr "\n\n"
+			IL_0133: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0138: ldloc.2
+			IL_0139: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_013e: stloc.s 8
+			IL_0140: ldloc.s 8
+			IL_0142: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0147: ldstr "\n"
+			IL_014c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0151: ret
 		} // end of method generateReleaseSection::__js_call__
 
 	} // end of class generateReleaseSection
@@ -1792,7 +1799,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x389d
+					// Method begins at RVA 0x38a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1817,7 +1824,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3778
+				// Method begins at RVA 0x3780
 				// Header size: 12
 				// Code size: 101 (0x65)
 				.maxstack 8
@@ -1893,7 +1900,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3894
+					// Method begins at RVA 0x389c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1913,7 +1920,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38a6
+					// Method begins at RVA 0x38ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1931,7 +1938,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x388b
+				// Method begins at RVA 0x3893
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1957,7 +1964,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2eb8
+			// Method begins at RVA 0x2ec0
 			// Header size: 12
 			// Code size: 2030 (0x7ee)
 			.maxstack 8
@@ -2794,7 +2801,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38af
+				// Method begins at RVA 0x38b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2814,7 +2821,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38b8
+				// Method begins at RVA 0x38c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2852,7 +2859,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x37e9
+			// Method begins at RVA 0x37f1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3296,7 +3303,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x38c1
+		// Method begins at RVA 0x38c9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3161
+				// Method begins at RVA 0x3169
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x317c
+						// Method begins at RVA 0x3184
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3185
+						// Method begins at RVA 0x318d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x318e
+						// Method begins at RVA 0x3196
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3197
+						// Method begins at RVA 0x319f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -124,7 +124,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3173
+					// Method begins at RVA 0x317b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -142,7 +142,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x316a
+				// Method begins at RVA 0x3172
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -445,7 +445,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31a9
+					// Method begins at RVA 0x31b1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -472,7 +472,7 @@
 				)
 				// Method begins at RVA 0x2bbc
 				// Header size: 12
-				// Code size: 405 (0x195)
+				// Code size: 409 (0x199)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -567,61 +567,63 @@
 				IL_00d3: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::min(object[])
 				IL_00d8: stloc.s 4
 				IL_00da: ldstr "#"
-				IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00e4: ldloc.s 4
-				IL_00e6: box [System.Runtime]System.Double
-				IL_00eb: stloc.s 12
-				IL_00ed: ldstr "repeat"
-				IL_00f2: ldloc.s 12
-				IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00f9: stloc.s 5
-				IL_00fb: ldarg.1
-				IL_00fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0101: stloc.s 8
-				IL_0103: ldloc.s 8
-				IL_0105: brtrue IL_0116
+				IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_00e4: stloc.s 11
+				IL_00e6: ldloc.s 4
+				IL_00e8: box [System.Runtime]System.Double
+				IL_00ed: stloc.s 12
+				IL_00ef: ldloc.s 11
+				IL_00f1: ldstr "repeat"
+				IL_00f6: ldloc.s 12
+				IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00fd: stloc.s 5
+				IL_00ff: ldarg.1
+				IL_0100: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0105: stloc.s 8
+				IL_0107: ldloc.s 8
+				IL_0109: brtrue IL_011a
 
-				IL_010a: ldstr ""
-				IL_010f: stloc.s 13
-				IL_0111: br IL_0119
+				IL_010e: ldstr ""
+				IL_0113: stloc.s 13
+				IL_0115: br IL_011d
 
-				IL_0116: ldarg.1
-				IL_0117: stloc.s 13
+				IL_011a: ldarg.1
+				IL_011b: stloc.s 13
 
-				IL_0119: ldloc.s 13
-				IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0120: stloc.s 7
-				IL_0122: ldstr "\\s+"
-				IL_0127: ldstr "g"
-				IL_012c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0131: stloc.s 14
-				IL_0133: ldloc.s 7
-				IL_0135: ldstr "replace"
-				IL_013a: ldloc.s 14
-				IL_013c: ldstr " "
-				IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0146: stloc.s 7
-				IL_0148: ldloc.s 7
-				IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_014f: ldstr "trim"
-				IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0159: stloc.s 6
-				IL_015b: ldloc.s 5
-				IL_015d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0162: stloc.s 11
-				IL_0164: ldstr "\n\n"
-				IL_0169: ldloc.s 11
-				IL_016b: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0170: ldstr " "
-				IL_0175: call string [System.Runtime]System.String::Concat(string, string)
-				IL_017a: ldloc.s 6
-				IL_017c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0181: stloc.s 11
-				IL_0183: ldloc.s 11
-				IL_0185: call string [System.Runtime]System.String::Concat(string, string)
-				IL_018a: ldstr "\n\n"
-				IL_018f: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0194: ret
+				IL_011d: ldloc.s 13
+				IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0124: stloc.s 7
+				IL_0126: ldstr "\\s+"
+				IL_012b: ldstr "g"
+				IL_0130: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_0135: stloc.s 14
+				IL_0137: ldloc.s 7
+				IL_0139: ldstr "replace"
+				IL_013e: ldloc.s 14
+				IL_0140: ldstr " "
+				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_014a: stloc.s 7
+				IL_014c: ldloc.s 7
+				IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0153: ldstr "trim"
+				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_015d: stloc.s 6
+				IL_015f: ldloc.s 5
+				IL_0161: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0166: stloc.s 11
+				IL_0168: ldstr "\n\n"
+				IL_016d: ldloc.s 11
+				IL_016f: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0174: ldstr " "
+				IL_0179: call string [System.Runtime]System.String::Concat(string, string)
+				IL_017e: ldloc.s 6
+				IL_0180: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0185: stloc.s 11
+				IL_0187: ldloc.s 11
+				IL_0189: call string [System.Runtime]System.String::Concat(string, string)
+				IL_018e: ldstr "\n\n"
+				IL_0193: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0198: ret
 			} // end of method FunctionExpression_L61C15::__js_call__
 
 		} // end of class FunctionExpression_L61C15
@@ -637,7 +639,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31b2
+					// Method begins at RVA 0x31ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -661,7 +663,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d60
+				// Method begins at RVA 0x2d64
 				// Header size: 12
 				// Code size: 140 (0x8c)
 				.maxstack 8
@@ -739,7 +741,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31bb
+					// Method begins at RVA 0x31c3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -763,7 +765,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2df8
+				// Method begins at RVA 0x2dfc
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -809,7 +811,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31cd
+						// Method begins at RVA 0x31d5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -833,9 +835,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3018
+					// Method begins at RVA 0x301c
 					// Header size: 12
-					// Code size: 221 (0xdd)
+					// Code size: 225 (0xe1)
 					.maxstack 8
 					.locals init (
 						[0] object,
@@ -892,55 +894,57 @@
 					IL_005c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_0061: stloc.3
 					IL_0062: ldloc.3
-					IL_0063: brfalse IL_0096
+					IL_0063: brfalse IL_009a
 
 					IL_0068: ldstr "(?:^|\\s)language-([^\\s]+)"
 					IL_006d: ldstr "i"
 					IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 					IL_0077: stloc.s 7
 					IL_0079: ldloc.s 7
-					IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0080: ldstr "exec"
-					IL_0085: ldloc.1
-					IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_008b: stloc.s 4
-					IL_008d: ldloc.s 4
-					IL_008f: stloc.s 8
-					IL_0091: br IL_0099
+					IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+					IL_0080: stloc.s 7
+					IL_0082: ldloc.s 7
+					IL_0084: ldstr "exec"
+					IL_0089: ldloc.1
+					IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_008f: stloc.s 4
+					IL_0091: ldloc.s 4
+					IL_0093: stloc.s 8
+					IL_0095: br IL_009d
 
-					IL_0096: ldloc.1
-					IL_0097: stloc.s 8
+					IL_009a: ldloc.1
+					IL_009b: stloc.s 8
 
-					IL_0099: ldloc.s 8
-					IL_009b: stloc.2
-					IL_009c: ldloc.2
-					IL_009d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00a2: stloc.3
-					IL_00a3: ldloc.3
-					IL_00a4: brfalse IL_00c3
+					IL_009d: ldloc.s 8
+					IL_009f: stloc.2
+					IL_00a0: ldloc.2
+					IL_00a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00a6: stloc.3
+					IL_00a7: ldloc.3
+					IL_00a8: brfalse IL_00c7
 
-					IL_00a9: ldloc.2
-					IL_00aa: ldc.r8 1
-					IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-					IL_00b8: stloc.s 4
-					IL_00ba: ldloc.s 4
-					IL_00bc: stloc.s 9
-					IL_00be: br IL_00c6
+					IL_00ad: ldloc.2
+					IL_00ae: ldc.r8 1
+					IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_00bc: stloc.s 4
+					IL_00be: ldloc.s 4
+					IL_00c0: stloc.s 9
+					IL_00c2: br IL_00ca
 
-					IL_00c3: ldloc.2
-					IL_00c4: stloc.s 9
+					IL_00c7: ldloc.2
+					IL_00c8: stloc.s 9
 
-					IL_00c6: ldloc.s 9
-					IL_00c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00cd: stloc.3
-					IL_00ce: ldloc.3
-					IL_00cf: brtrue IL_00da
+					IL_00ca: ldloc.s 9
+					IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00d1: stloc.3
+					IL_00d2: ldloc.3
+					IL_00d3: brtrue IL_00de
 
-					IL_00d4: ldstr ""
-					IL_00d9: ret
+					IL_00d8: ldstr ""
+					IL_00dd: ret
 
-					IL_00da: ldloc.s 9
-					IL_00dc: ret
+					IL_00de: ldloc.s 9
+					IL_00e0: ret
 				} // end of method ArrowFunction_L90C29::__js_call__
 
 			} // end of class ArrowFunction_L90C29
@@ -956,7 +960,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31d6
+						// Method begins at RVA 0x31de
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -974,7 +978,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31c4
+					// Method begins at RVA 0x31cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1000,7 +1004,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e24
+				// Method begins at RVA 0x2e28
 				// Header size: 12
 				// Code size: 488 (0x1e8)
 				.maxstack 8
@@ -1203,7 +1207,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31a0
+				// Method begins at RVA 0x31a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1468,7 +1472,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31df
+				// Method begins at RVA 0x31e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1893,7 +1897,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31f1
+					// Method begins at RVA 0x31f9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1913,7 +1917,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31fa
+					// Method begins at RVA 0x3202
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1931,7 +1935,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e8
+				// Method begins at RVA 0x31f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1957,7 +1961,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3158
+			// Method begins at RVA 0x3160
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2191,7 +2195,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x320c
+				// Method begins at RVA 0x3214
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2214,7 +2218,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3101
+			// Method begins at RVA 0x3109
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2243,7 +2247,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3215
+				// Method begins at RVA 0x321d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2268,7 +2272,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3104
+			// Method begins at RVA 0x310c
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -2305,7 +2309,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x321e
+				// Method begins at RVA 0x3226
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2329,7 +2333,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x311c
+			// Method begins at RVA 0x3124
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -2383,7 +2387,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3203
+			// Method begins at RVA 0x320b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2494,7 +2498,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3227
+		// Method begins at RVA 0x322f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3414
+				// Method begins at RVA 0x3418
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,14 +44,14 @@
 			)
 			// Method begins at RVA 0x2268
 			// Header size: 12
-			// Code size: 185 (0xb9)
+			// Code size: 193 (0xc1)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] string,
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[4] object,
 				[5] float64
 			)
 
@@ -59,64 +59,64 @@
 			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0006: stloc.2
 			IL_0007: ldloc.2
-			IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000d: stloc.3
+			IL_0008: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_000d: stloc.2
 			IL_000e: ldstr "\\\\"
 			IL_0013: ldstr "g"
 			IL_0018: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_001d: stloc.s 4
-			IL_001f: ldloc.3
-			IL_0020: ldstr "replace"
-			IL_0025: ldloc.s 4
-			IL_0027: ldstr "/"
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0031: stloc.0
-			IL_0032: ldloc.0
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0038: ldstr "split"
-			IL_003d: ldstr "/"
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0047: stloc.3
-			IL_0048: ldloc.3
+			IL_001d: stloc.3
+			IL_001e: ldloc.2
+			IL_001f: ldstr "replace"
+			IL_0024: ldloc.3
+			IL_0025: ldstr "/"
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_002f: stloc.0
+			IL_0030: ldloc.0
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0036: ldstr "split"
+			IL_003b: ldstr "/"
+			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0045: stloc.s 4
+			IL_0047: ldloc.s 4
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_004e: ldstr "Boolean"
 			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0058: stloc.3
-			IL_0059: ldstr "filter"
-			IL_005e: ldloc.3
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0064: stloc.1
-			IL_0065: ldloc.1
-			IL_0066: ldstr "length"
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0070: stloc.3
-			IL_0071: ldloc.3
-			IL_0072: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0077: ldc.r8 0.0
-			IL_0080: cgt
-			IL_0082: brfalse IL_00b0
+			IL_0058: stloc.s 4
+			IL_005a: ldstr "filter"
+			IL_005f: ldloc.s 4
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0066: stloc.1
+			IL_0067: ldloc.1
+			IL_0068: ldstr "length"
+			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0072: stloc.s 4
+			IL_0074: ldloc.s 4
+			IL_0076: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_007b: ldc.r8 0.0
+			IL_0084: cgt
+			IL_0086: brfalse IL_00b8
 
-			IL_0087: ldloc.1
-			IL_0088: ldstr "length"
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0092: stloc.3
-			IL_0093: ldloc.3
-			IL_0094: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0099: ldc.r8 1
-			IL_00a2: sub
-			IL_00a3: stloc.s 5
-			IL_00a5: ldloc.1
-			IL_00a6: ldloc.s 5
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00ad: stloc.3
-			IL_00ae: ldloc.3
-			IL_00af: ret
+			IL_008b: ldloc.1
+			IL_008c: ldstr "length"
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0096: stloc.s 4
+			IL_0098: ldloc.s 4
+			IL_009a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_009f: ldc.r8 1
+			IL_00a8: sub
+			IL_00a9: stloc.s 5
+			IL_00ab: ldloc.1
+			IL_00ac: ldloc.s 5
+			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00b3: stloc.s 4
+			IL_00b5: ldloc.s 4
+			IL_00b7: ret
 
-			IL_00b0: ldarg.1
-			IL_00b1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00b6: stloc.2
-			IL_00b7: ldloc.2
-			IL_00b8: ret
+			IL_00b8: ldarg.1
+			IL_00b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00be: stloc.2
+			IL_00bf: ldloc.2
+			IL_00c0: ret
 		} // end of method getAssemblyFileBaseName::__js_call__
 
 	} // end of class getAssemblyFileBaseName
@@ -136,7 +136,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3426
+					// Method begins at RVA 0x342a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x341d
+				// Method begins at RVA 0x3421
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -181,9 +181,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2330
+			// Method begins at RVA 0x2338
 			// Header size: 12
-			// Code size: 278 (0x116)
+			// Code size: 273 (0x111)
 			.maxstack 10
 			.locals init (
 				[0] object,
@@ -200,92 +200,91 @@
 			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0006: stloc.2
 			IL_0007: ldloc.2
-			IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000d: stloc.3
-			IL_000e: ldloc.3
-			IL_000f: castclass [System.Runtime]System.String
-			IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0019: stloc.2
-			IL_001a: ldloc.2
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0020: stloc.3
-			IL_0021: ldstr "[\\\\/]+"
-			IL_0026: ldstr "g"
-			IL_002b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0030: stloc.s 4
-			IL_0032: ldloc.3
-			IL_0033: ldstr "replace"
-			IL_0038: ldloc.s 4
-			IL_003a: ldstr "."
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0044: stloc.3
-			IL_0045: ldloc.3
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004b: ldstr "split"
-			IL_0050: ldstr "."
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_005a: stloc.3
-			IL_005b: ldloc.3
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0061: ldstr "Boolean"
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_006b: stloc.3
-			IL_006c: ldstr "filter"
-			IL_0071: ldloc.3
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0077: stloc.0
-			IL_0078: ldloc.0
-			IL_0079: ldstr "length"
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0083: stloc.3
-			IL_0084: ldloc.3
-			IL_0085: ldc.r8 0.0
-			IL_008e: box [System.Runtime]System.Double
-			IL_0093: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0098: stloc.s 5
-			IL_009a: ldloc.s 5
-			IL_009c: brfalse IL_00c6
+			IL_0008: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_000d: stloc.2
+			IL_000e: ldloc.2
+			IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0014: stloc.2
+			IL_0015: ldloc.2
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001b: stloc.3
+			IL_001c: ldstr "[\\\\/]+"
+			IL_0021: ldstr "g"
+			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_002b: stloc.s 4
+			IL_002d: ldloc.3
+			IL_002e: ldstr "replace"
+			IL_0033: ldloc.s 4
+			IL_0035: ldstr "."
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_003f: stloc.3
+			IL_0040: ldloc.3
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0046: ldstr "split"
+			IL_004b: ldstr "."
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0055: stloc.3
+			IL_0056: ldloc.3
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005c: ldstr "Boolean"
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0066: stloc.3
+			IL_0067: ldstr "filter"
+			IL_006c: ldloc.3
+			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0072: stloc.0
+			IL_0073: ldloc.0
+			IL_0074: ldstr "length"
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007e: stloc.3
+			IL_007f: ldloc.3
+			IL_0080: ldc.r8 0.0
+			IL_0089: box [System.Runtime]System.Double
+			IL_008e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0093: stloc.s 5
+			IL_0095: ldloc.s 5
+			IL_0097: brfalse IL_00c1
 
-			IL_00a1: ldstr "Category must contain at least one name segment."
-			IL_00a6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00b0: stloc.1
-			IL_00b1: ldloc.1
-			IL_00b2: isinst [System.Runtime]System.Exception
-			IL_00b7: dup
-			IL_00b8: brtrue IL_00c5
+			IL_009c: ldstr "Category must contain at least one name segment."
+			IL_00a1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00ab: stloc.1
+			IL_00ac: ldloc.1
+			IL_00ad: isinst [System.Runtime]System.Exception
+			IL_00b2: dup
+			IL_00b3: brtrue IL_00c0
 
-			IL_00bd: pop
-			IL_00be: ldloc.1
-			IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00c4: throw
+			IL_00b8: pop
+			IL_00b9: ldloc.1
+			IL_00ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00bf: throw
 
-			IL_00c5: throw
+			IL_00c0: throw
 
-			IL_00c6: ldloc.0
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00cc: ldstr "join"
-			IL_00d1: ldstr "."
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00db: stloc.3
-			IL_00dc: ldloc.0
-			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e2: ldstr "join"
-			IL_00e7: ldstr "/"
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00f1: stloc.s 6
-			IL_00f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00f8: dup
-			IL_00f9: ldstr "namespace"
-			IL_00fe: ldloc.3
-			IL_00ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0104: dup
-			IL_0105: ldstr "path"
-			IL_010a: ldloc.s 6
-			IL_010c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0111: stloc.s 7
-			IL_0113: ldloc.s 7
-			IL_0115: ret
+			IL_00c1: ldloc.0
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c7: ldstr "join"
+			IL_00cc: ldstr "."
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00d6: stloc.3
+			IL_00d7: ldloc.0
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00dd: ldstr "join"
+			IL_00e2: ldstr "/"
+			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ec: stloc.s 6
+			IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00f3: dup
+			IL_00f4: ldstr "namespace"
+			IL_00f9: ldloc.3
+			IL_00fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00ff: dup
+			IL_0100: ldstr "path"
+			IL_0105: ldloc.s 6
+			IL_0107: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_010c: stloc.s 7
+			IL_010e: ldloc.s 7
+			IL_0110: ret
 		} // end of method normalizeCategory::__js_call__
 
 	} // end of class normalizeCategory
@@ -301,7 +300,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x342f
+				// Method begins at RVA 0x3433
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -328,7 +327,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2454
+			// Method begins at RVA 0x2458
 			// Header size: 12
 			// Code size: 173 (0xad)
 			.maxstack 8
@@ -442,7 +441,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x344a
+					// Method begins at RVA 0x344e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -466,7 +465,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33a0
+				// Method begins at RVA 0x33a4
 				// Header size: 12
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -502,7 +501,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3453
+					// Method begins at RVA 0x3457
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -527,7 +526,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33c0
+				// Method begins at RVA 0x33c4
 				// Header size: 12
 				// Code size: 63 (0x3f)
 				.maxstack 8
@@ -588,7 +587,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3441
+					// Method begins at RVA 0x3445
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -609,7 +608,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3438
+				// Method begins at RVA 0x343c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -637,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x346e
+						// Method begins at RVA 0x3472
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -655,7 +654,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3465
+					// Method begins at RVA 0x3469
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -673,7 +672,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x345c
+				// Method begins at RVA 0x3460
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -701,7 +700,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2510
+			// Method begins at RVA 0x2514
 			// Header size: 12
 			// Code size: 575 (0x23f)
 			.maxstack 10
@@ -976,7 +975,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3480
+					// Method begins at RVA 0x3484
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -994,7 +993,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3477
+				// Method begins at RVA 0x347b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1022,7 +1021,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x276c
+			// Method begins at RVA 0x2770
 			// Header size: 12
 			// Code size: 315 (0x13b)
 			.maxstack 10
@@ -1217,7 +1216,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x349b
+						// Method begins at RVA 0x349f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1235,7 +1234,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3492
+					// Method begins at RVA 0x3496
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1253,7 +1252,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3489
+				// Method begins at RVA 0x348d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1280,7 +1279,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x28c4
+			// Method begins at RVA 0x28c8
 			// Header size: 12
 			// Code size: 351 (0x15f)
 			.maxstack 8
@@ -1470,7 +1469,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34a4
+				// Method begins at RVA 0x34a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1498,7 +1497,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2a30
+			// Method begins at RVA 0x2a34
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1569,7 +1568,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34ad
+				// Method begins at RVA 0x34b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1596,7 +1595,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2a9c
+			// Method begins at RVA 0x2aa0
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1673,7 +1672,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34bf
+					// Method begins at RVA 0x34c3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1693,7 +1692,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34c8
+					// Method begins at RVA 0x34cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1717,7 +1716,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34da
+						// Method begins at RVA 0x34de
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1735,7 +1734,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34d1
+					// Method begins at RVA 0x34d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1755,7 +1754,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34e3
+					// Method begins at RVA 0x34e7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1779,7 +1778,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34f5
+						// Method begins at RVA 0x34f9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1797,7 +1796,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34ec
+					// Method begins at RVA 0x34f0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1817,7 +1816,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34fe
+					// Method begins at RVA 0x3502
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1837,7 +1836,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3507
+					// Method begins at RVA 0x350b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1855,7 +1854,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34b6
+				// Method begins at RVA 0x34ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1881,7 +1880,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2b34
+			// Method begins at RVA 0x2b38
 			// Header size: 12
 			// Code size: 2125 (0x84d)
 			.maxstack 8
@@ -2625,7 +2624,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x340b
+			// Method begins at RVA 0x340f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2861,7 +2860,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3510
+		// Method begins at RVA 0x3514
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4553
+				// Method begins at RVA 0x455b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x455c
+				// Method begins at RVA 0x4564
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -355,7 +355,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x454a
+			// Method begins at RVA 0x4552
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -470,7 +470,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4577
+					// Method begins at RVA 0x457f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -488,7 +488,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x456e
+				// Method begins at RVA 0x4576
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -633,7 +633,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4580
+				// Method begins at RVA 0x4588
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -661,7 +661,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x459b
+						// Method begins at RVA 0x45a3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -681,7 +681,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45a4
+						// Method begins at RVA 0x45ac
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -701,7 +701,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45ad
+						// Method begins at RVA 0x45b5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -721,7 +721,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45b6
+						// Method begins at RVA 0x45be
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -741,7 +741,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45bf
+						// Method begins at RVA 0x45c7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -761,7 +761,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45c8
+						// Method begins at RVA 0x45d0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -779,7 +779,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4592
+					// Method begins at RVA 0x459a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -797,7 +797,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4589
+				// Method begins at RVA 0x4591
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1156,7 +1156,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4622
+							// Method begins at RVA 0x462a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1181,7 +1181,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44c4
+						// Method begins at RVA 0x44cc
 						// Header size: 12
 						// Code size: 38 (0x26)
 						.maxstack 8
@@ -1223,7 +1223,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x462b
+							// Method begins at RVA 0x4633
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1247,7 +1247,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44f8
+						// Method begins at RVA 0x4500
 						// Header size: 12
 						// Code size: 70 (0x46)
 						.maxstack 8
@@ -1326,7 +1326,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x4610
+								// Method begins at RVA 0x4618
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1344,7 +1344,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4607
+							// Method begins at RVA 0x460f
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1364,7 +1364,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4619
+							// Method begins at RVA 0x4621
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1386,7 +1386,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45fe
+						// Method begins at RVA 0x4606
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1411,7 +1411,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x4060
+					// Method begins at RVA 0x4068
 					// Header size: 12
 					// Code size: 1111 (0x457)
 					.maxstack 8
@@ -1914,7 +1914,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45ec
+						// Method begins at RVA 0x45f4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1934,7 +1934,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45f5
+						// Method begins at RVA 0x45fd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1957,7 +1957,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45e3
+					// Method begins at RVA 0x45eb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1983,7 +1983,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e40
+				// Method begins at RVA 0x3e48
 				// Header size: 12
 				// Code size: 516 (0x204)
 				.maxstack 8
@@ -2234,7 +2234,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45da
+					// Method begins at RVA 0x45e2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2256,7 +2256,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45d1
+				// Method begins at RVA 0x45d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2353,7 +2353,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4634
+				// Method begins at RVA 0x463c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2420,7 +2420,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4646
+					// Method begins at RVA 0x464e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2444,7 +2444,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4658
+						// Method begins at RVA 0x4660
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2462,7 +2462,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x464f
+					// Method begins at RVA 0x4657
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2480,7 +2480,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x463d
+				// Method begins at RVA 0x4645
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2745,7 +2745,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x466a
+					// Method begins at RVA 0x4672
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2765,7 +2765,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4673
+					// Method begins at RVA 0x467b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2785,7 +2785,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x467c
+					// Method begins at RVA 0x4684
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2805,7 +2805,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4685
+					// Method begins at RVA 0x468d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2829,7 +2829,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4697
+						// Method begins at RVA 0x469f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2849,7 +2849,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46a0
+						// Method begins at RVA 0x46a8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2873,7 +2873,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x46b2
+							// Method begins at RVA 0x46ba
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2891,7 +2891,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46a9
+						// Method begins at RVA 0x46b1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2911,7 +2911,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46bb
+						// Method begins at RVA 0x46c3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2929,7 +2929,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x468e
+					// Method begins at RVA 0x4696
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2947,7 +2947,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4661
+				// Method begins at RVA 0x4669
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2977,7 +2977,7 @@
 			)
 			// Method begins at RVA 0x2c2c
 			// Header size: 12
-			// Code size: 960 (0x3c0)
+			// Code size: 964 (0x3c4)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -2999,9 +2999,10 @@
 				[16] object[],
 				[17] bool,
 				[18] float64,
-				[19] object,
+				[19] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[20] object,
-				[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[21] object,
+				[22] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.3
@@ -3203,136 +3204,138 @@
 			IL_023c: stloc.s 10
 			// loop start (head: IL_023e)
 				IL_023e: ldc.i4.1
-				IL_023f: brfalse IL_035f
+				IL_023f: brfalse IL_0363
 
 				IL_0244: ldloc.s 8
-				IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_024b: ldstr "exec"
-				IL_0250: ldarg.2
-				IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0256: stloc.s 11
-				IL_0258: ldloc.s 11
-				IL_025a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_025f: ldc.i4.0
-				IL_0260: ceq
-				IL_0262: stloc.s 17
-				IL_0264: ldloc.s 17
-				IL_0266: brfalse IL_0270
+				IL_0246: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+				IL_024b: stloc.s 19
+				IL_024d: ldloc.s 19
+				IL_024f: ldstr "exec"
+				IL_0254: ldarg.2
+				IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_025a: stloc.s 11
+				IL_025c: ldloc.s 11
+				IL_025e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0263: ldc.i4.0
+				IL_0264: ceq
+				IL_0266: stloc.s 17
+				IL_0268: ldloc.s 17
+				IL_026a: brfalse IL_0274
 
-				IL_026b: br IL_035f
+				IL_026f: br IL_0363
 
-				IL_0270: ldloc.s 11
-				IL_0272: ldc.r8 0.0
-				IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0280: stloc.s 12
-				IL_0282: ldloc.s 10
-				IL_0284: stloc.s 19
-				IL_0286: ldloc.s 19
-				IL_0288: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_028d: ldc.r8 0.0
-				IL_0296: clt
-				IL_0298: brfalse IL_02af
+				IL_0274: ldloc.s 11
+				IL_0276: ldc.r8 0.0
+				IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0284: stloc.s 12
+				IL_0286: ldloc.s 10
+				IL_0288: stloc.s 20
+				IL_028a: ldloc.s 20
+				IL_028c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0291: ldc.r8 0.0
+				IL_029a: clt
+				IL_029c: brfalse IL_02b3
 
-				IL_029d: ldloc.s 11
-				IL_029f: ldstr "index"
-				IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02a9: stloc.s 15
-				IL_02ab: ldloc.s 15
-				IL_02ad: stloc.s 10
+				IL_02a1: ldloc.s 11
+				IL_02a3: ldstr "index"
+				IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_02ad: stloc.s 15
+				IL_02af: ldloc.s 15
+				IL_02b1: stloc.s 10
 
-				IL_02af: ldloc.s 12
-				IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02b6: ldstr "startsWith"
-				IL_02bb: ldstr "</"
-				IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02c5: stloc.s 15
-				IL_02c7: ldloc.s 15
-				IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02ce: stloc.s 17
-				IL_02d0: ldloc.s 17
-				IL_02d2: brfalse IL_034c
+				IL_02b3: ldloc.s 12
+				IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02ba: ldstr "startsWith"
+				IL_02bf: ldstr "</"
+				IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02c9: stloc.s 15
+				IL_02cb: ldloc.s 15
+				IL_02cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02d2: stloc.s 17
+				IL_02d4: ldloc.s 17
+				IL_02d6: brfalse IL_0350
 
-				IL_02d7: ldloc.s 9
-				IL_02d9: ldc.r8 1
-				IL_02e2: sub
-				IL_02e3: stloc.s 9
-				IL_02e5: ldloc.s 9
-				IL_02e7: stloc.s 18
-				IL_02e9: ldloc.s 18
-				IL_02eb: ldc.r8 0.0
-				IL_02f4: ceq
-				IL_02f6: brfalse IL_0347
+				IL_02db: ldloc.s 9
+				IL_02dd: ldc.r8 1
+				IL_02e6: sub
+				IL_02e7: stloc.s 9
+				IL_02e9: ldloc.s 9
+				IL_02eb: stloc.s 18
+				IL_02ed: ldloc.s 18
+				IL_02ef: ldc.r8 0.0
+				IL_02f8: ceq
+				IL_02fa: brfalse IL_034b
 
-				IL_02fb: ldarg.2
-				IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0301: stloc.s 15
-				IL_0303: ldloc.s 8
-				IL_0305: ldstr "lastIndex"
-				IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_030f: stloc.s 20
-				IL_0311: ldloc.s 15
-				IL_0313: ldstr "substring"
-				IL_0318: ldloc.s 10
-				IL_031a: ldloc.s 20
-				IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0321: stloc.s 20
-				IL_0323: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0328: dup
-				IL_0329: ldstr "tagName"
-				IL_032e: ldloc.s 6
-				IL_0330: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0335: dup
-				IL_0336: ldstr "html"
-				IL_033b: ldloc.s 20
-				IL_033d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0342: stloc.s 21
-				IL_0344: ldloc.s 21
-				IL_0346: ret
+				IL_02ff: ldarg.2
+				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0305: stloc.s 15
+				IL_0307: ldloc.s 8
+				IL_0309: ldstr "lastIndex"
+				IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0313: stloc.s 21
+				IL_0315: ldloc.s 15
+				IL_0317: ldstr "substring"
+				IL_031c: ldloc.s 10
+				IL_031e: ldloc.s 21
+				IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0325: stloc.s 21
+				IL_0327: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_032c: dup
+				IL_032d: ldstr "tagName"
+				IL_0332: ldloc.s 6
+				IL_0334: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0339: dup
+				IL_033a: ldstr "html"
+				IL_033f: ldloc.s 21
+				IL_0341: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0346: stloc.s 22
+				IL_0348: ldloc.s 22
+				IL_034a: ret
 
-				IL_0347: br IL_035a
+				IL_034b: br IL_035e
 
-				IL_034c: ldloc.s 9
-				IL_034e: ldc.r8 1
-				IL_0357: add
-				IL_0358: stloc.s 9
+				IL_0350: ldloc.s 9
+				IL_0352: ldc.r8 1
+				IL_035b: add
+				IL_035c: stloc.s 9
 
-				IL_035a: br IL_023e
+				IL_035e: br IL_023e
 			// end loop
 
-			IL_035f: ldloc.s 6
-			IL_0361: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0366: stloc.s 14
-			IL_0368: ldstr "Could not find a matching closing </"
-			IL_036d: ldloc.s 14
-			IL_036f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0374: ldstr "> for id '"
-			IL_0379: call string [System.Runtime]System.String::Concat(string, string)
-			IL_037e: ldarg.3
-			IL_037f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0384: stloc.s 14
-			IL_0386: ldloc.s 14
-			IL_0388: call string [System.Runtime]System.String::Concat(string, string)
-			IL_038d: ldstr "'."
-			IL_0392: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0397: stloc.s 14
-			IL_0399: ldloc.s 14
-			IL_039b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_03a5: stloc.s 13
-			IL_03a7: ldloc.s 13
-			IL_03a9: isinst [System.Runtime]System.Exception
-			IL_03ae: dup
-			IL_03af: brtrue IL_03bd
+			IL_0363: ldloc.s 6
+			IL_0365: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_036a: stloc.s 14
+			IL_036c: ldstr "Could not find a matching closing </"
+			IL_0371: ldloc.s 14
+			IL_0373: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0378: ldstr "> for id '"
+			IL_037d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0382: ldarg.3
+			IL_0383: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0388: stloc.s 14
+			IL_038a: ldloc.s 14
+			IL_038c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0391: ldstr "'."
+			IL_0396: call string [System.Runtime]System.String::Concat(string, string)
+			IL_039b: stloc.s 14
+			IL_039d: ldloc.s 14
+			IL_039f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03a9: stloc.s 13
+			IL_03ab: ldloc.s 13
+			IL_03ad: isinst [System.Runtime]System.Exception
+			IL_03b2: dup
+			IL_03b3: brtrue IL_03c1
 
-			IL_03b4: pop
-			IL_03b5: ldloc.s 13
-			IL_03b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03bc: throw
+			IL_03b8: pop
+			IL_03b9: ldloc.s 13
+			IL_03bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03c0: throw
 
-			IL_03bd: throw
+			IL_03c1: throw
 
-			IL_03be: ldnull
-			IL_03bf: ret
+			IL_03c2: ldnull
+			IL_03c3: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3352,7 +3355,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46cd
+					// Method begins at RVA 0x46d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3370,7 +3373,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46c4
+				// Method begins at RVA 0x46cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3398,9 +3401,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2ff8
+			// Method begins at RVA 0x2ffc
 			// Header size: 12
-			// Code size: 472 (0x1d8)
+			// Code size: 476 (0x1dc)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3412,15 +3415,16 @@
 				[6] object,
 				[7] object[],
 				[8] string,
-				[9] bool,
-				[10] object,
+				[9] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[10] bool,
 				[11] object,
 				[12] object,
 				[13] object,
 				[14] object,
 				[15] object,
-				[16] float64,
-				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[16] object,
+				[17] float64,
+				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.0
@@ -3450,144 +3454,146 @@
 			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_0047: stloc.1
 			IL_0048: ldloc.1
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004e: ldstr "exec"
-			IL_0053: ldarg.2
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0059: stloc.2
-			IL_005a: ldloc.2
-			IL_005b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0060: stloc.s 9
-			IL_0062: ldloc.s 9
-			IL_0064: brfalse IL_00b1
+			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_004e: stloc.s 9
+			IL_0050: ldloc.s 9
+			IL_0052: ldstr "exec"
+			IL_0057: ldarg.2
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_005d: stloc.2
+			IL_005e: ldloc.2
+			IL_005f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0064: stloc.s 10
+			IL_0066: ldloc.s 10
+			IL_0068: brfalse IL_00b5
 
-			IL_0069: ldloc.2
-			IL_006a: ldc.r8 1
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0078: stloc.s 10
-			IL_007a: ldloc.s 10
-			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0081: stloc.s 9
-			IL_0083: ldloc.s 9
-			IL_0085: brtrue IL_00a4
+			IL_006d: ldloc.2
+			IL_006e: ldc.r8 1
+			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_007c: stloc.s 11
+			IL_007e: ldloc.s 11
+			IL_0080: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0085: stloc.s 10
+			IL_0087: ldloc.s 10
+			IL_0089: brtrue IL_00a8
 
-			IL_008a: ldloc.2
-			IL_008b: ldc.r8 2
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0099: stloc.s 11
-			IL_009b: ldloc.s 11
-			IL_009d: stloc.s 13
-			IL_009f: br IL_00a8
+			IL_008e: ldloc.2
+			IL_008f: ldc.r8 2
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_009d: stloc.s 12
+			IL_009f: ldloc.s 12
+			IL_00a1: stloc.s 14
+			IL_00a3: br IL_00ac
 
-			IL_00a4: ldloc.s 10
-			IL_00a6: stloc.s 13
-
-			IL_00a8: ldloc.s 13
+			IL_00a8: ldloc.s 11
 			IL_00aa: stloc.s 14
-			IL_00ac: br IL_00b4
 
-			IL_00b1: ldloc.2
-			IL_00b2: stloc.s 14
+			IL_00ac: ldloc.s 14
+			IL_00ae: stloc.s 15
+			IL_00b0: br IL_00b8
 
-			IL_00b4: ldloc.s 14
-			IL_00b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00bb: stloc.s 9
-			IL_00bd: ldloc.s 9
-			IL_00bf: brtrue IL_00d0
+			IL_00b5: ldloc.2
+			IL_00b6: stloc.s 15
 
-			IL_00c4: ldstr ""
-			IL_00c9: stloc.s 14
-			IL_00cb: br IL_00d0
+			IL_00b8: ldloc.s 15
+			IL_00ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00bf: stloc.s 10
+			IL_00c1: ldloc.s 10
+			IL_00c3: brtrue IL_00d4
 
-			IL_00d0: ldloc.s 14
-			IL_00d2: stloc.3
-			IL_00d3: ldloc.3
-			IL_00d4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00d9: ldc.i4.0
-			IL_00da: ceq
-			IL_00dc: stloc.s 9
-			IL_00de: ldloc.s 9
-			IL_00e0: brfalse IL_00ec
+			IL_00c8: ldstr ""
+			IL_00cd: stloc.s 15
+			IL_00cf: br IL_00d4
 
-			IL_00e5: ldc.i4.0
-			IL_00e6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00eb: ret
+			IL_00d4: ldloc.s 15
+			IL_00d6: stloc.3
+			IL_00d7: ldloc.3
+			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00dd: ldc.i4.0
+			IL_00de: ceq
+			IL_00e0: stloc.s 10
+			IL_00e2: ldloc.s 10
+			IL_00e4: brfalse IL_00f0
 
-			IL_00ec: ldloc.3
-			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f2: castclass [System.Runtime]System.String
-			IL_00f7: ldstr "#"
-			IL_00fc: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0101: stloc.s 16
-			IL_0103: ldloc.s 16
-			IL_0105: box [System.Runtime]System.Double
-			IL_010a: stloc.s 4
-			IL_010c: ldloc.s 4
-			IL_010e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0113: ldc.r8 0.0
-			IL_011c: clt
-			IL_011e: ldc.i4.0
-			IL_011f: ceq
-			IL_0121: brfalse IL_0151
+			IL_00e9: ldc.i4.0
+			IL_00ea: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00ef: ret
 
-			IL_0126: ldloc.3
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_012c: castclass [System.Runtime]System.String
-			IL_0131: ldc.r8 0.0
-			IL_013a: box [System.Runtime]System.Double
-			IL_013f: ldloc.s 4
-			IL_0141: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_0146: stloc.s 8
-			IL_0148: ldloc.s 8
-			IL_014a: stloc.s 5
-			IL_014c: br IL_0154
+			IL_00f0: ldloc.3
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f6: castclass [System.Runtime]System.String
+			IL_00fb: ldstr "#"
+			IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0105: stloc.s 17
+			IL_0107: ldloc.s 17
+			IL_0109: box [System.Runtime]System.Double
+			IL_010e: stloc.s 4
+			IL_0110: ldloc.s 4
+			IL_0112: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0117: ldc.r8 0.0
+			IL_0120: clt
+			IL_0122: ldc.i4.0
+			IL_0123: ceq
+			IL_0125: brfalse IL_0155
 
-			IL_0151: ldloc.3
-			IL_0152: stloc.s 5
+			IL_012a: ldloc.3
+			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0130: castclass [System.Runtime]System.String
+			IL_0135: ldc.r8 0.0
+			IL_013e: box [System.Runtime]System.Double
+			IL_0143: ldloc.s 4
+			IL_0145: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_014a: stloc.s 8
+			IL_014c: ldloc.s 8
+			IL_014e: stloc.s 5
+			IL_0150: br IL_0158
 
-			IL_0154: ldloc.s 4
-			IL_0156: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_015b: ldc.r8 0.0
-			IL_0164: clt
-			IL_0166: ldc.i4.0
-			IL_0167: ceq
-			IL_0169: brfalse IL_01a1
+			IL_0155: ldloc.3
+			IL_0156: stloc.s 5
 
-			IL_016e: ldloc.3
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0174: stloc.s 10
-			IL_0176: ldloc.s 4
-			IL_0178: ldc.r8 1
-			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0186: stloc.s 14
-			IL_0188: ldloc.s 10
-			IL_018a: castclass [System.Runtime]System.String
-			IL_018f: ldloc.s 14
-			IL_0191: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_0196: stloc.s 8
-			IL_0198: ldloc.s 8
-			IL_019a: stloc.s 6
-			IL_019c: br IL_01a8
+			IL_0158: ldloc.s 4
+			IL_015a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_015f: ldc.r8 0.0
+			IL_0168: clt
+			IL_016a: ldc.i4.0
+			IL_016b: ceq
+			IL_016d: brfalse IL_01a5
 
-			IL_01a1: ldstr ""
-			IL_01a6: stloc.s 6
+			IL_0172: ldloc.3
+			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0178: stloc.s 11
+			IL_017a: ldloc.s 4
+			IL_017c: ldc.r8 1
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_018a: stloc.s 15
+			IL_018c: ldloc.s 11
+			IL_018e: castclass [System.Runtime]System.String
+			IL_0193: ldloc.s 15
+			IL_0195: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_019a: stloc.s 8
+			IL_019c: ldloc.s 8
+			IL_019e: stloc.s 6
+			IL_01a0: br IL_01ac
 
-			IL_01a8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01ad: dup
-			IL_01ae: ldstr "href"
-			IL_01b3: ldloc.3
-			IL_01b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01b9: dup
-			IL_01ba: ldstr "filePart"
-			IL_01bf: ldloc.s 5
-			IL_01c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01c6: dup
-			IL_01c7: ldstr "fragment"
-			IL_01cc: ldloc.s 6
-			IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01d3: stloc.s 17
-			IL_01d5: ldloc.s 17
-			IL_01d7: ret
+			IL_01a5: ldstr ""
+			IL_01aa: stloc.s 6
+
+			IL_01ac: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01b1: dup
+			IL_01b2: ldstr "href"
+			IL_01b7: ldloc.3
+			IL_01b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01bd: dup
+			IL_01be: ldstr "filePart"
+			IL_01c3: ldloc.s 5
+			IL_01c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01ca: dup
+			IL_01cb: ldstr "fragment"
+			IL_01d0: ldloc.s 6
+			IL_01d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01d7: stloc.s 18
+			IL_01d9: ldloc.s 18
+			IL_01db: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -3603,7 +3609,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46d6
+				// Method begins at RVA 0x46de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3629,7 +3635,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31dc
+			// Method begins at RVA 0x31e4
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -3721,7 +3727,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46e8
+					// Method begins at RVA 0x46f0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3741,7 +3747,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46f1
+					// Method begins at RVA 0x46f9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3761,7 +3767,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46fa
+					// Method begins at RVA 0x4702
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3785,7 +3791,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x470c
+						// Method begins at RVA 0x4714
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3805,7 +3811,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4715
+						// Method begins at RVA 0x471d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3823,7 +3829,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4703
+					// Method begins at RVA 0x470b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3843,7 +3849,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x471e
+					// Method begins at RVA 0x4726
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3863,7 +3869,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4727
+					// Method begins at RVA 0x472f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3903,7 +3909,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46df
+				// Method begins at RVA 0x46e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3927,7 +3933,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x326c
+			// Method begins at RVA 0x3274
 			// Header size: 12
 			// Code size: 3014 (0xbc6)
 			.maxstack 8
@@ -5365,7 +5371,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4565
+			// Method begins at RVA 0x456d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5621,7 +5627,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4730
+		// Method begins at RVA 0x4738
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4553
+				// Method begins at RVA 0x455b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x455c
+				// Method begins at RVA 0x4564
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -355,7 +355,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x454a
+			// Method begins at RVA 0x4552
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -470,7 +470,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4577
+					// Method begins at RVA 0x457f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -488,7 +488,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x456e
+				// Method begins at RVA 0x4576
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -633,7 +633,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4580
+				// Method begins at RVA 0x4588
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -661,7 +661,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x459b
+						// Method begins at RVA 0x45a3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -681,7 +681,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45a4
+						// Method begins at RVA 0x45ac
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -701,7 +701,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45ad
+						// Method begins at RVA 0x45b5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -721,7 +721,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45b6
+						// Method begins at RVA 0x45be
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -741,7 +741,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45bf
+						// Method begins at RVA 0x45c7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -761,7 +761,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45c8
+						// Method begins at RVA 0x45d0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -779,7 +779,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4592
+					// Method begins at RVA 0x459a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -797,7 +797,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4589
+				// Method begins at RVA 0x4591
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1156,7 +1156,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4622
+							// Method begins at RVA 0x462a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1181,7 +1181,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44c4
+						// Method begins at RVA 0x44cc
 						// Header size: 12
 						// Code size: 38 (0x26)
 						.maxstack 8
@@ -1223,7 +1223,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x462b
+							// Method begins at RVA 0x4633
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1247,7 +1247,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44f8
+						// Method begins at RVA 0x4500
 						// Header size: 12
 						// Code size: 70 (0x46)
 						.maxstack 8
@@ -1326,7 +1326,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x4610
+								// Method begins at RVA 0x4618
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1344,7 +1344,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4607
+							// Method begins at RVA 0x460f
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1364,7 +1364,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4619
+							// Method begins at RVA 0x4621
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1386,7 +1386,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45fe
+						// Method begins at RVA 0x4606
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1411,7 +1411,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x4060
+					// Method begins at RVA 0x4068
 					// Header size: 12
 					// Code size: 1111 (0x457)
 					.maxstack 8
@@ -1914,7 +1914,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45ec
+						// Method begins at RVA 0x45f4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1934,7 +1934,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45f5
+						// Method begins at RVA 0x45fd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1957,7 +1957,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45e3
+					// Method begins at RVA 0x45eb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1983,7 +1983,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e40
+				// Method begins at RVA 0x3e48
 				// Header size: 12
 				// Code size: 516 (0x204)
 				.maxstack 8
@@ -2234,7 +2234,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45da
+					// Method begins at RVA 0x45e2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2256,7 +2256,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45d1
+				// Method begins at RVA 0x45d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2353,7 +2353,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4634
+				// Method begins at RVA 0x463c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2420,7 +2420,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4646
+					// Method begins at RVA 0x464e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2444,7 +2444,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4658
+						// Method begins at RVA 0x4660
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2462,7 +2462,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x464f
+					// Method begins at RVA 0x4657
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2480,7 +2480,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x463d
+				// Method begins at RVA 0x4645
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2745,7 +2745,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x466a
+					// Method begins at RVA 0x4672
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2765,7 +2765,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4673
+					// Method begins at RVA 0x467b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2785,7 +2785,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x467c
+					// Method begins at RVA 0x4684
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2805,7 +2805,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4685
+					// Method begins at RVA 0x468d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2829,7 +2829,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4697
+						// Method begins at RVA 0x469f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2849,7 +2849,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46a0
+						// Method begins at RVA 0x46a8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2873,7 +2873,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x46b2
+							// Method begins at RVA 0x46ba
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2891,7 +2891,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46a9
+						// Method begins at RVA 0x46b1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2911,7 +2911,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46bb
+						// Method begins at RVA 0x46c3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2929,7 +2929,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x468e
+					// Method begins at RVA 0x4696
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2947,7 +2947,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4661
+				// Method begins at RVA 0x4669
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2977,7 +2977,7 @@
 			)
 			// Method begins at RVA 0x2c2c
 			// Header size: 12
-			// Code size: 960 (0x3c0)
+			// Code size: 964 (0x3c4)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -2999,9 +2999,10 @@
 				[16] object[],
 				[17] bool,
 				[18] float64,
-				[19] object,
+				[19] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[20] object,
-				[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[21] object,
+				[22] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.3
@@ -3203,136 +3204,138 @@
 			IL_023c: stloc.s 10
 			// loop start (head: IL_023e)
 				IL_023e: ldc.i4.1
-				IL_023f: brfalse IL_035f
+				IL_023f: brfalse IL_0363
 
 				IL_0244: ldloc.s 8
-				IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_024b: ldstr "exec"
-				IL_0250: ldarg.2
-				IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0256: stloc.s 11
-				IL_0258: ldloc.s 11
-				IL_025a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_025f: ldc.i4.0
-				IL_0260: ceq
-				IL_0262: stloc.s 17
-				IL_0264: ldloc.s 17
-				IL_0266: brfalse IL_0270
+				IL_0246: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+				IL_024b: stloc.s 19
+				IL_024d: ldloc.s 19
+				IL_024f: ldstr "exec"
+				IL_0254: ldarg.2
+				IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_025a: stloc.s 11
+				IL_025c: ldloc.s 11
+				IL_025e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0263: ldc.i4.0
+				IL_0264: ceq
+				IL_0266: stloc.s 17
+				IL_0268: ldloc.s 17
+				IL_026a: brfalse IL_0274
 
-				IL_026b: br IL_035f
+				IL_026f: br IL_0363
 
-				IL_0270: ldloc.s 11
-				IL_0272: ldc.r8 0.0
-				IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0280: stloc.s 12
-				IL_0282: ldloc.s 10
-				IL_0284: stloc.s 19
-				IL_0286: ldloc.s 19
-				IL_0288: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_028d: ldc.r8 0.0
-				IL_0296: clt
-				IL_0298: brfalse IL_02af
+				IL_0274: ldloc.s 11
+				IL_0276: ldc.r8 0.0
+				IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0284: stloc.s 12
+				IL_0286: ldloc.s 10
+				IL_0288: stloc.s 20
+				IL_028a: ldloc.s 20
+				IL_028c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0291: ldc.r8 0.0
+				IL_029a: clt
+				IL_029c: brfalse IL_02b3
 
-				IL_029d: ldloc.s 11
-				IL_029f: ldstr "index"
-				IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02a9: stloc.s 15
-				IL_02ab: ldloc.s 15
-				IL_02ad: stloc.s 10
+				IL_02a1: ldloc.s 11
+				IL_02a3: ldstr "index"
+				IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_02ad: stloc.s 15
+				IL_02af: ldloc.s 15
+				IL_02b1: stloc.s 10
 
-				IL_02af: ldloc.s 12
-				IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02b6: ldstr "startsWith"
-				IL_02bb: ldstr "</"
-				IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02c5: stloc.s 15
-				IL_02c7: ldloc.s 15
-				IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02ce: stloc.s 17
-				IL_02d0: ldloc.s 17
-				IL_02d2: brfalse IL_034c
+				IL_02b3: ldloc.s 12
+				IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02ba: ldstr "startsWith"
+				IL_02bf: ldstr "</"
+				IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02c9: stloc.s 15
+				IL_02cb: ldloc.s 15
+				IL_02cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02d2: stloc.s 17
+				IL_02d4: ldloc.s 17
+				IL_02d6: brfalse IL_0350
 
-				IL_02d7: ldloc.s 9
-				IL_02d9: ldc.r8 1
-				IL_02e2: sub
-				IL_02e3: stloc.s 9
-				IL_02e5: ldloc.s 9
-				IL_02e7: stloc.s 18
-				IL_02e9: ldloc.s 18
-				IL_02eb: ldc.r8 0.0
-				IL_02f4: ceq
-				IL_02f6: brfalse IL_0347
+				IL_02db: ldloc.s 9
+				IL_02dd: ldc.r8 1
+				IL_02e6: sub
+				IL_02e7: stloc.s 9
+				IL_02e9: ldloc.s 9
+				IL_02eb: stloc.s 18
+				IL_02ed: ldloc.s 18
+				IL_02ef: ldc.r8 0.0
+				IL_02f8: ceq
+				IL_02fa: brfalse IL_034b
 
-				IL_02fb: ldarg.2
-				IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0301: stloc.s 15
-				IL_0303: ldloc.s 8
-				IL_0305: ldstr "lastIndex"
-				IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_030f: stloc.s 20
-				IL_0311: ldloc.s 15
-				IL_0313: ldstr "substring"
-				IL_0318: ldloc.s 10
-				IL_031a: ldloc.s 20
-				IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0321: stloc.s 20
-				IL_0323: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0328: dup
-				IL_0329: ldstr "tagName"
-				IL_032e: ldloc.s 6
-				IL_0330: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0335: dup
-				IL_0336: ldstr "html"
-				IL_033b: ldloc.s 20
-				IL_033d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0342: stloc.s 21
-				IL_0344: ldloc.s 21
-				IL_0346: ret
+				IL_02ff: ldarg.2
+				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0305: stloc.s 15
+				IL_0307: ldloc.s 8
+				IL_0309: ldstr "lastIndex"
+				IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0313: stloc.s 21
+				IL_0315: ldloc.s 15
+				IL_0317: ldstr "substring"
+				IL_031c: ldloc.s 10
+				IL_031e: ldloc.s 21
+				IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0325: stloc.s 21
+				IL_0327: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_032c: dup
+				IL_032d: ldstr "tagName"
+				IL_0332: ldloc.s 6
+				IL_0334: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0339: dup
+				IL_033a: ldstr "html"
+				IL_033f: ldloc.s 21
+				IL_0341: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0346: stloc.s 22
+				IL_0348: ldloc.s 22
+				IL_034a: ret
 
-				IL_0347: br IL_035a
+				IL_034b: br IL_035e
 
-				IL_034c: ldloc.s 9
-				IL_034e: ldc.r8 1
-				IL_0357: add
-				IL_0358: stloc.s 9
+				IL_0350: ldloc.s 9
+				IL_0352: ldc.r8 1
+				IL_035b: add
+				IL_035c: stloc.s 9
 
-				IL_035a: br IL_023e
+				IL_035e: br IL_023e
 			// end loop
 
-			IL_035f: ldloc.s 6
-			IL_0361: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0366: stloc.s 14
-			IL_0368: ldstr "Could not find a matching closing </"
-			IL_036d: ldloc.s 14
-			IL_036f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0374: ldstr "> for id '"
-			IL_0379: call string [System.Runtime]System.String::Concat(string, string)
-			IL_037e: ldarg.3
-			IL_037f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0384: stloc.s 14
-			IL_0386: ldloc.s 14
-			IL_0388: call string [System.Runtime]System.String::Concat(string, string)
-			IL_038d: ldstr "'."
-			IL_0392: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0397: stloc.s 14
-			IL_0399: ldloc.s 14
-			IL_039b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_03a5: stloc.s 13
-			IL_03a7: ldloc.s 13
-			IL_03a9: isinst [System.Runtime]System.Exception
-			IL_03ae: dup
-			IL_03af: brtrue IL_03bd
+			IL_0363: ldloc.s 6
+			IL_0365: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_036a: stloc.s 14
+			IL_036c: ldstr "Could not find a matching closing </"
+			IL_0371: ldloc.s 14
+			IL_0373: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0378: ldstr "> for id '"
+			IL_037d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0382: ldarg.3
+			IL_0383: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0388: stloc.s 14
+			IL_038a: ldloc.s 14
+			IL_038c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0391: ldstr "'."
+			IL_0396: call string [System.Runtime]System.String::Concat(string, string)
+			IL_039b: stloc.s 14
+			IL_039d: ldloc.s 14
+			IL_039f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03a9: stloc.s 13
+			IL_03ab: ldloc.s 13
+			IL_03ad: isinst [System.Runtime]System.Exception
+			IL_03b2: dup
+			IL_03b3: brtrue IL_03c1
 
-			IL_03b4: pop
-			IL_03b5: ldloc.s 13
-			IL_03b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03bc: throw
+			IL_03b8: pop
+			IL_03b9: ldloc.s 13
+			IL_03bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03c0: throw
 
-			IL_03bd: throw
+			IL_03c1: throw
 
-			IL_03be: ldnull
-			IL_03bf: ret
+			IL_03c2: ldnull
+			IL_03c3: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3352,7 +3355,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46cd
+					// Method begins at RVA 0x46d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3370,7 +3373,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46c4
+				// Method begins at RVA 0x46cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3398,9 +3401,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2ff8
+			// Method begins at RVA 0x2ffc
 			// Header size: 12
-			// Code size: 472 (0x1d8)
+			// Code size: 476 (0x1dc)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3412,15 +3415,16 @@
 				[6] object,
 				[7] object[],
 				[8] string,
-				[9] bool,
-				[10] object,
+				[9] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[10] bool,
 				[11] object,
 				[12] object,
 				[13] object,
 				[14] object,
 				[15] object,
-				[16] float64,
-				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[16] object,
+				[17] float64,
+				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.0
@@ -3450,144 +3454,146 @@
 			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_0047: stloc.1
 			IL_0048: ldloc.1
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004e: ldstr "exec"
-			IL_0053: ldarg.2
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0059: stloc.2
-			IL_005a: ldloc.2
-			IL_005b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0060: stloc.s 9
-			IL_0062: ldloc.s 9
-			IL_0064: brfalse IL_00b1
+			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_004e: stloc.s 9
+			IL_0050: ldloc.s 9
+			IL_0052: ldstr "exec"
+			IL_0057: ldarg.2
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_005d: stloc.2
+			IL_005e: ldloc.2
+			IL_005f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0064: stloc.s 10
+			IL_0066: ldloc.s 10
+			IL_0068: brfalse IL_00b5
 
-			IL_0069: ldloc.2
-			IL_006a: ldc.r8 1
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0078: stloc.s 10
-			IL_007a: ldloc.s 10
-			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0081: stloc.s 9
-			IL_0083: ldloc.s 9
-			IL_0085: brtrue IL_00a4
+			IL_006d: ldloc.2
+			IL_006e: ldc.r8 1
+			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_007c: stloc.s 11
+			IL_007e: ldloc.s 11
+			IL_0080: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0085: stloc.s 10
+			IL_0087: ldloc.s 10
+			IL_0089: brtrue IL_00a8
 
-			IL_008a: ldloc.2
-			IL_008b: ldc.r8 2
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0099: stloc.s 11
-			IL_009b: ldloc.s 11
-			IL_009d: stloc.s 13
-			IL_009f: br IL_00a8
+			IL_008e: ldloc.2
+			IL_008f: ldc.r8 2
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_009d: stloc.s 12
+			IL_009f: ldloc.s 12
+			IL_00a1: stloc.s 14
+			IL_00a3: br IL_00ac
 
-			IL_00a4: ldloc.s 10
-			IL_00a6: stloc.s 13
-
-			IL_00a8: ldloc.s 13
+			IL_00a8: ldloc.s 11
 			IL_00aa: stloc.s 14
-			IL_00ac: br IL_00b4
 
-			IL_00b1: ldloc.2
-			IL_00b2: stloc.s 14
+			IL_00ac: ldloc.s 14
+			IL_00ae: stloc.s 15
+			IL_00b0: br IL_00b8
 
-			IL_00b4: ldloc.s 14
-			IL_00b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00bb: stloc.s 9
-			IL_00bd: ldloc.s 9
-			IL_00bf: brtrue IL_00d0
+			IL_00b5: ldloc.2
+			IL_00b6: stloc.s 15
 
-			IL_00c4: ldstr ""
-			IL_00c9: stloc.s 14
-			IL_00cb: br IL_00d0
+			IL_00b8: ldloc.s 15
+			IL_00ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00bf: stloc.s 10
+			IL_00c1: ldloc.s 10
+			IL_00c3: brtrue IL_00d4
 
-			IL_00d0: ldloc.s 14
-			IL_00d2: stloc.3
-			IL_00d3: ldloc.3
-			IL_00d4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00d9: ldc.i4.0
-			IL_00da: ceq
-			IL_00dc: stloc.s 9
-			IL_00de: ldloc.s 9
-			IL_00e0: brfalse IL_00ec
+			IL_00c8: ldstr ""
+			IL_00cd: stloc.s 15
+			IL_00cf: br IL_00d4
 
-			IL_00e5: ldc.i4.0
-			IL_00e6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00eb: ret
+			IL_00d4: ldloc.s 15
+			IL_00d6: stloc.3
+			IL_00d7: ldloc.3
+			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00dd: ldc.i4.0
+			IL_00de: ceq
+			IL_00e0: stloc.s 10
+			IL_00e2: ldloc.s 10
+			IL_00e4: brfalse IL_00f0
 
-			IL_00ec: ldloc.3
-			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f2: castclass [System.Runtime]System.String
-			IL_00f7: ldstr "#"
-			IL_00fc: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0101: stloc.s 16
-			IL_0103: ldloc.s 16
-			IL_0105: box [System.Runtime]System.Double
-			IL_010a: stloc.s 4
-			IL_010c: ldloc.s 4
-			IL_010e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0113: ldc.r8 0.0
-			IL_011c: clt
-			IL_011e: ldc.i4.0
-			IL_011f: ceq
-			IL_0121: brfalse IL_0151
+			IL_00e9: ldc.i4.0
+			IL_00ea: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00ef: ret
 
-			IL_0126: ldloc.3
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_012c: castclass [System.Runtime]System.String
-			IL_0131: ldc.r8 0.0
-			IL_013a: box [System.Runtime]System.Double
-			IL_013f: ldloc.s 4
-			IL_0141: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_0146: stloc.s 8
-			IL_0148: ldloc.s 8
-			IL_014a: stloc.s 5
-			IL_014c: br IL_0154
+			IL_00f0: ldloc.3
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f6: castclass [System.Runtime]System.String
+			IL_00fb: ldstr "#"
+			IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0105: stloc.s 17
+			IL_0107: ldloc.s 17
+			IL_0109: box [System.Runtime]System.Double
+			IL_010e: stloc.s 4
+			IL_0110: ldloc.s 4
+			IL_0112: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0117: ldc.r8 0.0
+			IL_0120: clt
+			IL_0122: ldc.i4.0
+			IL_0123: ceq
+			IL_0125: brfalse IL_0155
 
-			IL_0151: ldloc.3
-			IL_0152: stloc.s 5
+			IL_012a: ldloc.3
+			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0130: castclass [System.Runtime]System.String
+			IL_0135: ldc.r8 0.0
+			IL_013e: box [System.Runtime]System.Double
+			IL_0143: ldloc.s 4
+			IL_0145: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_014a: stloc.s 8
+			IL_014c: ldloc.s 8
+			IL_014e: stloc.s 5
+			IL_0150: br IL_0158
 
-			IL_0154: ldloc.s 4
-			IL_0156: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_015b: ldc.r8 0.0
-			IL_0164: clt
-			IL_0166: ldc.i4.0
-			IL_0167: ceq
-			IL_0169: brfalse IL_01a1
+			IL_0155: ldloc.3
+			IL_0156: stloc.s 5
 
-			IL_016e: ldloc.3
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0174: stloc.s 10
-			IL_0176: ldloc.s 4
-			IL_0178: ldc.r8 1
-			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0186: stloc.s 14
-			IL_0188: ldloc.s 10
-			IL_018a: castclass [System.Runtime]System.String
-			IL_018f: ldloc.s 14
-			IL_0191: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_0196: stloc.s 8
-			IL_0198: ldloc.s 8
-			IL_019a: stloc.s 6
-			IL_019c: br IL_01a8
+			IL_0158: ldloc.s 4
+			IL_015a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_015f: ldc.r8 0.0
+			IL_0168: clt
+			IL_016a: ldc.i4.0
+			IL_016b: ceq
+			IL_016d: brfalse IL_01a5
 
-			IL_01a1: ldstr ""
-			IL_01a6: stloc.s 6
+			IL_0172: ldloc.3
+			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0178: stloc.s 11
+			IL_017a: ldloc.s 4
+			IL_017c: ldc.r8 1
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_018a: stloc.s 15
+			IL_018c: ldloc.s 11
+			IL_018e: castclass [System.Runtime]System.String
+			IL_0193: ldloc.s 15
+			IL_0195: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_019a: stloc.s 8
+			IL_019c: ldloc.s 8
+			IL_019e: stloc.s 6
+			IL_01a0: br IL_01ac
 
-			IL_01a8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01ad: dup
-			IL_01ae: ldstr "href"
-			IL_01b3: ldloc.3
-			IL_01b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01b9: dup
-			IL_01ba: ldstr "filePart"
-			IL_01bf: ldloc.s 5
-			IL_01c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01c6: dup
-			IL_01c7: ldstr "fragment"
-			IL_01cc: ldloc.s 6
-			IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01d3: stloc.s 17
-			IL_01d5: ldloc.s 17
-			IL_01d7: ret
+			IL_01a5: ldstr ""
+			IL_01aa: stloc.s 6
+
+			IL_01ac: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01b1: dup
+			IL_01b2: ldstr "href"
+			IL_01b7: ldloc.3
+			IL_01b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01bd: dup
+			IL_01be: ldstr "filePart"
+			IL_01c3: ldloc.s 5
+			IL_01c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01ca: dup
+			IL_01cb: ldstr "fragment"
+			IL_01d0: ldloc.s 6
+			IL_01d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01d7: stloc.s 18
+			IL_01d9: ldloc.s 18
+			IL_01db: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -3603,7 +3609,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46d6
+				// Method begins at RVA 0x46de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3629,7 +3635,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31dc
+			// Method begins at RVA 0x31e4
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -3721,7 +3727,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46e8
+					// Method begins at RVA 0x46f0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3741,7 +3747,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46f1
+					// Method begins at RVA 0x46f9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3761,7 +3767,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46fa
+					// Method begins at RVA 0x4702
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3785,7 +3791,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x470c
+						// Method begins at RVA 0x4714
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3805,7 +3811,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4715
+						// Method begins at RVA 0x471d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3823,7 +3829,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4703
+					// Method begins at RVA 0x470b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3843,7 +3849,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x471e
+					// Method begins at RVA 0x4726
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3863,7 +3869,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4727
+					// Method begins at RVA 0x472f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3903,7 +3909,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46df
+				// Method begins at RVA 0x46e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3927,7 +3933,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x326c
+			// Method begins at RVA 0x3274
 			// Header size: 12
 			// Code size: 3014 (0xbc6)
 			.maxstack 8
@@ -5365,7 +5371,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4565
+			// Method begins at RVA 0x456d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5621,7 +5627,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4730
+		// Method begins at RVA 0x4738
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36a0
+				// Method begins at RVA 0x36a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36a9
+				// Method begins at RVA 0x36ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -157,7 +157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36b2
+				// Method begins at RVA 0x36b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -224,7 +224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36bb
+				// Method begins at RVA 0x36bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -322,7 +322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36c4
+				// Method begins at RVA 0x36c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -351,123 +351,128 @@
 			)
 			// Method begins at RVA 0x23c8
 			// Header size: 12
-			// Code size: 281 (0x119)
+			// Code size: 287 (0x11f)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[4] bool,
-				[5] object[],
-				[6] string
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Date,
+				[3] object,
+				[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[5] bool,
+				[6] object[],
+				[7] string
 			)
 
 			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.Date::Construct()
-			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000a: ldstr "toISOString"
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0014: stloc.2
-			IL_0015: ldloc.2
-			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001b: stloc.2
-			IL_001c: ldstr "\\..+Z$"
-			IL_0021: ldstr ""
-			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_002b: stloc.3
-			IL_002c: ldloc.2
-			IL_002d: ldstr "replace"
-			IL_0032: ldloc.3
-			IL_0033: ldstr "Z"
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_003d: stloc.0
-			IL_003e: ldc.i4.0
-			IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0044: stloc.1
-			IL_0045: ldloc.1
-			IL_0046: ldstr "# Node Support Coverage"
-			IL_004b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0050: pop
-			IL_0051: ldloc.1
-			IL_0052: ldstr ""
-			IL_0057: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_005c: pop
-			IL_005d: ldarg.2
-			IL_005e: ldstr "nodeVersionTarget"
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0068: stloc.2
-			IL_0069: ldloc.2
-			IL_006a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_006f: stloc.s 4
-			IL_0071: ldloc.s 4
-			IL_0073: brfalse IL_00be
+			IL_0005: stloc.2
+			IL_0006: ldloc.2
+			IL_0007: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Date>(!!0)
+			IL_000c: stloc.2
+			IL_000d: ldloc.2
+			IL_000e: ldstr "toISOString"
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0018: stloc.3
+			IL_0019: ldloc.3
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001f: stloc.3
+			IL_0020: ldstr "\\..+Z$"
+			IL_0025: ldstr ""
+			IL_002a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_002f: stloc.s 4
+			IL_0031: ldloc.3
+			IL_0032: ldstr "replace"
+			IL_0037: ldloc.s 4
+			IL_0039: ldstr "Z"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0043: stloc.0
+			IL_0044: ldc.i4.0
+			IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_004a: stloc.1
+			IL_004b: ldloc.1
+			IL_004c: ldstr "# Node Support Coverage"
+			IL_0051: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0056: pop
+			IL_0057: ldloc.1
+			IL_0058: ldstr ""
+			IL_005d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0062: pop
+			IL_0063: ldarg.2
+			IL_0064: ldstr "nodeVersionTarget"
+			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_006e: stloc.3
+			IL_006f: ldloc.3
+			IL_0070: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0075: stloc.s 5
+			IL_0077: ldloc.s 5
+			IL_0079: brfalse IL_00c4
 
-			IL_0078: ldarg.0
-			IL_0079: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-			IL_007e: ldc.i4.1
-			IL_007f: newarr [System.Runtime]System.Object
-			IL_0084: dup
-			IL_0085: ldc.i4.0
-			IL_0086: ldarg.0
-			IL_0087: stelem.ref
-			IL_0088: stloc.s 5
-			IL_008a: ldarg.2
-			IL_008b: ldstr "nodeVersionTarget"
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0095: stloc.2
-			IL_0096: ldloc.s 5
-			IL_0098: ldloc.2
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_009e: stloc.2
-			IL_009f: ldloc.2
-			IL_00a0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00a5: stloc.s 6
-			IL_00a7: ldstr "Target: "
-			IL_00ac: ldloc.s 6
-			IL_00ae: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00b3: stloc.s 6
-			IL_00b5: ldloc.1
-			IL_00b6: ldloc.s 6
-			IL_00b8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_00bd: pop
+			IL_007e: ldarg.0
+			IL_007f: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+			IL_0084: ldc.i4.1
+			IL_0085: newarr [System.Runtime]System.Object
+			IL_008a: dup
+			IL_008b: ldc.i4.0
+			IL_008c: ldarg.0
+			IL_008d: stelem.ref
+			IL_008e: stloc.s 6
+			IL_0090: ldarg.2
+			IL_0091: ldstr "nodeVersionTarget"
+			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_009b: stloc.3
+			IL_009c: ldloc.s 6
+			IL_009e: ldloc.3
+			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00a4: stloc.3
+			IL_00a5: ldloc.3
+			IL_00a6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00ab: stloc.s 7
+			IL_00ad: ldstr "Target: "
+			IL_00b2: ldloc.s 7
+			IL_00b4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00b9: stloc.s 7
+			IL_00bb: ldloc.1
+			IL_00bc: ldloc.s 7
+			IL_00be: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00c3: pop
 
-			IL_00be: ldarg.0
-			IL_00bf: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-			IL_00c4: ldc.i4.1
-			IL_00c5: newarr [System.Runtime]System.Object
-			IL_00ca: dup
-			IL_00cb: ldc.i4.0
-			IL_00cc: ldarg.0
-			IL_00cd: stelem.ref
-			IL_00ce: ldloc.0
-			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00d4: stloc.2
-			IL_00d5: ldloc.2
-			IL_00d6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00db: stloc.s 6
-			IL_00dd: ldstr "Generated: "
-			IL_00e2: ldloc.s 6
-			IL_00e4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00e9: stloc.s 6
-			IL_00eb: ldloc.1
-			IL_00ec: ldloc.s 6
-			IL_00ee: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_00f3: pop
-			IL_00f4: ldloc.1
-			IL_00f5: ldstr ""
-			IL_00fa: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_00ff: pop
-			IL_0100: ldloc.1
-			IL_0101: ldc.i4.1
-			IL_0102: newarr [System.Runtime]System.Object
-			IL_0107: dup
-			IL_0108: ldc.i4.0
-			IL_0109: ldstr "\n"
-			IL_010e: stelem.ref
-			IL_010f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0114: stloc.s 6
-			IL_0116: ldloc.s 6
-			IL_0118: ret
+			IL_00c4: ldarg.0
+			IL_00c5: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+			IL_00ca: ldc.i4.1
+			IL_00cb: newarr [System.Runtime]System.Object
+			IL_00d0: dup
+			IL_00d1: ldc.i4.0
+			IL_00d2: ldarg.0
+			IL_00d3: stelem.ref
+			IL_00d4: ldloc.0
+			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00da: stloc.3
+			IL_00db: ldloc.3
+			IL_00dc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00e1: stloc.s 7
+			IL_00e3: ldstr "Generated: "
+			IL_00e8: ldloc.s 7
+			IL_00ea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00ef: stloc.s 7
+			IL_00f1: ldloc.1
+			IL_00f2: ldloc.s 7
+			IL_00f4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00f9: pop
+			IL_00fa: ldloc.1
+			IL_00fb: ldstr ""
+			IL_0100: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0105: pop
+			IL_0106: ldloc.1
+			IL_0107: ldc.i4.1
+			IL_0108: newarr [System.Runtime]System.Object
+			IL_010d: dup
+			IL_010e: ldc.i4.0
+			IL_010f: ldstr "\n"
+			IL_0114: stelem.ref
+			IL_0115: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_011a: stloc.s 7
+			IL_011c: ldloc.s 7
+			IL_011e: ret
 		} // end of method renderHeader::__js_call__
 
 	} // end of class renderHeader
@@ -493,7 +498,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36d6
+					// Method begins at RVA 0x36da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -518,7 +523,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3650
+				// Method begins at RVA 0x3654
 				// Header size: 12
 				// Code size: 59 (0x3b)
 				.maxstack 8
@@ -570,7 +575,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36cd
+				// Method begins at RVA 0x36d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -597,7 +602,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x24f0
+			// Method begins at RVA 0x24f4
 			// Header size: 12
 			// Code size: 174 (0xae)
 			.maxstack 8
@@ -695,7 +700,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36df
+				// Method begins at RVA 0x36e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -719,7 +724,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36f1
+					// Method begins at RVA 0x36f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -737,7 +742,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36e8
+				// Method begins at RVA 0x36ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -764,7 +769,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x25ac
+			// Method begins at RVA 0x25b0
 			// Header size: 12
 			// Code size: 617 (0x269)
 			.maxstack 10
@@ -1044,7 +1049,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36fa
+				// Method begins at RVA 0x36fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1068,7 +1073,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x370c
+					// Method begins at RVA 0x3710
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1092,7 +1097,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x371e
+						// Method begins at RVA 0x3722
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1110,7 +1115,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3715
+					// Method begins at RVA 0x3719
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1128,7 +1133,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3703
+				// Method begins at RVA 0x3707
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1155,7 +1160,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2840
+			// Method begins at RVA 0x2844
 			// Header size: 12
 			// Code size: 789 (0x315)
 			.maxstack 11
@@ -1525,7 +1530,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3727
+				// Method begins at RVA 0x372b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1553,7 +1558,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3742
+						// Method begins at RVA 0x3746
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1573,7 +1578,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x374b
+						// Method begins at RVA 0x374f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1593,7 +1598,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3754
+						// Method begins at RVA 0x3758
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1611,7 +1616,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3739
+					// Method begins at RVA 0x373d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1629,7 +1634,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3730
+				// Method begins at RVA 0x3734
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1656,7 +1661,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2b98
+			// Method begins at RVA 0x2b9c
 			// Header size: 12
 			// Code size: 760 (0x2f8)
 			.maxstack 10
@@ -1998,7 +2003,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x375d
+				// Method begins at RVA 0x3761
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2026,7 +2031,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3778
+						// Method begins at RVA 0x377c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2046,7 +2051,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3781
+						// Method begins at RVA 0x3785
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2066,7 +2071,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x378a
+						// Method begins at RVA 0x378e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2090,7 +2095,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x379c
+							// Method begins at RVA 0x37a0
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2108,7 +2113,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3793
+						// Method begins at RVA 0x3797
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2126,7 +2131,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x376f
+					// Method begins at RVA 0x3773
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2144,7 +2149,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3766
+				// Method begins at RVA 0x376a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2171,7 +2176,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2eb8
+			// Method begins at RVA 0x2ebc
 			// Header size: 12
 			// Code size: 1054 (0x41e)
 			.maxstack 11
@@ -2623,7 +2628,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37a5
+				// Method begins at RVA 0x37a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2643,7 +2648,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37ae
+				// Method begins at RVA 0x37b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2667,7 +2672,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3318
+			// Method begins at RVA 0x331c
 			// Header size: 12
 			// Code size: 286 (0x11e)
 			.maxstack 10
@@ -2825,7 +2830,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37b7
+				// Method begins at RVA 0x37bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2851,7 +2856,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x3454
+			// Method begins at RVA 0x3458
 			// Header size: 12
 			// Code size: 496 (0x1f0)
 			.maxstack 8
@@ -3030,13 +3035,13 @@
 			IL_0156: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
 			IL_015b: stloc.s 10
 			IL_015d: ldloc.s 10
-			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0164: stloc.s 8
+			IL_015f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0164: stloc.s 10
 			IL_0166: ldstr "\\r?\\n"
 			IL_016b: ldstr "g"
 			IL_0170: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_0175: stloc.s 11
-			IL_0177: ldloc.s 8
+			IL_0177: ldloc.s 10
 			IL_0179: ldstr "replace"
 			IL_017e: ldloc.s 11
 			IL_0180: ldstr "\n"
@@ -3117,7 +3122,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3697
+			// Method begins at RVA 0x369b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3375,7 +3380,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x37c0
+		// Method begins at RVA 0x37c4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Indices_Exec.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Indices_Exec.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2363
+			// Method begins at RVA 0x2367
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 775 (0x307)
+		// Code size: 779 (0x30b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_Indices_Exec/Scope,
@@ -61,209 +61,213 @@
 		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_0016: stloc.3
 		IL_0017: ldloc.3
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_001d: ldstr "exec"
-		IL_0022: ldstr "b"
-		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_002c: stloc.1
-		IL_002d: ldstr "console"
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003c: stloc.s 4
-		IL_003e: ldloc.1
-		IL_003f: stloc.s 5
-		IL_0041: ldloc.s 5
-		IL_0043: ldc.i4.0
-		IL_0044: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0049: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_004e: stloc.s 6
-		IL_0050: ldloc.s 6
-		IL_0052: box [System.Runtime]System.Boolean
-		IL_0057: stloc.s 7
-		IL_0059: ldloc.s 4
-		IL_005b: ldstr "log"
-		IL_0060: ldloc.s 7
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0067: pop
-		IL_0068: ldstr "console"
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0077: stloc.s 4
-		IL_0079: ldloc.1
-		IL_007a: ldstr "indices"
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0084: stloc.s 5
-		IL_0086: ldloc.s 5
-		IL_0088: ldstr "length"
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0092: stloc.s 5
-		IL_0094: ldloc.s 4
-		IL_0096: ldstr "log"
-		IL_009b: ldloc.s 5
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a2: pop
-		IL_00a3: ldstr "console"
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b2: stloc.s 5
-		IL_00b4: ldloc.1
-		IL_00b5: ldstr "indices"
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00bf: stloc.s 4
-		IL_00c1: ldloc.s 4
-		IL_00c3: ldc.r8 0.0
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00d1: stloc.s 4
-		IL_00d3: ldloc.s 4
-		IL_00d5: ldc.r8 0.0
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00e3: stloc.s 4
-		IL_00e5: ldloc.s 5
-		IL_00e7: ldstr "log"
-		IL_00ec: ldloc.s 4
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f3: pop
-		IL_00f4: ldstr "console"
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0103: stloc.s 4
-		IL_0105: ldloc.1
-		IL_0106: ldstr "indices"
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0110: stloc.s 5
-		IL_0112: ldloc.s 5
-		IL_0114: ldc.r8 0.0
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0122: stloc.s 5
-		IL_0124: ldloc.s 5
-		IL_0126: ldc.r8 1
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0134: stloc.s 5
-		IL_0136: ldloc.s 4
-		IL_0138: ldstr "log"
-		IL_013d: ldloc.s 5
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0144: pop
-		IL_0145: ldstr "console"
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0154: stloc.s 5
-		IL_0156: ldloc.1
-		IL_0157: ldstr "indices"
-		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0161: stloc.s 4
-		IL_0163: ldloc.s 4
-		IL_0165: ldc.r8 1
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0173: stloc.s 4
-		IL_0175: ldloc.s 4
-		IL_0177: ldc.i4.0
-		IL_0178: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_017d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0182: stloc.s 6
-		IL_0184: ldloc.s 6
-		IL_0186: box [System.Runtime]System.Boolean
-		IL_018b: stloc.s 7
-		IL_018d: ldloc.s 5
-		IL_018f: ldstr "log"
-		IL_0194: ldloc.s 7
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019b: pop
-		IL_019c: ldstr "a(d)?"
-		IL_01a1: ldstr "d"
-		IL_01a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_01ab: stloc.3
-		IL_01ac: ldloc.3
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b2: ldstr "exec"
-		IL_01b7: ldstr "bad"
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c1: stloc.2
-		IL_01c2: ldstr "console"
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d1: stloc.s 5
-		IL_01d3: ldloc.2
-		IL_01d4: ldstr "indices"
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01de: stloc.s 4
-		IL_01e0: ldloc.s 4
-		IL_01e2: ldc.r8 0.0
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01f0: stloc.s 4
-		IL_01f2: ldloc.s 4
-		IL_01f4: ldc.r8 0.0
-		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0202: stloc.s 4
-		IL_0204: ldloc.s 5
-		IL_0206: ldstr "log"
-		IL_020b: ldloc.s 4
-		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0212: pop
-		IL_0213: ldstr "console"
-		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0222: stloc.s 4
-		IL_0224: ldloc.2
-		IL_0225: ldstr "indices"
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_022f: stloc.s 5
-		IL_0231: ldloc.s 5
-		IL_0233: ldc.r8 0.0
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0241: stloc.s 5
-		IL_0243: ldloc.s 5
-		IL_0245: ldc.r8 1
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0253: stloc.s 5
-		IL_0255: ldloc.s 4
-		IL_0257: ldstr "log"
-		IL_025c: ldloc.s 5
-		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0263: pop
-		IL_0264: ldstr "console"
-		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0273: stloc.s 5
-		IL_0275: ldloc.2
-		IL_0276: ldstr "indices"
-		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0280: stloc.s 4
-		IL_0282: ldloc.s 4
-		IL_0284: ldc.r8 1
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0292: stloc.s 4
-		IL_0294: ldloc.s 4
-		IL_0296: ldc.r8 0.0
-		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02a4: stloc.s 4
-		IL_02a6: ldloc.s 5
-		IL_02a8: ldstr "log"
-		IL_02ad: ldloc.s 4
-		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b4: pop
-		IL_02b5: ldstr "console"
-		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c4: stloc.s 4
-		IL_02c6: ldloc.2
-		IL_02c7: ldstr "indices"
-		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02d1: stloc.s 5
-		IL_02d3: ldloc.s 5
-		IL_02d5: ldc.r8 1
-		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02e3: stloc.s 5
-		IL_02e5: ldloc.s 5
-		IL_02e7: ldc.r8 1
-		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02f5: stloc.s 5
-		IL_02f7: ldloc.s 4
-		IL_02f9: ldstr "log"
-		IL_02fe: ldloc.s 5
-		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0305: pop
-		IL_0306: ret
+		IL_0018: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_001d: stloc.3
+		IL_001e: ldloc.3
+		IL_001f: ldstr "exec"
+		IL_0024: ldstr "b"
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_002e: stloc.1
+		IL_002f: ldstr "console"
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003e: stloc.s 4
+		IL_0040: ldloc.1
+		IL_0041: stloc.s 5
+		IL_0043: ldloc.s 5
+		IL_0045: ldc.i4.0
+		IL_0046: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_004b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0050: stloc.s 6
+		IL_0052: ldloc.s 6
+		IL_0054: box [System.Runtime]System.Boolean
+		IL_0059: stloc.s 7
+		IL_005b: ldloc.s 4
+		IL_005d: ldstr "log"
+		IL_0062: ldloc.s 7
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0069: pop
+		IL_006a: ldstr "console"
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0079: stloc.s 4
+		IL_007b: ldloc.1
+		IL_007c: ldstr "indices"
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0086: stloc.s 5
+		IL_0088: ldloc.s 5
+		IL_008a: ldstr "length"
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0094: stloc.s 5
+		IL_0096: ldloc.s 4
+		IL_0098: ldstr "log"
+		IL_009d: ldloc.s 5
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a4: pop
+		IL_00a5: ldstr "console"
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b4: stloc.s 5
+		IL_00b6: ldloc.1
+		IL_00b7: ldstr "indices"
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c1: stloc.s 4
+		IL_00c3: ldloc.s 4
+		IL_00c5: ldc.r8 0.0
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00d3: stloc.s 4
+		IL_00d5: ldloc.s 4
+		IL_00d7: ldc.r8 0.0
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00e5: stloc.s 4
+		IL_00e7: ldloc.s 5
+		IL_00e9: ldstr "log"
+		IL_00ee: ldloc.s 4
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f5: pop
+		IL_00f6: ldstr "console"
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0105: stloc.s 4
+		IL_0107: ldloc.1
+		IL_0108: ldstr "indices"
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0112: stloc.s 5
+		IL_0114: ldloc.s 5
+		IL_0116: ldc.r8 0.0
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0124: stloc.s 5
+		IL_0126: ldloc.s 5
+		IL_0128: ldc.r8 1
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0136: stloc.s 5
+		IL_0138: ldloc.s 4
+		IL_013a: ldstr "log"
+		IL_013f: ldloc.s 5
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0146: pop
+		IL_0147: ldstr "console"
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0156: stloc.s 5
+		IL_0158: ldloc.1
+		IL_0159: ldstr "indices"
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0163: stloc.s 4
+		IL_0165: ldloc.s 4
+		IL_0167: ldc.r8 1
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0175: stloc.s 4
+		IL_0177: ldloc.s 4
+		IL_0179: ldc.i4.0
+		IL_017a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_017f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0184: stloc.s 6
+		IL_0186: ldloc.s 6
+		IL_0188: box [System.Runtime]System.Boolean
+		IL_018d: stloc.s 7
+		IL_018f: ldloc.s 5
+		IL_0191: ldstr "log"
+		IL_0196: ldloc.s 7
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019d: pop
+		IL_019e: ldstr "a(d)?"
+		IL_01a3: ldstr "d"
+		IL_01a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_01ad: stloc.3
+		IL_01ae: ldloc.3
+		IL_01af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_01b4: stloc.3
+		IL_01b5: ldloc.3
+		IL_01b6: ldstr "exec"
+		IL_01bb: ldstr "bad"
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c5: stloc.2
+		IL_01c6: ldstr "console"
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d5: stloc.s 5
+		IL_01d7: ldloc.2
+		IL_01d8: ldstr "indices"
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e2: stloc.s 4
+		IL_01e4: ldloc.s 4
+		IL_01e6: ldc.r8 0.0
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01f4: stloc.s 4
+		IL_01f6: ldloc.s 4
+		IL_01f8: ldc.r8 0.0
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0206: stloc.s 4
+		IL_0208: ldloc.s 5
+		IL_020a: ldstr "log"
+		IL_020f: ldloc.s 4
+		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0216: pop
+		IL_0217: ldstr "console"
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0226: stloc.s 4
+		IL_0228: ldloc.2
+		IL_0229: ldstr "indices"
+		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0233: stloc.s 5
+		IL_0235: ldloc.s 5
+		IL_0237: ldc.r8 0.0
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0245: stloc.s 5
+		IL_0247: ldloc.s 5
+		IL_0249: ldc.r8 1
+		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0257: stloc.s 5
+		IL_0259: ldloc.s 4
+		IL_025b: ldstr "log"
+		IL_0260: ldloc.s 5
+		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0267: pop
+		IL_0268: ldstr "console"
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0277: stloc.s 5
+		IL_0279: ldloc.2
+		IL_027a: ldstr "indices"
+		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0284: stloc.s 4
+		IL_0286: ldloc.s 4
+		IL_0288: ldc.r8 1
+		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0296: stloc.s 4
+		IL_0298: ldloc.s 4
+		IL_029a: ldc.r8 0.0
+		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02a8: stloc.s 4
+		IL_02aa: ldloc.s 5
+		IL_02ac: ldstr "log"
+		IL_02b1: ldloc.s 4
+		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b8: pop
+		IL_02b9: ldstr "console"
+		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c8: stloc.s 4
+		IL_02ca: ldloc.2
+		IL_02cb: ldstr "indices"
+		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02d5: stloc.s 5
+		IL_02d7: ldloc.s 5
+		IL_02d9: ldc.r8 1
+		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02e7: stloc.s 5
+		IL_02e9: ldloc.s 5
+		IL_02eb: ldc.r8 1
+		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02f9: stloc.s 5
+		IL_02fb: ldloc.s 4
+		IL_02fd: ldstr "log"
+		IL_0302: ldloc.s 5
+		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0309: pop
+		IL_030a: ret
 	} // end of method IntrinsicCallables_RegExp_Indices_Exec::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_Indices_Exec
@@ -275,7 +279,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x236c
+		// Method begins at RVA 0x2370
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ModernFlags_Basic.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ModernFlags_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24cd
+				// Method begins at RVA 0x24c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d6
+				// Method begins at RVA 0x24ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24df
+				// Method begins at RVA 0x24d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24e8
+				// Method begins at RVA 0x24dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24c4
+			// Method begins at RVA 0x24b8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1098 (0x44a)
+		// Code size: 1087 (0x43f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope,
@@ -223,258 +223,263 @@
 		IL_0113: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_0118: stloc.s 11
 		IL_011a: ldloc.s 11
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0121: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_0126: ldstr "\ud83d\ude00"
-		IL_012b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0130: stloc.s 9
-		IL_0132: ldloc.s 10
-		IL_0134: ldstr "log"
-		IL_0139: ldloc.s 9
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0140: pop
-		IL_0141: ldstr "console"
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0150: stloc.s 9
-		IL_0152: ldstr "\\u{1F600}"
-		IL_0157: ldstr "u"
-		IL_015c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0161: stloc.s 11
-		IL_0163: ldloc.s 11
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016a: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_016f: ldstr "\ud83d\ude00"
-		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0179: stloc.s 10
-		IL_017b: ldloc.s 9
-		IL_017d: ldstr "log"
-		IL_0182: ldloc.s 10
-		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0189: pop
-		IL_018a: ldstr "console"
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0199: stloc.s 10
-		IL_019b: ldstr "^.$"
-		IL_01a0: ldstr "s"
-		IL_01a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_01aa: stloc.s 11
-		IL_01ac: ldloc.s 11
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b3: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_01b8: ldstr "\n"
-		IL_01bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_01c2: stloc.s 9
-		IL_01c4: ldloc.s 10
-		IL_01c6: ldstr "log"
-		IL_01cb: ldloc.s 9
-		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d2: pop
-		IL_01d3: ldstr "console"
-		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e2: stloc.s 9
-		IL_01e4: ldstr "^.$"
-		IL_01e9: ldstr ""
-		IL_01ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_01f3: stloc.s 11
-		IL_01f5: ldloc.s 11
-		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01fc: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_0201: ldstr "\r"
-		IL_0206: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_020b: stloc.s 10
-		IL_020d: ldloc.s 9
-		IL_020f: ldstr "log"
-		IL_0214: ldloc.s 10
-		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_021b: pop
-		IL_021c: ldstr "console"
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022b: stloc.s 10
-		IL_022d: ldstr "^.$"
-		IL_0232: ldstr ""
-		IL_0237: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_023c: stloc.s 11
-		IL_023e: ldloc.s 11
-		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0245: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_024a: ldstr "\u2028"
-		IL_024f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0254: stloc.s 9
-		IL_0256: ldloc.s 10
-		IL_0258: ldstr "log"
-		IL_025d: ldloc.s 9
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0264: pop
-		IL_0265: ldstr "console"
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0274: stloc.s 9
-		IL_0276: ldstr "^.$"
-		IL_027b: ldstr ""
-		IL_0280: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0285: stloc.s 11
-		IL_0287: ldloc.s 11
-		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028e: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_0293: ldstr "\u2029"
-		IL_0298: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_029d: stloc.s 10
-		IL_029f: ldloc.s 9
-		IL_02a1: ldstr "log"
-		IL_02a6: ldloc.s 10
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ad: pop
+		IL_011c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0121: stloc.s 11
+		IL_0123: ldloc.s 11
+		IL_0125: ldstr "\ud83d\ude00"
+		IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_012f: stloc.s 9
+		IL_0131: ldloc.s 10
+		IL_0133: ldstr "log"
+		IL_0138: ldloc.s 9
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013f: pop
+		IL_0140: ldstr "console"
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014f: stloc.s 9
+		IL_0151: ldstr "\\u{1F600}"
+		IL_0156: ldstr "u"
+		IL_015b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0160: stloc.s 11
+		IL_0162: ldloc.s 11
+		IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0169: stloc.s 11
+		IL_016b: ldloc.s 11
+		IL_016d: ldstr "\ud83d\ude00"
+		IL_0172: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0177: stloc.s 10
+		IL_0179: ldloc.s 9
+		IL_017b: ldstr "log"
+		IL_0180: ldloc.s 10
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0187: pop
+		IL_0188: ldstr "console"
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0197: stloc.s 10
+		IL_0199: ldstr "^.$"
+		IL_019e: ldstr "s"
+		IL_01a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_01a8: stloc.s 11
+		IL_01aa: ldloc.s 11
+		IL_01ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_01b1: stloc.s 11
+		IL_01b3: ldloc.s 11
+		IL_01b5: ldstr "\n"
+		IL_01ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_01bf: stloc.s 9
+		IL_01c1: ldloc.s 10
+		IL_01c3: ldstr "log"
+		IL_01c8: ldloc.s 9
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01cf: pop
+		IL_01d0: ldstr "console"
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01df: stloc.s 9
+		IL_01e1: ldstr "^.$"
+		IL_01e6: ldstr ""
+		IL_01eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_01f0: stloc.s 11
+		IL_01f2: ldloc.s 11
+		IL_01f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_01f9: stloc.s 11
+		IL_01fb: ldloc.s 11
+		IL_01fd: ldstr "\r"
+		IL_0202: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0207: stloc.s 10
+		IL_0209: ldloc.s 9
+		IL_020b: ldstr "log"
+		IL_0210: ldloc.s 10
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0217: pop
+		IL_0218: ldstr "console"
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0227: stloc.s 10
+		IL_0229: ldstr "^.$"
+		IL_022e: ldstr ""
+		IL_0233: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0238: stloc.s 11
+		IL_023a: ldloc.s 11
+		IL_023c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0241: stloc.s 11
+		IL_0243: ldloc.s 11
+		IL_0245: ldstr "\u2028"
+		IL_024a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_024f: stloc.s 9
+		IL_0251: ldloc.s 10
+		IL_0253: ldstr "log"
+		IL_0258: ldloc.s 9
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025f: pop
+		IL_0260: ldstr "console"
+		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_026f: stloc.s 9
+		IL_0271: ldstr "^.$"
+		IL_0276: ldstr ""
+		IL_027b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0280: stloc.s 11
+		IL_0282: ldloc.s 11
+		IL_0284: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0289: stloc.s 11
+		IL_028b: ldloc.s 11
+		IL_028d: ldstr "\u2029"
+		IL_0292: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0297: stloc.s 10
+		IL_0299: ldloc.s 9
+		IL_029b: ldstr "log"
+		IL_02a0: ldloc.s 10
+		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a7: pop
 		.try
 		{
-			IL_02ae: nop
-			IL_02af: ldstr "a"
-			IL_02b4: ldstr "v"
-			IL_02b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_02be: pop
-			IL_02bf: ldstr "console"
-			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ce: ldstr "log"
-			IL_02d3: ldstr "no-error"
-			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02dd: pop
-			IL_02de: leave IL_03ac
+			IL_02a8: nop
+			IL_02a9: ldstr "a"
+			IL_02ae: ldstr "v"
+			IL_02b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_02b8: pop
+			IL_02b9: ldstr "console"
+			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c8: ldstr "log"
+			IL_02cd: ldstr "no-error"
+			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02d7: pop
+			IL_02d8: leave IL_03a1
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02e3: stloc.2
-			IL_02e4: ldloc.2
-			IL_02e5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02ea: dup
-			IL_02eb: brtrue IL_0300
+			IL_02dd: stloc.2
+			IL_02de: ldloc.2
+			IL_02df: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02e4: dup
+			IL_02e5: brtrue IL_02fa
 
-			IL_02f0: pop
-			IL_02f1: ldloc.2
-			IL_02f2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02f7: dup
-			IL_02f8: brtrue IL_030b
+			IL_02ea: pop
+			IL_02eb: ldloc.2
+			IL_02ec: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02f1: dup
+			IL_02f2: brtrue IL_0305
 
-			IL_02fd: pop
-			IL_02fe: rethrow
+			IL_02f7: pop
+			IL_02f8: rethrow
 
-			IL_0300: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02ff: stloc.3
+			IL_0300: br IL_0306
+
 			IL_0305: stloc.3
-			IL_0306: br IL_030c
 
-			IL_030b: stloc.3
-
-			IL_030c: ldloc.3
-			IL_030d: stloc.s 4
-			IL_030f: ldstr "console"
-			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_031e: stloc.s 10
-			IL_0320: ldloc.s 4
-			IL_0322: ldstr "name"
-			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_032c: stloc.s 9
-			IL_032e: ldloc.s 10
-			IL_0330: ldstr "log"
-			IL_0335: ldloc.s 9
-			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_033c: pop
-			IL_033d: ldstr "console"
-			IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_034c: stloc.s 9
-			IL_034e: ldloc.s 4
-			IL_0350: ldstr "message"
-			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_035a: stloc.s 10
-			IL_035c: ldloc.s 10
-			IL_035e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0363: stloc.s 12
-			IL_0365: ldloc.s 12
-			IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_036c: stloc.s 10
-			IL_036e: ldloc.s 10
-			IL_0370: castclass [System.Runtime]System.String
-			IL_0375: ldstr "v"
-			IL_037a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_037f: ldc.r8 0.0
-			IL_0388: clt
-			IL_038a: ldc.i4.0
-			IL_038b: ceq
-			IL_038d: stloc.s 13
-			IL_038f: ldloc.s 13
-			IL_0391: box [System.Runtime]System.Boolean
-			IL_0396: stloc.s 14
-			IL_0398: ldloc.s 9
-			IL_039a: ldstr "log"
-			IL_039f: ldloc.s 14
-			IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03a6: pop
-			IL_03a7: leave IL_03ac
+			IL_0306: ldloc.3
+			IL_0307: stloc.s 4
+			IL_0309: ldstr "console"
+			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0318: stloc.s 10
+			IL_031a: ldloc.s 4
+			IL_031c: ldstr "name"
+			IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0326: stloc.s 9
+			IL_0328: ldloc.s 10
+			IL_032a: ldstr "log"
+			IL_032f: ldloc.s 9
+			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0336: pop
+			IL_0337: ldstr "console"
+			IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0346: stloc.s 9
+			IL_0348: ldloc.s 4
+			IL_034a: ldstr "message"
+			IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0354: stloc.s 10
+			IL_0356: ldloc.s 10
+			IL_0358: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_035d: stloc.s 12
+			IL_035f: ldloc.s 12
+			IL_0361: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0366: stloc.s 12
+			IL_0368: ldloc.s 12
+			IL_036a: ldstr "v"
+			IL_036f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0374: ldc.r8 0.0
+			IL_037d: clt
+			IL_037f: ldc.i4.0
+			IL_0380: ceq
+			IL_0382: stloc.s 13
+			IL_0384: ldloc.s 13
+			IL_0386: box [System.Runtime]System.Boolean
+			IL_038b: stloc.s 14
+			IL_038d: ldloc.s 9
+			IL_038f: ldstr "log"
+			IL_0394: ldloc.s 14
+			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_039b: pop
+			IL_039c: leave IL_03a1
 		} // end handler
 		.try
 		{
-			IL_03ac: nop
-			IL_03ad: ldstr "a"
-			IL_03b2: ldstr "gg"
-			IL_03b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_03bc: pop
-			IL_03bd: ldstr "console"
-			IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03cc: ldstr "log"
-			IL_03d1: ldstr "no-error"
-			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03db: pop
-			IL_03dc: leave IL_0446
+			IL_03a1: nop
+			IL_03a2: ldstr "a"
+			IL_03a7: ldstr "gg"
+			IL_03ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_03b1: pop
+			IL_03b2: ldstr "console"
+			IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03c1: ldstr "log"
+			IL_03c6: ldstr "no-error"
+			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03d0: pop
+			IL_03d1: leave IL_043b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03e1: stloc.s 5
-			IL_03e3: ldloc.s 5
-			IL_03e5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03ea: dup
-			IL_03eb: brtrue IL_0401
+			IL_03d6: stloc.s 5
+			IL_03d8: ldloc.s 5
+			IL_03da: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03df: dup
+			IL_03e0: brtrue IL_03f6
 
-			IL_03f0: pop
-			IL_03f1: ldloc.s 5
-			IL_03f3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03f8: dup
-			IL_03f9: brtrue IL_040d
+			IL_03e5: pop
+			IL_03e6: ldloc.s 5
+			IL_03e8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03ed: dup
+			IL_03ee: brtrue IL_0402
 
-			IL_03fe: pop
-			IL_03ff: rethrow
+			IL_03f3: pop
+			IL_03f4: rethrow
 
-			IL_0401: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0406: stloc.s 6
-			IL_0408: br IL_040f
+			IL_03f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03fb: stloc.s 6
+			IL_03fd: br IL_0404
 
-			IL_040d: stloc.s 6
+			IL_0402: stloc.s 6
 
-			IL_040f: ldloc.s 6
-			IL_0411: stloc.s 7
-			IL_0413: ldstr "console"
-			IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0422: stloc.s 9
-			IL_0424: ldloc.s 7
-			IL_0426: ldstr "name"
-			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0430: stloc.s 10
-			IL_0432: ldloc.s 9
-			IL_0434: ldstr "log"
-			IL_0439: ldloc.s 10
-			IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0440: pop
-			IL_0441: leave IL_0446
+			IL_0404: ldloc.s 6
+			IL_0406: stloc.s 7
+			IL_0408: ldstr "console"
+			IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0417: stloc.s 9
+			IL_0419: ldloc.s 7
+			IL_041b: ldstr "name"
+			IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0425: stloc.s 10
+			IL_0427: ldloc.s 9
+			IL_0429: ldstr "log"
+			IL_042e: ldloc.s 10
+			IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0435: pop
+			IL_0436: leave IL_043b
 		} // end handler
 
-		IL_0446: ldnull
-		IL_0447: stloc.s 8
-		IL_0449: ret
+		IL_043b: ldnull
+		IL_043c: stloc.s 8
+		IL_043e: ret
 	} // end of method IntrinsicCallables_RegExp_ModernFlags_Basic::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_ModernFlags_Basic
@@ -486,7 +491,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24f1
+		// Method begins at RVA 0x24e5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Test_LastIndex_Global.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Test_LastIndex_Global.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2215
+			// Method begins at RVA 0x2211
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 441 (0x1b9)
+		// Code size: 437 (0x1b5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_Test_LastIndex_Global/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[2] string,
 			[3] object,
-			[4] object
+			[4] object,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		)
 
 		IL_0000: newobj instance void Modules.IntrinsicCallables_RegExp_Test_LastIndex_Global/Scope::.ctor()
@@ -77,114 +78,118 @@
 		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0057: stloc.s 4
 		IL_0059: ldloc.1
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005f: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_0064: ldloc.2
-		IL_0065: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_006a: stloc.3
-		IL_006b: ldloc.s 4
-		IL_006d: ldstr "log"
-		IL_0072: ldloc.3
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0078: pop
-		IL_0079: ldstr "console"
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0088: stloc.3
-		IL_0089: ldloc.1
-		IL_008a: ldstr "lastIndex"
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0094: stloc.s 4
-		IL_0096: ldloc.3
-		IL_0097: ldstr "log"
-		IL_009c: ldloc.s 4
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a3: pop
-		IL_00a4: ldstr "console"
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b3: stloc.s 4
-		IL_00b5: ldloc.1
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bb: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_00c0: ldloc.2
-		IL_00c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_00c6: stloc.3
-		IL_00c7: ldloc.s 4
-		IL_00c9: ldstr "log"
-		IL_00ce: ldloc.3
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d4: pop
-		IL_00d5: ldstr "console"
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e4: stloc.3
-		IL_00e5: ldloc.1
-		IL_00e6: ldstr "lastIndex"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f0: stloc.s 4
-		IL_00f2: ldloc.3
-		IL_00f3: ldstr "log"
-		IL_00f8: ldloc.s 4
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ff: pop
-		IL_0100: ldstr "console"
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010f: stloc.s 4
-		IL_0111: ldloc.1
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0117: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_011c: ldloc.2
-		IL_011d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0122: stloc.3
-		IL_0123: ldloc.s 4
-		IL_0125: ldstr "log"
-		IL_012a: ldloc.3
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0130: pop
-		IL_0131: ldstr "console"
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0140: stloc.3
-		IL_0141: ldloc.1
-		IL_0142: ldstr "lastIndex"
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_014c: stloc.s 4
-		IL_014e: ldloc.3
-		IL_014f: ldstr "log"
-		IL_0154: ldloc.s 4
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015b: pop
-		IL_015c: ldstr "console"
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016b: stloc.s 4
-		IL_016d: ldloc.1
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0173: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_0178: ldloc.2
-		IL_0179: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_017e: stloc.3
-		IL_017f: ldloc.s 4
-		IL_0181: ldstr "log"
-		IL_0186: ldloc.3
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018c: pop
-		IL_018d: ldstr "console"
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019c: stloc.3
-		IL_019d: ldloc.1
-		IL_019e: ldstr "lastIndex"
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a8: stloc.s 4
-		IL_01aa: ldloc.3
-		IL_01ab: ldstr "log"
-		IL_01b0: ldloc.s 4
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b7: pop
-		IL_01b8: ret
+		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_005f: stloc.s 5
+		IL_0061: ldloc.s 5
+		IL_0063: ldloc.2
+		IL_0064: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0069: stloc.3
+		IL_006a: ldloc.s 4
+		IL_006c: ldstr "log"
+		IL_0071: ldloc.3
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0077: pop
+		IL_0078: ldstr "console"
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0087: stloc.3
+		IL_0088: ldloc.1
+		IL_0089: ldstr "lastIndex"
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0093: stloc.s 4
+		IL_0095: ldloc.3
+		IL_0096: ldstr "log"
+		IL_009b: ldloc.s 4
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a2: pop
+		IL_00a3: ldstr "console"
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b2: stloc.s 4
+		IL_00b4: ldloc.1
+		IL_00b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_00ba: stloc.s 5
+		IL_00bc: ldloc.s 5
+		IL_00be: ldloc.2
+		IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_00c4: stloc.3
+		IL_00c5: ldloc.s 4
+		IL_00c7: ldstr "log"
+		IL_00cc: ldloc.3
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d2: pop
+		IL_00d3: ldstr "console"
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e2: stloc.3
+		IL_00e3: ldloc.1
+		IL_00e4: ldstr "lastIndex"
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ee: stloc.s 4
+		IL_00f0: ldloc.3
+		IL_00f1: ldstr "log"
+		IL_00f6: ldloc.s 4
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fd: pop
+		IL_00fe: ldstr "console"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010d: stloc.s 4
+		IL_010f: ldloc.1
+		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0115: stloc.s 5
+		IL_0117: ldloc.s 5
+		IL_0119: ldloc.2
+		IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_011f: stloc.3
+		IL_0120: ldloc.s 4
+		IL_0122: ldstr "log"
+		IL_0127: ldloc.3
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012d: pop
+		IL_012e: ldstr "console"
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013d: stloc.3
+		IL_013e: ldloc.1
+		IL_013f: ldstr "lastIndex"
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0149: stloc.s 4
+		IL_014b: ldloc.3
+		IL_014c: ldstr "log"
+		IL_0151: ldloc.s 4
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0158: pop
+		IL_0159: ldstr "console"
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0168: stloc.s 4
+		IL_016a: ldloc.1
+		IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0170: stloc.s 5
+		IL_0172: ldloc.s 5
+		IL_0174: ldloc.2
+		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_017a: stloc.3
+		IL_017b: ldloc.s 4
+		IL_017d: ldstr "log"
+		IL_0182: ldloc.3
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0188: pop
+		IL_0189: ldstr "console"
+		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0198: stloc.3
+		IL_0199: ldloc.1
+		IL_019a: ldstr "lastIndex"
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a4: stloc.s 4
+		IL_01a6: ldloc.3
+		IL_01a7: ldstr "log"
+		IL_01ac: ldloc.s 4
+		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b3: pop
+		IL_01b4: ret
 	} // end of method IntrinsicCallables_RegExp_Test_LastIndex_Global::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_Test_LastIndex_Global
@@ -196,7 +201,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x221e
+		// Method begins at RVA 0x221a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Test_LastIndex_Sticky.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Test_LastIndex_Sticky.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e4
+			// Method begins at RVA 0x22de
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 648 (0x288)
+		// Code size: 642 (0x282)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_Test_LastIndex_Sticky/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[2] string,
 			[3] object,
-			[4] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.IntrinsicCallables_RegExp_Test_LastIndex_Sticky/Scope::.ctor()
@@ -70,182 +71,188 @@
 		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0042: stloc.3
 		IL_0043: ldloc.1
-		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0049: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_004e: ldloc.2
-		IL_004f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0054: stloc.s 4
-		IL_0056: ldloc.3
-		IL_0057: ldstr "log"
-		IL_005c: ldloc.s 4
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0063: pop
-		IL_0064: ldstr "console"
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0073: stloc.s 4
-		IL_0075: ldloc.1
-		IL_0076: ldstr "lastIndex"
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0080: stloc.3
-		IL_0081: ldloc.s 4
-		IL_0083: ldstr "log"
-		IL_0088: ldloc.3
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008e: pop
-		IL_008f: ldstr "console"
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009e: stloc.3
-		IL_009f: ldloc.1
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a5: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_00aa: ldloc.2
-		IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_00b0: stloc.s 4
-		IL_00b2: ldloc.3
-		IL_00b3: ldstr "log"
-		IL_00b8: ldloc.s 4
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bf: pop
-		IL_00c0: ldstr "console"
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cf: stloc.s 4
-		IL_00d1: ldloc.1
-		IL_00d2: ldstr "lastIndex"
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00dc: stloc.3
-		IL_00dd: ldloc.s 4
-		IL_00df: ldstr "log"
-		IL_00e4: ldloc.3
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ea: pop
-		IL_00eb: ldstr "console"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fa: stloc.3
-		IL_00fb: ldloc.1
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0101: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_0106: ldloc.2
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_010c: stloc.s 4
-		IL_010e: ldloc.3
-		IL_010f: ldstr "log"
-		IL_0114: ldloc.s 4
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011b: pop
-		IL_011c: ldstr "console"
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012b: stloc.s 4
-		IL_012d: ldloc.1
-		IL_012e: ldstr "lastIndex"
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0138: stloc.3
-		IL_0139: ldloc.s 4
-		IL_013b: ldstr "log"
-		IL_0140: ldloc.3
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0146: pop
-		IL_0147: ldstr "console"
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0156: stloc.3
-		IL_0157: ldloc.1
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015d: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_0162: ldloc.2
-		IL_0163: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0168: stloc.s 4
-		IL_016a: ldloc.3
-		IL_016b: ldstr "log"
-		IL_0170: ldloc.s 4
-		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0177: pop
-		IL_0178: ldstr "console"
-		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0187: stloc.s 4
-		IL_0189: ldloc.1
-		IL_018a: ldstr "lastIndex"
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0194: stloc.3
-		IL_0195: ldloc.s 4
-		IL_0197: ldstr "log"
-		IL_019c: ldloc.3
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a2: pop
-		IL_01a3: ldloc.1
-		IL_01a4: ldstr "lastIndex"
-		IL_01a9: ldc.r8 0.0
-		IL_01b2: ldc.i4.1
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_01b8: pop
-		IL_01b9: ldstr "console"
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c8: stloc.3
-		IL_01c9: ldloc.1
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01cf: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_01d4: ldloc.2
-		IL_01d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_01da: stloc.s 4
-		IL_01dc: ldloc.3
-		IL_01dd: ldstr "log"
-		IL_01e2: ldloc.s 4
-		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e9: pop
-		IL_01ea: ldstr "console"
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f9: stloc.s 4
-		IL_01fb: ldloc.1
-		IL_01fc: ldstr "lastIndex"
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0206: stloc.3
-		IL_0207: ldloc.s 4
-		IL_0209: ldstr "log"
-		IL_020e: ldloc.3
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0214: pop
-		IL_0215: ldloc.1
-		IL_0216: ldstr "lastIndex"
-		IL_021b: ldc.r8 (00 00 00 00 00 00 F0 7F)
-		IL_0224: ldc.i4.1
-		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_022a: pop
-		IL_022b: ldstr "console"
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023a: stloc.3
-		IL_023b: ldloc.1
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0241: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_0246: ldloc.2
-		IL_0247: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_024c: stloc.s 4
-		IL_024e: ldloc.3
-		IL_024f: ldstr "log"
-		IL_0254: ldloc.s 4
-		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025b: pop
-		IL_025c: ldstr "console"
-		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026b: stloc.s 4
-		IL_026d: ldloc.1
-		IL_026e: ldstr "lastIndex"
-		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0278: stloc.3
-		IL_0279: ldloc.s 4
-		IL_027b: ldstr "log"
-		IL_0280: ldloc.3
-		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0286: pop
-		IL_0287: ret
+		IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0049: stloc.s 4
+		IL_004b: ldloc.s 4
+		IL_004d: ldloc.2
+		IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0053: stloc.s 5
+		IL_0055: ldloc.3
+		IL_0056: ldstr "log"
+		IL_005b: ldloc.s 5
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0062: pop
+		IL_0063: ldstr "console"
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0072: stloc.s 5
+		IL_0074: ldloc.1
+		IL_0075: ldstr "lastIndex"
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_007f: stloc.3
+		IL_0080: ldloc.s 5
+		IL_0082: ldstr "log"
+		IL_0087: ldloc.3
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008d: pop
+		IL_008e: ldstr "console"
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009d: stloc.3
+		IL_009e: ldloc.1
+		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_00a4: stloc.s 4
+		IL_00a6: ldloc.s 4
+		IL_00a8: ldloc.2
+		IL_00a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_00ae: stloc.s 5
+		IL_00b0: ldloc.3
+		IL_00b1: ldstr "log"
+		IL_00b6: ldloc.s 5
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bd: pop
+		IL_00be: ldstr "console"
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cd: stloc.s 5
+		IL_00cf: ldloc.1
+		IL_00d0: ldstr "lastIndex"
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00da: stloc.3
+		IL_00db: ldloc.s 5
+		IL_00dd: ldstr "log"
+		IL_00e2: ldloc.3
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e8: pop
+		IL_00e9: ldstr "console"
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f8: stloc.3
+		IL_00f9: ldloc.1
+		IL_00fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_00ff: stloc.s 4
+		IL_0101: ldloc.s 4
+		IL_0103: ldloc.2
+		IL_0104: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0109: stloc.s 5
+		IL_010b: ldloc.3
+		IL_010c: ldstr "log"
+		IL_0111: ldloc.s 5
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0118: pop
+		IL_0119: ldstr "console"
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0128: stloc.s 5
+		IL_012a: ldloc.1
+		IL_012b: ldstr "lastIndex"
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0135: stloc.3
+		IL_0136: ldloc.s 5
+		IL_0138: ldstr "log"
+		IL_013d: ldloc.3
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0143: pop
+		IL_0144: ldstr "console"
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0153: stloc.3
+		IL_0154: ldloc.1
+		IL_0155: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_015a: stloc.s 4
+		IL_015c: ldloc.s 4
+		IL_015e: ldloc.2
+		IL_015f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0164: stloc.s 5
+		IL_0166: ldloc.3
+		IL_0167: ldstr "log"
+		IL_016c: ldloc.s 5
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0173: pop
+		IL_0174: ldstr "console"
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0183: stloc.s 5
+		IL_0185: ldloc.1
+		IL_0186: ldstr "lastIndex"
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0190: stloc.3
+		IL_0191: ldloc.s 5
+		IL_0193: ldstr "log"
+		IL_0198: ldloc.3
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019e: pop
+		IL_019f: ldloc.1
+		IL_01a0: ldstr "lastIndex"
+		IL_01a5: ldc.r8 0.0
+		IL_01ae: ldc.i4.1
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_01b4: pop
+		IL_01b5: ldstr "console"
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c4: stloc.3
+		IL_01c5: ldloc.1
+		IL_01c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_01cb: stloc.s 4
+		IL_01cd: ldloc.s 4
+		IL_01cf: ldloc.2
+		IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_01d5: stloc.s 5
+		IL_01d7: ldloc.3
+		IL_01d8: ldstr "log"
+		IL_01dd: ldloc.s 5
+		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e4: pop
+		IL_01e5: ldstr "console"
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f4: stloc.s 5
+		IL_01f6: ldloc.1
+		IL_01f7: ldstr "lastIndex"
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0201: stloc.3
+		IL_0202: ldloc.s 5
+		IL_0204: ldstr "log"
+		IL_0209: ldloc.3
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_020f: pop
+		IL_0210: ldloc.1
+		IL_0211: ldstr "lastIndex"
+		IL_0216: ldc.r8 (00 00 00 00 00 00 F0 7F)
+		IL_021f: ldc.i4.1
+		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0225: pop
+		IL_0226: ldstr "console"
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0235: stloc.3
+		IL_0236: ldloc.1
+		IL_0237: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_023c: stloc.s 4
+		IL_023e: ldloc.s 4
+		IL_0240: ldloc.2
+		IL_0241: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0246: stloc.s 5
+		IL_0248: ldloc.3
+		IL_0249: ldstr "log"
+		IL_024e: ldloc.s 5
+		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0255: pop
+		IL_0256: ldstr "console"
+		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0265: stloc.s 5
+		IL_0267: ldloc.1
+		IL_0268: ldstr "lastIndex"
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0272: stloc.3
+		IL_0273: ldloc.s 5
+		IL_0275: ldstr "log"
+		IL_027a: ldloc.3
+		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0280: pop
+		IL_0281: ret
 	} // end of method IntrinsicCallables_RegExp_Test_LastIndex_Sticky::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_Test_LastIndex_Sticky
@@ -257,7 +264,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22ed
+		// Method begins at RVA 0x22e7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ToString_Basic.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ToString_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x212a
+			// Method begins at RVA 0x2132
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 206 (0xce)
+		// Code size: 214 (0xd6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_ToString_Basic/Scope,
@@ -48,7 +48,8 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[3] object,
 			[4] object,
-			[5] object
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.IntrinsicCallables_RegExp_ToString_Basic/Scope::.ctor()
@@ -63,52 +64,56 @@
 		IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0026: stloc.s 4
 		IL_0028: ldloc.1
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_002e: ldstr "toString"
-		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0038: stloc.s 5
-		IL_003a: ldloc.s 4
-		IL_003c: ldstr "log"
-		IL_0041: ldloc.s 5
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0048: pop
-		IL_0049: ldstr "test"
-		IL_004e: ldstr ""
-		IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0058: stloc.2
-		IL_0059: ldstr "console"
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0068: stloc.s 5
-		IL_006a: ldloc.2
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0070: ldstr "toString"
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_007a: stloc.s 4
-		IL_007c: ldloc.s 5
-		IL_007e: ldstr "log"
-		IL_0083: ldloc.s 4
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008a: pop
-		IL_008b: ldstr "hello"
-		IL_0090: ldstr "i"
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.RegExp::Call(object, object)
-		IL_009a: stloc.3
-		IL_009b: ldstr "console"
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00aa: stloc.s 4
-		IL_00ac: ldloc.3
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_002e: stloc.s 5
+		IL_0030: ldloc.s 5
+		IL_0032: ldstr "toString"
+		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_003c: stloc.s 6
+		IL_003e: ldloc.s 4
+		IL_0040: ldstr "log"
+		IL_0045: ldloc.s 6
+		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004c: pop
+		IL_004d: ldstr "test"
+		IL_0052: ldstr ""
+		IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_005c: stloc.2
+		IL_005d: ldstr "console"
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006c: stloc.s 6
+		IL_006e: ldloc.2
+		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0074: stloc.s 5
+		IL_0076: ldloc.s 5
+		IL_0078: ldstr "toString"
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0082: stloc.s 4
+		IL_0084: ldloc.s 6
+		IL_0086: ldstr "log"
+		IL_008b: ldloc.s 4
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0092: pop
+		IL_0093: ldstr "hello"
+		IL_0098: ldstr "i"
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.RegExp::Call(object, object)
+		IL_00a2: stloc.3
+		IL_00a3: ldstr "console"
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b2: ldstr "toString"
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00bc: stloc.s 5
-		IL_00be: ldloc.s 4
-		IL_00c0: ldstr "log"
-		IL_00c5: ldloc.s 5
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cc: pop
-		IL_00cd: ret
+		IL_00b2: stloc.s 4
+		IL_00b4: ldloc.3
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ba: ldstr "toString"
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00c4: stloc.s 6
+		IL_00c6: ldloc.s 4
+		IL_00c8: ldstr "log"
+		IL_00cd: ldloc.s 6
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d4: pop
+		IL_00d5: ret
 	} // end of method IntrinsicCallables_RegExp_ToString_Basic::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_ToString_Basic
@@ -120,7 +125,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2133
+		// Method begins at RVA 0x213b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Clear_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Clear_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2103
+			// Method begins at RVA 0x210d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 167 (0xa7)
+		// Code size: 177 (0xb1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Clear_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] object,
-			[3] object
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Clear_Basic/Scope::.ctor()
@@ -55,51 +56,57 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0013: ldstr "set"
-		IL_0018: ldstr "key1"
-		IL_001d: ldstr "value1"
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0027: pop
-		IL_0028: ldloc.1
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_002e: ldstr "set"
-		IL_0033: ldstr "key2"
-		IL_0038: ldstr "value2"
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0042: pop
-		IL_0043: ldstr "console"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldstr "size"
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_005e: stloc.3
-		IL_005f: ldloc.2
-		IL_0060: ldstr "log"
-		IL_0065: ldloc.3
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006b: pop
-		IL_006c: ldloc.1
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0072: ldstr "clear"
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_007c: pop
-		IL_007d: ldstr "console"
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008c: stloc.3
-		IL_008d: ldloc.1
-		IL_008e: ldstr "size"
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0098: stloc.2
-		IL_0099: ldloc.3
-		IL_009a: ldstr "log"
-		IL_009f: ldloc.2
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a5: pop
-		IL_00a6: ret
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0013: stloc.2
+		IL_0014: ldloc.2
+		IL_0015: ldstr "set"
+		IL_001a: ldstr "key1"
+		IL_001f: ldstr "value1"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0029: pop
+		IL_002a: ldloc.1
+		IL_002b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0030: stloc.2
+		IL_0031: ldloc.2
+		IL_0032: ldstr "set"
+		IL_0037: ldstr "key2"
+		IL_003c: ldstr "value2"
+		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0046: pop
+		IL_0047: ldstr "console"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0056: stloc.3
+		IL_0057: ldloc.1
+		IL_0058: ldstr "size"
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0062: stloc.s 4
+		IL_0064: ldloc.3
+		IL_0065: ldstr "log"
+		IL_006a: ldloc.s 4
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0071: pop
+		IL_0072: ldloc.1
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0078: stloc.2
+		IL_0079: ldloc.2
+		IL_007a: ldstr "clear"
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0084: pop
+		IL_0085: ldstr "console"
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0094: stloc.s 4
+		IL_0096: ldloc.1
+		IL_0097: ldstr "size"
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a1: stloc.3
+		IL_00a2: ldloc.s 4
+		IL_00a4: ldstr "log"
+		IL_00a9: ldloc.3
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00af: pop
+		IL_00b0: ret
 	} // end of method Map_Clear_Basic::__js_module_init__
 
 } // end of class Modules.Map_Clear_Basic
@@ -111,7 +118,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x210c
+		// Method begins at RVA 0x2116
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x291a
+						// Method begins at RVA 0x292a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2911
+					// Method begins at RVA 0x2921
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x268c
+				// Method begins at RVA 0x269c
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -178,7 +178,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2908
+				// Method begins at RVA 0x2918
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -204,7 +204,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x23e8
+			// Method begins at RVA 0x23f8
 			// Header size: 12
 			// Code size: 226 (0xe2)
 			.maxstack 8
@@ -311,7 +311,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2935
+						// Method begins at RVA 0x2945
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -329,7 +329,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x292c
+					// Method begins at RVA 0x293c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -353,7 +353,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2760
+				// Method begins at RVA 0x2770
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -458,7 +458,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x293e
+					// Method begins at RVA 0x294e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -482,7 +482,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2833
+				// Method begins at RVA 0x2843
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -520,7 +520,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2923
+				// Method begins at RVA 0x2933
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -546,7 +546,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x24d8
+			// Method begins at RVA 0x24e8
 			// Header size: 12
 			// Code size: 254 (0xfe)
 			.maxstack 8
@@ -671,7 +671,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2959
+						// Method begins at RVA 0x2969
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -689,7 +689,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2950
+					// Method begins at RVA 0x2960
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -713,7 +713,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x285c
+				// Method begins at RVA 0x286c
 				// Header size: 12
 				// Code size: 113 (0x71)
 				.maxstack 8
@@ -779,7 +779,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2962
+					// Method begins at RVA 0x2972
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -803,7 +803,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x28d9
+				// Method begins at RVA 0x28e9
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -839,7 +839,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2947
+				// Method begins at RVA 0x2957
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -865,7 +865,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x25e4
+			// Method begins at RVA 0x25f4
 			// Header size: 12
 			// Code size: 154 (0x9a)
 			.maxstack 8
@@ -965,7 +965,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x296b
+				// Method begins at RVA 0x297b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -985,7 +985,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2974
+				// Method begins at RVA 0x2984
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1007,7 +1007,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x28ff
+			// Method begins at RVA 0x290f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1033,7 +1033,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 892 (0x37c)
+		// Code size: 908 (0x38c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Constructor_Iterable/Scope,
@@ -1051,9 +1051,10 @@
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[14] object,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[16] bool,
-			[17] object
+			[15] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[16] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[17] bool,
+			[18] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Constructor_Iterable/Scope::.ctor()
@@ -1107,242 +1108,250 @@
 		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_009b: stloc.s 14
 		IL_009d: ldloc.2
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a3: ldstr "get"
-		IL_00a8: ldstr "alpha"
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b2: stloc.s 11
-		IL_00b4: ldloc.s 14
-		IL_00b6: ldstr "log"
-		IL_00bb: ldloc.s 11
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c2: pop
-		IL_00c3: ldstr "console"
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d2: stloc.s 11
-		IL_00d4: ldloc.2
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00da: ldstr "get"
-		IL_00df: ldstr "beta"
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e9: stloc.s 14
-		IL_00eb: ldloc.s 11
-		IL_00ed: ldstr "log"
-		IL_00f2: ldloc.s 14
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f9: pop
-		IL_00fa: ldloc.0
-		IL_00fb: ldc.i4.0
-		IL_00fc: box [System.Runtime]System.Boolean
-		IL_0101: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_0106: ldstr "iterator"
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0110: stloc.s 14
-		IL_0112: ldloc.0
-		IL_0113: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_0118: ldftn object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
-		IL_011e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0123: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0128: ldc.i4.0
-		IL_0129: conv.r8
-		IL_012a: ldstr ""
-		IL_012f: ldc.i4.0
-		IL_0130: ldc.i4.1
-		IL_0131: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0136: stloc.s 12
-		IL_0138: ldloc.s 12
-		IL_013a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_013f: stloc.s 12
-		IL_0141: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0146: stloc.s 13
-		IL_0148: ldloc.s 13
-		IL_014a: ldloc.s 14
-		IL_014c: ldloc.s 12
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_0153: pop
-		IL_0154: ldloc.s 13
-		IL_0156: stloc.3
-		IL_0157: ldloc.3
-		IL_0158: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_015d: stloc.s 4
-		IL_015f: ldstr "console"
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016e: stloc.s 14
-		IL_0170: ldloc.0
-		IL_0171: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_0176: stloc.s 11
-		IL_0178: ldloc.s 14
-		IL_017a: ldstr "log"
-		IL_017f: ldloc.s 11
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0186: pop
-		IL_0187: ldstr "console"
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0196: stloc.s 11
-		IL_0198: ldloc.s 4
-		IL_019a: ldstr "size"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a4: stloc.s 14
-		IL_01a6: ldloc.s 11
-		IL_01a8: ldstr "log"
-		IL_01ad: ldloc.s 14
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b4: pop
-		IL_01b5: ldc.i4.1
-		IL_01b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01bb: dup
-		IL_01bc: ldc.i4.1
-		IL_01bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01c2: dup
-		IL_01c3: ldstr "short"
-		IL_01c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_01cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_01d2: stloc.s 15
-		IL_01d4: ldloc.s 15
-		IL_01d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_01db: stloc.s 5
-		IL_01dd: ldstr "console"
-		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ec: stloc.s 14
-		IL_01ee: ldloc.s 5
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f5: ldstr "has"
-		IL_01fa: ldstr "short"
-		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0204: stloc.s 11
-		IL_0206: ldloc.s 14
-		IL_0208: ldstr "log"
-		IL_020d: ldloc.s 11
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0214: pop
-		IL_0215: ldstr "console"
-		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0224: stloc.s 11
-		IL_0226: ldloc.s 5
-		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022d: ldstr "get"
-		IL_0232: ldstr "short"
-		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023c: stloc.s 14
-		IL_023e: ldloc.s 14
-		IL_0240: ldnull
-		IL_0241: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0246: stloc.s 16
-		IL_0248: ldloc.s 16
-		IL_024a: box [System.Runtime]System.Boolean
-		IL_024f: stloc.s 17
-		IL_0251: ldloc.s 11
-		IL_0253: ldstr "log"
+		IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_00a3: stloc.s 15
+		IL_00a5: ldloc.s 15
+		IL_00a7: ldstr "get"
+		IL_00ac: ldstr "alpha"
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b6: stloc.s 11
+		IL_00b8: ldloc.s 14
+		IL_00ba: ldstr "log"
+		IL_00bf: ldloc.s 11
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c6: pop
+		IL_00c7: ldstr "console"
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d6: stloc.s 11
+		IL_00d8: ldloc.2
+		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_00de: stloc.s 15
+		IL_00e0: ldloc.s 15
+		IL_00e2: ldstr "get"
+		IL_00e7: ldstr "beta"
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f1: stloc.s 14
+		IL_00f3: ldloc.s 11
+		IL_00f5: ldstr "log"
+		IL_00fa: ldloc.s 14
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0101: pop
+		IL_0102: ldloc.0
+		IL_0103: ldc.i4.0
+		IL_0104: box [System.Runtime]System.Boolean
+		IL_0109: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_010e: ldstr "iterator"
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0118: stloc.s 14
+		IL_011a: ldloc.0
+		IL_011b: castclass Modules.Map_Constructor_Iterable/Scope
+		IL_0120: ldftn object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
+		IL_0126: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_012b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0130: ldc.i4.0
+		IL_0131: conv.r8
+		IL_0132: ldstr ""
+		IL_0137: ldc.i4.0
+		IL_0138: ldc.i4.1
+		IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_013e: stloc.s 12
+		IL_0140: ldloc.s 12
+		IL_0142: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0147: stloc.s 12
+		IL_0149: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_014e: stloc.s 13
+		IL_0150: ldloc.s 13
+		IL_0152: ldloc.s 14
+		IL_0154: ldloc.s 12
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_015b: pop
+		IL_015c: ldloc.s 13
+		IL_015e: stloc.3
+		IL_015f: ldloc.3
+		IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+		IL_0165: stloc.s 4
+		IL_0167: ldstr "console"
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0176: stloc.s 14
+		IL_0178: ldloc.0
+		IL_0179: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_017e: stloc.s 11
+		IL_0180: ldloc.s 14
+		IL_0182: ldstr "log"
+		IL_0187: ldloc.s 11
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018e: pop
+		IL_018f: ldstr "console"
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019e: stloc.s 11
+		IL_01a0: ldloc.s 4
+		IL_01a2: ldstr "size"
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ac: stloc.s 14
+		IL_01ae: ldloc.s 11
+		IL_01b0: ldstr "log"
+		IL_01b5: ldloc.s 14
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bc: pop
+		IL_01bd: ldc.i4.1
+		IL_01be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01c3: dup
+		IL_01c4: ldc.i4.1
+		IL_01c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01ca: dup
+		IL_01cb: ldstr "short"
+		IL_01d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01da: stloc.s 16
+		IL_01dc: ldloc.s 16
+		IL_01de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+		IL_01e3: stloc.s 5
+		IL_01e5: ldstr "console"
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f4: stloc.s 14
+		IL_01f6: ldloc.s 5
+		IL_01f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_01fd: stloc.s 15
+		IL_01ff: ldloc.s 15
+		IL_0201: ldstr "has"
+		IL_0206: ldstr "short"
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0210: stloc.s 11
+		IL_0212: ldloc.s 14
+		IL_0214: ldstr "log"
+		IL_0219: ldloc.s 11
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0220: pop
+		IL_0221: ldstr "console"
+		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0230: stloc.s 11
+		IL_0232: ldloc.s 5
+		IL_0234: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0239: stloc.s 15
+		IL_023b: ldloc.s 15
+		IL_023d: ldstr "get"
+		IL_0242: ldstr "short"
+		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024c: stloc.s 14
+		IL_024e: ldloc.s 14
+		IL_0250: ldnull
+		IL_0251: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0256: stloc.s 17
 		IL_0258: ldloc.s 17
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025f: pop
-		IL_0260: ldloc.0
-		IL_0261: ldc.i4.0
-		IL_0262: box [System.Runtime]System.Boolean
-		IL_0267: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
-		IL_026c: ldstr "iterator"
-		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0276: stloc.s 11
-		IL_0278: ldloc.0
-		IL_0279: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_027e: ldftn object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
-		IL_0284: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0289: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_028e: ldc.i4.0
-		IL_028f: conv.r8
-		IL_0290: ldstr ""
-		IL_0295: ldc.i4.0
-		IL_0296: ldc.i4.1
-		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_029c: stloc.s 12
-		IL_029e: ldloc.s 12
-		IL_02a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_02a5: stloc.s 12
-		IL_02a7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02ac: stloc.s 13
-		IL_02ae: ldloc.s 13
-		IL_02b0: ldloc.s 11
-		IL_02b2: ldloc.s 12
-		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_02b9: pop
-		IL_02ba: ldloc.s 13
-		IL_02bc: stloc.s 6
+		IL_025a: box [System.Runtime]System.Boolean
+		IL_025f: stloc.s 18
+		IL_0261: ldloc.s 11
+		IL_0263: ldstr "log"
+		IL_0268: ldloc.s 18
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_026f: pop
+		IL_0270: ldloc.0
+		IL_0271: ldc.i4.0
+		IL_0272: box [System.Runtime]System.Boolean
+		IL_0277: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
+		IL_027c: ldstr "iterator"
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0286: stloc.s 11
+		IL_0288: ldloc.0
+		IL_0289: castclass Modules.Map_Constructor_Iterable/Scope
+		IL_028e: ldftn object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
+		IL_0294: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0299: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_029e: ldc.i4.0
+		IL_029f: conv.r8
+		IL_02a0: ldstr ""
+		IL_02a5: ldc.i4.0
+		IL_02a6: ldc.i4.1
+		IL_02a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_02ac: stloc.s 12
+		IL_02ae: ldloc.s 12
+		IL_02b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_02b5: stloc.s 12
+		IL_02b7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02bc: stloc.s 13
+		IL_02be: ldloc.s 13
+		IL_02c0: ldloc.s 11
+		IL_02c2: ldloc.s 12
+		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_02c9: pop
+		IL_02ca: ldloc.s 13
+		IL_02cc: stloc.s 6
 		.try
 		{
-			IL_02be: nop
-			IL_02bf: ldloc.s 6
-			IL_02c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-			IL_02c6: pop
-			IL_02c7: ldstr "console"
-			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02d6: ldstr "log"
-			IL_02db: ldstr "no error"
-			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02e5: pop
-			IL_02e6: leave IL_0350
+			IL_02ce: nop
+			IL_02cf: ldloc.s 6
+			IL_02d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+			IL_02d6: pop
+			IL_02d7: ldstr "console"
+			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02e6: ldstr "log"
+			IL_02eb: ldstr "no error"
+			IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02f5: pop
+			IL_02f6: leave IL_0360
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02eb: stloc.s 7
-			IL_02ed: ldloc.s 7
-			IL_02ef: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02f4: dup
-			IL_02f5: brtrue IL_030b
+			IL_02fb: stloc.s 7
+			IL_02fd: ldloc.s 7
+			IL_02ff: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0304: dup
+			IL_0305: brtrue IL_031b
 
-			IL_02fa: pop
-			IL_02fb: ldloc.s 7
-			IL_02fd: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0302: dup
-			IL_0303: brtrue IL_0317
+			IL_030a: pop
+			IL_030b: ldloc.s 7
+			IL_030d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0312: dup
+			IL_0313: brtrue IL_0327
 
-			IL_0308: pop
-			IL_0309: rethrow
+			IL_0318: pop
+			IL_0319: rethrow
 
-			IL_030b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0310: stloc.s 8
-			IL_0312: br IL_0319
+			IL_031b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0320: stloc.s 8
+			IL_0322: br IL_0329
 
-			IL_0317: stloc.s 8
+			IL_0327: stloc.s 8
 
-			IL_0319: ldloc.s 8
-			IL_031b: stloc.s 9
-			IL_031d: ldstr "console"
-			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_032c: stloc.s 11
-			IL_032e: ldloc.s 9
-			IL_0330: ldstr "name"
-			IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_033a: stloc.s 14
-			IL_033c: ldloc.s 11
-			IL_033e: ldstr "log"
-			IL_0343: ldloc.s 14
-			IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_034a: pop
-			IL_034b: leave IL_0350
+			IL_0329: ldloc.s 8
+			IL_032b: stloc.s 9
+			IL_032d: ldstr "console"
+			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_033c: stloc.s 11
+			IL_033e: ldloc.s 9
+			IL_0340: ldstr "name"
+			IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_034a: stloc.s 14
+			IL_034c: ldloc.s 11
+			IL_034e: ldstr "log"
+			IL_0353: ldloc.s 14
+			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_035a: pop
+			IL_035b: leave IL_0360
 		} // end handler
 
-		IL_0350: ldstr "console"
-		IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_035f: stloc.s 14
-		IL_0361: ldloc.0
-		IL_0362: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
-		IL_0367: stloc.s 11
-		IL_0369: ldloc.s 14
-		IL_036b: ldstr "log"
-		IL_0370: ldloc.s 11
-		IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0377: pop
-		IL_0378: ldnull
-		IL_0379: stloc.s 10
-		IL_037b: ret
+		IL_0360: ldstr "console"
+		IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_036f: stloc.s 14
+		IL_0371: ldloc.0
+		IL_0372: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
+		IL_0377: stloc.s 11
+		IL_0379: ldloc.s 14
+		IL_037b: ldstr "log"
+		IL_0380: ldloc.s 11
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0387: pop
+		IL_0388: ldnull
+		IL_0389: stloc.s 10
+		IL_038b: ret
 	} // end of method Map_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Map_Constructor_Iterable
@@ -1354,7 +1363,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x297d
+		// Method begins at RVA 0x298d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Delete_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Delete_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211e
+			// Method begins at RVA 0x212c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 194 (0xc2)
+		// Code size: 208 (0xd0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Delete_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] object,
-			[3] object
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Delete_Basic/Scope::.ctor()
@@ -55,58 +56,66 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0013: ldstr "set"
-		IL_0018: ldstr "key1"
-		IL_001d: ldstr "value1"
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0027: pop
-		IL_0028: ldstr "console"
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0037: stloc.2
-		IL_0038: ldloc.1
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003e: ldstr "delete"
-		IL_0043: ldstr "key1"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004d: stloc.3
-		IL_004e: ldloc.2
-		IL_004f: ldstr "log"
-		IL_0054: ldloc.3
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005a: pop
-		IL_005b: ldstr "console"
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006a: stloc.3
-		IL_006b: ldloc.1
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0071: ldstr "has"
-		IL_0076: ldstr "key1"
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0080: stloc.2
-		IL_0081: ldloc.3
-		IL_0082: ldstr "log"
-		IL_0087: ldloc.2
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008d: pop
-		IL_008e: ldstr "console"
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009d: stloc.2
-		IL_009e: ldloc.1
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a4: ldstr "delete"
-		IL_00a9: ldstr "key2"
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b3: stloc.3
-		IL_00b4: ldloc.2
-		IL_00b5: ldstr "log"
-		IL_00ba: ldloc.3
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c0: pop
-		IL_00c1: ret
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0013: stloc.2
+		IL_0014: ldloc.2
+		IL_0015: ldstr "set"
+		IL_001a: ldstr "key1"
+		IL_001f: ldstr "value1"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0029: pop
+		IL_002a: ldstr "console"
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0039: stloc.3
+		IL_003a: ldloc.1
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0040: stloc.2
+		IL_0041: ldloc.2
+		IL_0042: ldstr "delete"
+		IL_0047: ldstr "key1"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0051: stloc.s 4
+		IL_0053: ldloc.3
+		IL_0054: ldstr "log"
+		IL_0059: ldloc.s 4
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0060: pop
+		IL_0061: ldstr "console"
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0070: stloc.s 4
+		IL_0072: ldloc.1
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0078: stloc.2
+		IL_0079: ldloc.2
+		IL_007a: ldstr "has"
+		IL_007f: ldstr "key1"
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0089: stloc.3
+		IL_008a: ldloc.s 4
+		IL_008c: ldstr "log"
+		IL_0091: ldloc.3
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0097: pop
+		IL_0098: ldstr "console"
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a7: stloc.3
+		IL_00a8: ldloc.1
+		IL_00a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_00ae: stloc.2
+		IL_00af: ldloc.2
+		IL_00b0: ldstr "delete"
+		IL_00b5: ldstr "key2"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bf: stloc.s 4
+		IL_00c1: ldloc.3
+		IL_00c2: ldstr "log"
+		IL_00c7: ldloc.s 4
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ce: pop
+		IL_00cf: ret
 	} // end of method Map_Delete_Basic::__js_module_init__
 
 } // end of class Modules.Map_Delete_Basic
@@ -118,7 +127,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2127
+		// Method begins at RVA 0x2135
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Has_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Has_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20eb
+			// Method begins at RVA 0x20f5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 143 (0x8f)
+		// Code size: 153 (0x99)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Has_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] object,
-			[3] object
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Has_Basic/Scope::.ctor()
@@ -55,43 +56,49 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0013: ldstr "set"
-		IL_0018: ldstr "key1"
-		IL_001d: ldstr "value1"
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0027: pop
-		IL_0028: ldstr "console"
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0037: stloc.2
-		IL_0038: ldloc.1
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003e: ldstr "has"
-		IL_0043: ldstr "key1"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004d: stloc.3
-		IL_004e: ldloc.2
-		IL_004f: ldstr "log"
-		IL_0054: ldloc.3
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005a: pop
-		IL_005b: ldstr "console"
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006a: stloc.3
-		IL_006b: ldloc.1
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0071: ldstr "has"
-		IL_0076: ldstr "key2"
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0080: stloc.2
-		IL_0081: ldloc.3
-		IL_0082: ldstr "log"
-		IL_0087: ldloc.2
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008d: pop
-		IL_008e: ret
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0013: stloc.2
+		IL_0014: ldloc.2
+		IL_0015: ldstr "set"
+		IL_001a: ldstr "key1"
+		IL_001f: ldstr "value1"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0029: pop
+		IL_002a: ldstr "console"
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0039: stloc.3
+		IL_003a: ldloc.1
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0040: stloc.2
+		IL_0041: ldloc.2
+		IL_0042: ldstr "has"
+		IL_0047: ldstr "key1"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0051: stloc.s 4
+		IL_0053: ldloc.3
+		IL_0054: ldstr "log"
+		IL_0059: ldloc.s 4
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0060: pop
+		IL_0061: ldstr "console"
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0070: stloc.s 4
+		IL_0072: ldloc.1
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0078: stloc.2
+		IL_0079: ldloc.2
+		IL_007a: ldstr "has"
+		IL_007f: ldstr "key2"
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0089: stloc.3
+		IL_008a: ldloc.s 4
+		IL_008c: ldstr "log"
+		IL_0091: ldloc.3
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0097: pop
+		IL_0098: ret
 	} // end of method Map_Has_Basic::__js_module_init__
 
 } // end of class Modules.Map_Has_Basic
@@ -103,7 +110,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f4
+		// Method begins at RVA 0x20fe
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Keys_Values_Entries.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Keys_Values_Entries.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x226a
+			// Method begins at RVA 0x227e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 526 (0x20e)
+		// Code size: 546 (0x222)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Keys_Values_Entries/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[4] object,
-			[5] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Keys_Values_Entries/Scope::.ctor()
@@ -57,134 +58,144 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0013: ldstr "set"
-		IL_0018: ldstr "a"
-		IL_001d: ldc.r8 1
-		IL_0026: box [System.Runtime]System.Double
-		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0030: pop
-		IL_0031: ldloc.1
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0037: ldstr "set"
-		IL_003c: ldstr "b"
-		IL_0041: ldc.r8 2
-		IL_004a: box [System.Runtime]System.Double
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0054: pop
-		IL_0055: ldloc.1
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005b: ldstr "set"
-		IL_0060: ldstr "c"
-		IL_0065: ldc.r8 3
-		IL_006e: box [System.Runtime]System.Double
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0078: pop
-		IL_0079: ldloc.1
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007f: ldstr "keys"
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0089: stloc.s 4
-		IL_008b: ldloc.s 4
-		IL_008d: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0092: stloc.2
-		IL_0093: ldstr "console"
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a2: ldloc.2
-		IL_00a3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_00a8: box [System.Runtime]System.Double
-		IL_00ad: stloc.s 5
-		IL_00af: ldstr "log"
-		IL_00b4: ldloc.s 5
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bb: pop
-		IL_00bc: ldstr "console"
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cb: ldloc.2
-		IL_00cc: ldc.r8 0.0
-		IL_00d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_00da: stloc.s 4
-		IL_00dc: ldstr "log"
-		IL_00e1: ldloc.s 4
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e8: pop
-		IL_00e9: ldstr "console"
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f8: ldloc.2
-		IL_00f9: ldc.r8 1
-		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0107: stloc.s 4
-		IL_0109: ldstr "log"
-		IL_010e: ldloc.s 4
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0115: pop
-		IL_0116: ldstr "console"
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0125: ldloc.2
-		IL_0126: ldc.r8 2
-		IL_012f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0134: stloc.s 4
-		IL_0136: ldstr "log"
-		IL_013b: ldloc.s 4
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0142: pop
-		IL_0143: ldloc.1
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0149: ldstr "values"
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0153: stloc.s 4
-		IL_0155: ldloc.s 4
-		IL_0157: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_015c: stloc.3
-		IL_015d: ldstr "console"
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016c: ldloc.3
-		IL_016d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0172: box [System.Runtime]System.Double
-		IL_0177: stloc.s 5
-		IL_0179: ldstr "log"
-		IL_017e: ldloc.s 5
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0185: pop
-		IL_0186: ldstr "console"
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0195: ldloc.3
-		IL_0196: ldc.r8 0.0
-		IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01a4: stloc.s 4
-		IL_01a6: ldstr "log"
-		IL_01ab: ldloc.s 4
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b2: pop
-		IL_01b3: ldstr "console"
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c2: ldloc.3
-		IL_01c3: ldc.r8 1
-		IL_01cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01d1: stloc.s 4
-		IL_01d3: ldstr "log"
-		IL_01d8: ldloc.s 4
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01df: pop
-		IL_01e0: ldstr "console"
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ef: ldloc.3
-		IL_01f0: ldc.r8 2
-		IL_01f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01fe: stloc.s 4
-		IL_0200: ldstr "log"
-		IL_0205: ldloc.s 4
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020c: pop
-		IL_020d: ret
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0013: stloc.s 4
+		IL_0015: ldloc.s 4
+		IL_0017: ldstr "set"
+		IL_001c: ldstr "a"
+		IL_0021: ldc.r8 1
+		IL_002a: box [System.Runtime]System.Double
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0034: pop
+		IL_0035: ldloc.1
+		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_003b: stloc.s 4
+		IL_003d: ldloc.s 4
+		IL_003f: ldstr "set"
+		IL_0044: ldstr "b"
+		IL_0049: ldc.r8 2
+		IL_0052: box [System.Runtime]System.Double
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_005c: pop
+		IL_005d: ldloc.1
+		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0063: stloc.s 4
+		IL_0065: ldloc.s 4
+		IL_0067: ldstr "set"
+		IL_006c: ldstr "c"
+		IL_0071: ldc.r8 3
+		IL_007a: box [System.Runtime]System.Double
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0084: pop
+		IL_0085: ldloc.1
+		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_008b: stloc.s 4
+		IL_008d: ldloc.s 4
+		IL_008f: ldstr "keys"
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0099: stloc.s 5
+		IL_009b: ldloc.s 5
+		IL_009d: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_00a2: stloc.2
+		IL_00a3: ldstr "console"
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b2: ldloc.2
+		IL_00b3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_00b8: box [System.Runtime]System.Double
+		IL_00bd: stloc.s 6
+		IL_00bf: ldstr "log"
+		IL_00c4: ldloc.s 6
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cb: pop
+		IL_00cc: ldstr "console"
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00db: ldloc.2
+		IL_00dc: ldc.r8 0.0
+		IL_00e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_00ea: stloc.s 5
+		IL_00ec: ldstr "log"
+		IL_00f1: ldloc.s 5
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f8: pop
+		IL_00f9: ldstr "console"
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0108: ldloc.2
+		IL_0109: ldc.r8 1
+		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0117: stloc.s 5
+		IL_0119: ldstr "log"
+		IL_011e: ldloc.s 5
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0125: pop
+		IL_0126: ldstr "console"
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0135: ldloc.2
+		IL_0136: ldc.r8 2
+		IL_013f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0144: stloc.s 5
+		IL_0146: ldstr "log"
+		IL_014b: ldloc.s 5
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0152: pop
+		IL_0153: ldloc.1
+		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0159: stloc.s 4
+		IL_015b: ldloc.s 4
+		IL_015d: ldstr "values"
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0167: stloc.s 5
+		IL_0169: ldloc.s 5
+		IL_016b: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0170: stloc.3
+		IL_0171: ldstr "console"
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0180: ldloc.3
+		IL_0181: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0186: box [System.Runtime]System.Double
+		IL_018b: stloc.s 6
+		IL_018d: ldstr "log"
+		IL_0192: ldloc.s 6
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0199: pop
+		IL_019a: ldstr "console"
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a9: ldloc.3
+		IL_01aa: ldc.r8 0.0
+		IL_01b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01b8: stloc.s 5
+		IL_01ba: ldstr "log"
+		IL_01bf: ldloc.s 5
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c6: pop
+		IL_01c7: ldstr "console"
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d6: ldloc.3
+		IL_01d7: ldc.r8 1
+		IL_01e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01e5: stloc.s 5
+		IL_01e7: ldstr "log"
+		IL_01ec: ldloc.s 5
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f3: pop
+		IL_01f4: ldstr "console"
+		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0203: ldloc.3
+		IL_0204: ldc.r8 2
+		IL_020d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0212: stloc.s 5
+		IL_0214: ldstr "log"
+		IL_0219: ldloc.s 5
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0220: pop
+		IL_0221: ret
 	} // end of method Map_Keys_Values_Entries::__js_module_init__
 
 } // end of class Modules.Map_Keys_Values_Entries
@@ -196,7 +207,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2273
+		// Method begins at RVA 0x2287
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Multiple_Keys.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Multiple_Keys.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217d
+			// Method begins at RVA 0x2191
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 289 (0x121)
+		// Code size: 309 (0x135)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Multiple_Keys/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] object,
-			[3] object
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Multiple_Keys/Scope::.ctor()
@@ -55,85 +56,97 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0013: ldstr "set"
-		IL_0018: ldstr "key1"
-		IL_001d: ldstr "value1"
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0027: pop
-		IL_0028: ldloc.1
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_002e: ldstr "set"
-		IL_0033: ldstr "key2"
-		IL_0038: ldstr "value2"
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0042: pop
-		IL_0043: ldloc.1
-		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0049: ldstr "set"
-		IL_004e: ldstr "key3"
-		IL_0053: ldstr "value3"
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_005d: pop
-		IL_005e: ldstr "console"
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006d: stloc.2
-		IL_006e: ldloc.1
-		IL_006f: ldstr "size"
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0079: stloc.3
-		IL_007a: ldloc.2
-		IL_007b: ldstr "log"
-		IL_0080: ldloc.3
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0086: pop
-		IL_0087: ldstr "console"
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0096: stloc.3
-		IL_0097: ldloc.1
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009d: ldstr "get"
-		IL_00a2: ldstr "key1"
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ac: stloc.2
-		IL_00ad: ldloc.3
-		IL_00ae: ldstr "log"
-		IL_00b3: ldloc.2
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b9: pop
-		IL_00ba: ldstr "console"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c9: stloc.2
-		IL_00ca: ldloc.1
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d0: ldstr "get"
-		IL_00d5: ldstr "key2"
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00df: stloc.3
-		IL_00e0: ldloc.2
-		IL_00e1: ldstr "log"
-		IL_00e6: ldloc.3
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ec: pop
-		IL_00ed: ldstr "console"
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fc: stloc.3
-		IL_00fd: ldloc.1
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0103: ldstr "get"
-		IL_0108: ldstr "key3"
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0112: stloc.2
-		IL_0113: ldloc.3
-		IL_0114: ldstr "log"
-		IL_0119: ldloc.2
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011f: pop
-		IL_0120: ret
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0013: stloc.2
+		IL_0014: ldloc.2
+		IL_0015: ldstr "set"
+		IL_001a: ldstr "key1"
+		IL_001f: ldstr "value1"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0029: pop
+		IL_002a: ldloc.1
+		IL_002b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0030: stloc.2
+		IL_0031: ldloc.2
+		IL_0032: ldstr "set"
+		IL_0037: ldstr "key2"
+		IL_003c: ldstr "value2"
+		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0046: pop
+		IL_0047: ldloc.1
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_004d: stloc.2
+		IL_004e: ldloc.2
+		IL_004f: ldstr "set"
+		IL_0054: ldstr "key3"
+		IL_0059: ldstr "value3"
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0063: pop
+		IL_0064: ldstr "console"
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0073: stloc.3
+		IL_0074: ldloc.1
+		IL_0075: ldstr "size"
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_007f: stloc.s 4
+		IL_0081: ldloc.3
+		IL_0082: ldstr "log"
+		IL_0087: ldloc.s 4
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008e: pop
+		IL_008f: ldstr "console"
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009e: stloc.s 4
+		IL_00a0: ldloc.1
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_00a6: stloc.2
+		IL_00a7: ldloc.2
+		IL_00a8: ldstr "get"
+		IL_00ad: ldstr "key1"
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b7: stloc.3
+		IL_00b8: ldloc.s 4
+		IL_00ba: ldstr "log"
+		IL_00bf: ldloc.3
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c5: pop
+		IL_00c6: ldstr "console"
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d5: stloc.3
+		IL_00d6: ldloc.1
+		IL_00d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_00dc: stloc.2
+		IL_00dd: ldloc.2
+		IL_00de: ldstr "get"
+		IL_00e3: ldstr "key2"
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ed: stloc.s 4
+		IL_00ef: ldloc.3
+		IL_00f0: ldstr "log"
+		IL_00f5: ldloc.s 4
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fc: pop
+		IL_00fd: ldstr "console"
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010c: stloc.s 4
+		IL_010e: ldloc.1
+		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0114: stloc.2
+		IL_0115: ldloc.2
+		IL_0116: ldstr "get"
+		IL_011b: ldstr "key3"
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0125: stloc.3
+		IL_0126: ldloc.s 4
+		IL_0128: ldstr "log"
+		IL_012d: ldloc.3
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0133: pop
+		IL_0134: ret
 	} // end of method Map_Multiple_Keys::__js_module_init__
 
 } // end of class Modules.Map_Multiple_Keys
@@ -145,7 +158,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2186
+		// Method begins at RVA 0x219a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Null_Key.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Null_Key.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20ee
+			// Method begins at RVA 0x20f8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 146 (0x92)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Null_Key/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] object,
-			[3] object
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Null_Key/Scope::.ctor()
@@ -55,46 +56,52 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0013: ldstr "set"
-		IL_0018: ldc.i4.0
-		IL_0019: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_001e: ldstr "nullValue"
-		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0028: pop
-		IL_0029: ldstr "console"
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0038: stloc.2
-		IL_0039: ldloc.1
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003f: ldstr "has"
-		IL_0044: ldc.i4.0
-		IL_0045: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004f: stloc.3
-		IL_0050: ldloc.2
-		IL_0051: ldstr "log"
-		IL_0056: ldloc.3
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005c: pop
-		IL_005d: ldstr "console"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006c: stloc.3
-		IL_006d: ldloc.1
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0073: ldstr "get"
-		IL_0078: ldc.i4.0
-		IL_0079: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0083: stloc.2
-		IL_0084: ldloc.3
-		IL_0085: ldstr "log"
-		IL_008a: ldloc.2
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0090: pop
-		IL_0091: ret
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0013: stloc.2
+		IL_0014: ldloc.2
+		IL_0015: ldstr "set"
+		IL_001a: ldc.i4.0
+		IL_001b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0020: ldstr "nullValue"
+		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_002a: pop
+		IL_002b: ldstr "console"
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003a: stloc.3
+		IL_003b: ldloc.1
+		IL_003c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0041: stloc.2
+		IL_0042: ldloc.2
+		IL_0043: ldstr "has"
+		IL_0048: ldc.i4.0
+		IL_0049: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0053: stloc.s 4
+		IL_0055: ldloc.3
+		IL_0056: ldstr "log"
+		IL_005b: ldloc.s 4
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0062: pop
+		IL_0063: ldstr "console"
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0072: stloc.s 4
+		IL_0074: ldloc.1
+		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_007a: stloc.2
+		IL_007b: ldloc.2
+		IL_007c: ldstr "get"
+		IL_0081: ldc.i4.0
+		IL_0082: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008c: stloc.3
+		IL_008d: ldloc.s 4
+		IL_008f: ldstr "log"
+		IL_0094: ldloc.3
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method Map_Null_Key::__js_module_init__
 
 } // end of class Modules.Map_Null_Key
@@ -106,7 +113,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f7
+		// Method begins at RVA 0x2101
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Set_Get_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Set_Get_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20b8
+			// Method begins at RVA 0x20be
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 92 (0x5c)
+		// Code size: 98 (0x62)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Set_Get_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] object,
-			[3] object
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Set_Get_Basic/Scope::.ctor()
@@ -55,28 +56,32 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0013: ldstr "set"
-		IL_0018: ldstr "key1"
-		IL_001d: ldstr "value1"
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0027: pop
-		IL_0028: ldstr "console"
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0037: stloc.2
-		IL_0038: ldloc.1
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003e: ldstr "get"
-		IL_0043: ldstr "key1"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004d: stloc.3
-		IL_004e: ldloc.2
-		IL_004f: ldstr "log"
-		IL_0054: ldloc.3
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005a: pop
-		IL_005b: ret
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0013: stloc.2
+		IL_0014: ldloc.2
+		IL_0015: ldstr "set"
+		IL_001a: ldstr "key1"
+		IL_001f: ldstr "value1"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0029: pop
+		IL_002a: ldstr "console"
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0039: stloc.3
+		IL_003a: ldloc.1
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0040: stloc.2
+		IL_0041: ldloc.2
+		IL_0042: ldstr "get"
+		IL_0047: ldstr "key1"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0051: stloc.s 4
+		IL_0053: ldloc.3
+		IL_0054: ldstr "log"
+		IL_0059: ldloc.s 4
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0060: pop
+		IL_0061: ret
 	} // end of method Map_Set_Get_Basic::__js_module_init__
 
 } // end of class Modules.Map_Set_Get_Basic
@@ -88,7 +93,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20c1
+		// Method begins at RVA 0x20c7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Set_Returns_This.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Set_Returns_This.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20b9
+			// Method begins at RVA 0x20bd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 93 (0x5d)
+		// Code size: 97 (0x61)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Set_Returns_This/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
 			[2] object,
-			[3] object,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.Map,
 			[4] object,
-			[5] bool,
-			[6] object
+			[5] object,
+			[6] bool,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Set_Returns_This/Scope::.ctor()
@@ -58,31 +59,33 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0013: ldstr "set"
-		IL_0018: ldstr "key1"
-		IL_001d: ldstr "value1"
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0027: stloc.2
-		IL_0028: ldstr "console"
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0037: stloc.3
-		IL_0038: ldloc.2
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0013: stloc.3
+		IL_0014: ldloc.3
+		IL_0015: ldstr "set"
+		IL_001a: ldstr "key1"
+		IL_001f: ldstr "value1"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0029: stloc.2
+		IL_002a: ldstr "console"
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0039: stloc.s 4
-		IL_003b: ldloc.s 4
-		IL_003d: ldloc.1
-		IL_003e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0043: stloc.s 5
-		IL_0045: ldloc.s 5
-		IL_0047: box [System.Runtime]System.Boolean
-		IL_004c: stloc.s 6
-		IL_004e: ldloc.3
-		IL_004f: ldstr "log"
-		IL_0054: ldloc.s 6
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005b: pop
-		IL_005c: ret
+		IL_003b: ldloc.2
+		IL_003c: stloc.s 5
+		IL_003e: ldloc.s 5
+		IL_0040: ldloc.1
+		IL_0041: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0046: stloc.s 6
+		IL_0048: ldloc.s 6
+		IL_004a: box [System.Runtime]System.Boolean
+		IL_004f: stloc.s 7
+		IL_0051: ldloc.s 4
+		IL_0053: ldstr "log"
+		IL_0058: ldloc.s 7
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005f: pop
+		IL_0060: ret
 	} // end of method Map_Set_Returns_This::__js_module_init__
 
 } // end of class Modules.Map_Set_Returns_This
@@ -94,7 +97,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20c2
+		// Method begins at RVA 0x20c6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Size_Property.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Size_Property.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211b
+			// Method begins at RVA 0x2123
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 191 (0xbf)
+		// Code size: 199 (0xc7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Size_Property/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
 			[2] object,
-			[3] object
+			[3] object,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Map
 		)
 
 		IL_0000: newobj instance void Modules.Map_Size_Property/Scope::.ctor()
@@ -68,46 +69,50 @@
 		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0035: pop
 		IL_0036: ldloc.1
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003c: ldstr "set"
-		IL_0041: ldstr "key1"
-		IL_0046: ldstr "value1"
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0050: pop
-		IL_0051: ldstr "console"
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0060: stloc.3
-		IL_0061: ldloc.1
-		IL_0062: ldstr "size"
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_006c: stloc.2
-		IL_006d: ldloc.3
-		IL_006e: ldstr "log"
-		IL_0073: ldloc.2
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0079: pop
-		IL_007a: ldloc.1
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0080: ldstr "set"
-		IL_0085: ldstr "key2"
-		IL_008a: ldstr "value2"
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0094: pop
-		IL_0095: ldstr "console"
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a4: stloc.2
-		IL_00a5: ldloc.1
-		IL_00a6: ldstr "size"
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b0: stloc.3
-		IL_00b1: ldloc.2
-		IL_00b2: ldstr "log"
-		IL_00b7: ldloc.3
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bd: pop
-		IL_00be: ret
+		IL_0037: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_003c: stloc.s 4
+		IL_003e: ldloc.s 4
+		IL_0040: ldstr "set"
+		IL_0045: ldstr "key1"
+		IL_004a: ldstr "value1"
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0054: pop
+		IL_0055: ldstr "console"
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0064: stloc.3
+		IL_0065: ldloc.1
+		IL_0066: ldstr "size"
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0070: stloc.2
+		IL_0071: ldloc.3
+		IL_0072: ldstr "log"
+		IL_0077: ldloc.2
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007d: pop
+		IL_007e: ldloc.1
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0084: stloc.s 4
+		IL_0086: ldloc.s 4
+		IL_0088: ldstr "set"
+		IL_008d: ldstr "key2"
+		IL_0092: ldstr "value2"
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_009c: pop
+		IL_009d: ldstr "console"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ac: stloc.2
+		IL_00ad: ldloc.1
+		IL_00ae: ldstr "size"
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b8: stloc.3
+		IL_00b9: ldloc.2
+		IL_00ba: ldstr "log"
+		IL_00bf: ldloc.3
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c5: pop
+		IL_00c6: ret
 	} // end of method Map_Size_Property::__js_module_init__
 
 } // end of class Modules.Map_Size_Property
@@ -119,7 +124,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2124
+		// Method begins at RVA 0x212c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Symbol_Iterator.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Symbol_Iterator.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2298
+			// Method begins at RVA 0x22a4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 572 (0x23c)
+		// Code size: 584 (0x248)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Symbol_Iterator/Scope,
@@ -50,8 +50,10 @@
 			[4] object,
 			[5] object,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[7] object,
-			[8] object
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[8] object,
+			[9] object[],
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Symbol_Iterator/Scope::.ctor()
@@ -84,136 +86,142 @@
 		IL_005d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
 		IL_0062: stloc.1
 		IL_0063: ldloc.1
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0069: ldstr "iterator"
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0073: ldc.i4.0
-		IL_0074: newarr [System.Runtime]System.Object
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_007e: stloc.2
-		IL_007f: ldloc.2
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0085: ldstr "next"
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_008f: stloc.3
-		IL_0090: ldloc.2
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0096: ldstr "next"
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00a0: stloc.s 4
-		IL_00a2: ldloc.2
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a8: ldstr "next"
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00b2: stloc.s 5
-		IL_00b4: ldstr "console"
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c3: stloc.s 7
-		IL_00c5: ldloc.3
-		IL_00c6: ldstr "done"
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d0: stloc.s 8
-		IL_00d2: ldloc.s 7
-		IL_00d4: ldstr "log"
-		IL_00d9: ldloc.s 8
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e0: pop
-		IL_00e1: ldstr "console"
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f0: stloc.s 8
-		IL_00f2: ldloc.3
-		IL_00f3: ldstr "value"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fd: stloc.s 7
-		IL_00ff: ldloc.s 7
-		IL_0101: ldc.r8 0.0
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_010f: stloc.s 7
-		IL_0111: ldloc.s 8
-		IL_0113: ldstr "log"
-		IL_0118: ldloc.s 7
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011f: pop
-		IL_0120: ldstr "console"
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012f: stloc.s 7
-		IL_0131: ldloc.3
-		IL_0132: ldstr "value"
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013c: stloc.s 8
-		IL_013e: ldloc.s 8
-		IL_0140: ldc.r8 1
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_014e: stloc.s 8
-		IL_0150: ldloc.s 7
-		IL_0152: ldstr "log"
-		IL_0157: ldloc.s 8
-		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015e: pop
-		IL_015f: ldstr "console"
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016e: stloc.s 8
-		IL_0170: ldloc.s 4
-		IL_0172: ldstr "done"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017c: stloc.s 7
-		IL_017e: ldloc.s 8
-		IL_0180: ldstr "log"
-		IL_0185: ldloc.s 7
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018c: pop
-		IL_018d: ldstr "console"
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019c: stloc.s 7
-		IL_019e: ldloc.s 4
-		IL_01a0: ldstr "value"
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01aa: stloc.s 8
-		IL_01ac: ldloc.s 8
-		IL_01ae: ldc.r8 0.0
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01bc: stloc.s 8
-		IL_01be: ldloc.s 7
-		IL_01c0: ldstr "log"
-		IL_01c5: ldloc.s 8
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01cc: pop
-		IL_01cd: ldstr "console"
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01dc: stloc.s 8
-		IL_01de: ldloc.s 4
-		IL_01e0: ldstr "value"
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ea: stloc.s 7
-		IL_01ec: ldloc.s 7
-		IL_01ee: ldc.r8 1
-		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01fc: stloc.s 7
-		IL_01fe: ldloc.s 8
-		IL_0200: ldstr "log"
-		IL_0205: ldloc.s 7
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020c: pop
-		IL_020d: ldstr "console"
-		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021c: stloc.s 7
-		IL_021e: ldloc.s 5
-		IL_0220: ldstr "done"
-		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_022a: stloc.s 8
-		IL_022c: ldloc.s 7
-		IL_022e: ldstr "log"
-		IL_0233: ldloc.s 8
-		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023a: pop
-		IL_023b: ret
+		IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0069: stloc.s 7
+		IL_006b: ldstr "iterator"
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0075: stloc.s 8
+		IL_0077: ldc.i4.0
+		IL_0078: newarr [System.Runtime]System.Object
+		IL_007d: stloc.s 9
+		IL_007f: ldloc.s 7
+		IL_0081: ldloc.s 8
+		IL_0083: ldloc.s 9
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_008a: stloc.2
+		IL_008b: ldloc.2
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0091: ldstr "next"
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_009b: stloc.3
+		IL_009c: ldloc.2
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a2: ldstr "next"
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00ac: stloc.s 4
+		IL_00ae: ldloc.2
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b4: ldstr "next"
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00be: stloc.s 5
+		IL_00c0: ldstr "console"
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cf: stloc.s 8
+		IL_00d1: ldloc.3
+		IL_00d2: ldstr "done"
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00dc: stloc.s 10
+		IL_00de: ldloc.s 8
+		IL_00e0: ldstr "log"
+		IL_00e5: ldloc.s 10
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ec: pop
+		IL_00ed: ldstr "console"
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fc: stloc.s 10
+		IL_00fe: ldloc.3
+		IL_00ff: ldstr "value"
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0109: stloc.s 8
+		IL_010b: ldloc.s 8
+		IL_010d: ldc.r8 0.0
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_011b: stloc.s 8
+		IL_011d: ldloc.s 10
+		IL_011f: ldstr "log"
+		IL_0124: ldloc.s 8
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012b: pop
+		IL_012c: ldstr "console"
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013b: stloc.s 8
+		IL_013d: ldloc.3
+		IL_013e: ldstr "value"
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0148: stloc.s 10
+		IL_014a: ldloc.s 10
+		IL_014c: ldc.r8 1
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_015a: stloc.s 10
+		IL_015c: ldloc.s 8
+		IL_015e: ldstr "log"
+		IL_0163: ldloc.s 10
+		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016a: pop
+		IL_016b: ldstr "console"
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017a: stloc.s 10
+		IL_017c: ldloc.s 4
+		IL_017e: ldstr "done"
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0188: stloc.s 8
+		IL_018a: ldloc.s 10
+		IL_018c: ldstr "log"
+		IL_0191: ldloc.s 8
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0198: pop
+		IL_0199: ldstr "console"
+		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a8: stloc.s 8
+		IL_01aa: ldloc.s 4
+		IL_01ac: ldstr "value"
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01b6: stloc.s 10
+		IL_01b8: ldloc.s 10
+		IL_01ba: ldc.r8 0.0
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01c8: stloc.s 10
+		IL_01ca: ldloc.s 8
+		IL_01cc: ldstr "log"
+		IL_01d1: ldloc.s 10
+		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d8: pop
+		IL_01d9: ldstr "console"
+		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e8: stloc.s 10
+		IL_01ea: ldloc.s 4
+		IL_01ec: ldstr "value"
+		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01f6: stloc.s 8
+		IL_01f8: ldloc.s 8
+		IL_01fa: ldc.r8 1
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0208: stloc.s 8
+		IL_020a: ldloc.s 10
+		IL_020c: ldstr "log"
+		IL_0211: ldloc.s 8
+		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0218: pop
+		IL_0219: ldstr "console"
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0228: stloc.s 8
+		IL_022a: ldloc.s 5
+		IL_022c: ldstr "done"
+		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0236: stloc.s 10
+		IL_0238: ldloc.s 8
+		IL_023a: ldstr "log"
+		IL_023f: ldloc.s 10
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0246: pop
+		IL_0247: ret
 	} // end of method Map_Symbol_Iterator::__js_module_init__
 
 } // end of class Modules.Map_Symbol_Iterator
@@ -225,7 +233,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22a1
+		// Method begins at RVA 0x22ad
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Update_Existing_Key.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Update_Existing_Key.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x212f
+			// Method begins at RVA 0x213d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 211 (0xd3)
+		// Code size: 225 (0xe1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Update_Existing_Key/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] object,
-			[3] object
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Update_Existing_Key/Scope::.ctor()
@@ -55,63 +56,71 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0013: ldstr "set"
-		IL_0018: ldstr "key1"
-		IL_001d: ldstr "value1"
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0027: pop
-		IL_0028: ldstr "console"
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0037: stloc.2
-		IL_0038: ldloc.1
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003e: ldstr "get"
-		IL_0043: ldstr "key1"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004d: stloc.3
-		IL_004e: ldloc.2
-		IL_004f: ldstr "log"
-		IL_0054: ldloc.3
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005a: pop
-		IL_005b: ldloc.1
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0061: ldstr "set"
-		IL_0066: ldstr "key1"
-		IL_006b: ldstr "value2"
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0075: pop
-		IL_0076: ldstr "console"
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0085: stloc.3
-		IL_0086: ldloc.1
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008c: ldstr "get"
-		IL_0091: ldstr "key1"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009b: stloc.2
-		IL_009c: ldloc.3
-		IL_009d: ldstr "log"
-		IL_00a2: ldloc.2
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a8: pop
-		IL_00a9: ldstr "console"
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b8: stloc.2
-		IL_00b9: ldloc.1
-		IL_00ba: ldstr "size"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0013: stloc.2
+		IL_0014: ldloc.2
+		IL_0015: ldstr "set"
+		IL_001a: ldstr "key1"
+		IL_001f: ldstr "value1"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0029: pop
+		IL_002a: ldstr "console"
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0039: stloc.3
+		IL_003a: ldloc.1
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0040: stloc.2
+		IL_0041: ldloc.2
+		IL_0042: ldstr "get"
+		IL_0047: ldstr "key1"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0051: stloc.s 4
+		IL_0053: ldloc.3
+		IL_0054: ldstr "log"
+		IL_0059: ldloc.s 4
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0060: pop
+		IL_0061: ldloc.1
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0067: stloc.2
+		IL_0068: ldloc.2
+		IL_0069: ldstr "set"
+		IL_006e: ldstr "key1"
+		IL_0073: ldstr "value2"
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_007d: pop
+		IL_007e: ldstr "console"
+		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008d: stloc.s 4
+		IL_008f: ldloc.1
+		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
+		IL_0095: stloc.2
+		IL_0096: ldloc.2
+		IL_0097: ldstr "get"
+		IL_009c: ldstr "key1"
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a6: stloc.3
+		IL_00a7: ldloc.s 4
+		IL_00a9: ldstr "log"
+		IL_00ae: ldloc.3
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b4: pop
+		IL_00b5: ldstr "console"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00c4: stloc.3
-		IL_00c5: ldloc.2
-		IL_00c6: ldstr "log"
-		IL_00cb: ldloc.3
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d1: pop
-		IL_00d2: ret
+		IL_00c5: ldloc.1
+		IL_00c6: ldstr "size"
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d0: stloc.s 4
+		IL_00d2: ldloc.3
+		IL_00d3: ldstr "log"
+		IL_00d8: ldloc.s 4
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00df: pop
+		IL_00e0: ret
 	} // end of method Map_Update_Existing_Key::__js_module_init__
 
 } // end of class Modules.Map_Update_Existing_Key
@@ -123,7 +132,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2138
+		// Method begins at RVA 0x2146
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Advanced_CoreApis.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Advanced_CoreApis.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2726
+			// Method begins at RVA 0x2772
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1738 (0x6ca)
+		// Code size: 1814 (0x716)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Buffer_Advanced_CoreApis/Scope,
@@ -50,11 +50,12 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-			[7] object,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 			[8] object,
-			[9] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-			[10] float64,
-			[11] object
+			[9] object,
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+			[11] float64,
+			[12] object
 		)
 
 		IL_0000: newobj instance void Modules.Buffer_Advanced_CoreApis/Scope::.ctor()
@@ -80,404 +81,442 @@
 		IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 		IL_005d: stloc.1
 		IL_005e: ldloc.1
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0064: ldstr "slice"
-		IL_0069: ldc.r8 1
-		IL_0072: box [System.Runtime]System.Double
-		IL_0077: ldc.r8 4
-		IL_0080: box [System.Runtime]System.Double
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_008a: stloc.2
-		IL_008b: ldloc.2
-		IL_008c: ldc.r8 0.0
-		IL_0095: ldc.r8 99
-		IL_009e: ldc.i4.1
-		IL_009f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_00a4: ldstr "console"
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b3: stloc.s 7
-		IL_00b5: ldloc.1
-		IL_00b6: ldc.r8 1
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00c4: stloc.s 8
-		IL_00c6: ldloc.s 7
-		IL_00c8: ldstr "log"
-		IL_00cd: ldloc.s 8
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d4: pop
-		IL_00d5: ldloc.1
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00db: ldstr "subarray"
-		IL_00e0: ldc.r8 2
-		IL_00e9: box [System.Runtime]System.Double
-		IL_00ee: ldc.r8 5
-		IL_00f7: box [System.Runtime]System.Double
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0101: stloc.3
-		IL_0102: ldloc.3
-		IL_0103: ldc.r8 1
-		IL_010c: ldc.r8 77
-		IL_0115: ldc.i4.1
-		IL_0116: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_011b: ldstr "console"
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012a: stloc.s 8
-		IL_012c: ldloc.1
-		IL_012d: ldc.r8 3
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_013b: stloc.s 7
-		IL_013d: ldloc.s 8
-		IL_013f: ldstr "log"
-		IL_0144: ldloc.s 7
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014b: pop
-		IL_014c: ldstr "console"
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015b: stloc.s 7
-		IL_015d: ldloc.1
+		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0064: stloc.s 7
+		IL_0066: ldloc.s 7
+		IL_0068: ldstr "slice"
+		IL_006d: ldc.r8 1
+		IL_0076: box [System.Runtime]System.Double
+		IL_007b: ldc.r8 4
+		IL_0084: box [System.Runtime]System.Double
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_008e: stloc.2
+		IL_008f: ldloc.2
+		IL_0090: ldc.r8 0.0
+		IL_0099: ldc.r8 99
+		IL_00a2: ldc.i4.1
+		IL_00a3: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_00a8: ldstr "console"
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b7: stloc.s 8
+		IL_00b9: ldloc.1
+		IL_00ba: ldc.r8 1
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00c8: stloc.s 9
+		IL_00ca: ldloc.s 8
+		IL_00cc: ldstr "log"
+		IL_00d1: ldloc.s 9
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d8: pop
+		IL_00d9: ldloc.1
+		IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_00df: stloc.s 7
+		IL_00e1: ldloc.s 7
+		IL_00e3: ldstr "subarray"
+		IL_00e8: ldc.r8 2
+		IL_00f1: box [System.Runtime]System.Double
+		IL_00f6: ldc.r8 5
+		IL_00ff: box [System.Runtime]System.Double
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0109: stloc.3
+		IL_010a: ldloc.3
+		IL_010b: ldc.r8 1
+		IL_0114: ldc.r8 77
+		IL_011d: ldc.i4.1
+		IL_011e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0123: ldstr "console"
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0132: stloc.s 9
+		IL_0134: ldloc.1
+		IL_0135: ldc.r8 3
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0143: stloc.s 8
+		IL_0145: ldloc.s 9
+		IL_0147: ldstr "log"
+		IL_014c: ldloc.s 8
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0153: pop
+		IL_0154: ldstr "console"
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0163: ldc.i4.5
-		IL_0164: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0169: dup
-		IL_016a: ldc.r8 1
-		IL_0173: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0178: dup
-		IL_0179: ldc.r8 99
-		IL_0182: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0187: dup
-		IL_0188: ldc.r8 3
-		IL_0191: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0196: dup
-		IL_0197: ldc.r8 77
-		IL_01a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01a5: dup
-		IL_01a6: ldc.r8 5
-		IL_01af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01b4: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_01b9: stloc.s 9
-		IL_01bb: ldstr "equals"
-		IL_01c0: ldloc.s 9
-		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c7: stloc.s 8
-		IL_01c9: ldloc.s 7
-		IL_01cb: ldstr "log"
-		IL_01d0: ldloc.s 8
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d7: pop
-		IL_01d8: ldstr "console"
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e7: stloc.s 8
-		IL_01e9: ldloc.1
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ef: ldstr "indexOf"
-		IL_01f4: ldc.r8 77
-		IL_01fd: box [System.Runtime]System.Double
-		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0207: stloc.s 7
-		IL_0209: ldloc.s 8
-		IL_020b: ldstr "log"
-		IL_0210: ldloc.s 7
+		IL_0163: stloc.s 8
+		IL_0165: ldloc.1
+		IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_016b: stloc.s 7
+		IL_016d: ldc.i4.5
+		IL_016e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0173: dup
+		IL_0174: ldc.r8 1
+		IL_017d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0182: dup
+		IL_0183: ldc.r8 99
+		IL_018c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0191: dup
+		IL_0192: ldc.r8 3
+		IL_019b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01a0: dup
+		IL_01a1: ldc.r8 77
+		IL_01aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01af: dup
+		IL_01b0: ldc.r8 5
+		IL_01b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01be: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_01c3: stloc.s 10
+		IL_01c5: ldloc.s 7
+		IL_01c7: ldstr "equals"
+		IL_01cc: ldloc.s 10
+		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d3: stloc.s 9
+		IL_01d5: ldloc.s 8
+		IL_01d7: ldstr "log"
+		IL_01dc: ldloc.s 9
+		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e3: pop
+		IL_01e4: ldstr "console"
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f3: stloc.s 9
+		IL_01f5: ldloc.1
+		IL_01f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_01fb: stloc.s 10
+		IL_01fd: ldloc.s 10
+		IL_01ff: ldstr "indexOf"
+		IL_0204: ldc.r8 77
+		IL_020d: box [System.Runtime]System.Double
 		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0217: pop
-		IL_0218: ldstr "console"
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0227: stloc.s 7
-		IL_0229: ldloc.1
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022f: ldc.i4.2
-		IL_0230: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0235: dup
-		IL_0236: ldc.r8 77
-		IL_023f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0244: dup
-		IL_0245: ldc.r8 5
-		IL_024e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0253: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_0258: stloc.s 9
-		IL_025a: ldstr "lastIndexOf"
-		IL_025f: ldloc.s 9
-		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0266: stloc.s 8
-		IL_0268: ldloc.s 7
-		IL_026a: ldstr "log"
-		IL_026f: ldloc.s 8
-		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0276: pop
-		IL_0277: ldc.r8 6
-		IL_0280: box [System.Runtime]System.Double
-		IL_0285: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-		IL_028a: stloc.s 4
-		IL_028c: ldloc.s 4
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0293: ldstr "fill"
-		IL_0298: ldstr "ab"
-		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a2: pop
-		IL_02a3: ldstr "console"
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b2: stloc.s 8
-		IL_02b4: ldloc.s 4
-		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02bb: ldstr "toString"
-		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_02c5: stloc.s 7
-		IL_02c7: ldloc.s 8
-		IL_02c9: ldstr "log"
-		IL_02ce: ldloc.s 7
-		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d5: pop
-		IL_02d6: ldstr "console"
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e5: stloc.s 7
-		IL_02e7: ldloc.s 4
-		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ee: ldstr "indexOf"
-		IL_02f3: ldstr "ba"
-		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02fd: stloc.s 8
-		IL_02ff: ldloc.s 7
-		IL_0301: ldstr "log"
-		IL_0306: ldloc.s 8
-		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_030d: pop
-		IL_030e: ldstr "console"
-		IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_031d: stloc.s 8
-		IL_031f: ldloc.s 4
-		IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0326: ldstr "lastIndexOf"
-		IL_032b: ldstr "ab"
-		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0335: stloc.s 7
-		IL_0337: ldloc.s 8
-		IL_0339: ldstr "log"
-		IL_033e: ldloc.s 7
-		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0345: pop
-		IL_0346: ldstr "console"
-		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0355: stloc.s 7
-		IL_0357: ldloc.s 4
-		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_035e: ldstr "includes"
-		IL_0363: ldstr "zz"
-		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_036d: stloc.s 8
-		IL_036f: ldloc.s 7
-		IL_0371: ldstr "log"
-		IL_0376: ldloc.s 8
-		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_037d: pop
-		IL_037e: ldc.r8 16
-		IL_0387: box [System.Runtime]System.Double
-		IL_038c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-		IL_0391: stloc.s 5
-		IL_0393: ldloc.s 5
-		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_039a: ldstr "writeFloatLE"
-		IL_039f: ldc.r8 3.5
-		IL_03a8: box [System.Runtime]System.Double
-		IL_03ad: ldc.r8 0.0
-		IL_03b6: box [System.Runtime]System.Double
-		IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03c0: pop
-		IL_03c1: ldloc.s 5
-		IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03c8: ldstr "writeFloatBE"
-		IL_03cd: ldc.r8 3.5
-		IL_03d6: box [System.Runtime]System.Double
-		IL_03db: ldc.r8 4
-		IL_03e4: box [System.Runtime]System.Double
-		IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03ee: pop
-		IL_03ef: ldloc.s 5
-		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03f6: ldstr "writeDoubleLE"
-		IL_03fb: ldc.r8 10.25
-		IL_0404: box [System.Runtime]System.Double
-		IL_0409: ldc.r8 8
-		IL_0412: box [System.Runtime]System.Double
-		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_041c: pop
-		IL_041d: ldstr "console"
-		IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_042c: stloc.s 8
-		IL_042e: ldloc.s 5
-		IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0435: ldstr "readFloatLE"
-		IL_043a: ldc.r8 0.0
-		IL_0443: box [System.Runtime]System.Double
-		IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_044d: stloc.s 7
-		IL_044f: ldloc.s 7
-		IL_0451: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0456: ldc.r8 100
-		IL_045f: mul
-		IL_0460: stloc.s 10
-		IL_0462: ldloc.s 10
-		IL_0464: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
-		IL_0469: ldc.r8 100
-		IL_0472: div
-		IL_0473: stloc.s 10
-		IL_0475: ldloc.s 10
-		IL_0477: box [System.Runtime]System.Double
-		IL_047c: stloc.s 11
-		IL_047e: ldloc.s 8
-		IL_0480: ldstr "log"
-		IL_0485: ldloc.s 11
-		IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_048c: pop
-		IL_048d: ldstr "console"
-		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_049c: stloc.s 8
-		IL_049e: ldloc.s 5
-		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04a5: ldstr "readFloatBE"
-		IL_04aa: ldc.r8 4
-		IL_04b3: box [System.Runtime]System.Double
-		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04bd: stloc.s 7
-		IL_04bf: ldloc.s 7
-		IL_04c1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_04c6: ldc.r8 100
-		IL_04cf: mul
-		IL_04d0: stloc.s 10
-		IL_04d2: ldloc.s 10
-		IL_04d4: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
-		IL_04d9: ldc.r8 100
-		IL_04e2: div
-		IL_04e3: stloc.s 10
-		IL_04e5: ldloc.s 10
-		IL_04e7: box [System.Runtime]System.Double
-		IL_04ec: stloc.s 11
-		IL_04ee: ldloc.s 8
-		IL_04f0: ldstr "log"
-		IL_04f5: ldloc.s 11
-		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04fc: pop
-		IL_04fd: ldstr "console"
-		IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_050c: stloc.s 8
-		IL_050e: ldloc.s 5
-		IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0515: ldstr "readDoubleLE"
-		IL_051a: ldc.r8 8
+		IL_0217: stloc.s 8
+		IL_0219: ldloc.s 9
+		IL_021b: ldstr "log"
+		IL_0220: ldloc.s 8
+		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0227: pop
+		IL_0228: ldstr "console"
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0237: stloc.s 8
+		IL_0239: ldloc.1
+		IL_023a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_023f: stloc.s 10
+		IL_0241: ldc.i4.2
+		IL_0242: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0247: dup
+		IL_0248: ldc.r8 77
+		IL_0251: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0256: dup
+		IL_0257: ldc.r8 5
+		IL_0260: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0265: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_026a: stloc.s 7
+		IL_026c: ldloc.s 10
+		IL_026e: ldstr "lastIndexOf"
+		IL_0273: ldloc.s 7
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027a: stloc.s 9
+		IL_027c: ldloc.s 8
+		IL_027e: ldstr "log"
+		IL_0283: ldloc.s 9
+		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028a: pop
+		IL_028b: ldc.r8 6
+		IL_0294: box [System.Runtime]System.Double
+		IL_0299: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+		IL_029e: stloc.s 4
+		IL_02a0: ldloc.s 4
+		IL_02a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_02a7: stloc.s 7
+		IL_02a9: ldloc.s 7
+		IL_02ab: ldstr "fill"
+		IL_02b0: ldstr "ab"
+		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ba: pop
+		IL_02bb: ldstr "console"
+		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ca: stloc.s 9
+		IL_02cc: ldloc.s 4
+		IL_02ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_02d3: stloc.s 7
+		IL_02d5: ldloc.s 7
+		IL_02d7: ldstr "toString"
+		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02e1: stloc.s 8
+		IL_02e3: ldloc.s 9
+		IL_02e5: ldstr "log"
+		IL_02ea: ldloc.s 8
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02f1: pop
+		IL_02f2: ldstr "console"
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0301: stloc.s 8
+		IL_0303: ldloc.s 4
+		IL_0305: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_030a: stloc.s 7
+		IL_030c: ldloc.s 7
+		IL_030e: ldstr "indexOf"
+		IL_0313: ldstr "ba"
+		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_031d: stloc.s 9
+		IL_031f: ldloc.s 8
+		IL_0321: ldstr "log"
+		IL_0326: ldloc.s 9
+		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_032d: pop
+		IL_032e: ldstr "console"
+		IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_033d: stloc.s 9
+		IL_033f: ldloc.s 4
+		IL_0341: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0346: stloc.s 7
+		IL_0348: ldloc.s 7
+		IL_034a: ldstr "lastIndexOf"
+		IL_034f: ldstr "ab"
+		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0359: stloc.s 8
+		IL_035b: ldloc.s 9
+		IL_035d: ldstr "log"
+		IL_0362: ldloc.s 8
+		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0369: pop
+		IL_036a: ldstr "console"
+		IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0379: stloc.s 8
+		IL_037b: ldloc.s 4
+		IL_037d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0382: stloc.s 7
+		IL_0384: ldloc.s 7
+		IL_0386: ldstr "includes"
+		IL_038b: ldstr "zz"
+		IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0395: stloc.s 9
+		IL_0397: ldloc.s 8
+		IL_0399: ldstr "log"
+		IL_039e: ldloc.s 9
+		IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a5: pop
+		IL_03a6: ldc.r8 16
+		IL_03af: box [System.Runtime]System.Double
+		IL_03b4: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+		IL_03b9: stloc.s 5
+		IL_03bb: ldloc.s 5
+		IL_03bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_03c2: stloc.s 7
+		IL_03c4: ldloc.s 7
+		IL_03c6: ldstr "writeFloatLE"
+		IL_03cb: ldc.r8 3.5
+		IL_03d4: box [System.Runtime]System.Double
+		IL_03d9: ldc.r8 0.0
+		IL_03e2: box [System.Runtime]System.Double
+		IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03ec: pop
+		IL_03ed: ldloc.s 5
+		IL_03ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_03f4: stloc.s 7
+		IL_03f6: ldloc.s 7
+		IL_03f8: ldstr "writeFloatBE"
+		IL_03fd: ldc.r8 3.5
+		IL_0406: box [System.Runtime]System.Double
+		IL_040b: ldc.r8 4
+		IL_0414: box [System.Runtime]System.Double
+		IL_0419: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_041e: pop
+		IL_041f: ldloc.s 5
+		IL_0421: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0426: stloc.s 7
+		IL_0428: ldloc.s 7
+		IL_042a: ldstr "writeDoubleLE"
+		IL_042f: ldc.r8 10.25
+		IL_0438: box [System.Runtime]System.Double
+		IL_043d: ldc.r8 8
+		IL_0446: box [System.Runtime]System.Double
+		IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0450: pop
+		IL_0451: ldstr "console"
+		IL_0456: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0460: stloc.s 9
+		IL_0462: ldloc.s 5
+		IL_0464: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0469: stloc.s 7
+		IL_046b: ldloc.s 7
+		IL_046d: ldstr "readFloatLE"
+		IL_0472: ldc.r8 0.0
+		IL_047b: box [System.Runtime]System.Double
+		IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0485: stloc.s 8
+		IL_0487: ldloc.s 8
+		IL_0489: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_048e: ldc.r8 100
+		IL_0497: mul
+		IL_0498: stloc.s 11
+		IL_049a: ldloc.s 11
+		IL_049c: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
+		IL_04a1: ldc.r8 100
+		IL_04aa: div
+		IL_04ab: stloc.s 11
+		IL_04ad: ldloc.s 11
+		IL_04af: box [System.Runtime]System.Double
+		IL_04b4: stloc.s 12
+		IL_04b6: ldloc.s 9
+		IL_04b8: ldstr "log"
+		IL_04bd: ldloc.s 12
+		IL_04bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04c4: pop
+		IL_04c5: ldstr "console"
+		IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04d4: stloc.s 9
+		IL_04d6: ldloc.s 5
+		IL_04d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_04dd: stloc.s 7
+		IL_04df: ldloc.s 7
+		IL_04e1: ldstr "readFloatBE"
+		IL_04e6: ldc.r8 4
+		IL_04ef: box [System.Runtime]System.Double
+		IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04f9: stloc.s 8
+		IL_04fb: ldloc.s 8
+		IL_04fd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0502: ldc.r8 100
+		IL_050b: mul
+		IL_050c: stloc.s 11
+		IL_050e: ldloc.s 11
+		IL_0510: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
+		IL_0515: ldc.r8 100
+		IL_051e: div
+		IL_051f: stloc.s 11
+		IL_0521: ldloc.s 11
 		IL_0523: box [System.Runtime]System.Double
-		IL_0528: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_052d: stloc.s 7
-		IL_052f: ldloc.s 7
-		IL_0531: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0536: ldc.r8 100
-		IL_053f: mul
-		IL_0540: stloc.s 10
-		IL_0542: ldloc.s 10
-		IL_0544: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
-		IL_0549: ldc.r8 100
-		IL_0552: div
-		IL_0553: stloc.s 10
-		IL_0555: ldloc.s 10
-		IL_0557: box [System.Runtime]System.Double
-		IL_055c: stloc.s 11
-		IL_055e: ldloc.s 8
-		IL_0560: ldstr "log"
-		IL_0565: ldloc.s 11
-		IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_056c: pop
-		IL_056d: ldloc.s 5
-		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0574: ldc.r8 2.5
-		IL_057d: neg
-		IL_057e: stloc.s 10
-		IL_0580: ldloc.s 10
-		IL_0582: box [System.Runtime]System.Double
-		IL_0587: stloc.s 11
-		IL_0589: ldstr "writeDoubleBE"
-		IL_058e: ldloc.s 11
-		IL_0590: ldc.r8 0.0
-		IL_0599: box [System.Runtime]System.Double
-		IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_05a3: pop
-		IL_05a4: ldstr "console"
-		IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05b3: stloc.s 8
-		IL_05b5: ldloc.s 5
-		IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05bc: ldstr "readDoubleBE"
-		IL_05c1: ldc.r8 0.0
-		IL_05ca: box [System.Runtime]System.Double
-		IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05d4: stloc.s 7
-		IL_05d6: ldloc.s 7
-		IL_05d8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_05dd: ldc.r8 10
-		IL_05e6: mul
-		IL_05e7: stloc.s 10
-		IL_05e9: ldloc.s 10
-		IL_05eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
-		IL_05f0: ldc.r8 10
-		IL_05f9: div
-		IL_05fa: stloc.s 10
-		IL_05fc: ldloc.s 10
-		IL_05fe: box [System.Runtime]System.Double
-		IL_0603: stloc.s 11
-		IL_0605: ldloc.s 8
-		IL_0607: ldstr "log"
-		IL_060c: ldloc.s 11
-		IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0613: pop
-		IL_0614: ldc.r8 4
-		IL_061d: box [System.Runtime]System.Double
-		IL_0622: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::allocUnsafe(object)
-		IL_0627: stloc.s 6
-		IL_0629: ldloc.s 6
-		IL_062b: ldc.r8 0.0
-		IL_0634: ldc.r8 1
-		IL_063d: ldc.i4.1
-		IL_063e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_0643: ldloc.s 6
-		IL_0645: ldc.r8 1
-		IL_064e: ldc.r8 2
-		IL_0657: ldc.i4.1
-		IL_0658: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_065d: ldloc.s 6
-		IL_065f: ldc.r8 2
-		IL_0668: ldc.r8 3
-		IL_0671: ldc.i4.1
-		IL_0672: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_0677: ldloc.s 6
-		IL_0679: ldc.r8 3
-		IL_0682: ldc.r8 4
-		IL_068b: ldc.i4.1
-		IL_068c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_0691: ldstr "console"
-		IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_069b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06a0: stloc.s 8
-		IL_06a2: ldloc.s 6
-		IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06a9: ldstr "toString"
-		IL_06ae: ldstr "hex"
-		IL_06b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06b8: stloc.s 7
-		IL_06ba: ldloc.s 8
-		IL_06bc: ldstr "log"
-		IL_06c1: ldloc.s 7
-		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06c8: pop
-		IL_06c9: ret
+		IL_0528: stloc.s 12
+		IL_052a: ldloc.s 9
+		IL_052c: ldstr "log"
+		IL_0531: ldloc.s 12
+		IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0538: pop
+		IL_0539: ldstr "console"
+		IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0548: stloc.s 9
+		IL_054a: ldloc.s 5
+		IL_054c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0551: stloc.s 7
+		IL_0553: ldloc.s 7
+		IL_0555: ldstr "readDoubleLE"
+		IL_055a: ldc.r8 8
+		IL_0563: box [System.Runtime]System.Double
+		IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_056d: stloc.s 8
+		IL_056f: ldloc.s 8
+		IL_0571: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0576: ldc.r8 100
+		IL_057f: mul
+		IL_0580: stloc.s 11
+		IL_0582: ldloc.s 11
+		IL_0584: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
+		IL_0589: ldc.r8 100
+		IL_0592: div
+		IL_0593: stloc.s 11
+		IL_0595: ldloc.s 11
+		IL_0597: box [System.Runtime]System.Double
+		IL_059c: stloc.s 12
+		IL_059e: ldloc.s 9
+		IL_05a0: ldstr "log"
+		IL_05a5: ldloc.s 12
+		IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05ac: pop
+		IL_05ad: ldloc.s 5
+		IL_05af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_05b4: stloc.s 7
+		IL_05b6: ldc.r8 2.5
+		IL_05bf: neg
+		IL_05c0: stloc.s 11
+		IL_05c2: ldloc.s 11
+		IL_05c4: box [System.Runtime]System.Double
+		IL_05c9: stloc.s 12
+		IL_05cb: ldloc.s 7
+		IL_05cd: ldstr "writeDoubleBE"
+		IL_05d2: ldloc.s 12
+		IL_05d4: ldc.r8 0.0
+		IL_05dd: box [System.Runtime]System.Double
+		IL_05e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_05e7: pop
+		IL_05e8: ldstr "console"
+		IL_05ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05f7: stloc.s 9
+		IL_05f9: ldloc.s 5
+		IL_05fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0600: stloc.s 7
+		IL_0602: ldloc.s 7
+		IL_0604: ldstr "readDoubleBE"
+		IL_0609: ldc.r8 0.0
+		IL_0612: box [System.Runtime]System.Double
+		IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_061c: stloc.s 8
+		IL_061e: ldloc.s 8
+		IL_0620: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0625: ldc.r8 10
+		IL_062e: mul
+		IL_062f: stloc.s 11
+		IL_0631: ldloc.s 11
+		IL_0633: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
+		IL_0638: ldc.r8 10
+		IL_0641: div
+		IL_0642: stloc.s 11
+		IL_0644: ldloc.s 11
+		IL_0646: box [System.Runtime]System.Double
+		IL_064b: stloc.s 12
+		IL_064d: ldloc.s 9
+		IL_064f: ldstr "log"
+		IL_0654: ldloc.s 12
+		IL_0656: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_065b: pop
+		IL_065c: ldc.r8 4
+		IL_0665: box [System.Runtime]System.Double
+		IL_066a: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::allocUnsafe(object)
+		IL_066f: stloc.s 6
+		IL_0671: ldloc.s 6
+		IL_0673: ldc.r8 0.0
+		IL_067c: ldc.r8 1
+		IL_0685: ldc.i4.1
+		IL_0686: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_068b: ldloc.s 6
+		IL_068d: ldc.r8 1
+		IL_0696: ldc.r8 2
+		IL_069f: ldc.i4.1
+		IL_06a0: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_06a5: ldloc.s 6
+		IL_06a7: ldc.r8 2
+		IL_06b0: ldc.r8 3
+		IL_06b9: ldc.i4.1
+		IL_06ba: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_06bf: ldloc.s 6
+		IL_06c1: ldc.r8 3
+		IL_06ca: ldc.r8 4
+		IL_06d3: ldc.i4.1
+		IL_06d4: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_06d9: ldstr "console"
+		IL_06de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06e8: stloc.s 9
+		IL_06ea: ldloc.s 6
+		IL_06ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_06f1: stloc.s 7
+		IL_06f3: ldloc.s 7
+		IL_06f5: ldstr "toString"
+		IL_06fa: ldstr "hex"
+		IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0704: stloc.s 8
+		IL_0706: ldloc.s 9
+		IL_0708: ldstr "log"
+		IL_070d: ldloc.s 8
+		IL_070f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0714: pop
+		IL_0715: ret
 	} // end of method Buffer_Advanced_CoreApis::__js_module_init__
 
 } // end of class Modules.Buffer_Advanced_CoreApis
@@ -489,7 +528,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x272f
+		// Method begins at RVA 0x277b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Alloc_ByteLength_Concat.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Alloc_ByteLength_Concat.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2366
+			// Method begins at RVA 0x2382
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 778 (0x30a)
+		// Code size: 806 (0x326)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Buffer_Alloc_ByteLength_Concat/Scope,
@@ -54,7 +54,8 @@
 			[8] object,
 			[9] float64,
 			[10] object,
-			[11] object
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+			[12] object
 		)
 
 		IL_0000: newobj instance void Modules.Buffer_Alloc_ByteLength_Concat/Scope::.ctor()
@@ -84,183 +85,197 @@
 		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_005b: stloc.s 8
 		IL_005d: ldloc.1
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0063: ldstr "toString"
-		IL_0068: ldstr "hex"
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: stloc.s 11
-		IL_0074: ldloc.s 8
-		IL_0076: ldstr "log"
-		IL_007b: ldloc.s 11
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0082: pop
-		IL_0083: ldc.r8 5
-		IL_008c: box [System.Runtime]System.Double
-		IL_0091: ldstr "ab"
-		IL_0096: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object, object)
-		IL_009b: stloc.2
-		IL_009c: ldstr "console"
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ab: stloc.s 11
-		IL_00ad: ldloc.2
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b3: ldstr "toString"
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00bd: stloc.s 8
-		IL_00bf: ldloc.s 11
-		IL_00c1: ldstr "log"
-		IL_00c6: ldloc.s 8
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cd: pop
-		IL_00ce: ldc.r8 3
-		IL_00d7: box [System.Runtime]System.Double
-		IL_00dc: ldc.r8 65
-		IL_00e5: box [System.Runtime]System.Double
-		IL_00ea: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object, object)
-		IL_00ef: stloc.3
-		IL_00f0: ldstr "console"
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ff: stloc.s 8
-		IL_0101: ldloc.3
+		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0063: stloc.s 11
+		IL_0065: ldloc.s 11
+		IL_0067: ldstr "toString"
+		IL_006c: ldstr "hex"
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0076: stloc.s 12
+		IL_0078: ldloc.s 8
+		IL_007a: ldstr "log"
+		IL_007f: ldloc.s 12
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0086: pop
+		IL_0087: ldc.r8 5
+		IL_0090: box [System.Runtime]System.Double
+		IL_0095: ldstr "ab"
+		IL_009a: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object, object)
+		IL_009f: stloc.2
+		IL_00a0: ldstr "console"
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00af: stloc.s 12
+		IL_00b1: ldloc.2
+		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_00b7: stloc.s 11
+		IL_00b9: ldloc.s 11
+		IL_00bb: ldstr "toString"
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00c5: stloc.s 8
+		IL_00c7: ldloc.s 12
+		IL_00c9: ldstr "log"
+		IL_00ce: ldloc.s 8
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d5: pop
+		IL_00d6: ldc.r8 3
+		IL_00df: box [System.Runtime]System.Double
+		IL_00e4: ldc.r8 65
+		IL_00ed: box [System.Runtime]System.Double
+		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object, object)
+		IL_00f7: stloc.3
+		IL_00f8: ldstr "console"
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0107: ldstr "toString"
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0111: stloc.s 11
-		IL_0113: ldloc.s 8
-		IL_0115: ldstr "log"
-		IL_011a: ldloc.s 11
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0121: pop
-		IL_0122: ldstr "console"
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0131: ldstr "hello"
-		IL_0136: call float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::byteLength(object)
-		IL_013b: box [System.Runtime]System.Double
-		IL_0140: stloc.s 10
-		IL_0142: ldstr "log"
-		IL_0147: ldloc.s 10
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014e: pop
-		IL_014f: ldstr "console"
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015e: ldstr "6869"
-		IL_0163: ldstr "hex"
-		IL_0168: call float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::byteLength(object, object)
-		IL_016d: box [System.Runtime]System.Double
-		IL_0172: stloc.s 10
-		IL_0174: ldstr "log"
-		IL_0179: ldloc.s 10
-		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0180: pop
-		IL_0181: ldstr "console"
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0190: ldstr "aGk="
-		IL_0195: ldstr "base64"
-		IL_019a: call float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::byteLength(object, object)
-		IL_019f: box [System.Runtime]System.Double
-		IL_01a4: stloc.s 10
-		IL_01a6: ldstr "log"
-		IL_01ab: ldloc.s 10
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b2: pop
-		IL_01b3: ldstr "6869"
-		IL_01b8: ldstr "hex"
-		IL_01bd: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object, object)
-		IL_01c2: stloc.s 4
-		IL_01c4: ldstr "aGk="
-		IL_01c9: ldstr "base64"
-		IL_01ce: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object, object)
-		IL_01d3: stloc.s 5
-		IL_01d5: ldstr "console"
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e4: stloc.s 11
-		IL_01e6: ldloc.s 4
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ed: ldstr "toString"
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01f7: stloc.s 8
-		IL_01f9: ldloc.s 11
-		IL_01fb: ldstr "log"
-		IL_0200: ldloc.s 8
-		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0207: pop
-		IL_0208: ldstr "console"
-		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0217: stloc.s 8
-		IL_0219: ldloc.s 5
-		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0220: ldstr "toString"
-		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_022a: stloc.s 11
-		IL_022c: ldloc.s 8
-		IL_022e: ldstr "log"
-		IL_0233: ldloc.s 11
-		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023a: pop
-		IL_023b: ldc.i4.3
-		IL_023c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0241: dup
-		IL_0242: ldloc.s 4
-		IL_0244: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0249: dup
-		IL_024a: ldstr "!"
-		IL_024f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_0254: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0259: dup
-		IL_025a: ldloc.s 5
-		IL_025c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0261: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
-		IL_0266: stloc.s 6
-		IL_0268: ldstr "console"
-		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0277: stloc.s 11
-		IL_0279: ldloc.s 6
-		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0280: ldstr "toString"
-		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_028a: stloc.s 8
-		IL_028c: ldloc.s 11
-		IL_028e: ldstr "log"
-		IL_0293: ldloc.s 8
-		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_029a: pop
-		IL_029b: ldc.i4.2
-		IL_029c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02a1: dup
-		IL_02a2: ldstr "hello"
-		IL_02a7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_02ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_02b1: dup
-		IL_02b2: ldstr "world"
-		IL_02b7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_02bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_02c1: ldc.r8 7
-		IL_02ca: box [System.Runtime]System.Double
-		IL_02cf: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object, object)
-		IL_02d4: stloc.s 7
-		IL_02d6: ldstr "console"
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e5: stloc.s 8
-		IL_02e7: ldloc.s 7
-		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ee: ldstr "toString"
-		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_02f8: stloc.s 11
-		IL_02fa: ldloc.s 8
-		IL_02fc: ldstr "log"
-		IL_0301: ldloc.s 11
-		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0308: pop
-		IL_0309: ret
+		IL_0107: stloc.s 8
+		IL_0109: ldloc.3
+		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_010f: stloc.s 11
+		IL_0111: ldloc.s 11
+		IL_0113: ldstr "toString"
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_011d: stloc.s 12
+		IL_011f: ldloc.s 8
+		IL_0121: ldstr "log"
+		IL_0126: ldloc.s 12
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012d: pop
+		IL_012e: ldstr "console"
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013d: ldstr "hello"
+		IL_0142: call float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::byteLength(object)
+		IL_0147: box [System.Runtime]System.Double
+		IL_014c: stloc.s 10
+		IL_014e: ldstr "log"
+		IL_0153: ldloc.s 10
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015a: pop
+		IL_015b: ldstr "console"
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016a: ldstr "6869"
+		IL_016f: ldstr "hex"
+		IL_0174: call float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::byteLength(object, object)
+		IL_0179: box [System.Runtime]System.Double
+		IL_017e: stloc.s 10
+		IL_0180: ldstr "log"
+		IL_0185: ldloc.s 10
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018c: pop
+		IL_018d: ldstr "console"
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019c: ldstr "aGk="
+		IL_01a1: ldstr "base64"
+		IL_01a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::byteLength(object, object)
+		IL_01ab: box [System.Runtime]System.Double
+		IL_01b0: stloc.s 10
+		IL_01b2: ldstr "log"
+		IL_01b7: ldloc.s 10
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01be: pop
+		IL_01bf: ldstr "6869"
+		IL_01c4: ldstr "hex"
+		IL_01c9: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object, object)
+		IL_01ce: stloc.s 4
+		IL_01d0: ldstr "aGk="
+		IL_01d5: ldstr "base64"
+		IL_01da: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object, object)
+		IL_01df: stloc.s 5
+		IL_01e1: ldstr "console"
+		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f0: stloc.s 12
+		IL_01f2: ldloc.s 4
+		IL_01f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_01f9: stloc.s 11
+		IL_01fb: ldloc.s 11
+		IL_01fd: ldstr "toString"
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0207: stloc.s 8
+		IL_0209: ldloc.s 12
+		IL_020b: ldstr "log"
+		IL_0210: ldloc.s 8
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0217: pop
+		IL_0218: ldstr "console"
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0227: stloc.s 8
+		IL_0229: ldloc.s 5
+		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0230: stloc.s 11
+		IL_0232: ldloc.s 11
+		IL_0234: ldstr "toString"
+		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_023e: stloc.s 12
+		IL_0240: ldloc.s 8
+		IL_0242: ldstr "log"
+		IL_0247: ldloc.s 12
+		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024e: pop
+		IL_024f: ldc.i4.3
+		IL_0250: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0255: dup
+		IL_0256: ldloc.s 4
+		IL_0258: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_025d: dup
+		IL_025e: ldstr "!"
+		IL_0263: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0268: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_026d: dup
+		IL_026e: ldloc.s 5
+		IL_0270: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0275: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
+		IL_027a: stloc.s 6
+		IL_027c: ldstr "console"
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028b: stloc.s 12
+		IL_028d: ldloc.s 6
+		IL_028f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0294: stloc.s 11
+		IL_0296: ldloc.s 11
+		IL_0298: ldstr "toString"
+		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02a2: stloc.s 8
+		IL_02a4: ldloc.s 12
+		IL_02a6: ldstr "log"
+		IL_02ab: ldloc.s 8
+		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b2: pop
+		IL_02b3: ldc.i4.2
+		IL_02b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02b9: dup
+		IL_02ba: ldstr "hello"
+		IL_02bf: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_02c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_02c9: dup
+		IL_02ca: ldstr "world"
+		IL_02cf: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_02d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_02d9: ldc.r8 7
+		IL_02e2: box [System.Runtime]System.Double
+		IL_02e7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object, object)
+		IL_02ec: stloc.s 7
+		IL_02ee: ldstr "console"
+		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fd: stloc.s 8
+		IL_02ff: ldloc.s 7
+		IL_0301: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0306: stloc.s 11
+		IL_0308: ldloc.s 11
+		IL_030a: ldstr "toString"
+		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0314: stloc.s 12
+		IL_0316: ldloc.s 8
+		IL_0318: ldstr "log"
+		IL_031d: ldloc.s 12
+		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0324: pop
+		IL_0325: ret
 	} // end of method Buffer_Alloc_ByteLength_Concat::__js_module_init__
 
 } // end of class Modules.Buffer_Alloc_ByteLength_Concat
@@ -272,7 +287,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x236f
+		// Method begins at RVA 0x238b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Constructor_Legacy.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Constructor_Legacy.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x215e
+			// Method begins at RVA 0x2166
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 258 (0x102)
+		// Code size: 266 (0x10a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Buffer_Constructor_Legacy/Scope,
@@ -49,9 +49,10 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object,
-			[6] object,
-			[7] float64,
-			[8] object
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+			[7] object,
+			[8] float64,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.Buffer_Constructor_Legacy/Scope::.ctor()
@@ -83,47 +84,51 @@
 		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0071: stloc.s 5
 		IL_0073: ldloc.1
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0079: ldstr "toString"
-		IL_007e: ldstr "utf8"
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0088: stloc.s 6
-		IL_008a: ldloc.s 5
-		IL_008c: ldstr "log"
-		IL_0091: ldloc.s 6
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0098: pop
-		IL_0099: ldstr "console"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a8: stloc.s 6
-		IL_00aa: ldloc.2
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b0: ldstr "toString"
-		IL_00b5: ldstr "utf8"
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bf: stloc.s 5
-		IL_00c1: ldloc.s 6
-		IL_00c3: ldstr "log"
-		IL_00c8: ldloc.s 5
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cf: pop
-		IL_00d0: ldstr "console"
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00df: stloc.s 5
-		IL_00e1: ldloc.3
-		IL_00e2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-		IL_00e7: stloc.s 7
-		IL_00e9: ldloc.s 7
-		IL_00eb: box [System.Runtime]System.Double
-		IL_00f0: stloc.s 8
-		IL_00f2: ldloc.s 5
-		IL_00f4: ldstr "log"
-		IL_00f9: ldloc.s 8
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0100: pop
-		IL_0101: ret
+		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0079: stloc.s 6
+		IL_007b: ldloc.s 6
+		IL_007d: ldstr "toString"
+		IL_0082: ldstr "utf8"
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008c: stloc.s 7
+		IL_008e: ldloc.s 5
+		IL_0090: ldstr "log"
+		IL_0095: ldloc.s 7
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009c: pop
+		IL_009d: ldstr "console"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ac: stloc.s 7
+		IL_00ae: ldloc.2
+		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_00b4: stloc.s 6
+		IL_00b6: ldloc.s 6
+		IL_00b8: ldstr "toString"
+		IL_00bd: ldstr "utf8"
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c7: stloc.s 5
+		IL_00c9: ldloc.s 7
+		IL_00cb: ldstr "log"
+		IL_00d0: ldloc.s 5
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d7: pop
+		IL_00d8: ldstr "console"
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e7: stloc.s 5
+		IL_00e9: ldloc.3
+		IL_00ea: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+		IL_00ef: stloc.s 8
+		IL_00f1: ldloc.s 8
+		IL_00f3: box [System.Runtime]System.Double
+		IL_00f8: stloc.s 9
+		IL_00fa: ldloc.s 5
+		IL_00fc: ldstr "log"
+		IL_0101: ldloc.s 9
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0108: pop
+		IL_0109: ret
 	} // end of method Buffer_Constructor_Legacy::__js_module_init__
 
 } // end of class Modules.Buffer_Constructor_Legacy
@@ -135,7 +140,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2167
+		// Method begins at RVA 0x216f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_From_And_IsBuffer.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_From_And_IsBuffer.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2254
+			// Method begins at RVA 0x2260
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 504 (0x1f8)
+		// Code size: 516 (0x204)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Buffer_From_And_IsBuffer/Scope,
@@ -51,7 +51,8 @@
 			[5] object,
 			[6] float64,
 			[7] object,
-			[8] object
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.Buffer_From_And_IsBuffer/Scope::.ctor()
@@ -91,109 +92,115 @@
 		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_007b: stloc.s 5
 		IL_007d: ldloc.1
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0083: ldstr "toString"
-		IL_0088: ldstr "utf8"
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0092: stloc.s 8
-		IL_0094: ldloc.s 5
-		IL_0096: ldstr "log"
-		IL_009b: ldloc.s 8
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a2: pop
-		IL_00a3: ldc.i4.3
-		IL_00a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00a9: dup
-		IL_00aa: ldc.r8 65
-		IL_00b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00b8: dup
-		IL_00b9: ldc.r8 66
-		IL_00c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00c7: dup
-		IL_00c8: ldc.r8 67
-		IL_00d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00d6: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_00db: stloc.2
-		IL_00dc: ldstr "console"
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00eb: ldloc.2
-		IL_00ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-		IL_00f1: box [System.Runtime]System.Boolean
-		IL_00f6: stloc.s 4
-		IL_00f8: ldstr "log"
-		IL_00fd: ldloc.s 4
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0104: pop
-		IL_0105: ldstr "console"
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0114: stloc.s 8
-		IL_0116: ldloc.2
-		IL_0117: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-		IL_011c: stloc.s 6
-		IL_011e: ldloc.s 6
-		IL_0120: box [System.Runtime]System.Double
-		IL_0125: stloc.s 7
-		IL_0127: ldloc.s 8
-		IL_0129: ldstr "log"
-		IL_012e: ldloc.s 7
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0135: pop
-		IL_0136: ldstr "console"
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0145: stloc.s 8
-		IL_0147: ldloc.2
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014d: ldstr "toString"
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0157: stloc.s 5
-		IL_0159: ldloc.s 8
-		IL_015b: ldstr "log"
-		IL_0160: ldloc.s 5
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0167: pop
-		IL_0168: ldloc.2
-		IL_0169: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_016e: stloc.3
-		IL_016f: ldstr "console"
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017e: ldloc.3
-		IL_017f: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-		IL_0184: box [System.Runtime]System.Boolean
-		IL_0189: stloc.s 4
-		IL_018b: ldstr "log"
-		IL_0190: ldloc.s 4
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0197: pop
-		IL_0198: ldstr "console"
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a7: stloc.s 5
-		IL_01a9: ldloc.3
+		IL_007e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0083: stloc.s 8
+		IL_0085: ldloc.s 8
+		IL_0087: ldstr "toString"
+		IL_008c: ldstr "utf8"
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0096: stloc.s 9
+		IL_0098: ldloc.s 5
+		IL_009a: ldstr "log"
+		IL_009f: ldloc.s 9
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a6: pop
+		IL_00a7: ldc.i4.3
+		IL_00a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00ad: dup
+		IL_00ae: ldc.r8 65
+		IL_00b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00bc: dup
+		IL_00bd: ldc.r8 66
+		IL_00c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00cb: dup
+		IL_00cc: ldc.r8 67
+		IL_00d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00da: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_00df: stloc.2
+		IL_00e0: ldstr "console"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ef: ldloc.2
+		IL_00f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+		IL_00f5: box [System.Runtime]System.Boolean
+		IL_00fa: stloc.s 4
+		IL_00fc: ldstr "log"
+		IL_0101: ldloc.s 4
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0108: pop
+		IL_0109: ldstr "console"
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0118: stloc.s 9
+		IL_011a: ldloc.2
+		IL_011b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+		IL_0120: stloc.s 6
+		IL_0122: ldloc.s 6
+		IL_0124: box [System.Runtime]System.Double
+		IL_0129: stloc.s 7
+		IL_012b: ldloc.s 9
+		IL_012d: ldstr "log"
+		IL_0132: ldloc.s 7
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0139: pop
+		IL_013a: ldstr "console"
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0149: stloc.s 9
+		IL_014b: ldloc.2
+		IL_014c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0151: stloc.s 8
+		IL_0153: ldloc.s 8
+		IL_0155: ldstr "toString"
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_015f: stloc.s 5
+		IL_0161: ldloc.s 9
+		IL_0163: ldstr "log"
+		IL_0168: ldloc.s 5
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016f: pop
+		IL_0170: ldloc.2
+		IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0176: stloc.3
+		IL_0177: ldstr "console"
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0186: ldloc.3
+		IL_0187: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+		IL_018c: box [System.Runtime]System.Boolean
+		IL_0191: stloc.s 4
+		IL_0193: ldstr "log"
+		IL_0198: ldloc.s 4
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019f: pop
+		IL_01a0: ldstr "console"
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01af: ldstr "toString"
-		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01b9: stloc.s 8
-		IL_01bb: ldloc.s 5
-		IL_01bd: ldstr "log"
-		IL_01c2: ldloc.s 8
-		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c9: pop
-		IL_01ca: ldstr "console"
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01de: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-		IL_01e3: box [System.Runtime]System.Boolean
-		IL_01e8: stloc.s 4
-		IL_01ea: ldstr "log"
-		IL_01ef: ldloc.s 4
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f6: pop
-		IL_01f7: ret
+		IL_01af: stloc.s 5
+		IL_01b1: ldloc.3
+		IL_01b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_01b7: stloc.s 8
+		IL_01b9: ldloc.s 8
+		IL_01bb: ldstr "toString"
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01c5: stloc.s 9
+		IL_01c7: ldloc.s 5
+		IL_01c9: ldstr "log"
+		IL_01ce: ldloc.s 9
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d5: pop
+		IL_01d6: ldstr "console"
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+		IL_01ef: box [System.Runtime]System.Boolean
+		IL_01f4: stloc.s 4
+		IL_01f6: ldstr "log"
+		IL_01fb: ldloc.s 4
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0202: pop
+		IL_0203: ret
 	} // end of method Buffer_From_And_IsBuffer::__js_module_init__
 
 } // end of class Modules.Buffer_From_And_IsBuffer
@@ -205,7 +212,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x225d
+		// Method begins at RVA 0x2269
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_ReadWrite_Methods.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_ReadWrite_Methods.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2758
+			// Method begins at RVA 0x27c0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1788 (0x6fc)
+		// Code size: 1892 (0x764)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Buffer_ReadWrite_Methods/Scope,
@@ -50,9 +50,10 @@
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] object,
-			[8] float64,
-			[9] object
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+			[8] object,
+			[9] float64,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Buffer_ReadWrite_Methods/Scope::.ctor()
@@ -91,402 +92,454 @@
 		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_009a: stloc.s 6
 		IL_009c: ldloc.1
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a2: ldstr "readInt8"
-		IL_00a7: ldc.r8 0.0
-		IL_00b0: box [System.Runtime]System.Double
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ba: stloc.s 7
-		IL_00bc: ldloc.s 6
-		IL_00be: ldstr "log"
-		IL_00c3: ldloc.s 7
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ca: pop
-		IL_00cb: ldstr "console"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00da: stloc.s 7
-		IL_00dc: ldloc.1
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e2: ldstr "readInt8"
-		IL_00e7: ldc.r8 1
-		IL_00f0: box [System.Runtime]System.Double
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fa: stloc.s 6
-		IL_00fc: ldloc.s 7
-		IL_00fe: ldstr "log"
-		IL_0103: ldloc.s 6
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010a: pop
-		IL_010b: ldstr "console"
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011a: stloc.s 6
-		IL_011c: ldloc.1
+		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_00a2: stloc.s 7
+		IL_00a4: ldloc.s 7
+		IL_00a6: ldstr "readInt8"
+		IL_00ab: ldc.r8 0.0
+		IL_00b4: box [System.Runtime]System.Double
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00be: stloc.s 8
+		IL_00c0: ldloc.s 6
+		IL_00c2: ldstr "log"
+		IL_00c7: ldloc.s 8
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ce: pop
+		IL_00cf: ldstr "console"
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00de: stloc.s 8
+		IL_00e0: ldloc.1
+		IL_00e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_00e6: stloc.s 7
+		IL_00e8: ldloc.s 7
+		IL_00ea: ldstr "readInt8"
+		IL_00ef: ldc.r8 1
+		IL_00f8: box [System.Runtime]System.Double
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0102: stloc.s 6
+		IL_0104: ldloc.s 8
+		IL_0106: ldstr "log"
+		IL_010b: ldloc.s 6
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0112: pop
+		IL_0113: ldstr "console"
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0122: ldstr "readUInt8"
-		IL_0127: ldc.r8 0.0
-		IL_0130: box [System.Runtime]System.Double
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013a: stloc.s 7
-		IL_013c: ldloc.s 6
-		IL_013e: ldstr "log"
-		IL_0143: ldloc.s 7
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014a: pop
-		IL_014b: ldstr "console"
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015a: stloc.s 7
-		IL_015c: ldloc.1
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0162: ldstr "readUInt8"
-		IL_0167: ldc.r8 1
-		IL_0170: box [System.Runtime]System.Double
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017a: stloc.s 6
-		IL_017c: ldloc.s 7
-		IL_017e: ldstr "log"
-		IL_0183: ldloc.s 6
+		IL_0122: stloc.s 6
+		IL_0124: ldloc.1
+		IL_0125: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_012a: stloc.s 7
+		IL_012c: ldloc.s 7
+		IL_012e: ldstr "readUInt8"
+		IL_0133: ldc.r8 0.0
+		IL_013c: box [System.Runtime]System.Double
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0146: stloc.s 8
+		IL_0148: ldloc.s 6
+		IL_014a: ldstr "log"
+		IL_014f: ldloc.s 8
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0156: pop
+		IL_0157: ldstr "console"
+		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0166: stloc.s 8
+		IL_0168: ldloc.1
+		IL_0169: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_016e: stloc.s 7
+		IL_0170: ldloc.s 7
+		IL_0172: ldstr "readUInt8"
+		IL_0177: ldc.r8 1
+		IL_0180: box [System.Runtime]System.Double
 		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018a: pop
-		IL_018b: ldstr "console"
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019a: stloc.s 6
-		IL_019c: ldloc.1
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a2: ldstr "readInt16BE"
-		IL_01a7: ldc.r8 0.0
-		IL_01b0: box [System.Runtime]System.Double
-		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ba: stloc.s 7
-		IL_01bc: ldloc.s 6
-		IL_01be: ldstr "log"
-		IL_01c3: ldloc.s 7
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ca: pop
-		IL_01cb: ldstr "console"
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01da: stloc.s 7
-		IL_01dc: ldloc.1
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e2: ldstr "readInt16LE"
-		IL_01e7: ldc.r8 0.0
-		IL_01f0: box [System.Runtime]System.Double
-		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fa: stloc.s 6
-		IL_01fc: ldloc.s 7
-		IL_01fe: ldstr "log"
-		IL_0203: ldloc.s 6
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020a: pop
-		IL_020b: ldstr "console"
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021a: stloc.s 6
-		IL_021c: ldloc.1
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0222: ldstr "readUInt16BE"
-		IL_0227: ldc.r8 0.0
-		IL_0230: box [System.Runtime]System.Double
-		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018a: stloc.s 6
+		IL_018c: ldloc.s 8
+		IL_018e: ldstr "log"
+		IL_0193: ldloc.s 6
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019a: pop
+		IL_019b: ldstr "console"
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01aa: stloc.s 6
+		IL_01ac: ldloc.1
+		IL_01ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_01b2: stloc.s 7
+		IL_01b4: ldloc.s 7
+		IL_01b6: ldstr "readInt16BE"
+		IL_01bb: ldc.r8 0.0
+		IL_01c4: box [System.Runtime]System.Double
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ce: stloc.s 8
+		IL_01d0: ldloc.s 6
+		IL_01d2: ldstr "log"
+		IL_01d7: ldloc.s 8
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01de: pop
+		IL_01df: ldstr "console"
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ee: stloc.s 8
+		IL_01f0: ldloc.1
+		IL_01f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_01f6: stloc.s 7
+		IL_01f8: ldloc.s 7
+		IL_01fa: ldstr "readInt16LE"
+		IL_01ff: ldc.r8 0.0
+		IL_0208: box [System.Runtime]System.Double
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0212: stloc.s 6
+		IL_0214: ldloc.s 8
+		IL_0216: ldstr "log"
+		IL_021b: ldloc.s 6
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0222: pop
+		IL_0223: ldstr "console"
+		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0232: stloc.s 6
+		IL_0234: ldloc.1
+		IL_0235: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 		IL_023a: stloc.s 7
-		IL_023c: ldloc.s 6
-		IL_023e: ldstr "log"
-		IL_0243: ldloc.s 7
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024a: pop
-		IL_024b: ldstr "console"
-		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025a: stloc.s 7
-		IL_025c: ldloc.1
-		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0262: ldstr "readUInt16LE"
-		IL_0267: ldc.r8 0.0
-		IL_0270: box [System.Runtime]System.Double
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027a: stloc.s 6
-		IL_027c: ldloc.s 7
-		IL_027e: ldstr "log"
-		IL_0283: ldloc.s 6
-		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_028a: pop
-		IL_028b: ldstr "console"
-		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_023c: ldloc.s 7
+		IL_023e: ldstr "readUInt16BE"
+		IL_0243: ldc.r8 0.0
+		IL_024c: box [System.Runtime]System.Double
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0256: stloc.s 8
+		IL_0258: ldloc.s 6
+		IL_025a: ldstr "log"
+		IL_025f: ldloc.s 8
+		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0266: pop
+		IL_0267: ldstr "console"
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0276: stloc.s 8
+		IL_0278: ldloc.1
+		IL_0279: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_027e: stloc.s 7
+		IL_0280: ldloc.s 7
+		IL_0282: ldstr "readUInt16LE"
+		IL_0287: ldc.r8 0.0
+		IL_0290: box [System.Runtime]System.Double
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_029a: stloc.s 6
-		IL_029c: ldloc.1
-		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a2: ldstr "readInt32BE"
-		IL_02a7: ldc.r8 2
-		IL_02b0: box [System.Runtime]System.Double
-		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ba: stloc.s 7
-		IL_02bc: ldloc.s 6
-		IL_02be: ldstr "log"
-		IL_02c3: ldloc.s 7
-		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ca: pop
-		IL_02cb: ldstr "console"
-		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02da: stloc.s 7
-		IL_02dc: ldloc.1
-		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e2: ldstr "readInt32LE"
-		IL_02e7: ldc.r8 2
-		IL_02f0: box [System.Runtime]System.Double
-		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02fa: stloc.s 6
-		IL_02fc: ldloc.s 7
-		IL_02fe: ldstr "log"
-		IL_0303: ldloc.s 6
-		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_030a: pop
-		IL_030b: ldstr "console"
-		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_031a: stloc.s 6
-		IL_031c: ldloc.1
-		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0322: ldstr "readUInt32BE"
-		IL_0327: ldc.r8 2
-		IL_0330: box [System.Runtime]System.Double
-		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_033a: stloc.s 7
-		IL_033c: ldloc.s 6
-		IL_033e: ldstr "log"
-		IL_0343: ldloc.s 7
-		IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_034a: pop
-		IL_034b: ldstr "console"
-		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_035a: stloc.s 7
-		IL_035c: ldloc.1
-		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0362: ldstr "readUInt32LE"
-		IL_0367: ldc.r8 2
-		IL_0370: box [System.Runtime]System.Double
-		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_037a: stloc.s 6
-		IL_037c: ldloc.s 7
-		IL_037e: ldstr "log"
-		IL_0383: ldloc.s 6
-		IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_038a: pop
-		IL_038b: ldc.r8 8
-		IL_0394: box [System.Runtime]System.Double
-		IL_0399: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-		IL_039e: stloc.2
-		IL_039f: ldloc.2
-		IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03a5: ldstr "writeInt8"
-		IL_03aa: ldc.r8 127
-		IL_03b3: box [System.Runtime]System.Double
-		IL_03b8: ldc.r8 0.0
-		IL_03c1: box [System.Runtime]System.Double
-		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03cb: pop
-		IL_03cc: ldloc.2
-		IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d2: ldc.r8 128
-		IL_03db: neg
-		IL_03dc: stloc.s 8
-		IL_03de: ldloc.s 8
-		IL_03e0: box [System.Runtime]System.Double
-		IL_03e5: stloc.s 9
-		IL_03e7: ldstr "writeInt8"
-		IL_03ec: ldloc.s 9
-		IL_03ee: ldc.r8 1
-		IL_03f7: box [System.Runtime]System.Double
-		IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0401: pop
-		IL_0402: ldstr "console"
-		IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0411: stloc.s 6
-		IL_0413: ldloc.2
-		IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0419: ldstr "readInt8"
-		IL_041e: ldc.r8 0.0
-		IL_0427: box [System.Runtime]System.Double
-		IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0431: stloc.s 7
-		IL_0433: ldloc.s 6
-		IL_0435: ldstr "log"
-		IL_043a: ldloc.s 7
-		IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0441: pop
-		IL_0442: ldstr "console"
-		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_029c: ldloc.s 8
+		IL_029e: ldstr "log"
+		IL_02a3: ldloc.s 6
+		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02aa: pop
+		IL_02ab: ldstr "console"
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ba: stloc.s 6
+		IL_02bc: ldloc.1
+		IL_02bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_02c2: stloc.s 7
+		IL_02c4: ldloc.s 7
+		IL_02c6: ldstr "readInt32BE"
+		IL_02cb: ldc.r8 2
+		IL_02d4: box [System.Runtime]System.Double
+		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02de: stloc.s 8
+		IL_02e0: ldloc.s 6
+		IL_02e2: ldstr "log"
+		IL_02e7: ldloc.s 8
+		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ee: pop
+		IL_02ef: ldstr "console"
+		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fe: stloc.s 8
+		IL_0300: ldloc.1
+		IL_0301: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0306: stloc.s 7
+		IL_0308: ldloc.s 7
+		IL_030a: ldstr "readInt32LE"
+		IL_030f: ldc.r8 2
+		IL_0318: box [System.Runtime]System.Double
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0322: stloc.s 6
+		IL_0324: ldloc.s 8
+		IL_0326: ldstr "log"
+		IL_032b: ldloc.s 6
+		IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0332: pop
+		IL_0333: ldstr "console"
+		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0342: stloc.s 6
+		IL_0344: ldloc.1
+		IL_0345: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_034a: stloc.s 7
+		IL_034c: ldloc.s 7
+		IL_034e: ldstr "readUInt32BE"
+		IL_0353: ldc.r8 2
+		IL_035c: box [System.Runtime]System.Double
+		IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0366: stloc.s 8
+		IL_0368: ldloc.s 6
+		IL_036a: ldstr "log"
+		IL_036f: ldloc.s 8
+		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0376: pop
+		IL_0377: ldstr "console"
+		IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0386: stloc.s 8
+		IL_0388: ldloc.1
+		IL_0389: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_038e: stloc.s 7
+		IL_0390: ldloc.s 7
+		IL_0392: ldstr "readUInt32LE"
+		IL_0397: ldc.r8 2
+		IL_03a0: box [System.Runtime]System.Double
+		IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03aa: stloc.s 6
+		IL_03ac: ldloc.s 8
+		IL_03ae: ldstr "log"
+		IL_03b3: ldloc.s 6
+		IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03ba: pop
+		IL_03bb: ldc.r8 8
+		IL_03c4: box [System.Runtime]System.Double
+		IL_03c9: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+		IL_03ce: stloc.2
+		IL_03cf: ldloc.2
+		IL_03d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_03d5: stloc.s 7
+		IL_03d7: ldloc.s 7
+		IL_03d9: ldstr "writeInt8"
+		IL_03de: ldc.r8 127
+		IL_03e7: box [System.Runtime]System.Double
+		IL_03ec: ldc.r8 0.0
+		IL_03f5: box [System.Runtime]System.Double
+		IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03ff: pop
+		IL_0400: ldloc.2
+		IL_0401: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0406: stloc.s 7
+		IL_0408: ldc.r8 128
+		IL_0411: neg
+		IL_0412: stloc.s 9
+		IL_0414: ldloc.s 9
+		IL_0416: box [System.Runtime]System.Double
+		IL_041b: stloc.s 10
+		IL_041d: ldloc.s 7
+		IL_041f: ldstr "writeInt8"
+		IL_0424: ldloc.s 10
+		IL_0426: ldc.r8 1
+		IL_042f: box [System.Runtime]System.Double
+		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0439: pop
+		IL_043a: ldstr "console"
+		IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0449: stloc.s 6
+		IL_044b: ldloc.2
+		IL_044c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 		IL_0451: stloc.s 7
-		IL_0453: ldloc.2
-		IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0459: ldstr "readInt8"
-		IL_045e: ldc.r8 1
-		IL_0467: box [System.Runtime]System.Double
-		IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0471: stloc.s 6
-		IL_0473: ldloc.s 7
-		IL_0475: ldstr "log"
-		IL_047a: ldloc.s 6
-		IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0481: pop
-		IL_0482: ldloc.2
-		IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0488: ldstr "writeUInt8"
-		IL_048d: ldc.r8 255
-		IL_0496: box [System.Runtime]System.Double
-		IL_049b: ldc.r8 2
-		IL_04a4: box [System.Runtime]System.Double
-		IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04ae: pop
-		IL_04af: ldstr "console"
-		IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04be: stloc.s 6
-		IL_04c0: ldloc.2
-		IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04c6: ldstr "readUInt8"
-		IL_04cb: ldc.r8 2
-		IL_04d4: box [System.Runtime]System.Double
-		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04de: stloc.s 7
-		IL_04e0: ldloc.s 6
-		IL_04e2: ldstr "log"
-		IL_04e7: ldloc.s 7
-		IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04ee: pop
-		IL_04ef: ldloc.2
-		IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04f5: ldstr "writeInt16BE"
-		IL_04fa: ldc.r8 4660
-		IL_0503: box [System.Runtime]System.Double
-		IL_0508: ldc.r8 3
-		IL_0511: box [System.Runtime]System.Double
-		IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_051b: pop
-		IL_051c: ldstr "console"
-		IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_052b: stloc.s 7
-		IL_052d: ldloc.2
-		IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0533: ldstr "readInt16BE"
-		IL_0538: ldc.r8 3
-		IL_0541: box [System.Runtime]System.Double
-		IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_054b: stloc.s 6
-		IL_054d: ldloc.s 7
-		IL_054f: ldstr "log"
-		IL_0554: ldloc.s 6
-		IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_055b: pop
-		IL_055c: ldloc.2
-		IL_055d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0562: ldc.r8 1
-		IL_056b: neg
-		IL_056c: stloc.s 8
-		IL_056e: ldloc.s 8
-		IL_0570: box [System.Runtime]System.Double
-		IL_0575: stloc.s 9
-		IL_0577: ldstr "writeInt32LE"
-		IL_057c: ldloc.s 9
-		IL_057e: ldc.r8 0.0
-		IL_0587: box [System.Runtime]System.Double
-		IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0591: pop
-		IL_0592: ldstr "console"
-		IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05a1: stloc.s 6
-		IL_05a3: ldloc.2
-		IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05a9: ldstr "readInt32LE"
-		IL_05ae: ldc.r8 0.0
-		IL_05b7: box [System.Runtime]System.Double
-		IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05c1: stloc.s 7
-		IL_05c3: ldloc.s 6
-		IL_05c5: ldstr "log"
-		IL_05ca: ldloc.s 7
-		IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05d1: pop
-		IL_05d2: ldc.r8 10
+		IL_0453: ldloc.s 7
+		IL_0455: ldstr "readInt8"
+		IL_045a: ldc.r8 0.0
+		IL_0463: box [System.Runtime]System.Double
+		IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_046d: stloc.s 8
+		IL_046f: ldloc.s 6
+		IL_0471: ldstr "log"
+		IL_0476: ldloc.s 8
+		IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_047d: pop
+		IL_047e: ldstr "console"
+		IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_048d: stloc.s 8
+		IL_048f: ldloc.2
+		IL_0490: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0495: stloc.s 7
+		IL_0497: ldloc.s 7
+		IL_0499: ldstr "readInt8"
+		IL_049e: ldc.r8 1
+		IL_04a7: box [System.Runtime]System.Double
+		IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04b1: stloc.s 6
+		IL_04b3: ldloc.s 8
+		IL_04b5: ldstr "log"
+		IL_04ba: ldloc.s 6
+		IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04c1: pop
+		IL_04c2: ldloc.2
+		IL_04c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_04c8: stloc.s 7
+		IL_04ca: ldloc.s 7
+		IL_04cc: ldstr "writeUInt8"
+		IL_04d1: ldc.r8 255
+		IL_04da: box [System.Runtime]System.Double
+		IL_04df: ldc.r8 2
+		IL_04e8: box [System.Runtime]System.Double
+		IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04f2: pop
+		IL_04f3: ldstr "console"
+		IL_04f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0502: stloc.s 6
+		IL_0504: ldloc.2
+		IL_0505: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_050a: stloc.s 7
+		IL_050c: ldloc.s 7
+		IL_050e: ldstr "readUInt8"
+		IL_0513: ldc.r8 2
+		IL_051c: box [System.Runtime]System.Double
+		IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0526: stloc.s 8
+		IL_0528: ldloc.s 6
+		IL_052a: ldstr "log"
+		IL_052f: ldloc.s 8
+		IL_0531: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0536: pop
+		IL_0537: ldloc.2
+		IL_0538: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_053d: stloc.s 7
+		IL_053f: ldloc.s 7
+		IL_0541: ldstr "writeInt16BE"
+		IL_0546: ldc.r8 4660
+		IL_054f: box [System.Runtime]System.Double
+		IL_0554: ldc.r8 3
+		IL_055d: box [System.Runtime]System.Double
+		IL_0562: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0567: pop
+		IL_0568: ldstr "console"
+		IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0577: stloc.s 8
+		IL_0579: ldloc.2
+		IL_057a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_057f: stloc.s 7
+		IL_0581: ldloc.s 7
+		IL_0583: ldstr "readInt16BE"
+		IL_0588: ldc.r8 3
+		IL_0591: box [System.Runtime]System.Double
+		IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_059b: stloc.s 6
+		IL_059d: ldloc.s 8
+		IL_059f: ldstr "log"
+		IL_05a4: ldloc.s 6
+		IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05ab: pop
+		IL_05ac: ldloc.2
+		IL_05ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_05b2: stloc.s 7
+		IL_05b4: ldc.r8 1
+		IL_05bd: neg
+		IL_05be: stloc.s 9
+		IL_05c0: ldloc.s 9
+		IL_05c2: box [System.Runtime]System.Double
+		IL_05c7: stloc.s 10
+		IL_05c9: ldloc.s 7
+		IL_05cb: ldstr "writeInt32LE"
+		IL_05d0: ldloc.s 10
+		IL_05d2: ldc.r8 0.0
 		IL_05db: box [System.Runtime]System.Double
-		IL_05e0: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-		IL_05e5: stloc.3
-		IL_05e6: ldloc.3
-		IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05ec: ldstr "write"
-		IL_05f1: ldstr "hello"
-		IL_05f6: ldc.r8 0.0
-		IL_05ff: box [System.Runtime]System.Double
-		IL_0604: ldc.r8 5
-		IL_060d: box [System.Runtime]System.Double
-		IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0617: stloc.s 4
-		IL_0619: ldstr "console"
-		IL_061e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0623: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0628: ldstr "log"
-		IL_062d: ldloc.s 4
-		IL_062f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0634: pop
-		IL_0635: ldstr "console"
-		IL_063a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_063f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_05e5: pop
+		IL_05e6: ldstr "console"
+		IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05f5: stloc.s 6
+		IL_05f7: ldloc.2
+		IL_05f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_05fd: stloc.s 7
+		IL_05ff: ldloc.s 7
+		IL_0601: ldstr "readInt32LE"
+		IL_0606: ldc.r8 0.0
+		IL_060f: box [System.Runtime]System.Double
+		IL_0614: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0619: stloc.s 8
+		IL_061b: ldloc.s 6
+		IL_061d: ldstr "log"
+		IL_0622: ldloc.s 8
+		IL_0624: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0629: pop
+		IL_062a: ldc.r8 10
+		IL_0633: box [System.Runtime]System.Double
+		IL_0638: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+		IL_063d: stloc.3
+		IL_063e: ldloc.3
+		IL_063f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 		IL_0644: stloc.s 7
-		IL_0646: ldloc.3
-		IL_0647: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_064c: ldstr "toString"
-		IL_0651: ldstr "utf8"
-		IL_0656: ldc.r8 0.0
-		IL_065f: box [System.Runtime]System.Double
-		IL_0664: ldc.r8 5
-		IL_066d: box [System.Runtime]System.Double
-		IL_0672: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0677: stloc.s 6
-		IL_0679: ldloc.s 7
-		IL_067b: ldstr "log"
-		IL_0680: ldloc.s 6
-		IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0687: pop
-		IL_0688: ldloc.3
-		IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_068e: ldstr "write"
-		IL_0693: ldstr "world"
-		IL_0698: ldc.r8 5
-		IL_06a1: box [System.Runtime]System.Double
-		IL_06a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_06ab: stloc.s 5
-		IL_06ad: ldstr "console"
-		IL_06b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06bc: ldstr "log"
-		IL_06c1: ldloc.s 5
-		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06c8: pop
-		IL_06c9: ldstr "console"
-		IL_06ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06d8: stloc.s 6
-		IL_06da: ldloc.3
-		IL_06db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06e0: ldstr "toString"
-		IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_06ea: stloc.s 7
-		IL_06ec: ldloc.s 6
-		IL_06ee: ldstr "log"
-		IL_06f3: ldloc.s 7
-		IL_06f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06fa: pop
-		IL_06fb: ret
+		IL_0646: ldloc.s 7
+		IL_0648: ldstr "write"
+		IL_064d: ldstr "hello"
+		IL_0652: ldc.r8 0.0
+		IL_065b: box [System.Runtime]System.Double
+		IL_0660: ldc.r8 5
+		IL_0669: box [System.Runtime]System.Double
+		IL_066e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0673: stloc.s 4
+		IL_0675: ldstr "console"
+		IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_067f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0684: ldstr "log"
+		IL_0689: ldloc.s 4
+		IL_068b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0690: pop
+		IL_0691: ldstr "console"
+		IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_069b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06a0: stloc.s 8
+		IL_06a2: ldloc.3
+		IL_06a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_06a8: stloc.s 7
+		IL_06aa: ldloc.s 7
+		IL_06ac: ldstr "toString"
+		IL_06b1: ldstr "utf8"
+		IL_06b6: ldc.r8 0.0
+		IL_06bf: box [System.Runtime]System.Double
+		IL_06c4: ldc.r8 5
+		IL_06cd: box [System.Runtime]System.Double
+		IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_06d7: stloc.s 6
+		IL_06d9: ldloc.s 8
+		IL_06db: ldstr "log"
+		IL_06e0: ldloc.s 6
+		IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06e7: pop
+		IL_06e8: ldloc.3
+		IL_06e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_06ee: stloc.s 7
+		IL_06f0: ldloc.s 7
+		IL_06f2: ldstr "write"
+		IL_06f7: ldstr "world"
+		IL_06fc: ldc.r8 5
+		IL_0705: box [System.Runtime]System.Double
+		IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_070f: stloc.s 5
+		IL_0711: ldstr "console"
+		IL_0716: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0720: ldstr "log"
+		IL_0725: ldloc.s 5
+		IL_0727: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_072c: pop
+		IL_072d: ldstr "console"
+		IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0737: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_073c: stloc.s 6
+		IL_073e: ldloc.3
+		IL_073f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0744: stloc.s 7
+		IL_0746: ldloc.s 7
+		IL_0748: ldstr "toString"
+		IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0752: stloc.s 8
+		IL_0754: ldloc.s 6
+		IL_0756: ldstr "log"
+		IL_075b: ldloc.s 8
+		IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0762: pop
+		IL_0763: ret
 	} // end of method Buffer_ReadWrite_Methods::__js_module_init__
 
 } // end of class Modules.Buffer_ReadWrite_Methods
@@ -498,7 +551,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2761
+		// Method begins at RVA 0x27c9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Slice_Copy_IndexAccess.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Slice_Copy_IndexAccess.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24e8
+			// Method begins at RVA 0x24f8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1164 (0x48c)
+		// Code size: 1180 (0x49c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Buffer_Slice_Copy_IndexAccess/Scope,
@@ -49,11 +49,12 @@
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-			[6] object,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 			[7] object,
-			[8] float64,
-			[9] object,
-			[10] object
+			[8] object,
+			[9] float64,
+			[10] object,
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.Buffer_Slice_Copy_IndexAccess/Scope::.ctor()
@@ -79,286 +80,294 @@
 		IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 		IL_005d: stloc.1
 		IL_005e: ldloc.1
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0064: ldstr "slice"
-		IL_0069: ldc.r8 1
-		IL_0072: box [System.Runtime]System.Double
-		IL_0077: ldc.r8 4
-		IL_0080: box [System.Runtime]System.Double
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_008a: stloc.2
-		IL_008b: ldstr "console"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009a: stloc.s 6
-		IL_009c: ldloc.2
-		IL_009d: ldstr "length"
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a7: stloc.s 7
-		IL_00a9: ldloc.s 6
-		IL_00ab: ldstr "log"
-		IL_00b0: ldloc.s 7
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b7: pop
-		IL_00b8: ldstr "console"
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c7: stloc.s 7
-		IL_00c9: ldloc.2
-		IL_00ca: ldc.r8 0.0
-		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00d8: stloc.s 6
-		IL_00da: ldloc.s 7
-		IL_00dc: ldstr "log"
-		IL_00e1: ldloc.s 6
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e8: pop
-		IL_00e9: ldstr "console"
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f8: stloc.s 6
-		IL_00fa: ldloc.2
-		IL_00fb: ldc.r8 1
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0109: stloc.s 7
-		IL_010b: ldloc.s 6
-		IL_010d: ldstr "log"
-		IL_0112: ldloc.s 7
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0119: pop
-		IL_011a: ldstr "console"
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0129: stloc.s 7
-		IL_012b: ldloc.2
-		IL_012c: ldc.r8 2
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_013a: stloc.s 6
-		IL_013c: ldloc.s 7
-		IL_013e: ldstr "log"
-		IL_0143: ldloc.s 6
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014a: pop
-		IL_014b: ldloc.1
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0151: ldc.r8 3
-		IL_015a: neg
-		IL_015b: stloc.s 8
-		IL_015d: ldloc.s 8
-		IL_015f: box [System.Runtime]System.Double
-		IL_0164: stloc.s 9
-		IL_0166: ldc.r8 1
-		IL_016f: neg
-		IL_0170: stloc.s 8
-		IL_0172: ldloc.s 8
-		IL_0174: box [System.Runtime]System.Double
-		IL_0179: stloc.s 10
-		IL_017b: ldstr "slice"
-		IL_0180: ldloc.s 9
-		IL_0182: ldloc.s 10
-		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0189: stloc.3
-		IL_018a: ldstr "console"
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0199: stloc.s 6
-		IL_019b: ldloc.3
-		IL_019c: ldstr "length"
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a6: stloc.s 7
-		IL_01a8: ldloc.s 6
-		IL_01aa: ldstr "log"
-		IL_01af: ldloc.s 7
-		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b6: pop
-		IL_01b7: ldstr "console"
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c6: stloc.s 7
-		IL_01c8: ldloc.3
-		IL_01c9: ldc.r8 0.0
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01d7: stloc.s 6
-		IL_01d9: ldloc.s 7
-		IL_01db: ldstr "log"
-		IL_01e0: ldloc.s 6
-		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e7: pop
-		IL_01e8: ldstr "console"
-		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f7: stloc.s 6
-		IL_01f9: ldloc.3
-		IL_01fa: ldc.r8 1
-		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0208: stloc.s 7
-		IL_020a: ldloc.s 6
-		IL_020c: ldstr "log"
-		IL_0211: ldloc.s 7
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0218: pop
-		IL_0219: ldc.r8 5
-		IL_0222: box [System.Runtime]System.Double
-		IL_0227: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-		IL_022c: stloc.s 4
-		IL_022e: ldloc.1
-		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0234: ldstr "copy"
-		IL_0239: ldc.i4.4
-		IL_023a: newarr [System.Runtime]System.Object
-		IL_023f: dup
-		IL_0240: ldc.i4.0
-		IL_0241: ldloc.s 4
-		IL_0243: stelem.ref
-		IL_0244: dup
-		IL_0245: ldc.i4.1
-		IL_0246: ldc.r8 1
-		IL_024f: box [System.Runtime]System.Double
-		IL_0254: stelem.ref
-		IL_0255: dup
-		IL_0256: ldc.i4.2
-		IL_0257: ldc.r8 1
-		IL_0260: box [System.Runtime]System.Double
-		IL_0265: stelem.ref
-		IL_0266: dup
-		IL_0267: ldc.i4.3
-		IL_0268: ldc.r8 4
-		IL_0271: box [System.Runtime]System.Double
-		IL_0276: stelem.ref
-		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_027c: pop
-		IL_027d: ldstr "console"
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028c: stloc.s 7
-		IL_028e: ldloc.s 4
-		IL_0290: ldc.r8 0.0
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_029e: stloc.s 6
-		IL_02a0: ldloc.s 7
-		IL_02a2: ldstr "log"
-		IL_02a7: ldloc.s 6
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ae: pop
-		IL_02af: ldstr "console"
-		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02be: stloc.s 6
-		IL_02c0: ldloc.s 4
-		IL_02c2: ldc.r8 1
-		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02d0: stloc.s 7
-		IL_02d2: ldloc.s 6
-		IL_02d4: ldstr "log"
-		IL_02d9: ldloc.s 7
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e0: pop
-		IL_02e1: ldstr "console"
-		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f0: stloc.s 7
-		IL_02f2: ldloc.s 4
-		IL_02f4: ldc.r8 2
-		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0302: stloc.s 6
-		IL_0304: ldloc.s 7
-		IL_0306: ldstr "log"
-		IL_030b: ldloc.s 6
-		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0312: pop
-		IL_0313: ldstr "console"
-		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0322: stloc.s 6
-		IL_0324: ldloc.s 4
-		IL_0326: ldc.r8 3
-		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0334: stloc.s 7
-		IL_0336: ldloc.s 6
-		IL_0338: ldstr "log"
-		IL_033d: ldloc.s 7
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0344: pop
-		IL_0345: ldstr "console"
-		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0354: stloc.s 7
-		IL_0356: ldloc.s 4
-		IL_0358: ldc.r8 4
-		IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0366: stloc.s 6
-		IL_0368: ldloc.s 7
-		IL_036a: ldstr "log"
-		IL_036f: ldloc.s 6
-		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0376: pop
-		IL_0377: ldc.r8 3
-		IL_0380: box [System.Runtime]System.Double
-		IL_0385: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-		IL_038a: stloc.s 5
-		IL_038c: ldloc.s 5
-		IL_038e: ldc.r8 0.0
-		IL_0397: ldc.r8 65
-		IL_03a0: ldc.i4.1
-		IL_03a1: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_03a6: ldloc.s 5
-		IL_03a8: ldc.r8 1
-		IL_03b1: ldc.r8 66
-		IL_03ba: ldc.i4.1
-		IL_03bb: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_03c0: ldloc.s 5
-		IL_03c2: ldc.r8 2
-		IL_03cb: ldc.r8 67
-		IL_03d4: ldc.i4.1
-		IL_03d5: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_03da: ldstr "console"
-		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03e9: stloc.s 6
-		IL_03eb: ldloc.s 5
-		IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03f2: ldstr "toString"
-		IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_03fc: stloc.s 7
-		IL_03fe: ldloc.s 6
-		IL_0400: ldstr "log"
-		IL_0405: ldloc.s 7
-		IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_040c: pop
-		IL_040d: ldstr "console"
-		IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_041c: stloc.s 7
-		IL_041e: ldloc.s 5
-		IL_0420: ldc.r8 10
-		IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_042e: stloc.s 6
-		IL_0430: ldloc.s 7
-		IL_0432: ldstr "log"
-		IL_0437: ldloc.s 6
-		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_043e: pop
-		IL_043f: ldloc.s 5
-		IL_0441: ldc.r8 10
-		IL_044a: ldc.r8 68
-		IL_0453: ldc.i4.1
-		IL_0454: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_0459: ldstr "console"
-		IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0468: stloc.s 6
-		IL_046a: ldloc.s 5
-		IL_046c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-		IL_0471: stloc.s 8
-		IL_0473: ldloc.s 8
-		IL_0475: box [System.Runtime]System.Double
-		IL_047a: stloc.s 10
-		IL_047c: ldloc.s 6
-		IL_047e: ldstr "log"
-		IL_0483: ldloc.s 10
-		IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_048a: pop
-		IL_048b: ret
+		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0064: stloc.s 6
+		IL_0066: ldloc.s 6
+		IL_0068: ldstr "slice"
+		IL_006d: ldc.r8 1
+		IL_0076: box [System.Runtime]System.Double
+		IL_007b: ldc.r8 4
+		IL_0084: box [System.Runtime]System.Double
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_008e: stloc.2
+		IL_008f: ldstr "console"
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009e: stloc.s 7
+		IL_00a0: ldloc.2
+		IL_00a1: ldstr "length"
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ab: stloc.s 8
+		IL_00ad: ldloc.s 7
+		IL_00af: ldstr "log"
+		IL_00b4: ldloc.s 8
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bb: pop
+		IL_00bc: ldstr "console"
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cb: stloc.s 8
+		IL_00cd: ldloc.2
+		IL_00ce: ldc.r8 0.0
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00dc: stloc.s 7
+		IL_00de: ldloc.s 8
+		IL_00e0: ldstr "log"
+		IL_00e5: ldloc.s 7
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ec: pop
+		IL_00ed: ldstr "console"
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fc: stloc.s 7
+		IL_00fe: ldloc.2
+		IL_00ff: ldc.r8 1
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_010d: stloc.s 8
+		IL_010f: ldloc.s 7
+		IL_0111: ldstr "log"
+		IL_0116: ldloc.s 8
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011d: pop
+		IL_011e: ldstr "console"
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012d: stloc.s 8
+		IL_012f: ldloc.2
+		IL_0130: ldc.r8 2
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_013e: stloc.s 7
+		IL_0140: ldloc.s 8
+		IL_0142: ldstr "log"
+		IL_0147: ldloc.s 7
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014e: pop
+		IL_014f: ldloc.1
+		IL_0150: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0155: stloc.s 6
+		IL_0157: ldc.r8 3
+		IL_0160: neg
+		IL_0161: stloc.s 9
+		IL_0163: ldloc.s 9
+		IL_0165: box [System.Runtime]System.Double
+		IL_016a: stloc.s 10
+		IL_016c: ldc.r8 1
+		IL_0175: neg
+		IL_0176: stloc.s 9
+		IL_0178: ldloc.s 9
+		IL_017a: box [System.Runtime]System.Double
+		IL_017f: stloc.s 11
+		IL_0181: ldloc.s 6
+		IL_0183: ldstr "slice"
+		IL_0188: ldloc.s 10
+		IL_018a: ldloc.s 11
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0191: stloc.3
+		IL_0192: ldstr "console"
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a1: stloc.s 7
+		IL_01a3: ldloc.3
+		IL_01a4: ldstr "length"
+		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ae: stloc.s 8
+		IL_01b0: ldloc.s 7
+		IL_01b2: ldstr "log"
+		IL_01b7: ldloc.s 8
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01be: pop
+		IL_01bf: ldstr "console"
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ce: stloc.s 8
+		IL_01d0: ldloc.3
+		IL_01d1: ldc.r8 0.0
+		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01df: stloc.s 7
+		IL_01e1: ldloc.s 8
+		IL_01e3: ldstr "log"
+		IL_01e8: ldloc.s 7
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ef: pop
+		IL_01f0: ldstr "console"
+		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ff: stloc.s 7
+		IL_0201: ldloc.3
+		IL_0202: ldc.r8 1
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0210: stloc.s 8
+		IL_0212: ldloc.s 7
+		IL_0214: ldstr "log"
+		IL_0219: ldloc.s 8
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0220: pop
+		IL_0221: ldc.r8 5
+		IL_022a: box [System.Runtime]System.Double
+		IL_022f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+		IL_0234: stloc.s 4
+		IL_0236: ldloc.1
+		IL_0237: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_023c: stloc.s 6
+		IL_023e: ldloc.s 6
+		IL_0240: ldstr "copy"
+		IL_0245: ldc.i4.4
+		IL_0246: newarr [System.Runtime]System.Object
+		IL_024b: dup
+		IL_024c: ldc.i4.0
+		IL_024d: ldloc.s 4
+		IL_024f: stelem.ref
+		IL_0250: dup
+		IL_0251: ldc.i4.1
+		IL_0252: ldc.r8 1
+		IL_025b: box [System.Runtime]System.Double
+		IL_0260: stelem.ref
+		IL_0261: dup
+		IL_0262: ldc.i4.2
+		IL_0263: ldc.r8 1
+		IL_026c: box [System.Runtime]System.Double
+		IL_0271: stelem.ref
+		IL_0272: dup
+		IL_0273: ldc.i4.3
+		IL_0274: ldc.r8 4
+		IL_027d: box [System.Runtime]System.Double
+		IL_0282: stelem.ref
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0288: pop
+		IL_0289: ldstr "console"
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0298: stloc.s 8
+		IL_029a: ldloc.s 4
+		IL_029c: ldc.r8 0.0
+		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02aa: stloc.s 7
+		IL_02ac: ldloc.s 8
+		IL_02ae: ldstr "log"
+		IL_02b3: ldloc.s 7
+		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ba: pop
+		IL_02bb: ldstr "console"
+		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ca: stloc.s 7
+		IL_02cc: ldloc.s 4
+		IL_02ce: ldc.r8 1
+		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02dc: stloc.s 8
+		IL_02de: ldloc.s 7
+		IL_02e0: ldstr "log"
+		IL_02e5: ldloc.s 8
+		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ec: pop
+		IL_02ed: ldstr "console"
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fc: stloc.s 8
+		IL_02fe: ldloc.s 4
+		IL_0300: ldc.r8 2
+		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_030e: stloc.s 7
+		IL_0310: ldloc.s 8
+		IL_0312: ldstr "log"
+		IL_0317: ldloc.s 7
+		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_031e: pop
+		IL_031f: ldstr "console"
+		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_032e: stloc.s 7
+		IL_0330: ldloc.s 4
+		IL_0332: ldc.r8 3
+		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0340: stloc.s 8
+		IL_0342: ldloc.s 7
+		IL_0344: ldstr "log"
+		IL_0349: ldloc.s 8
+		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0350: pop
+		IL_0351: ldstr "console"
+		IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0360: stloc.s 8
+		IL_0362: ldloc.s 4
+		IL_0364: ldc.r8 4
+		IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0372: stloc.s 7
+		IL_0374: ldloc.s 8
+		IL_0376: ldstr "log"
+		IL_037b: ldloc.s 7
+		IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0382: pop
+		IL_0383: ldc.r8 3
+		IL_038c: box [System.Runtime]System.Double
+		IL_0391: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+		IL_0396: stloc.s 5
+		IL_0398: ldloc.s 5
+		IL_039a: ldc.r8 0.0
+		IL_03a3: ldc.r8 65
+		IL_03ac: ldc.i4.1
+		IL_03ad: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_03b2: ldloc.s 5
+		IL_03b4: ldc.r8 1
+		IL_03bd: ldc.r8 66
+		IL_03c6: ldc.i4.1
+		IL_03c7: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_03cc: ldloc.s 5
+		IL_03ce: ldc.r8 2
+		IL_03d7: ldc.r8 67
+		IL_03e0: ldc.i4.1
+		IL_03e1: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_03e6: ldstr "console"
+		IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03f5: stloc.s 7
+		IL_03f7: ldloc.s 5
+		IL_03f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_03fe: stloc.s 6
+		IL_0400: ldloc.s 6
+		IL_0402: ldstr "toString"
+		IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_040c: stloc.s 8
+		IL_040e: ldloc.s 7
+		IL_0410: ldstr "log"
+		IL_0415: ldloc.s 8
+		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_041c: pop
+		IL_041d: ldstr "console"
+		IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_042c: stloc.s 8
+		IL_042e: ldloc.s 5
+		IL_0430: ldc.r8 10
+		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_043e: stloc.s 7
+		IL_0440: ldloc.s 8
+		IL_0442: ldstr "log"
+		IL_0447: ldloc.s 7
+		IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_044e: pop
+		IL_044f: ldloc.s 5
+		IL_0451: ldc.r8 10
+		IL_045a: ldc.r8 68
+		IL_0463: ldc.i4.1
+		IL_0464: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0469: ldstr "console"
+		IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0473: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0478: stloc.s 7
+		IL_047a: ldloc.s 5
+		IL_047c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+		IL_0481: stloc.s 9
+		IL_0483: ldloc.s 9
+		IL_0485: box [System.Runtime]System.Double
+		IL_048a: stloc.s 11
+		IL_048c: ldloc.s 7
+		IL_048e: ldstr "log"
+		IL_0493: ldloc.s 11
+		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_049a: pop
+		IL_049b: ret
 	} // end of method Buffer_Slice_Copy_IndexAccess::__js_module_init__
 
 } // end of class Modules.Buffer_Slice_Copy_IndexAccess
@@ -370,7 +379,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24f1
+		// Method begins at RVA 0x2501
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ebf
+					// Method begins at RVA 0x3ec3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ec8
+					// Method begins at RVA 0x3ecc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3eb6
+				// Method begins at RVA 0x3eba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -217,7 +217,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ed1
+				// Method begins at RVA 0x3ed5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -275,7 +275,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3eda
+				// Method begins at RVA 0x3ede
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -334,7 +334,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ee3
+				// Method begins at RVA 0x3ee7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -393,7 +393,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3eec
+				// Method begins at RVA 0x3ef0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -453,7 +453,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ef5
+				// Method begins at RVA 0x3ef9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -514,7 +514,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3efe
+				// Method begins at RVA 0x3f02
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -575,7 +575,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f07
+				// Method begins at RVA 0x3f0b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -603,40 +603,45 @@
 			)
 			// Method begins at RVA 0x2a94
 			// Header size: 12
-			// Code size: 80 (0x50)
+			// Code size: 84 (0x54)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000b: ldstr "pbkdf2Sync"
-			IL_0010: ldc.i4.4
-			IL_0011: newarr [System.Runtime]System.Object
-			IL_0016: dup
-			IL_0017: ldc.i4.0
-			IL_0018: ldstr "password"
-			IL_001d: stelem.ref
-			IL_001e: dup
-			IL_001f: ldc.i4.1
-			IL_0020: ldstr "salt"
-			IL_0025: stelem.ref
-			IL_0026: dup
-			IL_0027: ldc.i4.2
-			IL_0028: ldc.r8 1
-			IL_0031: box [System.Runtime]System.Double
-			IL_0036: stelem.ref
-			IL_0037: dup
-			IL_0038: ldc.i4.3
-			IL_0039: ldc.r8 16
-			IL_0042: box [System.Runtime]System.Double
-			IL_0047: stelem.ref
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_004d: stloc.0
-			IL_004e: ldloc.0
-			IL_004f: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule>(!!0)
+			IL_000d: stloc.0
+			IL_000e: ldloc.0
+			IL_000f: ldstr "pbkdf2Sync"
+			IL_0014: ldc.i4.4
+			IL_0015: newarr [System.Runtime]System.Object
+			IL_001a: dup
+			IL_001b: ldc.i4.0
+			IL_001c: ldstr "password"
+			IL_0021: stelem.ref
+			IL_0022: dup
+			IL_0023: ldc.i4.1
+			IL_0024: ldstr "salt"
+			IL_0029: stelem.ref
+			IL_002a: dup
+			IL_002b: ldc.i4.2
+			IL_002c: ldc.r8 1
+			IL_0035: box [System.Runtime]System.Double
+			IL_003a: stelem.ref
+			IL_003b: dup
+			IL_003c: ldc.i4.3
+			IL_003d: ldc.r8 16
+			IL_0046: box [System.Runtime]System.Double
+			IL_004b: stelem.ref
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_0051: stloc.1
+			IL_0052: ldloc.1
+			IL_0053: ret
 		} // end of method ArrowFunction_L22C35::__js_call__
 
 	} // end of class ArrowFunction_L22C35
@@ -652,7 +657,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f10
+				// Method begins at RVA 0x3f14
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -678,7 +683,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2af0
+			// Method begins at RVA 0x2af4
 			// Header size: 12
 			// Code size: 49 (0x31)
 			.maxstack 8
@@ -715,7 +720,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f19
+				// Method begins at RVA 0x3f1d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -741,7 +746,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2b30
+			// Method begins at RVA 0x2b34
 			// Header size: 12
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -779,7 +784,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f22
+				// Method begins at RVA 0x3f26
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -805,7 +810,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2b78
+			// Method begins at RVA 0x2b7c
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -843,7 +848,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f2b
+				// Method begins at RVA 0x3f2f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -869,7 +874,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2bb8
+			// Method begins at RVA 0x2bbc
 			// Header size: 12
 			// Code size: 74 (0x4a)
 			.maxstack 8
@@ -922,7 +927,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f34
+				// Method begins at RVA 0x3f38
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -948,7 +953,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2c10
+			// Method begins at RVA 0x2c14
 			// Header size: 12
 			// Code size: 49 (0x31)
 			.maxstack 8
@@ -985,7 +990,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f3d
+				// Method begins at RVA 0x3f41
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1011,7 +1016,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2c50
+			// Method begins at RVA 0x2c54
 			// Header size: 12
 			// Code size: 49 (0x31)
 			.maxstack 8
@@ -1048,7 +1053,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f46
+				// Method begins at RVA 0x3f4a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1074,7 +1079,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2c90
+			// Method begins at RVA 0x2c94
 			// Header size: 12
 			// Code size: 49 (0x31)
 			.maxstack 8
@@ -1111,7 +1116,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f4f
+				// Method begins at RVA 0x3f53
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1137,7 +1142,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2cd0
+			// Method begins at RVA 0x2cd4
 			// Header size: 12
 			// Code size: 59 (0x3b)
 			.maxstack 8
@@ -1182,7 +1187,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f58
+				// Method begins at RVA 0x3f5c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1208,7 +1213,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2d18
+			// Method begins at RVA 0x2d1c
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -1239,7 +1244,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f61
+				// Method begins at RVA 0x3f65
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1265,7 +1270,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2d3c
+			// Method begins at RVA 0x2d40
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -1306,7 +1311,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f6a
+				// Method begins at RVA 0x3f6e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1332,7 +1337,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2d6c
+			// Method begins at RVA 0x2d70
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -1364,7 +1369,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f73
+				// Method begins at RVA 0x3f77
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1390,7 +1395,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2d98
+			// Method begins at RVA 0x2d9c
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -1436,7 +1441,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f85
+					// Method begins at RVA 0x3f89
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1456,7 +1461,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f8e
+					// Method begins at RVA 0x3f92
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1480,7 +1485,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f7c
+				// Method begins at RVA 0x3f80
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1506,7 +1511,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2dcc
+			// Method begins at RVA 0x2dd0
 			// Header size: 12
 			// Code size: 573 (0x23d)
 			.maxstack 8
@@ -1778,7 +1783,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fa0
+					// Method begins at RVA 0x3fa4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1802,7 +1807,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x39f4
+				// Method begins at RVA 0x39f8
 				// Header size: 12
 				// Code size: 48 (0x30)
 				.maxstack 8
@@ -1842,7 +1847,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fa9
+					// Method begins at RVA 0x3fad
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1866,7 +1871,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3a30
+				// Method begins at RVA 0x3a34
 				// Header size: 12
 				// Code size: 127 (0x7f)
 				.maxstack 10
@@ -1936,7 +1941,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fb2
+					// Method begins at RVA 0x3fb6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1960,7 +1965,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3abc
+				// Method begins at RVA 0x3ac0
 				// Header size: 12
 				// Code size: 122 (0x7a)
 				.maxstack 10
@@ -2029,7 +2034,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fbb
+					// Method begins at RVA 0x3fbf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2053,7 +2058,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3b44
+				// Method begins at RVA 0x3b48
 				// Header size: 12
 				// Code size: 116 (0x74)
 				.maxstack 10
@@ -2120,7 +2125,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fc4
+					// Method begins at RVA 0x3fc8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2144,7 +2149,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3bc4
+				// Method begins at RVA 0x3bc8
 				// Header size: 12
 				// Code size: 127 (0x7f)
 				.maxstack 10
@@ -2214,7 +2219,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fcd
+					// Method begins at RVA 0x3fd1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2238,7 +2243,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3c50
+				// Method begins at RVA 0x3c54
 				// Header size: 12
 				// Code size: 127 (0x7f)
 				.maxstack 10
@@ -2308,7 +2313,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fd6
+					// Method begins at RVA 0x3fda
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2332,7 +2337,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3cdc
+				// Method begins at RVA 0x3ce0
 				// Header size: 12
 				// Code size: 136 (0x88)
 				.maxstack 10
@@ -2403,7 +2408,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fdf
+					// Method begins at RVA 0x3fe3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2427,7 +2432,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3d70
+				// Method begins at RVA 0x3d74
 				// Header size: 12
 				// Code size: 147 (0x93)
 				.maxstack 10
@@ -2501,7 +2506,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fe8
+					// Method begins at RVA 0x3fec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2525,7 +2530,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e10
+				// Method begins at RVA 0x3e14
 				// Header size: 12
 				// Code size: 65 (0x41)
 				.maxstack 8
@@ -2575,7 +2580,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ff1
+					// Method begins at RVA 0x3ff5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2599,7 +2604,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e60
+				// Method begins at RVA 0x3e64
 				// Header size: 12
 				// Code size: 65 (0x41)
 				.maxstack 8
@@ -2677,7 +2682,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f97
+				// Method begins at RVA 0x3f9b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2701,7 +2706,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3018
+			// Method begins at RVA 0x301c
 			// Header size: 12
 			// Code size: 2478 (0x9ae)
 			.maxstack 8
@@ -3957,7 +3962,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ffa
+				// Method begins at RVA 0x3ffe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3980,7 +3985,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x39d2
+			// Method begins at RVA 0x39d6
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -4025,7 +4030,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3ead
+			// Method begins at RVA 0x3eb1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4764,7 +4769,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4003
+		// Method begins at RVA 0x4007
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_GetRandomValues.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_GetRandomValues.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2284
+			// Method begins at RVA 0x2288
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 552 (0x228)
+		// Code size: 556 (0x22c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_WebCrypto_GetRandomValues/Scope,
@@ -56,7 +56,8 @@
 			[10] object,
 			[11] float64,
 			[12] object,
-			[13] object
+			[13] object,
+			[14] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
 		)
 
 		IL_0000: newobj instance void Modules.Require_Crypto_WebCrypto_GetRandomValues/Scope::.ctor()
@@ -202,22 +203,24 @@
 		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_01eb: stloc.s 13
 		IL_01ed: ldloc.s 6
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f4: ldstr "toString"
-		IL_01f9: ldstr "hex"
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0203: stloc.s 8
-		IL_0205: ldloc.s 8
-		IL_0207: ldstr "length"
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0211: stloc.s 8
-		IL_0213: ldloc.s 13
-		IL_0215: ldstr "log"
-		IL_021a: ldstr "buffer hex length:"
-		IL_021f: ldloc.s 8
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0226: pop
-		IL_0227: ret
+		IL_01ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_01f4: stloc.s 14
+		IL_01f6: ldloc.s 14
+		IL_01f8: ldstr "toString"
+		IL_01fd: ldstr "hex"
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0207: stloc.s 8
+		IL_0209: ldloc.s 8
+		IL_020b: ldstr "length"
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0215: stloc.s 8
+		IL_0217: ldloc.s 13
+		IL_0219: ldstr "log"
+		IL_021e: ldstr "buffer hex length:"
+		IL_0223: ldloc.s 8
+		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_022a: pop
+		IL_022b: ret
 	} // end of method Require_Crypto_WebCrypto_GetRandomValues::__js_module_init__
 
 } // end of class Modules.Require_Crypto_WebCrypto_GetRandomValues
@@ -229,7 +232,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x228d
+		// Method begins at RVA 0x2291
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
@@ -381,9 +381,9 @@
 			IL_0250: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 			IL_0255: stloc.s 10
 			IL_0257: ldloc.s 10
-			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_025e: stloc.s 9
-			IL_0260: ldloc.s 9
+			IL_0259: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_025e: stloc.s 10
+			IL_0260: ldloc.s 10
 			IL_0262: ldstr "toString"
 			IL_0267: ldstr "hex"
 			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
@@ -508,9 +508,9 @@
 			IL_0364: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 			IL_0369: stloc.s 10
 			IL_036b: ldloc.s 10
-			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0372: stloc.s 11
-			IL_0374: ldloc.s 11
+			IL_036d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_0372: stloc.s 10
+			IL_0374: ldloc.s 10
 			IL_0376: ldstr "toString"
 			IL_037b: ldstr "hex"
 			IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
@@ -635,9 +635,9 @@
 			IL_0478: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 			IL_047d: stloc.s 10
 			IL_047f: ldloc.s 10
-			IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0486: stloc.s 9
-			IL_0488: ldloc.s 9
+			IL_0481: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_0486: stloc.s 10
+			IL_0488: ldloc.s 10
 			IL_048a: ldstr "toString"
 			IL_048f: ldstr "hex"
 			IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
@@ -762,9 +762,9 @@
 			IL_058c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 			IL_0591: stloc.s 10
 			IL_0593: ldloc.s 10
-			IL_0595: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_059a: stloc.s 11
-			IL_059c: ldloc.s 11
+			IL_0595: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_059a: stloc.s 10
+			IL_059c: ldloc.s 10
 			IL_059e: ldstr "toString"
 			IL_05a3: ldstr "hex"
 			IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
@@ -1134,9 +1134,9 @@
 			IL_092b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 			IL_0930: stloc.s 10
 			IL_0932: ldloc.s 10
-			IL_0934: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0939: stloc.s 11
-			IL_093b: ldloc.s 11
+			IL_0934: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_0939: stloc.s 10
+			IL_093b: ldloc.s 10
 			IL_093d: ldstr "toString"
 			IL_0942: ldstr "hex"
 			IL_0947: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d45
+					// Method begins at RVA 0x2d74
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d4e
+					// Method begins at RVA 0x2d7d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d57
+					// Method begins at RVA 0x2d86
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -121,7 +121,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d3c
+				// Method begins at RVA 0x2d6b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -147,7 +147,7 @@
 			)
 			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 3127 (0xc37)
+			// Code size: 3174 (0xc66)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope,
@@ -172,11 +172,12 @@
 				[19] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 				[20] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[21] object[],
-				[22] object,
+				[22] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 				[23] object,
-				[24] bool,
-				[25] object,
-				[26] object
+				[24] object,
+				[25] bool,
+				[26] object,
+				[27] object
 			)
 
 			IL_0000: ldarg.0
@@ -209,14 +210,14 @@
 			IL_0042: brtrue IL_0054
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.s 26
+			IL_0048: ldc.i4.s 27
 			IL_004a: newarr [System.Runtime]System.Object
 			IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0054: ldloc.0
 			IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_005a: ldc.i4.0
-			IL_005b: ble IL_0138
+			IL_005b: ble IL_0143
 
 			IL_0060: ldloc.0
 			IL_0061: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -319,1308 +320,1337 @@
 			IL_0114: dup
 			IL_0115: ldc.i4.s 21
 			IL_0117: ldelem.ref
-			IL_0118: stloc.s 22
-			IL_011a: dup
-			IL_011b: ldc.i4.s 22
-			IL_011d: ldelem.ref
-			IL_011e: stloc.s 23
-			IL_0120: dup
-			IL_0121: ldc.i4.s 23
-			IL_0123: ldelem.ref
-			IL_0124: unbox.any [System.Runtime]System.Boolean
+			IL_0118: castclass [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
+			IL_011d: stloc.s 22
+			IL_011f: dup
+			IL_0120: ldc.i4.s 22
+			IL_0122: ldelem.ref
+			IL_0123: stloc.s 23
+			IL_0125: dup
+			IL_0126: ldc.i4.s 23
+			IL_0128: ldelem.ref
 			IL_0129: stloc.s 24
 			IL_012b: dup
 			IL_012c: ldc.i4.s 24
 			IL_012e: ldelem.ref
-			IL_012f: stloc.s 25
-			IL_0131: dup
-			IL_0132: ldc.i4.s 25
-			IL_0134: ldelem.ref
-			IL_0135: stloc.s 26
-			IL_0137: pop
+			IL_012f: unbox.any [System.Runtime]System.Boolean
+			IL_0134: stloc.s 25
+			IL_0136: dup
+			IL_0137: ldc.i4.s 25
+			IL_0139: ldelem.ref
+			IL_013a: stloc.s 26
+			IL_013c: dup
+			IL_013d: ldc.i4.s 26
+			IL_013f: ldelem.ref
+			IL_0140: stloc.s 27
+			IL_0142: pop
 
-			IL_0138: ldloc.0
-			IL_0139: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_013e: switch (IL_016b, IL_0b27, IL_0b6b, IL_0aa8, IL_03a9, IL_050c, IL_063e, IL_0748, IL_084a, IL_093d)
+			IL_0143: ldloc.0
+			IL_0144: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0149: switch (IL_0176, IL_0b56, IL_0b9a, IL_0ad7, IL_03ba, IL_0523, IL_065b, IL_076b, IL_0873, IL_096c)
 
-			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-			IL_0170: stloc.s 13
-			IL_0172: ldloc.s 13
-			IL_0174: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0179: stloc.s 14
-			IL_017b: ldstr ""
-			IL_0180: ldloc.s 14
-			IL_0182: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0187: ldstr "-"
-			IL_018c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0191: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-			IL_0196: stloc.s 15
-			IL_0198: ldloc.s 15
-			IL_019a: ldc.r8 1000000000
-			IL_01a3: mul
-			IL_01a4: stloc.s 15
-			IL_01a6: ldloc.s 15
-			IL_01a8: box [System.Runtime]System.Double
-			IL_01ad: stloc.s 16
-			IL_01af: ldloc.s 16
-			IL_01b1: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-			IL_01b6: stloc.s 15
-			IL_01b8: ldloc.s 15
-			IL_01ba: box [System.Runtime]System.Double
-			IL_01bf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01c4: stloc.s 14
-			IL_01c6: ldloc.s 14
-			IL_01c8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01cd: stloc.1
-			IL_01ce: ldarg.0
-			IL_01cf: ldc.i4.1
-			IL_01d0: ldelem.ref
-			IL_01d1: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_01d6: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::path
-			IL_01db: stloc.s 17
-			IL_01dd: ldarg.0
-			IL_01de: ldc.i4.1
-			IL_01df: ldelem.ref
-			IL_01e0: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_01e5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
-			IL_01ea: stloc.s 18
-			IL_01ec: ldloc.s 18
-			IL_01ee: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
-			IL_01f3: stloc.s 13
-			IL_01f5: ldloc.1
-			IL_01f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01fb: stloc.s 14
-			IL_01fd: ldstr "jroc-fs-open-position-"
-			IL_0202: ldloc.s 14
-			IL_0204: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0209: ldstr ".txt"
-			IL_020e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0213: stloc.s 14
-			IL_0215: ldloc.s 17
-			IL_0217: ldc.i4.2
-			IL_0218: newarr [System.Runtime]System.Object
-			IL_021d: dup
-			IL_021e: ldc.i4.0
-			IL_021f: ldloc.s 13
-			IL_0221: stelem.ref
-			IL_0222: dup
-			IL_0223: ldc.i4.1
-			IL_0224: ldloc.s 14
-			IL_0226: stelem.ref
-			IL_0227: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_022c: stloc.2
-			IL_022d: ldloc.0
-			IL_022e: ldc.i4.0
-			IL_022f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0234: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0239: ldloc.0
-			IL_023a: ldc.i4.0
-			IL_023b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0240: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0245: ldloc.0
-			IL_0246: ldc.i4.0
-			IL_0247: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_024c: ldloc.0
-			IL_024d: ldc.i4.0
-			IL_024e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0253: ldarg.0
-			IL_0254: ldc.i4.1
-			IL_0255: ldelem.ref
-			IL_0256: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_025b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0260: stloc.s 19
-			IL_0262: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0267: dup
-			IL_0268: ldstr "force"
-			IL_026d: ldc.i4.1
-			IL_026e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0273: stloc.s 20
-			IL_0275: ldloc.s 19
-			IL_0277: ldloc.2
-			IL_0278: ldloc.s 20
-			IL_027a: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_027f: ldarg.0
-			IL_0280: ldc.i4.1
-			IL_0281: ldelem.ref
-			IL_0282: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0287: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_028c: stloc.s 19
-			IL_028e: ldloc.s 19
-			IL_0290: ldloc.2
-			IL_0291: ldstr "hello"
-			IL_0296: ldstr "utf8"
-			IL_029b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_02a0: ldarg.0
-			IL_02a1: ldc.i4.1
-			IL_02a2: ldelem.ref
-			IL_02a3: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_02a8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_02ad: stloc.s 19
-			IL_02af: ldloc.s 19
-			IL_02b1: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
-			IL_02b6: stloc.s 13
-			IL_02b8: ldloc.s 13
-			IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02bf: stloc.s 13
-			IL_02c1: ldloc.s 13
-			IL_02c3: ldstr "open"
-			IL_02c8: ldloc.2
-			IL_02c9: ldstr "r+"
-			IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_02d3: stloc.s 13
-			IL_02d5: ldloc.0
-			IL_02d6: ldc.i4.4
-			IL_02d7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02dc: ldloc.0
-			IL_02dd: ldloc.s 13
-			IL_02df: ldarg.0
-			IL_02e0: ldc.i4.1
-			IL_02e1: ldloc.0
-			IL_02e2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02e7: ldc.i4.3
-			IL_02e8: ldstr "_pendingException"
-			IL_02ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_02f2: ldloc.0
-			IL_02f3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02f8: dup
-			IL_02f9: ldc.i4.0
-			IL_02fa: ldloc.1
-			IL_02fb: stelem.ref
-			IL_02fc: dup
-			IL_02fd: ldc.i4.1
-			IL_02fe: ldloc.2
-			IL_02ff: stelem.ref
-			IL_0300: dup
-			IL_0301: ldc.i4.2
-			IL_0302: ldloc.3
-			IL_0303: stelem.ref
-			IL_0304: dup
-			IL_0305: ldc.i4.3
-			IL_0306: ldloc.s 4
-			IL_0308: stelem.ref
-			IL_0309: dup
-			IL_030a: ldc.i4.4
-			IL_030b: ldloc.s 5
-			IL_030d: stelem.ref
-			IL_030e: dup
-			IL_030f: ldc.i4.5
-			IL_0310: ldloc.s 6
-			IL_0312: stelem.ref
-			IL_0313: dup
-			IL_0314: ldc.i4.6
-			IL_0315: ldloc.s 7
-			IL_0317: stelem.ref
-			IL_0318: dup
-			IL_0319: ldc.i4.7
-			IL_031a: ldloc.s 8
-			IL_031c: stelem.ref
-			IL_031d: dup
-			IL_031e: ldc.i4.8
-			IL_031f: ldloc.s 9
-			IL_0321: stelem.ref
-			IL_0322: dup
-			IL_0323: ldc.i4.s 9
-			IL_0325: ldloc.s 10
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
+			IL_017b: stloc.s 13
+			IL_017d: ldloc.s 13
+			IL_017f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0184: stloc.s 14
+			IL_0186: ldstr ""
+			IL_018b: ldloc.s 14
+			IL_018d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0192: ldstr "-"
+			IL_0197: call string [System.Runtime]System.String::Concat(string, string)
+			IL_019c: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+			IL_01a1: stloc.s 15
+			IL_01a3: ldloc.s 15
+			IL_01a5: ldc.r8 1000000000
+			IL_01ae: mul
+			IL_01af: stloc.s 15
+			IL_01b1: ldloc.s 15
+			IL_01b3: box [System.Runtime]System.Double
+			IL_01b8: stloc.s 16
+			IL_01ba: ldloc.s 16
+			IL_01bc: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+			IL_01c1: stloc.s 15
+			IL_01c3: ldloc.s 15
+			IL_01c5: box [System.Runtime]System.Double
+			IL_01ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01cf: stloc.s 14
+			IL_01d1: ldloc.s 14
+			IL_01d3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01d8: stloc.1
+			IL_01d9: ldarg.0
+			IL_01da: ldc.i4.1
+			IL_01db: ldelem.ref
+			IL_01dc: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_01e1: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::path
+			IL_01e6: stloc.s 17
+			IL_01e8: ldarg.0
+			IL_01e9: ldc.i4.1
+			IL_01ea: ldelem.ref
+			IL_01eb: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_01f0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
+			IL_01f5: stloc.s 18
+			IL_01f7: ldloc.s 18
+			IL_01f9: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
+			IL_01fe: stloc.s 13
+			IL_0200: ldloc.1
+			IL_0201: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0206: stloc.s 14
+			IL_0208: ldstr "jroc-fs-open-position-"
+			IL_020d: ldloc.s 14
+			IL_020f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0214: ldstr ".txt"
+			IL_0219: call string [System.Runtime]System.String::Concat(string, string)
+			IL_021e: stloc.s 14
+			IL_0220: ldloc.s 17
+			IL_0222: ldc.i4.2
+			IL_0223: newarr [System.Runtime]System.Object
+			IL_0228: dup
+			IL_0229: ldc.i4.0
+			IL_022a: ldloc.s 13
+			IL_022c: stelem.ref
+			IL_022d: dup
+			IL_022e: ldc.i4.1
+			IL_022f: ldloc.s 14
+			IL_0231: stelem.ref
+			IL_0232: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0237: stloc.2
+			IL_0238: ldloc.0
+			IL_0239: ldc.i4.0
+			IL_023a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_023f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0244: ldloc.0
+			IL_0245: ldc.i4.0
+			IL_0246: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_024b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0250: ldloc.0
+			IL_0251: ldc.i4.0
+			IL_0252: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0257: ldloc.0
+			IL_0258: ldc.i4.0
+			IL_0259: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_025e: ldarg.0
+			IL_025f: ldc.i4.1
+			IL_0260: ldelem.ref
+			IL_0261: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0266: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_026b: stloc.s 19
+			IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0272: dup
+			IL_0273: ldstr "force"
+			IL_0278: ldc.i4.1
+			IL_0279: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_027e: stloc.s 20
+			IL_0280: ldloc.s 19
+			IL_0282: ldloc.2
+			IL_0283: ldloc.s 20
+			IL_0285: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_028a: ldarg.0
+			IL_028b: ldc.i4.1
+			IL_028c: ldelem.ref
+			IL_028d: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0292: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0297: stloc.s 19
+			IL_0299: ldloc.s 19
+			IL_029b: ldloc.2
+			IL_029c: ldstr "hello"
+			IL_02a1: ldstr "utf8"
+			IL_02a6: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_02ab: ldarg.0
+			IL_02ac: ldc.i4.1
+			IL_02ad: ldelem.ref
+			IL_02ae: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_02b3: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_02b8: stloc.s 19
+			IL_02ba: ldloc.s 19
+			IL_02bc: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
+			IL_02c1: stloc.s 13
+			IL_02c3: ldloc.s 13
+			IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ca: stloc.s 13
+			IL_02cc: ldloc.s 13
+			IL_02ce: ldstr "open"
+			IL_02d3: ldloc.2
+			IL_02d4: ldstr "r+"
+			IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_02de: stloc.s 13
+			IL_02e0: ldloc.0
+			IL_02e1: ldc.i4.4
+			IL_02e2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02e7: ldloc.0
+			IL_02e8: ldloc.s 13
+			IL_02ea: ldarg.0
+			IL_02eb: ldc.i4.1
+			IL_02ec: ldloc.0
+			IL_02ed: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02f2: ldc.i4.3
+			IL_02f3: ldstr "_pendingException"
+			IL_02f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_02fd: ldloc.0
+			IL_02fe: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0303: dup
+			IL_0304: ldc.i4.0
+			IL_0305: ldloc.1
+			IL_0306: stelem.ref
+			IL_0307: dup
+			IL_0308: ldc.i4.1
+			IL_0309: ldloc.2
+			IL_030a: stelem.ref
+			IL_030b: dup
+			IL_030c: ldc.i4.2
+			IL_030d: ldloc.3
+			IL_030e: stelem.ref
+			IL_030f: dup
+			IL_0310: ldc.i4.3
+			IL_0311: ldloc.s 4
+			IL_0313: stelem.ref
+			IL_0314: dup
+			IL_0315: ldc.i4.4
+			IL_0316: ldloc.s 5
+			IL_0318: stelem.ref
+			IL_0319: dup
+			IL_031a: ldc.i4.5
+			IL_031b: ldloc.s 6
+			IL_031d: stelem.ref
+			IL_031e: dup
+			IL_031f: ldc.i4.6
+			IL_0320: ldloc.s 7
+			IL_0322: stelem.ref
+			IL_0323: dup
+			IL_0324: ldc.i4.7
+			IL_0325: ldloc.s 8
 			IL_0327: stelem.ref
 			IL_0328: dup
-			IL_0329: ldc.i4.s 10
-			IL_032b: ldloc.s 11
-			IL_032d: box [System.Runtime]System.Boolean
+			IL_0329: ldc.i4.8
+			IL_032a: ldloc.s 9
+			IL_032c: stelem.ref
+			IL_032d: dup
+			IL_032e: ldc.i4.s 9
+			IL_0330: ldloc.s 10
 			IL_0332: stelem.ref
 			IL_0333: dup
-			IL_0334: ldc.i4.s 11
-			IL_0336: ldloc.s 12
+			IL_0334: ldc.i4.s 10
+			IL_0336: ldloc.s 11
 			IL_0338: box [System.Runtime]System.Boolean
 			IL_033d: stelem.ref
 			IL_033e: dup
-			IL_033f: ldc.i4.s 12
-			IL_0341: ldloc.s 13
-			IL_0343: stelem.ref
-			IL_0344: dup
-			IL_0345: ldc.i4.s 13
-			IL_0347: ldloc.s 14
-			IL_0349: stelem.ref
-			IL_034a: dup
-			IL_034b: ldc.i4.s 14
-			IL_034d: ldloc.s 15
-			IL_034f: box [System.Runtime]System.Double
+			IL_033f: ldc.i4.s 11
+			IL_0341: ldloc.s 12
+			IL_0343: box [System.Runtime]System.Boolean
+			IL_0348: stelem.ref
+			IL_0349: dup
+			IL_034a: ldc.i4.s 12
+			IL_034c: ldloc.s 13
+			IL_034e: stelem.ref
+			IL_034f: dup
+			IL_0350: ldc.i4.s 13
+			IL_0352: ldloc.s 14
 			IL_0354: stelem.ref
 			IL_0355: dup
-			IL_0356: ldc.i4.s 15
-			IL_0358: ldloc.s 16
-			IL_035a: stelem.ref
-			IL_035b: dup
-			IL_035c: ldc.i4.s 16
-			IL_035e: ldloc.s 17
-			IL_0360: stelem.ref
-			IL_0361: dup
-			IL_0362: ldc.i4.s 17
-			IL_0364: ldloc.s 18
-			IL_0366: stelem.ref
-			IL_0367: dup
-			IL_0368: ldc.i4.s 18
-			IL_036a: ldloc.s 19
-			IL_036c: stelem.ref
-			IL_036d: dup
-			IL_036e: ldc.i4.s 19
-			IL_0370: ldloc.s 20
-			IL_0372: stelem.ref
-			IL_0373: dup
-			IL_0374: ldc.i4.s 20
-			IL_0376: ldloc.s 21
-			IL_0378: stelem.ref
-			IL_0379: dup
-			IL_037a: ldc.i4.s 21
-			IL_037c: ldloc.s 22
-			IL_037e: stelem.ref
-			IL_037f: dup
-			IL_0380: ldc.i4.s 22
-			IL_0382: ldloc.s 23
-			IL_0384: stelem.ref
-			IL_0385: dup
-			IL_0386: ldc.i4.s 23
-			IL_0388: ldloc.s 24
-			IL_038a: box [System.Runtime]System.Boolean
+			IL_0356: ldc.i4.s 14
+			IL_0358: ldloc.s 15
+			IL_035a: box [System.Runtime]System.Double
+			IL_035f: stelem.ref
+			IL_0360: dup
+			IL_0361: ldc.i4.s 15
+			IL_0363: ldloc.s 16
+			IL_0365: stelem.ref
+			IL_0366: dup
+			IL_0367: ldc.i4.s 16
+			IL_0369: ldloc.s 17
+			IL_036b: stelem.ref
+			IL_036c: dup
+			IL_036d: ldc.i4.s 17
+			IL_036f: ldloc.s 18
+			IL_0371: stelem.ref
+			IL_0372: dup
+			IL_0373: ldc.i4.s 18
+			IL_0375: ldloc.s 19
+			IL_0377: stelem.ref
+			IL_0378: dup
+			IL_0379: ldc.i4.s 19
+			IL_037b: ldloc.s 20
+			IL_037d: stelem.ref
+			IL_037e: dup
+			IL_037f: ldc.i4.s 20
+			IL_0381: ldloc.s 21
+			IL_0383: stelem.ref
+			IL_0384: dup
+			IL_0385: ldc.i4.s 21
+			IL_0387: ldloc.s 22
+			IL_0389: stelem.ref
+			IL_038a: dup
+			IL_038b: ldc.i4.s 22
+			IL_038d: ldloc.s 23
 			IL_038f: stelem.ref
 			IL_0390: dup
-			IL_0391: ldc.i4.s 24
-			IL_0393: ldloc.s 25
+			IL_0391: ldc.i4.s 23
+			IL_0393: ldloc.s 24
 			IL_0395: stelem.ref
 			IL_0396: dup
-			IL_0397: ldc.i4.s 25
-			IL_0399: ldloc.s 26
-			IL_039b: stelem.ref
-			IL_039c: pop
-			IL_039d: ldloc.0
-			IL_039e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03a3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03a8: ret
+			IL_0397: ldc.i4.s 24
+			IL_0399: ldloc.s 25
+			IL_039b: box [System.Runtime]System.Boolean
+			IL_03a0: stelem.ref
+			IL_03a1: dup
+			IL_03a2: ldc.i4.s 25
+			IL_03a4: ldloc.s 26
+			IL_03a6: stelem.ref
+			IL_03a7: dup
+			IL_03a8: ldc.i4.s 26
+			IL_03aa: ldloc.s 27
+			IL_03ac: stelem.ref
+			IL_03ad: pop
+			IL_03ae: ldloc.0
+			IL_03af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03b4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03b9: ret
 
-			IL_03a9: ldloc.0
-			IL_03aa: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited1
-			IL_03af: stloc.3
-			IL_03b0: ldc.r8 1
-			IL_03b9: box [System.Runtime]System.Double
-			IL_03be: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_03c3: stloc.s 4
-			IL_03c5: ldc.r8 1
-			IL_03ce: box [System.Runtime]System.Double
-			IL_03d3: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_03d8: stloc.s 5
-			IL_03da: ldloc.3
-			IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03e0: stloc.s 13
-			IL_03e2: ldloc.s 4
-			IL_03e4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_03e9: stloc.s 15
-			IL_03eb: ldloc.s 15
-			IL_03ed: box [System.Runtime]System.Double
-			IL_03f2: stloc.s 16
-			IL_03f4: ldc.i4.4
-			IL_03f5: newarr [System.Runtime]System.Object
-			IL_03fa: dup
-			IL_03fb: ldc.i4.0
-			IL_03fc: ldloc.s 4
-			IL_03fe: stelem.ref
-			IL_03ff: dup
-			IL_0400: ldc.i4.1
-			IL_0401: ldc.r8 0.0
-			IL_040a: box [System.Runtime]System.Double
+			IL_03ba: ldloc.0
+			IL_03bb: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited1
+			IL_03c0: stloc.3
+			IL_03c1: ldc.r8 1
+			IL_03ca: box [System.Runtime]System.Double
+			IL_03cf: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_03d4: stloc.s 4
+			IL_03d6: ldc.r8 1
+			IL_03df: box [System.Runtime]System.Double
+			IL_03e4: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_03e9: stloc.s 5
+			IL_03eb: ldloc.3
+			IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03f1: stloc.s 13
+			IL_03f3: ldloc.s 4
+			IL_03f5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_03fa: stloc.s 15
+			IL_03fc: ldloc.s 15
+			IL_03fe: box [System.Runtime]System.Double
+			IL_0403: stloc.s 16
+			IL_0405: ldc.i4.4
+			IL_0406: newarr [System.Runtime]System.Object
+			IL_040b: dup
+			IL_040c: ldc.i4.0
+			IL_040d: ldloc.s 4
 			IL_040f: stelem.ref
 			IL_0410: dup
-			IL_0411: ldc.i4.2
-			IL_0412: ldloc.s 16
-			IL_0414: stelem.ref
-			IL_0415: dup
-			IL_0416: ldc.i4.3
-			IL_0417: ldc.r8 2
-			IL_0420: box [System.Runtime]System.Double
+			IL_0411: ldc.i4.1
+			IL_0412: ldc.r8 0.0
+			IL_041b: box [System.Runtime]System.Double
+			IL_0420: stelem.ref
+			IL_0421: dup
+			IL_0422: ldc.i4.2
+			IL_0423: ldloc.s 16
 			IL_0425: stelem.ref
-			IL_0426: stloc.s 21
-			IL_0428: ldloc.s 13
-			IL_042a: ldstr "read"
-			IL_042f: ldloc.s 21
-			IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_0436: stloc.s 13
-			IL_0438: ldloc.0
-			IL_0439: ldc.i4.5
-			IL_043a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_043f: ldloc.0
-			IL_0440: ldloc.s 13
-			IL_0442: ldarg.0
-			IL_0443: ldc.i4.2
-			IL_0444: ldloc.0
-			IL_0445: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_044a: ldc.i4.3
-			IL_044b: ldstr "_pendingException"
-			IL_0450: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0426: dup
+			IL_0427: ldc.i4.3
+			IL_0428: ldc.r8 2
+			IL_0431: box [System.Runtime]System.Double
+			IL_0436: stelem.ref
+			IL_0437: stloc.s 21
+			IL_0439: ldloc.s 13
+			IL_043b: ldstr "read"
+			IL_0440: ldloc.s 21
+			IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_0447: stloc.s 13
+			IL_0449: ldloc.0
+			IL_044a: ldc.i4.5
+			IL_044b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0450: ldloc.0
+			IL_0451: ldloc.s 13
+			IL_0453: ldarg.0
+			IL_0454: ldc.i4.2
 			IL_0455: ldloc.0
-			IL_0456: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_045b: dup
-			IL_045c: ldc.i4.0
-			IL_045d: ldloc.1
-			IL_045e: stelem.ref
-			IL_045f: dup
-			IL_0460: ldc.i4.1
-			IL_0461: ldloc.2
-			IL_0462: stelem.ref
-			IL_0463: dup
-			IL_0464: ldc.i4.2
-			IL_0465: ldloc.3
-			IL_0466: stelem.ref
-			IL_0467: dup
-			IL_0468: ldc.i4.3
-			IL_0469: ldloc.s 4
-			IL_046b: stelem.ref
+			IL_0456: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_045b: ldc.i4.3
+			IL_045c: ldstr "_pendingException"
+			IL_0461: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0466: ldloc.0
+			IL_0467: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_046c: dup
-			IL_046d: ldc.i4.4
-			IL_046e: ldloc.s 5
-			IL_0470: stelem.ref
-			IL_0471: dup
-			IL_0472: ldc.i4.5
-			IL_0473: ldloc.s 6
-			IL_0475: stelem.ref
-			IL_0476: dup
-			IL_0477: ldc.i4.6
-			IL_0478: ldloc.s 7
-			IL_047a: stelem.ref
-			IL_047b: dup
-			IL_047c: ldc.i4.7
-			IL_047d: ldloc.s 8
-			IL_047f: stelem.ref
-			IL_0480: dup
-			IL_0481: ldc.i4.8
-			IL_0482: ldloc.s 9
-			IL_0484: stelem.ref
-			IL_0485: dup
-			IL_0486: ldc.i4.s 9
-			IL_0488: ldloc.s 10
-			IL_048a: stelem.ref
-			IL_048b: dup
-			IL_048c: ldc.i4.s 10
-			IL_048e: ldloc.s 11
-			IL_0490: box [System.Runtime]System.Boolean
+			IL_046d: ldc.i4.0
+			IL_046e: ldloc.1
+			IL_046f: stelem.ref
+			IL_0470: dup
+			IL_0471: ldc.i4.1
+			IL_0472: ldloc.2
+			IL_0473: stelem.ref
+			IL_0474: dup
+			IL_0475: ldc.i4.2
+			IL_0476: ldloc.3
+			IL_0477: stelem.ref
+			IL_0478: dup
+			IL_0479: ldc.i4.3
+			IL_047a: ldloc.s 4
+			IL_047c: stelem.ref
+			IL_047d: dup
+			IL_047e: ldc.i4.4
+			IL_047f: ldloc.s 5
+			IL_0481: stelem.ref
+			IL_0482: dup
+			IL_0483: ldc.i4.5
+			IL_0484: ldloc.s 6
+			IL_0486: stelem.ref
+			IL_0487: dup
+			IL_0488: ldc.i4.6
+			IL_0489: ldloc.s 7
+			IL_048b: stelem.ref
+			IL_048c: dup
+			IL_048d: ldc.i4.7
+			IL_048e: ldloc.s 8
+			IL_0490: stelem.ref
+			IL_0491: dup
+			IL_0492: ldc.i4.8
+			IL_0493: ldloc.s 9
 			IL_0495: stelem.ref
 			IL_0496: dup
-			IL_0497: ldc.i4.s 11
-			IL_0499: ldloc.s 12
-			IL_049b: box [System.Runtime]System.Boolean
-			IL_04a0: stelem.ref
-			IL_04a1: dup
-			IL_04a2: ldc.i4.s 12
-			IL_04a4: ldloc.s 13
+			IL_0497: ldc.i4.s 9
+			IL_0499: ldloc.s 10
+			IL_049b: stelem.ref
+			IL_049c: dup
+			IL_049d: ldc.i4.s 10
+			IL_049f: ldloc.s 11
+			IL_04a1: box [System.Runtime]System.Boolean
 			IL_04a6: stelem.ref
 			IL_04a7: dup
-			IL_04a8: ldc.i4.s 13
-			IL_04aa: ldloc.s 14
-			IL_04ac: stelem.ref
-			IL_04ad: dup
-			IL_04ae: ldc.i4.s 14
-			IL_04b0: ldloc.s 15
-			IL_04b2: box [System.Runtime]System.Double
+			IL_04a8: ldc.i4.s 11
+			IL_04aa: ldloc.s 12
+			IL_04ac: box [System.Runtime]System.Boolean
+			IL_04b1: stelem.ref
+			IL_04b2: dup
+			IL_04b3: ldc.i4.s 12
+			IL_04b5: ldloc.s 13
 			IL_04b7: stelem.ref
 			IL_04b8: dup
-			IL_04b9: ldc.i4.s 15
-			IL_04bb: ldloc.s 16
+			IL_04b9: ldc.i4.s 13
+			IL_04bb: ldloc.s 14
 			IL_04bd: stelem.ref
 			IL_04be: dup
-			IL_04bf: ldc.i4.s 16
-			IL_04c1: ldloc.s 17
-			IL_04c3: stelem.ref
-			IL_04c4: dup
-			IL_04c5: ldc.i4.s 17
-			IL_04c7: ldloc.s 18
-			IL_04c9: stelem.ref
-			IL_04ca: dup
-			IL_04cb: ldc.i4.s 18
-			IL_04cd: ldloc.s 19
-			IL_04cf: stelem.ref
-			IL_04d0: dup
-			IL_04d1: ldc.i4.s 19
-			IL_04d3: ldloc.s 20
-			IL_04d5: stelem.ref
-			IL_04d6: dup
-			IL_04d7: ldc.i4.s 20
-			IL_04d9: ldloc.s 21
-			IL_04db: stelem.ref
-			IL_04dc: dup
-			IL_04dd: ldc.i4.s 21
-			IL_04df: ldloc.s 22
-			IL_04e1: stelem.ref
-			IL_04e2: dup
-			IL_04e3: ldc.i4.s 22
-			IL_04e5: ldloc.s 23
-			IL_04e7: stelem.ref
-			IL_04e8: dup
-			IL_04e9: ldc.i4.s 23
-			IL_04eb: ldloc.s 24
-			IL_04ed: box [System.Runtime]System.Boolean
+			IL_04bf: ldc.i4.s 14
+			IL_04c1: ldloc.s 15
+			IL_04c3: box [System.Runtime]System.Double
+			IL_04c8: stelem.ref
+			IL_04c9: dup
+			IL_04ca: ldc.i4.s 15
+			IL_04cc: ldloc.s 16
+			IL_04ce: stelem.ref
+			IL_04cf: dup
+			IL_04d0: ldc.i4.s 16
+			IL_04d2: ldloc.s 17
+			IL_04d4: stelem.ref
+			IL_04d5: dup
+			IL_04d6: ldc.i4.s 17
+			IL_04d8: ldloc.s 18
+			IL_04da: stelem.ref
+			IL_04db: dup
+			IL_04dc: ldc.i4.s 18
+			IL_04de: ldloc.s 19
+			IL_04e0: stelem.ref
+			IL_04e1: dup
+			IL_04e2: ldc.i4.s 19
+			IL_04e4: ldloc.s 20
+			IL_04e6: stelem.ref
+			IL_04e7: dup
+			IL_04e8: ldc.i4.s 20
+			IL_04ea: ldloc.s 21
+			IL_04ec: stelem.ref
+			IL_04ed: dup
+			IL_04ee: ldc.i4.s 21
+			IL_04f0: ldloc.s 22
 			IL_04f2: stelem.ref
 			IL_04f3: dup
-			IL_04f4: ldc.i4.s 24
-			IL_04f6: ldloc.s 25
+			IL_04f4: ldc.i4.s 22
+			IL_04f6: ldloc.s 23
 			IL_04f8: stelem.ref
 			IL_04f9: dup
-			IL_04fa: ldc.i4.s 25
-			IL_04fc: ldloc.s 26
+			IL_04fa: ldc.i4.s 23
+			IL_04fc: ldloc.s 24
 			IL_04fe: stelem.ref
-			IL_04ff: pop
-			IL_0500: ldloc.0
-			IL_0501: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0506: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_050b: ret
+			IL_04ff: dup
+			IL_0500: ldc.i4.s 24
+			IL_0502: ldloc.s 25
+			IL_0504: box [System.Runtime]System.Boolean
+			IL_0509: stelem.ref
+			IL_050a: dup
+			IL_050b: ldc.i4.s 25
+			IL_050d: ldloc.s 26
+			IL_050f: stelem.ref
+			IL_0510: dup
+			IL_0511: ldc.i4.s 26
+			IL_0513: ldloc.s 27
+			IL_0515: stelem.ref
+			IL_0516: pop
+			IL_0517: ldloc.0
+			IL_0518: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_051d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0522: ret
 
-			IL_050c: ldloc.0
-			IL_050d: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited2
-			IL_0512: stloc.s 6
-			IL_0514: ldloc.3
-			IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_051a: stloc.s 13
-			IL_051c: ldloc.s 5
-			IL_051e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_0523: stloc.s 15
-			IL_0525: ldloc.s 15
-			IL_0527: box [System.Runtime]System.Double
-			IL_052c: stloc.s 16
-			IL_052e: ldc.i4.4
-			IL_052f: newarr [System.Runtime]System.Object
-			IL_0534: dup
-			IL_0535: ldc.i4.0
-			IL_0536: ldloc.s 5
-			IL_0538: stelem.ref
-			IL_0539: dup
-			IL_053a: ldc.i4.1
-			IL_053b: ldc.r8 0.0
-			IL_0544: box [System.Runtime]System.Double
-			IL_0549: stelem.ref
-			IL_054a: dup
-			IL_054b: ldc.i4.2
-			IL_054c: ldloc.s 16
-			IL_054e: stelem.ref
-			IL_054f: dup
-			IL_0550: ldc.i4.3
-			IL_0551: ldc.i4.0
-			IL_0552: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0557: stelem.ref
-			IL_0558: stloc.s 21
-			IL_055a: ldloc.s 13
-			IL_055c: ldstr "read"
-			IL_0561: ldloc.s 21
-			IL_0563: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_0568: stloc.s 13
-			IL_056a: ldloc.0
-			IL_056b: ldc.i4.6
-			IL_056c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0571: ldloc.0
-			IL_0572: ldloc.s 13
-			IL_0574: ldarg.0
-			IL_0575: ldc.i4.3
-			IL_0576: ldloc.0
-			IL_0577: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_057c: ldc.i4.3
-			IL_057d: ldstr "_pendingException"
-			IL_0582: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0587: ldloc.0
-			IL_0588: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_058d: dup
-			IL_058e: ldc.i4.0
-			IL_058f: ldloc.1
-			IL_0590: stelem.ref
-			IL_0591: dup
-			IL_0592: ldc.i4.1
-			IL_0593: ldloc.2
-			IL_0594: stelem.ref
-			IL_0595: dup
-			IL_0596: ldc.i4.2
-			IL_0597: ldloc.3
-			IL_0598: stelem.ref
-			IL_0599: dup
-			IL_059a: ldc.i4.3
-			IL_059b: ldloc.s 4
-			IL_059d: stelem.ref
-			IL_059e: dup
-			IL_059f: ldc.i4.4
-			IL_05a0: ldloc.s 5
-			IL_05a2: stelem.ref
-			IL_05a3: dup
-			IL_05a4: ldc.i4.5
-			IL_05a5: ldloc.s 6
+			IL_0523: ldloc.0
+			IL_0524: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited2
+			IL_0529: stloc.s 6
+			IL_052b: ldloc.3
+			IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0531: stloc.s 13
+			IL_0533: ldloc.s 5
+			IL_0535: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_053a: stloc.s 15
+			IL_053c: ldloc.s 15
+			IL_053e: box [System.Runtime]System.Double
+			IL_0543: stloc.s 16
+			IL_0545: ldc.i4.4
+			IL_0546: newarr [System.Runtime]System.Object
+			IL_054b: dup
+			IL_054c: ldc.i4.0
+			IL_054d: ldloc.s 5
+			IL_054f: stelem.ref
+			IL_0550: dup
+			IL_0551: ldc.i4.1
+			IL_0552: ldc.r8 0.0
+			IL_055b: box [System.Runtime]System.Double
+			IL_0560: stelem.ref
+			IL_0561: dup
+			IL_0562: ldc.i4.2
+			IL_0563: ldloc.s 16
+			IL_0565: stelem.ref
+			IL_0566: dup
+			IL_0567: ldc.i4.3
+			IL_0568: ldc.i4.0
+			IL_0569: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_056e: stelem.ref
+			IL_056f: stloc.s 21
+			IL_0571: ldloc.s 13
+			IL_0573: ldstr "read"
+			IL_0578: ldloc.s 21
+			IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_057f: stloc.s 13
+			IL_0581: ldloc.0
+			IL_0582: ldc.i4.6
+			IL_0583: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0588: ldloc.0
+			IL_0589: ldloc.s 13
+			IL_058b: ldarg.0
+			IL_058c: ldc.i4.3
+			IL_058d: ldloc.0
+			IL_058e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0593: ldc.i4.3
+			IL_0594: ldstr "_pendingException"
+			IL_0599: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_059e: ldloc.0
+			IL_059f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05a4: dup
+			IL_05a5: ldc.i4.0
+			IL_05a6: ldloc.1
 			IL_05a7: stelem.ref
 			IL_05a8: dup
-			IL_05a9: ldc.i4.6
-			IL_05aa: ldloc.s 7
-			IL_05ac: stelem.ref
-			IL_05ad: dup
-			IL_05ae: ldc.i4.7
-			IL_05af: ldloc.s 8
-			IL_05b1: stelem.ref
-			IL_05b2: dup
-			IL_05b3: ldc.i4.8
-			IL_05b4: ldloc.s 9
-			IL_05b6: stelem.ref
-			IL_05b7: dup
-			IL_05b8: ldc.i4.s 9
-			IL_05ba: ldloc.s 10
-			IL_05bc: stelem.ref
-			IL_05bd: dup
-			IL_05be: ldc.i4.s 10
-			IL_05c0: ldloc.s 11
-			IL_05c2: box [System.Runtime]System.Boolean
-			IL_05c7: stelem.ref
-			IL_05c8: dup
-			IL_05c9: ldc.i4.s 11
-			IL_05cb: ldloc.s 12
-			IL_05cd: box [System.Runtime]System.Boolean
-			IL_05d2: stelem.ref
-			IL_05d3: dup
-			IL_05d4: ldc.i4.s 12
-			IL_05d6: ldloc.s 13
-			IL_05d8: stelem.ref
-			IL_05d9: dup
-			IL_05da: ldc.i4.s 13
-			IL_05dc: ldloc.s 14
+			IL_05a9: ldc.i4.1
+			IL_05aa: ldloc.2
+			IL_05ab: stelem.ref
+			IL_05ac: dup
+			IL_05ad: ldc.i4.2
+			IL_05ae: ldloc.3
+			IL_05af: stelem.ref
+			IL_05b0: dup
+			IL_05b1: ldc.i4.3
+			IL_05b2: ldloc.s 4
+			IL_05b4: stelem.ref
+			IL_05b5: dup
+			IL_05b6: ldc.i4.4
+			IL_05b7: ldloc.s 5
+			IL_05b9: stelem.ref
+			IL_05ba: dup
+			IL_05bb: ldc.i4.5
+			IL_05bc: ldloc.s 6
+			IL_05be: stelem.ref
+			IL_05bf: dup
+			IL_05c0: ldc.i4.6
+			IL_05c1: ldloc.s 7
+			IL_05c3: stelem.ref
+			IL_05c4: dup
+			IL_05c5: ldc.i4.7
+			IL_05c6: ldloc.s 8
+			IL_05c8: stelem.ref
+			IL_05c9: dup
+			IL_05ca: ldc.i4.8
+			IL_05cb: ldloc.s 9
+			IL_05cd: stelem.ref
+			IL_05ce: dup
+			IL_05cf: ldc.i4.s 9
+			IL_05d1: ldloc.s 10
+			IL_05d3: stelem.ref
+			IL_05d4: dup
+			IL_05d5: ldc.i4.s 10
+			IL_05d7: ldloc.s 11
+			IL_05d9: box [System.Runtime]System.Boolean
 			IL_05de: stelem.ref
 			IL_05df: dup
-			IL_05e0: ldc.i4.s 14
-			IL_05e2: ldloc.s 15
-			IL_05e4: box [System.Runtime]System.Double
+			IL_05e0: ldc.i4.s 11
+			IL_05e2: ldloc.s 12
+			IL_05e4: box [System.Runtime]System.Boolean
 			IL_05e9: stelem.ref
 			IL_05ea: dup
-			IL_05eb: ldc.i4.s 15
-			IL_05ed: ldloc.s 16
+			IL_05eb: ldc.i4.s 12
+			IL_05ed: ldloc.s 13
 			IL_05ef: stelem.ref
 			IL_05f0: dup
-			IL_05f1: ldc.i4.s 16
-			IL_05f3: ldloc.s 17
+			IL_05f1: ldc.i4.s 13
+			IL_05f3: ldloc.s 14
 			IL_05f5: stelem.ref
 			IL_05f6: dup
-			IL_05f7: ldc.i4.s 17
-			IL_05f9: ldloc.s 18
-			IL_05fb: stelem.ref
-			IL_05fc: dup
-			IL_05fd: ldc.i4.s 18
-			IL_05ff: ldloc.s 19
-			IL_0601: stelem.ref
-			IL_0602: dup
-			IL_0603: ldc.i4.s 19
-			IL_0605: ldloc.s 20
-			IL_0607: stelem.ref
-			IL_0608: dup
-			IL_0609: ldc.i4.s 20
-			IL_060b: ldloc.s 21
-			IL_060d: stelem.ref
-			IL_060e: dup
-			IL_060f: ldc.i4.s 21
-			IL_0611: ldloc.s 22
-			IL_0613: stelem.ref
-			IL_0614: dup
-			IL_0615: ldc.i4.s 22
-			IL_0617: ldloc.s 23
-			IL_0619: stelem.ref
-			IL_061a: dup
-			IL_061b: ldc.i4.s 23
-			IL_061d: ldloc.s 24
-			IL_061f: box [System.Runtime]System.Boolean
+			IL_05f7: ldc.i4.s 14
+			IL_05f9: ldloc.s 15
+			IL_05fb: box [System.Runtime]System.Double
+			IL_0600: stelem.ref
+			IL_0601: dup
+			IL_0602: ldc.i4.s 15
+			IL_0604: ldloc.s 16
+			IL_0606: stelem.ref
+			IL_0607: dup
+			IL_0608: ldc.i4.s 16
+			IL_060a: ldloc.s 17
+			IL_060c: stelem.ref
+			IL_060d: dup
+			IL_060e: ldc.i4.s 17
+			IL_0610: ldloc.s 18
+			IL_0612: stelem.ref
+			IL_0613: dup
+			IL_0614: ldc.i4.s 18
+			IL_0616: ldloc.s 19
+			IL_0618: stelem.ref
+			IL_0619: dup
+			IL_061a: ldc.i4.s 19
+			IL_061c: ldloc.s 20
+			IL_061e: stelem.ref
+			IL_061f: dup
+			IL_0620: ldc.i4.s 20
+			IL_0622: ldloc.s 21
 			IL_0624: stelem.ref
 			IL_0625: dup
-			IL_0626: ldc.i4.s 24
-			IL_0628: ldloc.s 25
+			IL_0626: ldc.i4.s 21
+			IL_0628: ldloc.s 22
 			IL_062a: stelem.ref
 			IL_062b: dup
-			IL_062c: ldc.i4.s 25
-			IL_062e: ldloc.s 26
+			IL_062c: ldc.i4.s 22
+			IL_062e: ldloc.s 23
 			IL_0630: stelem.ref
-			IL_0631: pop
-			IL_0632: ldloc.0
-			IL_0633: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0638: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_063d: ret
+			IL_0631: dup
+			IL_0632: ldc.i4.s 23
+			IL_0634: ldloc.s 24
+			IL_0636: stelem.ref
+			IL_0637: dup
+			IL_0638: ldc.i4.s 24
+			IL_063a: ldloc.s 25
+			IL_063c: box [System.Runtime]System.Boolean
+			IL_0641: stelem.ref
+			IL_0642: dup
+			IL_0643: ldc.i4.s 25
+			IL_0645: ldloc.s 26
+			IL_0647: stelem.ref
+			IL_0648: dup
+			IL_0649: ldc.i4.s 26
+			IL_064b: ldloc.s 27
+			IL_064d: stelem.ref
+			IL_064e: pop
+			IL_064f: ldloc.0
+			IL_0650: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0655: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_065a: ret
 
-			IL_063e: ldloc.0
-			IL_063f: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited3
-			IL_0644: stloc.s 7
-			IL_0646: ldloc.3
-			IL_0647: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_064c: stloc.s 13
-			IL_064e: ldloc.s 13
-			IL_0650: ldstr "write"
-			IL_0655: ldstr "X"
-			IL_065a: ldc.r8 4
-			IL_0663: box [System.Runtime]System.Double
-			IL_0668: ldstr "utf8"
-			IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0672: stloc.s 13
-			IL_0674: ldloc.0
-			IL_0675: ldc.i4.7
-			IL_0676: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_067b: ldloc.0
-			IL_067c: ldloc.s 13
-			IL_067e: ldarg.0
-			IL_067f: ldc.i4.4
-			IL_0680: ldloc.0
-			IL_0681: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0686: ldc.i4.3
-			IL_0687: ldstr "_pendingException"
-			IL_068c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_065b: ldloc.0
+			IL_065c: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited3
+			IL_0661: stloc.s 7
+			IL_0663: ldloc.3
+			IL_0664: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0669: stloc.s 13
+			IL_066b: ldloc.s 13
+			IL_066d: ldstr "write"
+			IL_0672: ldstr "X"
+			IL_0677: ldc.r8 4
+			IL_0680: box [System.Runtime]System.Double
+			IL_0685: ldstr "utf8"
+			IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_068f: stloc.s 13
 			IL_0691: ldloc.0
-			IL_0692: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0697: dup
-			IL_0698: ldc.i4.0
-			IL_0699: ldloc.1
-			IL_069a: stelem.ref
-			IL_069b: dup
-			IL_069c: ldc.i4.1
-			IL_069d: ldloc.2
-			IL_069e: stelem.ref
-			IL_069f: dup
-			IL_06a0: ldc.i4.2
-			IL_06a1: ldloc.3
-			IL_06a2: stelem.ref
-			IL_06a3: dup
-			IL_06a4: ldc.i4.3
-			IL_06a5: ldloc.s 4
-			IL_06a7: stelem.ref
-			IL_06a8: dup
-			IL_06a9: ldc.i4.4
-			IL_06aa: ldloc.s 5
-			IL_06ac: stelem.ref
-			IL_06ad: dup
-			IL_06ae: ldc.i4.5
-			IL_06af: ldloc.s 6
-			IL_06b1: stelem.ref
-			IL_06b2: dup
-			IL_06b3: ldc.i4.6
-			IL_06b4: ldloc.s 7
-			IL_06b6: stelem.ref
-			IL_06b7: dup
-			IL_06b8: ldc.i4.7
-			IL_06b9: ldloc.s 8
+			IL_0692: ldc.i4.7
+			IL_0693: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0698: ldloc.0
+			IL_0699: ldloc.s 13
+			IL_069b: ldarg.0
+			IL_069c: ldc.i4.4
+			IL_069d: ldloc.0
+			IL_069e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_06a3: ldc.i4.3
+			IL_06a4: ldstr "_pendingException"
+			IL_06a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_06ae: ldloc.0
+			IL_06af: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_06b4: dup
+			IL_06b5: ldc.i4.0
+			IL_06b6: ldloc.1
+			IL_06b7: stelem.ref
+			IL_06b8: dup
+			IL_06b9: ldc.i4.1
+			IL_06ba: ldloc.2
 			IL_06bb: stelem.ref
 			IL_06bc: dup
-			IL_06bd: ldc.i4.8
-			IL_06be: ldloc.s 9
-			IL_06c0: stelem.ref
-			IL_06c1: dup
-			IL_06c2: ldc.i4.s 9
-			IL_06c4: ldloc.s 10
-			IL_06c6: stelem.ref
-			IL_06c7: dup
-			IL_06c8: ldc.i4.s 10
-			IL_06ca: ldloc.s 11
-			IL_06cc: box [System.Runtime]System.Boolean
-			IL_06d1: stelem.ref
-			IL_06d2: dup
-			IL_06d3: ldc.i4.s 11
-			IL_06d5: ldloc.s 12
-			IL_06d7: box [System.Runtime]System.Boolean
-			IL_06dc: stelem.ref
-			IL_06dd: dup
-			IL_06de: ldc.i4.s 12
-			IL_06e0: ldloc.s 13
-			IL_06e2: stelem.ref
-			IL_06e3: dup
-			IL_06e4: ldc.i4.s 13
-			IL_06e6: ldloc.s 14
-			IL_06e8: stelem.ref
-			IL_06e9: dup
-			IL_06ea: ldc.i4.s 14
-			IL_06ec: ldloc.s 15
-			IL_06ee: box [System.Runtime]System.Double
-			IL_06f3: stelem.ref
-			IL_06f4: dup
-			IL_06f5: ldc.i4.s 15
-			IL_06f7: ldloc.s 16
+			IL_06bd: ldc.i4.2
+			IL_06be: ldloc.3
+			IL_06bf: stelem.ref
+			IL_06c0: dup
+			IL_06c1: ldc.i4.3
+			IL_06c2: ldloc.s 4
+			IL_06c4: stelem.ref
+			IL_06c5: dup
+			IL_06c6: ldc.i4.4
+			IL_06c7: ldloc.s 5
+			IL_06c9: stelem.ref
+			IL_06ca: dup
+			IL_06cb: ldc.i4.5
+			IL_06cc: ldloc.s 6
+			IL_06ce: stelem.ref
+			IL_06cf: dup
+			IL_06d0: ldc.i4.6
+			IL_06d1: ldloc.s 7
+			IL_06d3: stelem.ref
+			IL_06d4: dup
+			IL_06d5: ldc.i4.7
+			IL_06d6: ldloc.s 8
+			IL_06d8: stelem.ref
+			IL_06d9: dup
+			IL_06da: ldc.i4.8
+			IL_06db: ldloc.s 9
+			IL_06dd: stelem.ref
+			IL_06de: dup
+			IL_06df: ldc.i4.s 9
+			IL_06e1: ldloc.s 10
+			IL_06e3: stelem.ref
+			IL_06e4: dup
+			IL_06e5: ldc.i4.s 10
+			IL_06e7: ldloc.s 11
+			IL_06e9: box [System.Runtime]System.Boolean
+			IL_06ee: stelem.ref
+			IL_06ef: dup
+			IL_06f0: ldc.i4.s 11
+			IL_06f2: ldloc.s 12
+			IL_06f4: box [System.Runtime]System.Boolean
 			IL_06f9: stelem.ref
 			IL_06fa: dup
-			IL_06fb: ldc.i4.s 16
-			IL_06fd: ldloc.s 17
+			IL_06fb: ldc.i4.s 12
+			IL_06fd: ldloc.s 13
 			IL_06ff: stelem.ref
 			IL_0700: dup
-			IL_0701: ldc.i4.s 17
-			IL_0703: ldloc.s 18
+			IL_0701: ldc.i4.s 13
+			IL_0703: ldloc.s 14
 			IL_0705: stelem.ref
 			IL_0706: dup
-			IL_0707: ldc.i4.s 18
-			IL_0709: ldloc.s 19
-			IL_070b: stelem.ref
-			IL_070c: dup
-			IL_070d: ldc.i4.s 19
-			IL_070f: ldloc.s 20
-			IL_0711: stelem.ref
-			IL_0712: dup
-			IL_0713: ldc.i4.s 20
-			IL_0715: ldloc.s 21
-			IL_0717: stelem.ref
-			IL_0718: dup
-			IL_0719: ldc.i4.s 21
-			IL_071b: ldloc.s 22
-			IL_071d: stelem.ref
-			IL_071e: dup
-			IL_071f: ldc.i4.s 22
-			IL_0721: ldloc.s 23
-			IL_0723: stelem.ref
-			IL_0724: dup
-			IL_0725: ldc.i4.s 23
-			IL_0727: ldloc.s 24
-			IL_0729: box [System.Runtime]System.Boolean
+			IL_0707: ldc.i4.s 14
+			IL_0709: ldloc.s 15
+			IL_070b: box [System.Runtime]System.Double
+			IL_0710: stelem.ref
+			IL_0711: dup
+			IL_0712: ldc.i4.s 15
+			IL_0714: ldloc.s 16
+			IL_0716: stelem.ref
+			IL_0717: dup
+			IL_0718: ldc.i4.s 16
+			IL_071a: ldloc.s 17
+			IL_071c: stelem.ref
+			IL_071d: dup
+			IL_071e: ldc.i4.s 17
+			IL_0720: ldloc.s 18
+			IL_0722: stelem.ref
+			IL_0723: dup
+			IL_0724: ldc.i4.s 18
+			IL_0726: ldloc.s 19
+			IL_0728: stelem.ref
+			IL_0729: dup
+			IL_072a: ldc.i4.s 19
+			IL_072c: ldloc.s 20
 			IL_072e: stelem.ref
 			IL_072f: dup
-			IL_0730: ldc.i4.s 24
-			IL_0732: ldloc.s 25
+			IL_0730: ldc.i4.s 20
+			IL_0732: ldloc.s 21
 			IL_0734: stelem.ref
 			IL_0735: dup
-			IL_0736: ldc.i4.s 25
-			IL_0738: ldloc.s 26
+			IL_0736: ldc.i4.s 21
+			IL_0738: ldloc.s 22
 			IL_073a: stelem.ref
-			IL_073b: pop
-			IL_073c: ldloc.0
-			IL_073d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0742: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0747: ret
+			IL_073b: dup
+			IL_073c: ldc.i4.s 22
+			IL_073e: ldloc.s 23
+			IL_0740: stelem.ref
+			IL_0741: dup
+			IL_0742: ldc.i4.s 23
+			IL_0744: ldloc.s 24
+			IL_0746: stelem.ref
+			IL_0747: dup
+			IL_0748: ldc.i4.s 24
+			IL_074a: ldloc.s 25
+			IL_074c: box [System.Runtime]System.Boolean
+			IL_0751: stelem.ref
+			IL_0752: dup
+			IL_0753: ldc.i4.s 25
+			IL_0755: ldloc.s 26
+			IL_0757: stelem.ref
+			IL_0758: dup
+			IL_0759: ldc.i4.s 26
+			IL_075b: ldloc.s 27
+			IL_075d: stelem.ref
+			IL_075e: pop
+			IL_075f: ldloc.0
+			IL_0760: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0765: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_076a: ret
 
-			IL_0748: ldloc.0
-			IL_0749: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited4
-			IL_074e: stloc.s 8
-			IL_0750: ldloc.3
-			IL_0751: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0756: stloc.s 13
-			IL_0758: ldloc.s 13
-			IL_075a: ldstr "write"
-			IL_075f: ldstr "Y"
-			IL_0764: ldc.i4.0
-			IL_0765: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_076a: ldstr "utf8"
-			IL_076f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0774: stloc.s 13
-			IL_0776: ldloc.0
-			IL_0777: ldc.i4.8
-			IL_0778: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_077d: ldloc.0
-			IL_077e: ldloc.s 13
-			IL_0780: ldarg.0
-			IL_0781: ldc.i4.5
-			IL_0782: ldloc.0
-			IL_0783: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0788: ldc.i4.3
-			IL_0789: ldstr "_pendingException"
-			IL_078e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0793: ldloc.0
-			IL_0794: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0799: dup
-			IL_079a: ldc.i4.0
-			IL_079b: ldloc.1
-			IL_079c: stelem.ref
-			IL_079d: dup
-			IL_079e: ldc.i4.1
-			IL_079f: ldloc.2
-			IL_07a0: stelem.ref
-			IL_07a1: dup
-			IL_07a2: ldc.i4.2
-			IL_07a3: ldloc.3
-			IL_07a4: stelem.ref
-			IL_07a5: dup
-			IL_07a6: ldc.i4.3
-			IL_07a7: ldloc.s 4
-			IL_07a9: stelem.ref
-			IL_07aa: dup
-			IL_07ab: ldc.i4.4
-			IL_07ac: ldloc.s 5
-			IL_07ae: stelem.ref
-			IL_07af: dup
-			IL_07b0: ldc.i4.5
-			IL_07b1: ldloc.s 6
-			IL_07b3: stelem.ref
-			IL_07b4: dup
-			IL_07b5: ldc.i4.6
-			IL_07b6: ldloc.s 7
-			IL_07b8: stelem.ref
-			IL_07b9: dup
-			IL_07ba: ldc.i4.7
-			IL_07bb: ldloc.s 8
-			IL_07bd: stelem.ref
-			IL_07be: dup
-			IL_07bf: ldc.i4.8
-			IL_07c0: ldloc.s 9
-			IL_07c2: stelem.ref
-			IL_07c3: dup
-			IL_07c4: ldc.i4.s 9
-			IL_07c6: ldloc.s 10
-			IL_07c8: stelem.ref
-			IL_07c9: dup
-			IL_07ca: ldc.i4.s 10
-			IL_07cc: ldloc.s 11
-			IL_07ce: box [System.Runtime]System.Boolean
-			IL_07d3: stelem.ref
-			IL_07d4: dup
-			IL_07d5: ldc.i4.s 11
-			IL_07d7: ldloc.s 12
-			IL_07d9: box [System.Runtime]System.Boolean
-			IL_07de: stelem.ref
-			IL_07df: dup
-			IL_07e0: ldc.i4.s 12
-			IL_07e2: ldloc.s 13
-			IL_07e4: stelem.ref
-			IL_07e5: dup
-			IL_07e6: ldc.i4.s 13
-			IL_07e8: ldloc.s 14
-			IL_07ea: stelem.ref
-			IL_07eb: dup
-			IL_07ec: ldc.i4.s 14
-			IL_07ee: ldloc.s 15
-			IL_07f0: box [System.Runtime]System.Double
-			IL_07f5: stelem.ref
-			IL_07f6: dup
-			IL_07f7: ldc.i4.s 15
-			IL_07f9: ldloc.s 16
-			IL_07fb: stelem.ref
-			IL_07fc: dup
-			IL_07fd: ldc.i4.s 16
-			IL_07ff: ldloc.s 17
+			IL_076b: ldloc.0
+			IL_076c: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited4
+			IL_0771: stloc.s 8
+			IL_0773: ldloc.3
+			IL_0774: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0779: stloc.s 13
+			IL_077b: ldloc.s 13
+			IL_077d: ldstr "write"
+			IL_0782: ldstr "Y"
+			IL_0787: ldc.i4.0
+			IL_0788: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_078d: ldstr "utf8"
+			IL_0792: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0797: stloc.s 13
+			IL_0799: ldloc.0
+			IL_079a: ldc.i4.8
+			IL_079b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07a0: ldloc.0
+			IL_07a1: ldloc.s 13
+			IL_07a3: ldarg.0
+			IL_07a4: ldc.i4.5
+			IL_07a5: ldloc.0
+			IL_07a6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07ab: ldc.i4.3
+			IL_07ac: ldstr "_pendingException"
+			IL_07b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_07b6: ldloc.0
+			IL_07b7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_07bc: dup
+			IL_07bd: ldc.i4.0
+			IL_07be: ldloc.1
+			IL_07bf: stelem.ref
+			IL_07c0: dup
+			IL_07c1: ldc.i4.1
+			IL_07c2: ldloc.2
+			IL_07c3: stelem.ref
+			IL_07c4: dup
+			IL_07c5: ldc.i4.2
+			IL_07c6: ldloc.3
+			IL_07c7: stelem.ref
+			IL_07c8: dup
+			IL_07c9: ldc.i4.3
+			IL_07ca: ldloc.s 4
+			IL_07cc: stelem.ref
+			IL_07cd: dup
+			IL_07ce: ldc.i4.4
+			IL_07cf: ldloc.s 5
+			IL_07d1: stelem.ref
+			IL_07d2: dup
+			IL_07d3: ldc.i4.5
+			IL_07d4: ldloc.s 6
+			IL_07d6: stelem.ref
+			IL_07d7: dup
+			IL_07d8: ldc.i4.6
+			IL_07d9: ldloc.s 7
+			IL_07db: stelem.ref
+			IL_07dc: dup
+			IL_07dd: ldc.i4.7
+			IL_07de: ldloc.s 8
+			IL_07e0: stelem.ref
+			IL_07e1: dup
+			IL_07e2: ldc.i4.8
+			IL_07e3: ldloc.s 9
+			IL_07e5: stelem.ref
+			IL_07e6: dup
+			IL_07e7: ldc.i4.s 9
+			IL_07e9: ldloc.s 10
+			IL_07eb: stelem.ref
+			IL_07ec: dup
+			IL_07ed: ldc.i4.s 10
+			IL_07ef: ldloc.s 11
+			IL_07f1: box [System.Runtime]System.Boolean
+			IL_07f6: stelem.ref
+			IL_07f7: dup
+			IL_07f8: ldc.i4.s 11
+			IL_07fa: ldloc.s 12
+			IL_07fc: box [System.Runtime]System.Boolean
 			IL_0801: stelem.ref
 			IL_0802: dup
-			IL_0803: ldc.i4.s 17
-			IL_0805: ldloc.s 18
+			IL_0803: ldc.i4.s 12
+			IL_0805: ldloc.s 13
 			IL_0807: stelem.ref
 			IL_0808: dup
-			IL_0809: ldc.i4.s 18
-			IL_080b: ldloc.s 19
+			IL_0809: ldc.i4.s 13
+			IL_080b: ldloc.s 14
 			IL_080d: stelem.ref
 			IL_080e: dup
-			IL_080f: ldc.i4.s 19
-			IL_0811: ldloc.s 20
-			IL_0813: stelem.ref
-			IL_0814: dup
-			IL_0815: ldc.i4.s 20
-			IL_0817: ldloc.s 21
-			IL_0819: stelem.ref
-			IL_081a: dup
-			IL_081b: ldc.i4.s 21
-			IL_081d: ldloc.s 22
-			IL_081f: stelem.ref
-			IL_0820: dup
-			IL_0821: ldc.i4.s 22
-			IL_0823: ldloc.s 23
-			IL_0825: stelem.ref
-			IL_0826: dup
-			IL_0827: ldc.i4.s 23
-			IL_0829: ldloc.s 24
-			IL_082b: box [System.Runtime]System.Boolean
+			IL_080f: ldc.i4.s 14
+			IL_0811: ldloc.s 15
+			IL_0813: box [System.Runtime]System.Double
+			IL_0818: stelem.ref
+			IL_0819: dup
+			IL_081a: ldc.i4.s 15
+			IL_081c: ldloc.s 16
+			IL_081e: stelem.ref
+			IL_081f: dup
+			IL_0820: ldc.i4.s 16
+			IL_0822: ldloc.s 17
+			IL_0824: stelem.ref
+			IL_0825: dup
+			IL_0826: ldc.i4.s 17
+			IL_0828: ldloc.s 18
+			IL_082a: stelem.ref
+			IL_082b: dup
+			IL_082c: ldc.i4.s 18
+			IL_082e: ldloc.s 19
 			IL_0830: stelem.ref
 			IL_0831: dup
-			IL_0832: ldc.i4.s 24
-			IL_0834: ldloc.s 25
+			IL_0832: ldc.i4.s 19
+			IL_0834: ldloc.s 20
 			IL_0836: stelem.ref
 			IL_0837: dup
-			IL_0838: ldc.i4.s 25
-			IL_083a: ldloc.s 26
+			IL_0838: ldc.i4.s 20
+			IL_083a: ldloc.s 21
 			IL_083c: stelem.ref
-			IL_083d: pop
-			IL_083e: ldloc.0
-			IL_083f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0844: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0849: ret
+			IL_083d: dup
+			IL_083e: ldc.i4.s 21
+			IL_0840: ldloc.s 22
+			IL_0842: stelem.ref
+			IL_0843: dup
+			IL_0844: ldc.i4.s 22
+			IL_0846: ldloc.s 23
+			IL_0848: stelem.ref
+			IL_0849: dup
+			IL_084a: ldc.i4.s 23
+			IL_084c: ldloc.s 24
+			IL_084e: stelem.ref
+			IL_084f: dup
+			IL_0850: ldc.i4.s 24
+			IL_0852: ldloc.s 25
+			IL_0854: box [System.Runtime]System.Boolean
+			IL_0859: stelem.ref
+			IL_085a: dup
+			IL_085b: ldc.i4.s 25
+			IL_085d: ldloc.s 26
+			IL_085f: stelem.ref
+			IL_0860: dup
+			IL_0861: ldc.i4.s 26
+			IL_0863: ldloc.s 27
+			IL_0865: stelem.ref
+			IL_0866: pop
+			IL_0867: ldloc.0
+			IL_0868: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_086d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0872: ret
 
-			IL_084a: ldloc.0
-			IL_084b: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited5
-			IL_0850: stloc.s 9
-			IL_0852: ldloc.3
-			IL_0853: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0858: stloc.s 13
-			IL_085a: ldloc.s 13
-			IL_085c: ldstr "close"
-			IL_0861: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0866: stloc.s 13
-			IL_0868: ldloc.0
-			IL_0869: ldc.i4.s 9
-			IL_086b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0870: ldloc.0
-			IL_0871: ldloc.s 13
-			IL_0873: ldarg.0
-			IL_0874: ldc.i4.6
-			IL_0875: ldloc.0
-			IL_0876: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_087b: ldc.i4.3
-			IL_087c: ldstr "_pendingException"
-			IL_0881: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0886: ldloc.0
-			IL_0887: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_088c: dup
-			IL_088d: ldc.i4.0
-			IL_088e: ldloc.1
-			IL_088f: stelem.ref
-			IL_0890: dup
-			IL_0891: ldc.i4.1
-			IL_0892: ldloc.2
-			IL_0893: stelem.ref
-			IL_0894: dup
-			IL_0895: ldc.i4.2
-			IL_0896: ldloc.3
-			IL_0897: stelem.ref
-			IL_0898: dup
-			IL_0899: ldc.i4.3
-			IL_089a: ldloc.s 4
-			IL_089c: stelem.ref
-			IL_089d: dup
-			IL_089e: ldc.i4.4
-			IL_089f: ldloc.s 5
-			IL_08a1: stelem.ref
-			IL_08a2: dup
-			IL_08a3: ldc.i4.5
-			IL_08a4: ldloc.s 6
-			IL_08a6: stelem.ref
-			IL_08a7: dup
-			IL_08a8: ldc.i4.6
-			IL_08a9: ldloc.s 7
-			IL_08ab: stelem.ref
-			IL_08ac: dup
-			IL_08ad: ldc.i4.7
-			IL_08ae: ldloc.s 8
-			IL_08b0: stelem.ref
-			IL_08b1: dup
-			IL_08b2: ldc.i4.8
-			IL_08b3: ldloc.s 9
-			IL_08b5: stelem.ref
-			IL_08b6: dup
-			IL_08b7: ldc.i4.s 9
-			IL_08b9: ldloc.s 10
-			IL_08bb: stelem.ref
-			IL_08bc: dup
-			IL_08bd: ldc.i4.s 10
-			IL_08bf: ldloc.s 11
-			IL_08c1: box [System.Runtime]System.Boolean
-			IL_08c6: stelem.ref
-			IL_08c7: dup
-			IL_08c8: ldc.i4.s 11
-			IL_08ca: ldloc.s 12
-			IL_08cc: box [System.Runtime]System.Boolean
-			IL_08d1: stelem.ref
-			IL_08d2: dup
-			IL_08d3: ldc.i4.s 12
-			IL_08d5: ldloc.s 13
-			IL_08d7: stelem.ref
-			IL_08d8: dup
-			IL_08d9: ldc.i4.s 13
-			IL_08db: ldloc.s 14
-			IL_08dd: stelem.ref
-			IL_08de: dup
-			IL_08df: ldc.i4.s 14
-			IL_08e1: ldloc.s 15
-			IL_08e3: box [System.Runtime]System.Double
-			IL_08e8: stelem.ref
-			IL_08e9: dup
-			IL_08ea: ldc.i4.s 15
-			IL_08ec: ldloc.s 16
-			IL_08ee: stelem.ref
-			IL_08ef: dup
-			IL_08f0: ldc.i4.s 16
-			IL_08f2: ldloc.s 17
-			IL_08f4: stelem.ref
-			IL_08f5: dup
-			IL_08f6: ldc.i4.s 17
-			IL_08f8: ldloc.s 18
+			IL_0873: ldloc.0
+			IL_0874: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited5
+			IL_0879: stloc.s 9
+			IL_087b: ldloc.3
+			IL_087c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0881: stloc.s 13
+			IL_0883: ldloc.s 13
+			IL_0885: ldstr "close"
+			IL_088a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_088f: stloc.s 13
+			IL_0891: ldloc.0
+			IL_0892: ldc.i4.s 9
+			IL_0894: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0899: ldloc.0
+			IL_089a: ldloc.s 13
+			IL_089c: ldarg.0
+			IL_089d: ldc.i4.6
+			IL_089e: ldloc.0
+			IL_089f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_08a4: ldc.i4.3
+			IL_08a5: ldstr "_pendingException"
+			IL_08aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_08af: ldloc.0
+			IL_08b0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08b5: dup
+			IL_08b6: ldc.i4.0
+			IL_08b7: ldloc.1
+			IL_08b8: stelem.ref
+			IL_08b9: dup
+			IL_08ba: ldc.i4.1
+			IL_08bb: ldloc.2
+			IL_08bc: stelem.ref
+			IL_08bd: dup
+			IL_08be: ldc.i4.2
+			IL_08bf: ldloc.3
+			IL_08c0: stelem.ref
+			IL_08c1: dup
+			IL_08c2: ldc.i4.3
+			IL_08c3: ldloc.s 4
+			IL_08c5: stelem.ref
+			IL_08c6: dup
+			IL_08c7: ldc.i4.4
+			IL_08c8: ldloc.s 5
+			IL_08ca: stelem.ref
+			IL_08cb: dup
+			IL_08cc: ldc.i4.5
+			IL_08cd: ldloc.s 6
+			IL_08cf: stelem.ref
+			IL_08d0: dup
+			IL_08d1: ldc.i4.6
+			IL_08d2: ldloc.s 7
+			IL_08d4: stelem.ref
+			IL_08d5: dup
+			IL_08d6: ldc.i4.7
+			IL_08d7: ldloc.s 8
+			IL_08d9: stelem.ref
+			IL_08da: dup
+			IL_08db: ldc.i4.8
+			IL_08dc: ldloc.s 9
+			IL_08de: stelem.ref
+			IL_08df: dup
+			IL_08e0: ldc.i4.s 9
+			IL_08e2: ldloc.s 10
+			IL_08e4: stelem.ref
+			IL_08e5: dup
+			IL_08e6: ldc.i4.s 10
+			IL_08e8: ldloc.s 11
+			IL_08ea: box [System.Runtime]System.Boolean
+			IL_08ef: stelem.ref
+			IL_08f0: dup
+			IL_08f1: ldc.i4.s 11
+			IL_08f3: ldloc.s 12
+			IL_08f5: box [System.Runtime]System.Boolean
 			IL_08fa: stelem.ref
 			IL_08fb: dup
-			IL_08fc: ldc.i4.s 18
-			IL_08fe: ldloc.s 19
+			IL_08fc: ldc.i4.s 12
+			IL_08fe: ldloc.s 13
 			IL_0900: stelem.ref
 			IL_0901: dup
-			IL_0902: ldc.i4.s 19
-			IL_0904: ldloc.s 20
+			IL_0902: ldc.i4.s 13
+			IL_0904: ldloc.s 14
 			IL_0906: stelem.ref
 			IL_0907: dup
-			IL_0908: ldc.i4.s 20
-			IL_090a: ldloc.s 21
-			IL_090c: stelem.ref
-			IL_090d: dup
-			IL_090e: ldc.i4.s 21
-			IL_0910: ldloc.s 22
-			IL_0912: stelem.ref
-			IL_0913: dup
-			IL_0914: ldc.i4.s 22
-			IL_0916: ldloc.s 23
-			IL_0918: stelem.ref
-			IL_0919: dup
-			IL_091a: ldc.i4.s 23
-			IL_091c: ldloc.s 24
-			IL_091e: box [System.Runtime]System.Boolean
+			IL_0908: ldc.i4.s 14
+			IL_090a: ldloc.s 15
+			IL_090c: box [System.Runtime]System.Double
+			IL_0911: stelem.ref
+			IL_0912: dup
+			IL_0913: ldc.i4.s 15
+			IL_0915: ldloc.s 16
+			IL_0917: stelem.ref
+			IL_0918: dup
+			IL_0919: ldc.i4.s 16
+			IL_091b: ldloc.s 17
+			IL_091d: stelem.ref
+			IL_091e: dup
+			IL_091f: ldc.i4.s 17
+			IL_0921: ldloc.s 18
 			IL_0923: stelem.ref
 			IL_0924: dup
-			IL_0925: ldc.i4.s 24
-			IL_0927: ldloc.s 25
+			IL_0925: ldc.i4.s 18
+			IL_0927: ldloc.s 19
 			IL_0929: stelem.ref
 			IL_092a: dup
-			IL_092b: ldc.i4.s 25
-			IL_092d: ldloc.s 26
+			IL_092b: ldc.i4.s 19
+			IL_092d: ldloc.s 20
 			IL_092f: stelem.ref
-			IL_0930: pop
-			IL_0931: ldloc.0
-			IL_0932: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0937: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_093c: ret
+			IL_0930: dup
+			IL_0931: ldc.i4.s 20
+			IL_0933: ldloc.s 21
+			IL_0935: stelem.ref
+			IL_0936: dup
+			IL_0937: ldc.i4.s 21
+			IL_0939: ldloc.s 22
+			IL_093b: stelem.ref
+			IL_093c: dup
+			IL_093d: ldc.i4.s 22
+			IL_093f: ldloc.s 23
+			IL_0941: stelem.ref
+			IL_0942: dup
+			IL_0943: ldc.i4.s 23
+			IL_0945: ldloc.s 24
+			IL_0947: stelem.ref
+			IL_0948: dup
+			IL_0949: ldc.i4.s 24
+			IL_094b: ldloc.s 25
+			IL_094d: box [System.Runtime]System.Boolean
+			IL_0952: stelem.ref
+			IL_0953: dup
+			IL_0954: ldc.i4.s 25
+			IL_0956: ldloc.s 26
+			IL_0958: stelem.ref
+			IL_0959: dup
+			IL_095a: ldc.i4.s 26
+			IL_095c: ldloc.s 27
+			IL_095e: stelem.ref
+			IL_095f: pop
+			IL_0960: ldloc.0
+			IL_0961: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0966: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_096b: ret
 
-			IL_093d: ldloc.0
-			IL_093e: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited6
-			IL_0943: pop
-			IL_0944: ldstr "console"
-			IL_0949: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_094e: stloc.s 13
-			IL_0950: ldloc.s 13
-			IL_0952: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0957: stloc.s 13
-			IL_0959: ldloc.s 4
-			IL_095b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0960: stloc.s 22
-			IL_0962: ldloc.s 22
-			IL_0964: ldstr "toString"
-			IL_0969: ldstr "utf8"
-			IL_096e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0973: stloc.s 22
-			IL_0975: ldloc.s 6
-			IL_0977: ldstr "bytesRead"
-			IL_097c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0981: stloc.s 23
-			IL_0983: ldloc.s 13
-			IL_0985: ldstr "log"
-			IL_098a: ldstr "ExplicitRead:"
-			IL_098f: ldloc.s 22
-			IL_0991: ldloc.s 23
-			IL_0993: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0998: pop
-			IL_0999: ldstr "console"
-			IL_099e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09a3: stloc.s 23
-			IL_09a5: ldloc.s 23
-			IL_09a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09ac: stloc.s 23
-			IL_09ae: ldloc.s 5
-			IL_09b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09b5: stloc.s 22
-			IL_09b7: ldloc.s 22
-			IL_09b9: ldstr "toString"
-			IL_09be: ldstr "utf8"
-			IL_09c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_09c8: stloc.s 22
-			IL_09ca: ldloc.s 7
-			IL_09cc: ldstr "bytesRead"
-			IL_09d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09d6: stloc.s 13
-			IL_09d8: ldloc.s 23
-			IL_09da: ldstr "log"
-			IL_09df: ldstr "ImplicitReadAfterExplicit:"
-			IL_09e4: ldloc.s 22
-			IL_09e6: ldloc.s 13
-			IL_09e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_09ed: pop
-			IL_09ee: ldstr "console"
-			IL_09f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09f8: stloc.s 13
-			IL_09fa: ldloc.s 13
-			IL_09fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a01: stloc.s 13
-			IL_0a03: ldloc.s 8
-			IL_0a05: ldstr "bytesWritten"
-			IL_0a0a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a0f: stloc.s 22
-			IL_0a11: ldloc.s 13
-			IL_0a13: ldstr "log"
-			IL_0a18: ldstr "ExplicitWriteBytes:"
-			IL_0a1d: ldloc.s 22
-			IL_0a1f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0a24: pop
-			IL_0a25: ldstr "console"
-			IL_0a2a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a2f: stloc.s 22
-			IL_0a31: ldloc.s 22
-			IL_0a33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a38: stloc.s 22
-			IL_0a3a: ldloc.s 9
-			IL_0a3c: ldstr "bytesWritten"
-			IL_0a41: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a46: stloc.s 13
-			IL_0a48: ldloc.s 22
-			IL_0a4a: ldstr "log"
-			IL_0a4f: ldstr "ImplicitWriteBytes:"
-			IL_0a54: ldloc.s 13
-			IL_0a56: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0a5b: pop
-			IL_0a5c: ldstr "console"
-			IL_0a61: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a66: stloc.s 13
-			IL_0a68: ldloc.s 13
-			IL_0a6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a6f: stloc.s 13
-			IL_0a71: ldarg.0
-			IL_0a72: ldc.i4.1
-			IL_0a73: ldelem.ref
-			IL_0a74: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0a79: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0a7e: stloc.s 19
-			IL_0a80: ldloc.s 19
-			IL_0a82: ldloc.2
-			IL_0a83: ldstr "utf8"
-			IL_0a88: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0a8d: stloc.s 22
-			IL_0a8f: ldloc.s 13
-			IL_0a91: ldstr "log"
-			IL_0a96: ldstr "FinalText:"
-			IL_0a9b: ldloc.s 22
-			IL_0a9d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0aa2: pop
-			IL_0aa3: br IL_0b3a
+			IL_096c: ldloc.0
+			IL_096d: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited6
+			IL_0972: pop
+			IL_0973: ldstr "console"
+			IL_0978: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_097d: stloc.s 13
+			IL_097f: ldloc.s 13
+			IL_0981: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0986: stloc.s 13
+			IL_0988: ldloc.s 4
+			IL_098a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_098f: stloc.s 22
+			IL_0991: ldloc.s 22
+			IL_0993: ldstr "toString"
+			IL_0998: ldstr "utf8"
+			IL_099d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_09a2: stloc.s 23
+			IL_09a4: ldloc.s 6
+			IL_09a6: ldstr "bytesRead"
+			IL_09ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09b0: stloc.s 24
+			IL_09b2: ldloc.s 13
+			IL_09b4: ldstr "log"
+			IL_09b9: ldstr "ExplicitRead:"
+			IL_09be: ldloc.s 23
+			IL_09c0: ldloc.s 24
+			IL_09c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_09c7: pop
+			IL_09c8: ldstr "console"
+			IL_09cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09d2: stloc.s 24
+			IL_09d4: ldloc.s 24
+			IL_09d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09db: stloc.s 24
+			IL_09dd: ldloc.s 5
+			IL_09df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_09e4: stloc.s 22
+			IL_09e6: ldloc.s 22
+			IL_09e8: ldstr "toString"
+			IL_09ed: ldstr "utf8"
+			IL_09f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_09f7: stloc.s 23
+			IL_09f9: ldloc.s 7
+			IL_09fb: ldstr "bytesRead"
+			IL_0a00: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a05: stloc.s 13
+			IL_0a07: ldloc.s 24
+			IL_0a09: ldstr "log"
+			IL_0a0e: ldstr "ImplicitReadAfterExplicit:"
+			IL_0a13: ldloc.s 23
+			IL_0a15: ldloc.s 13
+			IL_0a17: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0a1c: pop
+			IL_0a1d: ldstr "console"
+			IL_0a22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a27: stloc.s 13
+			IL_0a29: ldloc.s 13
+			IL_0a2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a30: stloc.s 13
+			IL_0a32: ldloc.s 8
+			IL_0a34: ldstr "bytesWritten"
+			IL_0a39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a3e: stloc.s 23
+			IL_0a40: ldloc.s 13
+			IL_0a42: ldstr "log"
+			IL_0a47: ldstr "ExplicitWriteBytes:"
+			IL_0a4c: ldloc.s 23
+			IL_0a4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0a53: pop
+			IL_0a54: ldstr "console"
+			IL_0a59: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a5e: stloc.s 23
+			IL_0a60: ldloc.s 23
+			IL_0a62: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a67: stloc.s 23
+			IL_0a69: ldloc.s 9
+			IL_0a6b: ldstr "bytesWritten"
+			IL_0a70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a75: stloc.s 13
+			IL_0a77: ldloc.s 23
+			IL_0a79: ldstr "log"
+			IL_0a7e: ldstr "ImplicitWriteBytes:"
+			IL_0a83: ldloc.s 13
+			IL_0a85: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0a8a: pop
+			IL_0a8b: ldstr "console"
+			IL_0a90: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a95: stloc.s 13
+			IL_0a97: ldloc.s 13
+			IL_0a99: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a9e: stloc.s 13
+			IL_0aa0: ldarg.0
+			IL_0aa1: ldc.i4.1
+			IL_0aa2: ldelem.ref
+			IL_0aa3: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0aa8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0aad: stloc.s 19
+			IL_0aaf: ldloc.s 19
+			IL_0ab1: ldloc.2
+			IL_0ab2: ldstr "utf8"
+			IL_0ab7: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0abc: stloc.s 23
+			IL_0abe: ldloc.s 13
+			IL_0ac0: ldstr "log"
+			IL_0ac5: ldstr "FinalText:"
+			IL_0aca: ldloc.s 23
+			IL_0acc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0ad1: pop
+			IL_0ad2: br IL_0b69
 
-			IL_0aa8: ldloc.0
-			IL_0aa9: ldc.i4.1
-			IL_0aaa: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0aaf: ldloc.0
-			IL_0ab0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0ab5: stloc.s 22
-			IL_0ab7: ldloc.0
-			IL_0ab8: ldc.i4.0
-			IL_0ab9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0abe: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0ac3: ldloc.0
-			IL_0ac4: ldc.i4.0
-			IL_0ac5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0aca: ldloc.s 22
-			IL_0acc: stloc.s 10
-			IL_0ace: ldstr "console"
-			IL_0ad3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ad8: stloc.s 22
-			IL_0ada: ldloc.s 22
-			IL_0adc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0ae1: stloc.s 22
-			IL_0ae3: ldloc.s 10
-			IL_0ae5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0aea: stloc.s 24
-			IL_0aec: ldloc.s 24
-			IL_0aee: brfalse IL_0b0a
+			IL_0ad7: ldloc.0
+			IL_0ad8: ldc.i4.1
+			IL_0ad9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0ade: ldloc.0
+			IL_0adf: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0ae4: stloc.s 23
+			IL_0ae6: ldloc.0
+			IL_0ae7: ldc.i4.0
+			IL_0ae8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0aed: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0af2: ldloc.0
+			IL_0af3: ldc.i4.0
+			IL_0af4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0af9: ldloc.s 23
+			IL_0afb: stloc.s 10
+			IL_0afd: ldstr "console"
+			IL_0b02: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b07: stloc.s 23
+			IL_0b09: ldloc.s 23
+			IL_0b0b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b10: stloc.s 23
+			IL_0b12: ldloc.s 10
+			IL_0b14: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0b19: stloc.s 25
+			IL_0b1b: ldloc.s 25
+			IL_0b1d: brfalse IL_0b39
 
-			IL_0af3: ldloc.s 10
-			IL_0af5: ldstr "message"
-			IL_0afa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0aff: stloc.s 13
-			IL_0b01: ldloc.s 13
-			IL_0b03: stloc.s 26
-			IL_0b05: br IL_0b0e
+			IL_0b22: ldloc.s 10
+			IL_0b24: ldstr "message"
+			IL_0b29: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b2e: stloc.s 13
+			IL_0b30: ldloc.s 13
+			IL_0b32: stloc.s 27
+			IL_0b34: br IL_0b3d
 
-			IL_0b0a: ldloc.s 10
-			IL_0b0c: stloc.s 26
+			IL_0b39: ldloc.s 10
+			IL_0b3b: stloc.s 27
 
-			IL_0b0e: ldloc.s 22
-			IL_0b10: ldstr "log"
-			IL_0b15: ldstr "Error:"
-			IL_0b1a: ldloc.s 26
-			IL_0b1c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0b21: pop
-			IL_0b22: br IL_0b3a
+			IL_0b3d: ldloc.s 23
+			IL_0b3f: ldstr "log"
+			IL_0b44: ldstr "Error:"
+			IL_0b49: ldloc.s 27
+			IL_0b4b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0b50: pop
+			IL_0b51: br IL_0b69
 
-			IL_0b27: ldloc.0
-			IL_0b28: ldc.i4.1
-			IL_0b29: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0b2e: ldloc.0
-			IL_0b2f: ldc.i4.0
-			IL_0b30: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0b35: br IL_0b3a
+			IL_0b56: ldloc.0
+			IL_0b57: ldc.i4.1
+			IL_0b58: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b5d: ldloc.0
+			IL_0b5e: ldc.i4.0
+			IL_0b5f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0b64: br IL_0b69
 
-			IL_0b3a: ldarg.0
-			IL_0b3b: ldc.i4.1
-			IL_0b3c: ldelem.ref
-			IL_0b3d: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0b42: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0b47: stloc.s 19
-			IL_0b49: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0b4e: dup
-			IL_0b4f: ldstr "force"
-			IL_0b54: ldc.i4.1
-			IL_0b55: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0b5a: stloc.s 20
-			IL_0b5c: ldloc.s 19
-			IL_0b5e: ldloc.2
-			IL_0b5f: ldloc.s 20
-			IL_0b61: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0b66: br IL_0b7e
+			IL_0b69: ldarg.0
+			IL_0b6a: ldc.i4.1
+			IL_0b6b: ldelem.ref
+			IL_0b6c: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0b71: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0b76: stloc.s 19
+			IL_0b78: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0b7d: dup
+			IL_0b7e: ldstr "force"
+			IL_0b83: ldc.i4.1
+			IL_0b84: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0b89: stloc.s 20
+			IL_0b8b: ldloc.s 19
+			IL_0b8d: ldloc.2
+			IL_0b8e: ldloc.s 20
+			IL_0b90: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0b95: br IL_0bad
 
-			IL_0b6b: ldloc.0
-			IL_0b6c: ldc.i4.1
-			IL_0b6d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0b72: ldloc.0
-			IL_0b73: ldc.i4.0
-			IL_0b74: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0b79: br IL_0b7e
+			IL_0b9a: ldloc.0
+			IL_0b9b: ldc.i4.1
+			IL_0b9c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0ba1: ldloc.0
+			IL_0ba2: ldc.i4.0
+			IL_0ba3: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0ba8: br IL_0bad
 
-			IL_0b7e: ldloc.0
-			IL_0b7f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0b84: stloc.s 11
-			IL_0b86: ldloc.s 11
-			IL_0b88: brfalse IL_0bc5
+			IL_0bad: ldloc.0
+			IL_0bae: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0bb3: stloc.s 11
+			IL_0bb5: ldloc.s 11
+			IL_0bb7: brfalse IL_0bf4
 
-			IL_0b8d: ldloc.0
-			IL_0b8e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0b93: stloc.s 22
-			IL_0b95: ldloc.0
-			IL_0b96: ldc.i4.m1
-			IL_0b97: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0b9c: ldloc.0
-			IL_0b9d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ba2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0ba7: ldarg.0
-			IL_0ba8: ldc.i4.1
-			IL_0ba9: newarr [System.Runtime]System.Object
-			IL_0bae: dup
-			IL_0baf: ldc.i4.0
-			IL_0bb0: ldloc.s 22
-			IL_0bb2: stelem.ref
-			IL_0bb3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0bb8: pop
-			IL_0bb9: ldloc.0
-			IL_0bba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bbf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bc4: ret
+			IL_0bbc: ldloc.0
+			IL_0bbd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0bc2: stloc.s 23
+			IL_0bc4: ldloc.0
+			IL_0bc5: ldc.i4.m1
+			IL_0bc6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0bcb: ldloc.0
+			IL_0bcc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bd1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0bd6: ldarg.0
+			IL_0bd7: ldc.i4.1
+			IL_0bd8: newarr [System.Runtime]System.Object
+			IL_0bdd: dup
+			IL_0bde: ldc.i4.0
+			IL_0bdf: ldloc.s 23
+			IL_0be1: stelem.ref
+			IL_0be2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0be7: pop
+			IL_0be8: ldloc.0
+			IL_0be9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bee: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0bf3: ret
 
-			IL_0bc5: ldloc.0
-			IL_0bc6: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0bcb: stloc.s 12
-			IL_0bcd: ldloc.s 12
-			IL_0bcf: brfalse IL_0c0c
+			IL_0bf4: ldloc.0
+			IL_0bf5: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0bfa: stloc.s 12
+			IL_0bfc: ldloc.s 12
+			IL_0bfe: brfalse IL_0c3b
 
-			IL_0bd4: ldloc.0
-			IL_0bd5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0bda: stloc.s 22
-			IL_0bdc: ldloc.0
-			IL_0bdd: ldc.i4.m1
-			IL_0bde: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0be3: ldloc.0
-			IL_0be4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0be9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0bee: ldarg.0
-			IL_0bef: ldc.i4.1
-			IL_0bf0: newarr [System.Runtime]System.Object
-			IL_0bf5: dup
-			IL_0bf6: ldc.i4.0
-			IL_0bf7: ldloc.s 22
-			IL_0bf9: stelem.ref
-			IL_0bfa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0bff: pop
-			IL_0c00: ldloc.0
-			IL_0c01: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c06: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c0b: ret
+			IL_0c03: ldloc.0
+			IL_0c04: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0c09: stloc.s 23
+			IL_0c0b: ldloc.0
+			IL_0c0c: ldc.i4.m1
+			IL_0c0d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c12: ldloc.0
+			IL_0c13: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c18: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0c1d: ldarg.0
+			IL_0c1e: ldc.i4.1
+			IL_0c1f: newarr [System.Runtime]System.Object
+			IL_0c24: dup
+			IL_0c25: ldc.i4.0
+			IL_0c26: ldloc.s 23
+			IL_0c28: stelem.ref
+			IL_0c29: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c2e: pop
+			IL_0c2f: ldloc.0
+			IL_0c30: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c35: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c3a: ret
 
-			IL_0c0c: ldloc.0
-			IL_0c0d: ldc.i4.m1
-			IL_0c0e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c13: ldloc.0
-			IL_0c14: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c19: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0c1e: ldarg.0
-			IL_0c1f: ldc.i4.1
-			IL_0c20: newarr [System.Runtime]System.Object
-			IL_0c25: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c2a: pop
-			IL_0c2b: ldloc.0
-			IL_0c2c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c31: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c36: ret
+			IL_0c3b: ldloc.0
+			IL_0c3c: ldc.i4.m1
+			IL_0c3d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c42: ldloc.0
+			IL_0c43: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c48: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0c4d: ldarg.0
+			IL_0c4e: ldc.i4.1
+			IL_0c4f: newarr [System.Runtime]System.Object
+			IL_0c54: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c59: pop
+			IL_0c5a: ldloc.0
+			IL_0c5b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c60: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c65: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1642,7 +1672,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2d33
+			// Method begins at RVA 0x2d62
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1743,7 +1773,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2d60
+		// Method begins at RVA 0x2d8f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_Read_Write_Close.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_Read_Write_Close.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a1d
+					// Method begins at RVA 0x2a40
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a26
+					// Method begins at RVA 0x2a49
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a2f
+					// Method begins at RVA 0x2a52
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -113,7 +113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a14
+				// Method begins at RVA 0x2a37
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -139,7 +139,7 @@
 			)
 			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 2319 (0x90f)
+			// Code size: 2354 (0x932)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope,
@@ -164,8 +164,9 @@
 				[19] object,
 				[20] bool,
 				[21] object,
-				[22] object,
-				[23] object
+				[22] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+				[23] object,
+				[24] object
 			)
 
 			IL_0000: ldarg.0
@@ -198,14 +199,14 @@
 			IL_0042: brtrue IL_0054
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.s 23
+			IL_0048: ldc.i4.s 24
 			IL_004a: newarr [System.Runtime]System.Object
 			IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0054: ldloc.0
 			IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_005a: ldc.i4.0
-			IL_005b: ble IL_0121
+			IL_005b: ble IL_012c
 
 			IL_0060: ldloc.0
 			IL_0061: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -308,897 +309,918 @@
 			IL_0114: dup
 			IL_0115: ldc.i4.s 21
 			IL_0117: ldelem.ref
-			IL_0118: stloc.s 22
-			IL_011a: dup
-			IL_011b: ldc.i4.s 22
-			IL_011d: ldelem.ref
-			IL_011e: stloc.s 23
-			IL_0120: pop
+			IL_0118: castclass [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
+			IL_011d: stloc.s 22
+			IL_011f: dup
+			IL_0120: ldc.i4.s 22
+			IL_0122: ldelem.ref
+			IL_0123: stloc.s 23
+			IL_0125: dup
+			IL_0126: ldc.i4.s 23
+			IL_0128: ldelem.ref
+			IL_0129: stloc.s 24
+			IL_012b: pop
 
-			IL_0121: ldloc.0
-			IL_0122: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0127: switch (IL_014c, IL_07ff, IL_0843, IL_0780, IL_0357, IL_044e, IL_058b, IL_066b)
+			IL_012c: ldloc.0
+			IL_012d: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0132: switch (IL_0157, IL_0822, IL_0866, IL_07a3, IL_0368, IL_0465, IL_05a8, IL_068e)
 
-			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-			IL_0151: stloc.s 10
-			IL_0153: ldloc.s 10
-			IL_0155: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_015a: stloc.s 11
-			IL_015c: ldstr ""
-			IL_0161: ldloc.s 11
-			IL_0163: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0168: ldstr "-"
-			IL_016d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0172: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-			IL_0177: stloc.s 12
-			IL_0179: ldloc.s 12
-			IL_017b: ldc.r8 1000000000
-			IL_0184: mul
-			IL_0185: stloc.s 12
-			IL_0187: ldloc.s 12
-			IL_0189: box [System.Runtime]System.Double
-			IL_018e: stloc.s 13
-			IL_0190: ldloc.s 13
-			IL_0192: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-			IL_0197: stloc.s 12
-			IL_0199: ldloc.s 12
-			IL_019b: box [System.Runtime]System.Double
-			IL_01a0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01a5: stloc.s 11
-			IL_01a7: ldloc.s 11
-			IL_01a9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ae: stloc.1
-			IL_01af: ldarg.0
-			IL_01b0: ldc.i4.1
-			IL_01b1: ldelem.ref
-			IL_01b2: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_01b7: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Open_Read_Write_Close/Scope::path
-			IL_01bc: stloc.s 14
-			IL_01be: ldarg.0
-			IL_01bf: ldc.i4.1
-			IL_01c0: ldelem.ref
-			IL_01c1: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_01c6: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Open_Read_Write_Close/Scope::os
-			IL_01cb: stloc.s 15
-			IL_01cd: ldloc.s 15
-			IL_01cf: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
-			IL_01d4: stloc.s 10
-			IL_01d6: ldloc.1
-			IL_01d7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01dc: stloc.s 11
-			IL_01de: ldstr "jroc-fs-open-"
-			IL_01e3: ldloc.s 11
-			IL_01e5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ea: ldstr ".txt"
-			IL_01ef: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01f4: stloc.s 11
-			IL_01f6: ldloc.s 14
-			IL_01f8: ldc.i4.2
-			IL_01f9: newarr [System.Runtime]System.Object
-			IL_01fe: dup
-			IL_01ff: ldc.i4.0
-			IL_0200: ldloc.s 10
-			IL_0202: stelem.ref
-			IL_0203: dup
-			IL_0204: ldc.i4.1
-			IL_0205: ldloc.s 11
-			IL_0207: stelem.ref
-			IL_0208: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_020d: stloc.2
-			IL_020e: ldloc.0
-			IL_020f: ldc.i4.0
-			IL_0210: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0215: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_021a: ldloc.0
-			IL_021b: ldc.i4.0
-			IL_021c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0221: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0226: ldloc.0
-			IL_0227: ldc.i4.0
-			IL_0228: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_022d: ldloc.0
-			IL_022e: ldc.i4.0
-			IL_022f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0234: ldarg.0
-			IL_0235: ldc.i4.1
-			IL_0236: ldelem.ref
-			IL_0237: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_023c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_0241: stloc.s 16
-			IL_0243: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0248: dup
-			IL_0249: ldstr "force"
-			IL_024e: ldc.i4.1
-			IL_024f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0254: stloc.s 17
-			IL_0256: ldloc.s 16
-			IL_0258: ldloc.2
-			IL_0259: ldloc.s 17
-			IL_025b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0260: ldarg.0
-			IL_0261: ldc.i4.1
-			IL_0262: ldelem.ref
-			IL_0263: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_0268: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_026d: stloc.s 16
-			IL_026f: ldloc.s 16
-			IL_0271: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
-			IL_0276: stloc.s 10
-			IL_0278: ldloc.s 10
-			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027f: stloc.s 10
-			IL_0281: ldloc.s 10
-			IL_0283: ldstr "open"
-			IL_0288: ldloc.2
-			IL_0289: ldstr "w+"
-			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0293: stloc.s 10
-			IL_0295: ldloc.0
-			IL_0296: ldc.i4.4
-			IL_0297: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_029c: ldloc.0
-			IL_029d: ldloc.s 10
-			IL_029f: ldarg.0
-			IL_02a0: ldc.i4.1
-			IL_02a1: ldloc.0
-			IL_02a2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02a7: ldc.i4.3
-			IL_02a8: ldstr "_pendingException"
-			IL_02ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_02b2: ldloc.0
-			IL_02b3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02b8: dup
-			IL_02b9: ldc.i4.0
-			IL_02ba: ldloc.1
-			IL_02bb: stelem.ref
-			IL_02bc: dup
-			IL_02bd: ldc.i4.1
-			IL_02be: ldloc.2
-			IL_02bf: stelem.ref
-			IL_02c0: dup
-			IL_02c1: ldc.i4.2
-			IL_02c2: ldloc.3
-			IL_02c3: stelem.ref
-			IL_02c4: dup
-			IL_02c5: ldc.i4.3
-			IL_02c6: ldloc.s 4
-			IL_02c8: stelem.ref
-			IL_02c9: dup
-			IL_02ca: ldc.i4.4
-			IL_02cb: ldloc.s 5
-			IL_02cd: stelem.ref
-			IL_02ce: dup
-			IL_02cf: ldc.i4.5
-			IL_02d0: ldloc.s 6
-			IL_02d2: stelem.ref
-			IL_02d3: dup
-			IL_02d4: ldc.i4.6
-			IL_02d5: ldloc.s 7
-			IL_02d7: stelem.ref
-			IL_02d8: dup
-			IL_02d9: ldc.i4.7
-			IL_02da: ldloc.s 8
-			IL_02dc: box [System.Runtime]System.Boolean
-			IL_02e1: stelem.ref
-			IL_02e2: dup
-			IL_02e3: ldc.i4.8
-			IL_02e4: ldloc.s 9
-			IL_02e6: box [System.Runtime]System.Boolean
-			IL_02eb: stelem.ref
-			IL_02ec: dup
-			IL_02ed: ldc.i4.s 9
-			IL_02ef: ldloc.s 10
-			IL_02f1: stelem.ref
-			IL_02f2: dup
-			IL_02f3: ldc.i4.s 10
-			IL_02f5: ldloc.s 11
-			IL_02f7: stelem.ref
-			IL_02f8: dup
-			IL_02f9: ldc.i4.s 11
-			IL_02fb: ldloc.s 12
-			IL_02fd: box [System.Runtime]System.Double
+			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
+			IL_015c: stloc.s 10
+			IL_015e: ldloc.s 10
+			IL_0160: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0165: stloc.s 11
+			IL_0167: ldstr ""
+			IL_016c: ldloc.s 11
+			IL_016e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0173: ldstr "-"
+			IL_0178: call string [System.Runtime]System.String::Concat(string, string)
+			IL_017d: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+			IL_0182: stloc.s 12
+			IL_0184: ldloc.s 12
+			IL_0186: ldc.r8 1000000000
+			IL_018f: mul
+			IL_0190: stloc.s 12
+			IL_0192: ldloc.s 12
+			IL_0194: box [System.Runtime]System.Double
+			IL_0199: stloc.s 13
+			IL_019b: ldloc.s 13
+			IL_019d: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+			IL_01a2: stloc.s 12
+			IL_01a4: ldloc.s 12
+			IL_01a6: box [System.Runtime]System.Double
+			IL_01ab: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01b0: stloc.s 11
+			IL_01b2: ldloc.s 11
+			IL_01b4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01b9: stloc.1
+			IL_01ba: ldarg.0
+			IL_01bb: ldc.i4.1
+			IL_01bc: ldelem.ref
+			IL_01bd: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_01c2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Open_Read_Write_Close/Scope::path
+			IL_01c7: stloc.s 14
+			IL_01c9: ldarg.0
+			IL_01ca: ldc.i4.1
+			IL_01cb: ldelem.ref
+			IL_01cc: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_01d1: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Open_Read_Write_Close/Scope::os
+			IL_01d6: stloc.s 15
+			IL_01d8: ldloc.s 15
+			IL_01da: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
+			IL_01df: stloc.s 10
+			IL_01e1: ldloc.1
+			IL_01e2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01e7: stloc.s 11
+			IL_01e9: ldstr "jroc-fs-open-"
+			IL_01ee: ldloc.s 11
+			IL_01f0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f5: ldstr ".txt"
+			IL_01fa: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ff: stloc.s 11
+			IL_0201: ldloc.s 14
+			IL_0203: ldc.i4.2
+			IL_0204: newarr [System.Runtime]System.Object
+			IL_0209: dup
+			IL_020a: ldc.i4.0
+			IL_020b: ldloc.s 10
+			IL_020d: stelem.ref
+			IL_020e: dup
+			IL_020f: ldc.i4.1
+			IL_0210: ldloc.s 11
+			IL_0212: stelem.ref
+			IL_0213: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0218: stloc.2
+			IL_0219: ldloc.0
+			IL_021a: ldc.i4.0
+			IL_021b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0220: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0225: ldloc.0
+			IL_0226: ldc.i4.0
+			IL_0227: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_022c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0231: ldloc.0
+			IL_0232: ldc.i4.0
+			IL_0233: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0238: ldloc.0
+			IL_0239: ldc.i4.0
+			IL_023a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_023f: ldarg.0
+			IL_0240: ldc.i4.1
+			IL_0241: ldelem.ref
+			IL_0242: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_0247: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_024c: stloc.s 16
+			IL_024e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0253: dup
+			IL_0254: ldstr "force"
+			IL_0259: ldc.i4.1
+			IL_025a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_025f: stloc.s 17
+			IL_0261: ldloc.s 16
+			IL_0263: ldloc.2
+			IL_0264: ldloc.s 17
+			IL_0266: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_026b: ldarg.0
+			IL_026c: ldc.i4.1
+			IL_026d: ldelem.ref
+			IL_026e: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_0273: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_0278: stloc.s 16
+			IL_027a: ldloc.s 16
+			IL_027c: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
+			IL_0281: stloc.s 10
+			IL_0283: ldloc.s 10
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_028a: stloc.s 10
+			IL_028c: ldloc.s 10
+			IL_028e: ldstr "open"
+			IL_0293: ldloc.2
+			IL_0294: ldstr "w+"
+			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_029e: stloc.s 10
+			IL_02a0: ldloc.0
+			IL_02a1: ldc.i4.4
+			IL_02a2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02a7: ldloc.0
+			IL_02a8: ldloc.s 10
+			IL_02aa: ldarg.0
+			IL_02ab: ldc.i4.1
+			IL_02ac: ldloc.0
+			IL_02ad: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02b2: ldc.i4.3
+			IL_02b3: ldstr "_pendingException"
+			IL_02b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_02bd: ldloc.0
+			IL_02be: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02c3: dup
+			IL_02c4: ldc.i4.0
+			IL_02c5: ldloc.1
+			IL_02c6: stelem.ref
+			IL_02c7: dup
+			IL_02c8: ldc.i4.1
+			IL_02c9: ldloc.2
+			IL_02ca: stelem.ref
+			IL_02cb: dup
+			IL_02cc: ldc.i4.2
+			IL_02cd: ldloc.3
+			IL_02ce: stelem.ref
+			IL_02cf: dup
+			IL_02d0: ldc.i4.3
+			IL_02d1: ldloc.s 4
+			IL_02d3: stelem.ref
+			IL_02d4: dup
+			IL_02d5: ldc.i4.4
+			IL_02d6: ldloc.s 5
+			IL_02d8: stelem.ref
+			IL_02d9: dup
+			IL_02da: ldc.i4.5
+			IL_02db: ldloc.s 6
+			IL_02dd: stelem.ref
+			IL_02de: dup
+			IL_02df: ldc.i4.6
+			IL_02e0: ldloc.s 7
+			IL_02e2: stelem.ref
+			IL_02e3: dup
+			IL_02e4: ldc.i4.7
+			IL_02e5: ldloc.s 8
+			IL_02e7: box [System.Runtime]System.Boolean
+			IL_02ec: stelem.ref
+			IL_02ed: dup
+			IL_02ee: ldc.i4.8
+			IL_02ef: ldloc.s 9
+			IL_02f1: box [System.Runtime]System.Boolean
+			IL_02f6: stelem.ref
+			IL_02f7: dup
+			IL_02f8: ldc.i4.s 9
+			IL_02fa: ldloc.s 10
+			IL_02fc: stelem.ref
+			IL_02fd: dup
+			IL_02fe: ldc.i4.s 10
+			IL_0300: ldloc.s 11
 			IL_0302: stelem.ref
 			IL_0303: dup
-			IL_0304: ldc.i4.s 12
-			IL_0306: ldloc.s 13
-			IL_0308: stelem.ref
-			IL_0309: dup
-			IL_030a: ldc.i4.s 13
-			IL_030c: ldloc.s 14
-			IL_030e: stelem.ref
-			IL_030f: dup
-			IL_0310: ldc.i4.s 14
-			IL_0312: ldloc.s 15
-			IL_0314: stelem.ref
-			IL_0315: dup
-			IL_0316: ldc.i4.s 15
-			IL_0318: ldloc.s 16
-			IL_031a: stelem.ref
-			IL_031b: dup
-			IL_031c: ldc.i4.s 16
-			IL_031e: ldloc.s 17
-			IL_0320: stelem.ref
-			IL_0321: dup
-			IL_0322: ldc.i4.s 17
-			IL_0324: ldloc.s 18
-			IL_0326: stelem.ref
-			IL_0327: dup
-			IL_0328: ldc.i4.s 18
-			IL_032a: ldloc.s 19
-			IL_032c: stelem.ref
-			IL_032d: dup
-			IL_032e: ldc.i4.s 19
-			IL_0330: ldloc.s 20
-			IL_0332: box [System.Runtime]System.Boolean
+			IL_0304: ldc.i4.s 11
+			IL_0306: ldloc.s 12
+			IL_0308: box [System.Runtime]System.Double
+			IL_030d: stelem.ref
+			IL_030e: dup
+			IL_030f: ldc.i4.s 12
+			IL_0311: ldloc.s 13
+			IL_0313: stelem.ref
+			IL_0314: dup
+			IL_0315: ldc.i4.s 13
+			IL_0317: ldloc.s 14
+			IL_0319: stelem.ref
+			IL_031a: dup
+			IL_031b: ldc.i4.s 14
+			IL_031d: ldloc.s 15
+			IL_031f: stelem.ref
+			IL_0320: dup
+			IL_0321: ldc.i4.s 15
+			IL_0323: ldloc.s 16
+			IL_0325: stelem.ref
+			IL_0326: dup
+			IL_0327: ldc.i4.s 16
+			IL_0329: ldloc.s 17
+			IL_032b: stelem.ref
+			IL_032c: dup
+			IL_032d: ldc.i4.s 17
+			IL_032f: ldloc.s 18
+			IL_0331: stelem.ref
+			IL_0332: dup
+			IL_0333: ldc.i4.s 18
+			IL_0335: ldloc.s 19
 			IL_0337: stelem.ref
 			IL_0338: dup
-			IL_0339: ldc.i4.s 20
-			IL_033b: ldloc.s 21
-			IL_033d: stelem.ref
-			IL_033e: dup
-			IL_033f: ldc.i4.s 21
-			IL_0341: ldloc.s 22
-			IL_0343: stelem.ref
-			IL_0344: dup
-			IL_0345: ldc.i4.s 22
-			IL_0347: ldloc.s 23
-			IL_0349: stelem.ref
-			IL_034a: pop
-			IL_034b: ldloc.0
-			IL_034c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0351: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0356: ret
+			IL_0339: ldc.i4.s 19
+			IL_033b: ldloc.s 20
+			IL_033d: box [System.Runtime]System.Boolean
+			IL_0342: stelem.ref
+			IL_0343: dup
+			IL_0344: ldc.i4.s 20
+			IL_0346: ldloc.s 21
+			IL_0348: stelem.ref
+			IL_0349: dup
+			IL_034a: ldc.i4.s 21
+			IL_034c: ldloc.s 22
+			IL_034e: stelem.ref
+			IL_034f: dup
+			IL_0350: ldc.i4.s 22
+			IL_0352: ldloc.s 23
+			IL_0354: stelem.ref
+			IL_0355: dup
+			IL_0356: ldc.i4.s 23
+			IL_0358: ldloc.s 24
+			IL_035a: stelem.ref
+			IL_035b: pop
+			IL_035c: ldloc.0
+			IL_035d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0362: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0367: ret
 
-			IL_0357: ldloc.0
-			IL_0358: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited1
-			IL_035d: stloc.3
-			IL_035e: ldloc.3
-			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0364: stloc.s 10
-			IL_0366: ldloc.s 10
-			IL_0368: ldstr "write"
-			IL_036d: ldstr "hello"
-			IL_0372: ldc.r8 0.0
-			IL_037b: box [System.Runtime]System.Double
-			IL_0380: ldstr "utf8"
-			IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_038a: stloc.s 10
-			IL_038c: ldloc.0
-			IL_038d: ldc.i4.5
-			IL_038e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0393: ldloc.0
-			IL_0394: ldloc.s 10
-			IL_0396: ldarg.0
-			IL_0397: ldc.i4.2
-			IL_0398: ldloc.0
-			IL_0399: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_039e: ldc.i4.3
-			IL_039f: ldstr "_pendingException"
-			IL_03a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0368: ldloc.0
+			IL_0369: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited1
+			IL_036e: stloc.3
+			IL_036f: ldloc.3
+			IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0375: stloc.s 10
+			IL_0377: ldloc.s 10
+			IL_0379: ldstr "write"
+			IL_037e: ldstr "hello"
+			IL_0383: ldc.r8 0.0
+			IL_038c: box [System.Runtime]System.Double
+			IL_0391: ldstr "utf8"
+			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_039b: stloc.s 10
+			IL_039d: ldloc.0
+			IL_039e: ldc.i4.5
+			IL_039f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03a4: ldloc.0
+			IL_03a5: ldloc.s 10
+			IL_03a7: ldarg.0
+			IL_03a8: ldc.i4.2
 			IL_03a9: ldloc.0
-			IL_03aa: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03af: dup
-			IL_03b0: ldc.i4.0
-			IL_03b1: ldloc.1
-			IL_03b2: stelem.ref
-			IL_03b3: dup
-			IL_03b4: ldc.i4.1
-			IL_03b5: ldloc.2
-			IL_03b6: stelem.ref
-			IL_03b7: dup
-			IL_03b8: ldc.i4.2
-			IL_03b9: ldloc.3
-			IL_03ba: stelem.ref
-			IL_03bb: dup
-			IL_03bc: ldc.i4.3
-			IL_03bd: ldloc.s 4
-			IL_03bf: stelem.ref
+			IL_03aa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03af: ldc.i4.3
+			IL_03b0: ldstr "_pendingException"
+			IL_03b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_03ba: ldloc.0
+			IL_03bb: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_03c0: dup
-			IL_03c1: ldc.i4.4
-			IL_03c2: ldloc.s 5
-			IL_03c4: stelem.ref
-			IL_03c5: dup
-			IL_03c6: ldc.i4.5
-			IL_03c7: ldloc.s 6
-			IL_03c9: stelem.ref
-			IL_03ca: dup
-			IL_03cb: ldc.i4.6
-			IL_03cc: ldloc.s 7
-			IL_03ce: stelem.ref
-			IL_03cf: dup
-			IL_03d0: ldc.i4.7
-			IL_03d1: ldloc.s 8
-			IL_03d3: box [System.Runtime]System.Boolean
-			IL_03d8: stelem.ref
-			IL_03d9: dup
-			IL_03da: ldc.i4.8
-			IL_03db: ldloc.s 9
-			IL_03dd: box [System.Runtime]System.Boolean
-			IL_03e2: stelem.ref
-			IL_03e3: dup
-			IL_03e4: ldc.i4.s 9
-			IL_03e6: ldloc.s 10
-			IL_03e8: stelem.ref
-			IL_03e9: dup
-			IL_03ea: ldc.i4.s 10
-			IL_03ec: ldloc.s 11
-			IL_03ee: stelem.ref
-			IL_03ef: dup
-			IL_03f0: ldc.i4.s 11
-			IL_03f2: ldloc.s 12
-			IL_03f4: box [System.Runtime]System.Double
+			IL_03c1: ldc.i4.0
+			IL_03c2: ldloc.1
+			IL_03c3: stelem.ref
+			IL_03c4: dup
+			IL_03c5: ldc.i4.1
+			IL_03c6: ldloc.2
+			IL_03c7: stelem.ref
+			IL_03c8: dup
+			IL_03c9: ldc.i4.2
+			IL_03ca: ldloc.3
+			IL_03cb: stelem.ref
+			IL_03cc: dup
+			IL_03cd: ldc.i4.3
+			IL_03ce: ldloc.s 4
+			IL_03d0: stelem.ref
+			IL_03d1: dup
+			IL_03d2: ldc.i4.4
+			IL_03d3: ldloc.s 5
+			IL_03d5: stelem.ref
+			IL_03d6: dup
+			IL_03d7: ldc.i4.5
+			IL_03d8: ldloc.s 6
+			IL_03da: stelem.ref
+			IL_03db: dup
+			IL_03dc: ldc.i4.6
+			IL_03dd: ldloc.s 7
+			IL_03df: stelem.ref
+			IL_03e0: dup
+			IL_03e1: ldc.i4.7
+			IL_03e2: ldloc.s 8
+			IL_03e4: box [System.Runtime]System.Boolean
+			IL_03e9: stelem.ref
+			IL_03ea: dup
+			IL_03eb: ldc.i4.8
+			IL_03ec: ldloc.s 9
+			IL_03ee: box [System.Runtime]System.Boolean
+			IL_03f3: stelem.ref
+			IL_03f4: dup
+			IL_03f5: ldc.i4.s 9
+			IL_03f7: ldloc.s 10
 			IL_03f9: stelem.ref
 			IL_03fa: dup
-			IL_03fb: ldc.i4.s 12
-			IL_03fd: ldloc.s 13
+			IL_03fb: ldc.i4.s 10
+			IL_03fd: ldloc.s 11
 			IL_03ff: stelem.ref
 			IL_0400: dup
-			IL_0401: ldc.i4.s 13
-			IL_0403: ldloc.s 14
-			IL_0405: stelem.ref
-			IL_0406: dup
-			IL_0407: ldc.i4.s 14
-			IL_0409: ldloc.s 15
-			IL_040b: stelem.ref
-			IL_040c: dup
-			IL_040d: ldc.i4.s 15
-			IL_040f: ldloc.s 16
-			IL_0411: stelem.ref
-			IL_0412: dup
-			IL_0413: ldc.i4.s 16
-			IL_0415: ldloc.s 17
-			IL_0417: stelem.ref
-			IL_0418: dup
-			IL_0419: ldc.i4.s 17
-			IL_041b: ldloc.s 18
-			IL_041d: stelem.ref
-			IL_041e: dup
-			IL_041f: ldc.i4.s 18
-			IL_0421: ldloc.s 19
-			IL_0423: stelem.ref
-			IL_0424: dup
-			IL_0425: ldc.i4.s 19
-			IL_0427: ldloc.s 20
-			IL_0429: box [System.Runtime]System.Boolean
+			IL_0401: ldc.i4.s 11
+			IL_0403: ldloc.s 12
+			IL_0405: box [System.Runtime]System.Double
+			IL_040a: stelem.ref
+			IL_040b: dup
+			IL_040c: ldc.i4.s 12
+			IL_040e: ldloc.s 13
+			IL_0410: stelem.ref
+			IL_0411: dup
+			IL_0412: ldc.i4.s 13
+			IL_0414: ldloc.s 14
+			IL_0416: stelem.ref
+			IL_0417: dup
+			IL_0418: ldc.i4.s 14
+			IL_041a: ldloc.s 15
+			IL_041c: stelem.ref
+			IL_041d: dup
+			IL_041e: ldc.i4.s 15
+			IL_0420: ldloc.s 16
+			IL_0422: stelem.ref
+			IL_0423: dup
+			IL_0424: ldc.i4.s 16
+			IL_0426: ldloc.s 17
+			IL_0428: stelem.ref
+			IL_0429: dup
+			IL_042a: ldc.i4.s 17
+			IL_042c: ldloc.s 18
 			IL_042e: stelem.ref
 			IL_042f: dup
-			IL_0430: ldc.i4.s 20
-			IL_0432: ldloc.s 21
+			IL_0430: ldc.i4.s 18
+			IL_0432: ldloc.s 19
 			IL_0434: stelem.ref
 			IL_0435: dup
-			IL_0436: ldc.i4.s 21
-			IL_0438: ldloc.s 22
-			IL_043a: stelem.ref
-			IL_043b: dup
-			IL_043c: ldc.i4.s 22
-			IL_043e: ldloc.s 23
-			IL_0440: stelem.ref
-			IL_0441: pop
-			IL_0442: ldloc.0
-			IL_0443: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0448: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_044d: ret
+			IL_0436: ldc.i4.s 19
+			IL_0438: ldloc.s 20
+			IL_043a: box [System.Runtime]System.Boolean
+			IL_043f: stelem.ref
+			IL_0440: dup
+			IL_0441: ldc.i4.s 20
+			IL_0443: ldloc.s 21
+			IL_0445: stelem.ref
+			IL_0446: dup
+			IL_0447: ldc.i4.s 21
+			IL_0449: ldloc.s 22
+			IL_044b: stelem.ref
+			IL_044c: dup
+			IL_044d: ldc.i4.s 22
+			IL_044f: ldloc.s 23
+			IL_0451: stelem.ref
+			IL_0452: dup
+			IL_0453: ldc.i4.s 23
+			IL_0455: ldloc.s 24
+			IL_0457: stelem.ref
+			IL_0458: pop
+			IL_0459: ldloc.0
+			IL_045a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_045f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0464: ret
 
-			IL_044e: ldloc.0
-			IL_044f: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited2
-			IL_0454: stloc.s 4
-			IL_0456: ldc.r8 5
-			IL_045f: box [System.Runtime]System.Double
-			IL_0464: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_0469: stloc.s 5
-			IL_046b: ldloc.3
-			IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0471: stloc.s 10
-			IL_0473: ldloc.s 5
-			IL_0475: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_047a: stloc.s 12
-			IL_047c: ldloc.s 12
-			IL_047e: box [System.Runtime]System.Double
-			IL_0483: stloc.s 13
-			IL_0485: ldc.i4.4
-			IL_0486: newarr [System.Runtime]System.Object
-			IL_048b: dup
-			IL_048c: ldc.i4.0
-			IL_048d: ldloc.s 5
-			IL_048f: stelem.ref
-			IL_0490: dup
-			IL_0491: ldc.i4.1
-			IL_0492: ldc.r8 0.0
-			IL_049b: box [System.Runtime]System.Double
-			IL_04a0: stelem.ref
-			IL_04a1: dup
-			IL_04a2: ldc.i4.2
-			IL_04a3: ldloc.s 13
-			IL_04a5: stelem.ref
-			IL_04a6: dup
-			IL_04a7: ldc.i4.3
-			IL_04a8: ldc.r8 0.0
-			IL_04b1: box [System.Runtime]System.Double
-			IL_04b6: stelem.ref
-			IL_04b7: stloc.s 18
-			IL_04b9: ldloc.s 10
-			IL_04bb: ldstr "read"
-			IL_04c0: ldloc.s 18
-			IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_04c7: stloc.s 10
-			IL_04c9: ldloc.0
-			IL_04ca: ldc.i4.6
-			IL_04cb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04d0: ldloc.0
-			IL_04d1: ldloc.s 10
-			IL_04d3: ldarg.0
-			IL_04d4: ldc.i4.3
-			IL_04d5: ldloc.0
-			IL_04d6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_04db: ldc.i4.3
-			IL_04dc: ldstr "_pendingException"
-			IL_04e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_04e6: ldloc.0
-			IL_04e7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_04ec: dup
-			IL_04ed: ldc.i4.0
-			IL_04ee: ldloc.1
-			IL_04ef: stelem.ref
-			IL_04f0: dup
-			IL_04f1: ldc.i4.1
-			IL_04f2: ldloc.2
-			IL_04f3: stelem.ref
-			IL_04f4: dup
-			IL_04f5: ldc.i4.2
-			IL_04f6: ldloc.3
-			IL_04f7: stelem.ref
-			IL_04f8: dup
-			IL_04f9: ldc.i4.3
-			IL_04fa: ldloc.s 4
-			IL_04fc: stelem.ref
-			IL_04fd: dup
-			IL_04fe: ldc.i4.4
-			IL_04ff: ldloc.s 5
-			IL_0501: stelem.ref
-			IL_0502: dup
-			IL_0503: ldc.i4.5
-			IL_0504: ldloc.s 6
+			IL_0465: ldloc.0
+			IL_0466: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited2
+			IL_046b: stloc.s 4
+			IL_046d: ldc.r8 5
+			IL_0476: box [System.Runtime]System.Double
+			IL_047b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_0480: stloc.s 5
+			IL_0482: ldloc.3
+			IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0488: stloc.s 10
+			IL_048a: ldloc.s 5
+			IL_048c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_0491: stloc.s 12
+			IL_0493: ldloc.s 12
+			IL_0495: box [System.Runtime]System.Double
+			IL_049a: stloc.s 13
+			IL_049c: ldc.i4.4
+			IL_049d: newarr [System.Runtime]System.Object
+			IL_04a2: dup
+			IL_04a3: ldc.i4.0
+			IL_04a4: ldloc.s 5
+			IL_04a6: stelem.ref
+			IL_04a7: dup
+			IL_04a8: ldc.i4.1
+			IL_04a9: ldc.r8 0.0
+			IL_04b2: box [System.Runtime]System.Double
+			IL_04b7: stelem.ref
+			IL_04b8: dup
+			IL_04b9: ldc.i4.2
+			IL_04ba: ldloc.s 13
+			IL_04bc: stelem.ref
+			IL_04bd: dup
+			IL_04be: ldc.i4.3
+			IL_04bf: ldc.r8 0.0
+			IL_04c8: box [System.Runtime]System.Double
+			IL_04cd: stelem.ref
+			IL_04ce: stloc.s 18
+			IL_04d0: ldloc.s 10
+			IL_04d2: ldstr "read"
+			IL_04d7: ldloc.s 18
+			IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_04de: stloc.s 10
+			IL_04e0: ldloc.0
+			IL_04e1: ldc.i4.6
+			IL_04e2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04e7: ldloc.0
+			IL_04e8: ldloc.s 10
+			IL_04ea: ldarg.0
+			IL_04eb: ldc.i4.3
+			IL_04ec: ldloc.0
+			IL_04ed: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04f2: ldc.i4.3
+			IL_04f3: ldstr "_pendingException"
+			IL_04f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_04fd: ldloc.0
+			IL_04fe: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0503: dup
+			IL_0504: ldc.i4.0
+			IL_0505: ldloc.1
 			IL_0506: stelem.ref
 			IL_0507: dup
-			IL_0508: ldc.i4.6
-			IL_0509: ldloc.s 7
-			IL_050b: stelem.ref
-			IL_050c: dup
-			IL_050d: ldc.i4.7
-			IL_050e: ldloc.s 8
-			IL_0510: box [System.Runtime]System.Boolean
-			IL_0515: stelem.ref
-			IL_0516: dup
-			IL_0517: ldc.i4.8
-			IL_0518: ldloc.s 9
-			IL_051a: box [System.Runtime]System.Boolean
-			IL_051f: stelem.ref
-			IL_0520: dup
-			IL_0521: ldc.i4.s 9
-			IL_0523: ldloc.s 10
-			IL_0525: stelem.ref
-			IL_0526: dup
-			IL_0527: ldc.i4.s 10
-			IL_0529: ldloc.s 11
-			IL_052b: stelem.ref
-			IL_052c: dup
-			IL_052d: ldc.i4.s 11
-			IL_052f: ldloc.s 12
-			IL_0531: box [System.Runtime]System.Double
+			IL_0508: ldc.i4.1
+			IL_0509: ldloc.2
+			IL_050a: stelem.ref
+			IL_050b: dup
+			IL_050c: ldc.i4.2
+			IL_050d: ldloc.3
+			IL_050e: stelem.ref
+			IL_050f: dup
+			IL_0510: ldc.i4.3
+			IL_0511: ldloc.s 4
+			IL_0513: stelem.ref
+			IL_0514: dup
+			IL_0515: ldc.i4.4
+			IL_0516: ldloc.s 5
+			IL_0518: stelem.ref
+			IL_0519: dup
+			IL_051a: ldc.i4.5
+			IL_051b: ldloc.s 6
+			IL_051d: stelem.ref
+			IL_051e: dup
+			IL_051f: ldc.i4.6
+			IL_0520: ldloc.s 7
+			IL_0522: stelem.ref
+			IL_0523: dup
+			IL_0524: ldc.i4.7
+			IL_0525: ldloc.s 8
+			IL_0527: box [System.Runtime]System.Boolean
+			IL_052c: stelem.ref
+			IL_052d: dup
+			IL_052e: ldc.i4.8
+			IL_052f: ldloc.s 9
+			IL_0531: box [System.Runtime]System.Boolean
 			IL_0536: stelem.ref
 			IL_0537: dup
-			IL_0538: ldc.i4.s 12
-			IL_053a: ldloc.s 13
+			IL_0538: ldc.i4.s 9
+			IL_053a: ldloc.s 10
 			IL_053c: stelem.ref
 			IL_053d: dup
-			IL_053e: ldc.i4.s 13
-			IL_0540: ldloc.s 14
+			IL_053e: ldc.i4.s 10
+			IL_0540: ldloc.s 11
 			IL_0542: stelem.ref
 			IL_0543: dup
-			IL_0544: ldc.i4.s 14
-			IL_0546: ldloc.s 15
-			IL_0548: stelem.ref
-			IL_0549: dup
-			IL_054a: ldc.i4.s 15
-			IL_054c: ldloc.s 16
-			IL_054e: stelem.ref
-			IL_054f: dup
-			IL_0550: ldc.i4.s 16
-			IL_0552: ldloc.s 17
-			IL_0554: stelem.ref
-			IL_0555: dup
-			IL_0556: ldc.i4.s 17
-			IL_0558: ldloc.s 18
-			IL_055a: stelem.ref
-			IL_055b: dup
-			IL_055c: ldc.i4.s 18
-			IL_055e: ldloc.s 19
-			IL_0560: stelem.ref
-			IL_0561: dup
-			IL_0562: ldc.i4.s 19
-			IL_0564: ldloc.s 20
-			IL_0566: box [System.Runtime]System.Boolean
+			IL_0544: ldc.i4.s 11
+			IL_0546: ldloc.s 12
+			IL_0548: box [System.Runtime]System.Double
+			IL_054d: stelem.ref
+			IL_054e: dup
+			IL_054f: ldc.i4.s 12
+			IL_0551: ldloc.s 13
+			IL_0553: stelem.ref
+			IL_0554: dup
+			IL_0555: ldc.i4.s 13
+			IL_0557: ldloc.s 14
+			IL_0559: stelem.ref
+			IL_055a: dup
+			IL_055b: ldc.i4.s 14
+			IL_055d: ldloc.s 15
+			IL_055f: stelem.ref
+			IL_0560: dup
+			IL_0561: ldc.i4.s 15
+			IL_0563: ldloc.s 16
+			IL_0565: stelem.ref
+			IL_0566: dup
+			IL_0567: ldc.i4.s 16
+			IL_0569: ldloc.s 17
 			IL_056b: stelem.ref
 			IL_056c: dup
-			IL_056d: ldc.i4.s 20
-			IL_056f: ldloc.s 21
+			IL_056d: ldc.i4.s 17
+			IL_056f: ldloc.s 18
 			IL_0571: stelem.ref
 			IL_0572: dup
-			IL_0573: ldc.i4.s 21
-			IL_0575: ldloc.s 22
+			IL_0573: ldc.i4.s 18
+			IL_0575: ldloc.s 19
 			IL_0577: stelem.ref
 			IL_0578: dup
-			IL_0579: ldc.i4.s 22
-			IL_057b: ldloc.s 23
-			IL_057d: stelem.ref
-			IL_057e: pop
-			IL_057f: ldloc.0
-			IL_0580: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0585: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_058a: ret
+			IL_0579: ldc.i4.s 19
+			IL_057b: ldloc.s 20
+			IL_057d: box [System.Runtime]System.Boolean
+			IL_0582: stelem.ref
+			IL_0583: dup
+			IL_0584: ldc.i4.s 20
+			IL_0586: ldloc.s 21
+			IL_0588: stelem.ref
+			IL_0589: dup
+			IL_058a: ldc.i4.s 21
+			IL_058c: ldloc.s 22
+			IL_058e: stelem.ref
+			IL_058f: dup
+			IL_0590: ldc.i4.s 22
+			IL_0592: ldloc.s 23
+			IL_0594: stelem.ref
+			IL_0595: dup
+			IL_0596: ldc.i4.s 23
+			IL_0598: ldloc.s 24
+			IL_059a: stelem.ref
+			IL_059b: pop
+			IL_059c: ldloc.0
+			IL_059d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05a2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05a7: ret
 
-			IL_058b: ldloc.0
-			IL_058c: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited3
-			IL_0591: stloc.s 6
-			IL_0593: ldloc.3
-			IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0599: stloc.s 10
-			IL_059b: ldloc.s 10
-			IL_059d: ldstr "close"
-			IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_05a7: stloc.s 10
-			IL_05a9: ldloc.0
-			IL_05aa: ldc.i4.7
-			IL_05ab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05b0: ldloc.0
-			IL_05b1: ldloc.s 10
-			IL_05b3: ldarg.0
-			IL_05b4: ldc.i4.4
-			IL_05b5: ldloc.0
-			IL_05b6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05bb: ldc.i4.3
-			IL_05bc: ldstr "_pendingException"
-			IL_05c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_05a8: ldloc.0
+			IL_05a9: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited3
+			IL_05ae: stloc.s 6
+			IL_05b0: ldloc.3
+			IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05b6: stloc.s 10
+			IL_05b8: ldloc.s 10
+			IL_05ba: ldstr "close"
+			IL_05bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_05c4: stloc.s 10
 			IL_05c6: ldloc.0
-			IL_05c7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05cc: dup
-			IL_05cd: ldc.i4.0
-			IL_05ce: ldloc.1
-			IL_05cf: stelem.ref
-			IL_05d0: dup
-			IL_05d1: ldc.i4.1
-			IL_05d2: ldloc.2
-			IL_05d3: stelem.ref
-			IL_05d4: dup
-			IL_05d5: ldc.i4.2
-			IL_05d6: ldloc.3
-			IL_05d7: stelem.ref
-			IL_05d8: dup
-			IL_05d9: ldc.i4.3
-			IL_05da: ldloc.s 4
-			IL_05dc: stelem.ref
-			IL_05dd: dup
-			IL_05de: ldc.i4.4
-			IL_05df: ldloc.s 5
-			IL_05e1: stelem.ref
-			IL_05e2: dup
-			IL_05e3: ldc.i4.5
-			IL_05e4: ldloc.s 6
-			IL_05e6: stelem.ref
-			IL_05e7: dup
-			IL_05e8: ldc.i4.6
-			IL_05e9: ldloc.s 7
-			IL_05eb: stelem.ref
-			IL_05ec: dup
-			IL_05ed: ldc.i4.7
-			IL_05ee: ldloc.s 8
-			IL_05f0: box [System.Runtime]System.Boolean
-			IL_05f5: stelem.ref
-			IL_05f6: dup
-			IL_05f7: ldc.i4.8
-			IL_05f8: ldloc.s 9
-			IL_05fa: box [System.Runtime]System.Boolean
-			IL_05ff: stelem.ref
-			IL_0600: dup
-			IL_0601: ldc.i4.s 9
-			IL_0603: ldloc.s 10
-			IL_0605: stelem.ref
-			IL_0606: dup
-			IL_0607: ldc.i4.s 10
-			IL_0609: ldloc.s 11
-			IL_060b: stelem.ref
-			IL_060c: dup
-			IL_060d: ldc.i4.s 11
-			IL_060f: ldloc.s 12
-			IL_0611: box [System.Runtime]System.Double
-			IL_0616: stelem.ref
-			IL_0617: dup
-			IL_0618: ldc.i4.s 12
-			IL_061a: ldloc.s 13
+			IL_05c7: ldc.i4.7
+			IL_05c8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05cd: ldloc.0
+			IL_05ce: ldloc.s 10
+			IL_05d0: ldarg.0
+			IL_05d1: ldc.i4.4
+			IL_05d2: ldloc.0
+			IL_05d3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05d8: ldc.i4.3
+			IL_05d9: ldstr "_pendingException"
+			IL_05de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_05e3: ldloc.0
+			IL_05e4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05e9: dup
+			IL_05ea: ldc.i4.0
+			IL_05eb: ldloc.1
+			IL_05ec: stelem.ref
+			IL_05ed: dup
+			IL_05ee: ldc.i4.1
+			IL_05ef: ldloc.2
+			IL_05f0: stelem.ref
+			IL_05f1: dup
+			IL_05f2: ldc.i4.2
+			IL_05f3: ldloc.3
+			IL_05f4: stelem.ref
+			IL_05f5: dup
+			IL_05f6: ldc.i4.3
+			IL_05f7: ldloc.s 4
+			IL_05f9: stelem.ref
+			IL_05fa: dup
+			IL_05fb: ldc.i4.4
+			IL_05fc: ldloc.s 5
+			IL_05fe: stelem.ref
+			IL_05ff: dup
+			IL_0600: ldc.i4.5
+			IL_0601: ldloc.s 6
+			IL_0603: stelem.ref
+			IL_0604: dup
+			IL_0605: ldc.i4.6
+			IL_0606: ldloc.s 7
+			IL_0608: stelem.ref
+			IL_0609: dup
+			IL_060a: ldc.i4.7
+			IL_060b: ldloc.s 8
+			IL_060d: box [System.Runtime]System.Boolean
+			IL_0612: stelem.ref
+			IL_0613: dup
+			IL_0614: ldc.i4.8
+			IL_0615: ldloc.s 9
+			IL_0617: box [System.Runtime]System.Boolean
 			IL_061c: stelem.ref
 			IL_061d: dup
-			IL_061e: ldc.i4.s 13
-			IL_0620: ldloc.s 14
+			IL_061e: ldc.i4.s 9
+			IL_0620: ldloc.s 10
 			IL_0622: stelem.ref
 			IL_0623: dup
-			IL_0624: ldc.i4.s 14
-			IL_0626: ldloc.s 15
+			IL_0624: ldc.i4.s 10
+			IL_0626: ldloc.s 11
 			IL_0628: stelem.ref
 			IL_0629: dup
-			IL_062a: ldc.i4.s 15
-			IL_062c: ldloc.s 16
-			IL_062e: stelem.ref
-			IL_062f: dup
-			IL_0630: ldc.i4.s 16
-			IL_0632: ldloc.s 17
-			IL_0634: stelem.ref
-			IL_0635: dup
-			IL_0636: ldc.i4.s 17
-			IL_0638: ldloc.s 18
-			IL_063a: stelem.ref
-			IL_063b: dup
-			IL_063c: ldc.i4.s 18
-			IL_063e: ldloc.s 19
-			IL_0640: stelem.ref
-			IL_0641: dup
-			IL_0642: ldc.i4.s 19
-			IL_0644: ldloc.s 20
-			IL_0646: box [System.Runtime]System.Boolean
+			IL_062a: ldc.i4.s 11
+			IL_062c: ldloc.s 12
+			IL_062e: box [System.Runtime]System.Double
+			IL_0633: stelem.ref
+			IL_0634: dup
+			IL_0635: ldc.i4.s 12
+			IL_0637: ldloc.s 13
+			IL_0639: stelem.ref
+			IL_063a: dup
+			IL_063b: ldc.i4.s 13
+			IL_063d: ldloc.s 14
+			IL_063f: stelem.ref
+			IL_0640: dup
+			IL_0641: ldc.i4.s 14
+			IL_0643: ldloc.s 15
+			IL_0645: stelem.ref
+			IL_0646: dup
+			IL_0647: ldc.i4.s 15
+			IL_0649: ldloc.s 16
 			IL_064b: stelem.ref
 			IL_064c: dup
-			IL_064d: ldc.i4.s 20
-			IL_064f: ldloc.s 21
+			IL_064d: ldc.i4.s 16
+			IL_064f: ldloc.s 17
 			IL_0651: stelem.ref
 			IL_0652: dup
-			IL_0653: ldc.i4.s 21
-			IL_0655: ldloc.s 22
+			IL_0653: ldc.i4.s 17
+			IL_0655: ldloc.s 18
 			IL_0657: stelem.ref
 			IL_0658: dup
-			IL_0659: ldc.i4.s 22
-			IL_065b: ldloc.s 23
+			IL_0659: ldc.i4.s 18
+			IL_065b: ldloc.s 19
 			IL_065d: stelem.ref
-			IL_065e: pop
-			IL_065f: ldloc.0
-			IL_0660: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0665: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_066a: ret
+			IL_065e: dup
+			IL_065f: ldc.i4.s 19
+			IL_0661: ldloc.s 20
+			IL_0663: box [System.Runtime]System.Boolean
+			IL_0668: stelem.ref
+			IL_0669: dup
+			IL_066a: ldc.i4.s 20
+			IL_066c: ldloc.s 21
+			IL_066e: stelem.ref
+			IL_066f: dup
+			IL_0670: ldc.i4.s 21
+			IL_0672: ldloc.s 22
+			IL_0674: stelem.ref
+			IL_0675: dup
+			IL_0676: ldc.i4.s 22
+			IL_0678: ldloc.s 23
+			IL_067a: stelem.ref
+			IL_067b: dup
+			IL_067c: ldc.i4.s 23
+			IL_067e: ldloc.s 24
+			IL_0680: stelem.ref
+			IL_0681: pop
+			IL_0682: ldloc.0
+			IL_0683: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0688: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_068d: ret
 
-			IL_066b: ldloc.0
-			IL_066c: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited4
-			IL_0671: pop
-			IL_0672: ldstr "console"
-			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_067c: stloc.s 10
-			IL_067e: ldloc.s 10
-			IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0685: stloc.s 10
-			IL_0687: ldloc.3
-			IL_0688: ldstr "fd"
-			IL_068d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0692: stloc.s 19
-			IL_0694: ldloc.s 19
-			IL_0696: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_069b: stloc.s 11
-			IL_069d: ldloc.s 11
-			IL_069f: ldstr "number"
-			IL_06a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_06a9: stloc.s 20
-			IL_06ab: ldloc.s 20
-			IL_06ad: box [System.Runtime]System.Boolean
-			IL_06b2: stloc.s 21
-			IL_06b4: ldloc.s 10
-			IL_06b6: ldstr "log"
-			IL_06bb: ldstr "FDIsNumber:"
-			IL_06c0: ldloc.s 21
-			IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_06c7: pop
-			IL_06c8: ldstr "console"
-			IL_06cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06d2: stloc.s 10
-			IL_06d4: ldloc.s 10
-			IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06db: stloc.s 10
-			IL_06dd: ldloc.s 4
-			IL_06df: ldstr "bytesWritten"
-			IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06e9: stloc.s 19
-			IL_06eb: ldloc.s 10
-			IL_06ed: ldstr "log"
-			IL_06f2: ldstr "BytesWritten:"
-			IL_06f7: ldloc.s 19
-			IL_06f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_06fe: pop
-			IL_06ff: ldstr "console"
-			IL_0704: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0709: stloc.s 19
-			IL_070b: ldloc.s 19
-			IL_070d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0712: stloc.s 19
-			IL_0714: ldloc.s 6
-			IL_0716: ldstr "bytesRead"
-			IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0720: stloc.s 10
-			IL_0722: ldloc.s 19
-			IL_0724: ldstr "log"
-			IL_0729: ldstr "BytesRead:"
-			IL_072e: ldloc.s 10
-			IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0735: pop
-			IL_0736: ldstr "console"
-			IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0740: stloc.s 10
-			IL_0742: ldloc.s 10
-			IL_0744: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0749: stloc.s 10
-			IL_074b: ldloc.s 5
-			IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0752: stloc.s 19
-			IL_0754: ldloc.s 19
-			IL_0756: ldstr "toString"
-			IL_075b: ldstr "utf8"
-			IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0765: stloc.s 19
-			IL_0767: ldloc.s 10
-			IL_0769: ldstr "log"
-			IL_076e: ldstr "BufferText:"
-			IL_0773: ldloc.s 19
-			IL_0775: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_077a: pop
-			IL_077b: br IL_0812
+			IL_068e: ldloc.0
+			IL_068f: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited4
+			IL_0694: pop
+			IL_0695: ldstr "console"
+			IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_069f: stloc.s 10
+			IL_06a1: ldloc.s 10
+			IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06a8: stloc.s 10
+			IL_06aa: ldloc.3
+			IL_06ab: ldstr "fd"
+			IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06b5: stloc.s 19
+			IL_06b7: ldloc.s 19
+			IL_06b9: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_06be: stloc.s 11
+			IL_06c0: ldloc.s 11
+			IL_06c2: ldstr "number"
+			IL_06c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_06cc: stloc.s 20
+			IL_06ce: ldloc.s 20
+			IL_06d0: box [System.Runtime]System.Boolean
+			IL_06d5: stloc.s 21
+			IL_06d7: ldloc.s 10
+			IL_06d9: ldstr "log"
+			IL_06de: ldstr "FDIsNumber:"
+			IL_06e3: ldloc.s 21
+			IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_06ea: pop
+			IL_06eb: ldstr "console"
+			IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06f5: stloc.s 10
+			IL_06f7: ldloc.s 10
+			IL_06f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06fe: stloc.s 10
+			IL_0700: ldloc.s 4
+			IL_0702: ldstr "bytesWritten"
+			IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_070c: stloc.s 19
+			IL_070e: ldloc.s 10
+			IL_0710: ldstr "log"
+			IL_0715: ldstr "BytesWritten:"
+			IL_071a: ldloc.s 19
+			IL_071c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0721: pop
+			IL_0722: ldstr "console"
+			IL_0727: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_072c: stloc.s 19
+			IL_072e: ldloc.s 19
+			IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0735: stloc.s 19
+			IL_0737: ldloc.s 6
+			IL_0739: ldstr "bytesRead"
+			IL_073e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0743: stloc.s 10
+			IL_0745: ldloc.s 19
+			IL_0747: ldstr "log"
+			IL_074c: ldstr "BytesRead:"
+			IL_0751: ldloc.s 10
+			IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0758: pop
+			IL_0759: ldstr "console"
+			IL_075e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0763: stloc.s 10
+			IL_0765: ldloc.s 10
+			IL_0767: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_076c: stloc.s 10
+			IL_076e: ldloc.s 5
+			IL_0770: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_0775: stloc.s 22
+			IL_0777: ldloc.s 22
+			IL_0779: ldstr "toString"
+			IL_077e: ldstr "utf8"
+			IL_0783: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0788: stloc.s 19
+			IL_078a: ldloc.s 10
+			IL_078c: ldstr "log"
+			IL_0791: ldstr "BufferText:"
+			IL_0796: ldloc.s 19
+			IL_0798: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_079d: pop
+			IL_079e: br IL_0835
 
-			IL_0780: ldloc.0
-			IL_0781: ldc.i4.1
-			IL_0782: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0787: ldloc.0
-			IL_0788: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_078d: stloc.s 19
-			IL_078f: ldloc.0
-			IL_0790: ldc.i4.0
-			IL_0791: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0796: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_079b: ldloc.0
-			IL_079c: ldc.i4.0
-			IL_079d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_07a2: ldloc.s 19
-			IL_07a4: stloc.s 7
-			IL_07a6: ldstr "console"
-			IL_07ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07a3: ldloc.0
+			IL_07a4: ldc.i4.1
+			IL_07a5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_07aa: ldloc.0
+			IL_07ab: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
 			IL_07b0: stloc.s 19
-			IL_07b2: ldloc.s 19
-			IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07b9: stloc.s 19
-			IL_07bb: ldloc.s 7
-			IL_07bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_07c2: stloc.s 20
-			IL_07c4: ldloc.s 20
-			IL_07c6: brfalse IL_07e2
+			IL_07b2: ldloc.0
+			IL_07b3: ldc.i4.0
+			IL_07b4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_07b9: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_07be: ldloc.0
+			IL_07bf: ldc.i4.0
+			IL_07c0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_07c5: ldloc.s 19
+			IL_07c7: stloc.s 7
+			IL_07c9: ldstr "console"
+			IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07d3: stloc.s 19
+			IL_07d5: ldloc.s 19
+			IL_07d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07dc: stloc.s 19
+			IL_07de: ldloc.s 7
+			IL_07e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_07e5: stloc.s 20
+			IL_07e7: ldloc.s 20
+			IL_07e9: brfalse IL_0805
 
-			IL_07cb: ldloc.s 7
-			IL_07cd: ldstr "message"
-			IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07d7: stloc.s 10
-			IL_07d9: ldloc.s 10
-			IL_07db: stloc.s 23
-			IL_07dd: br IL_07e6
+			IL_07ee: ldloc.s 7
+			IL_07f0: ldstr "message"
+			IL_07f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07fa: stloc.s 10
+			IL_07fc: ldloc.s 10
+			IL_07fe: stloc.s 24
+			IL_0800: br IL_0809
 
-			IL_07e2: ldloc.s 7
-			IL_07e4: stloc.s 23
+			IL_0805: ldloc.s 7
+			IL_0807: stloc.s 24
 
-			IL_07e6: ldloc.s 19
-			IL_07e8: ldstr "log"
-			IL_07ed: ldstr "Error:"
-			IL_07f2: ldloc.s 23
-			IL_07f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_07f9: pop
-			IL_07fa: br IL_0812
+			IL_0809: ldloc.s 19
+			IL_080b: ldstr "log"
+			IL_0810: ldstr "Error:"
+			IL_0815: ldloc.s 24
+			IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_081c: pop
+			IL_081d: br IL_0835
 
-			IL_07ff: ldloc.0
-			IL_0800: ldc.i4.1
-			IL_0801: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0806: ldloc.0
-			IL_0807: ldc.i4.0
-			IL_0808: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_080d: br IL_0812
+			IL_0822: ldloc.0
+			IL_0823: ldc.i4.1
+			IL_0824: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0829: ldloc.0
+			IL_082a: ldc.i4.0
+			IL_082b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0830: br IL_0835
 
-			IL_0812: ldarg.0
-			IL_0813: ldc.i4.1
-			IL_0814: ldelem.ref
-			IL_0815: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_081a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_081f: stloc.s 16
-			IL_0821: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0826: dup
-			IL_0827: ldstr "force"
-			IL_082c: ldc.i4.1
-			IL_082d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0832: stloc.s 17
-			IL_0834: ldloc.s 16
-			IL_0836: ldloc.2
-			IL_0837: ldloc.s 17
-			IL_0839: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_083e: br IL_0856
+			IL_0835: ldarg.0
+			IL_0836: ldc.i4.1
+			IL_0837: ldelem.ref
+			IL_0838: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_083d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_0842: stloc.s 16
+			IL_0844: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0849: dup
+			IL_084a: ldstr "force"
+			IL_084f: ldc.i4.1
+			IL_0850: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0855: stloc.s 17
+			IL_0857: ldloc.s 16
+			IL_0859: ldloc.2
+			IL_085a: ldloc.s 17
+			IL_085c: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0861: br IL_0879
 
-			IL_0843: ldloc.0
-			IL_0844: ldc.i4.1
-			IL_0845: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_084a: ldloc.0
-			IL_084b: ldc.i4.0
-			IL_084c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0851: br IL_0856
-
-			IL_0856: ldloc.0
-			IL_0857: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_085c: stloc.s 8
-			IL_085e: ldloc.s 8
-			IL_0860: brfalse IL_089d
-
-			IL_0865: ldloc.0
-			IL_0866: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_086b: stloc.s 19
+			IL_0866: ldloc.0
+			IL_0867: ldc.i4.1
+			IL_0868: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
 			IL_086d: ldloc.0
-			IL_086e: ldc.i4.m1
-			IL_086f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0874: ldloc.0
-			IL_0875: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_087a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_087f: ldarg.0
-			IL_0880: ldc.i4.1
-			IL_0881: newarr [System.Runtime]System.Object
-			IL_0886: dup
-			IL_0887: ldc.i4.0
-			IL_0888: ldloc.s 19
-			IL_088a: stelem.ref
-			IL_088b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0890: pop
-			IL_0891: ldloc.0
-			IL_0892: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0897: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_089c: ret
+			IL_086e: ldc.i4.0
+			IL_086f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0874: br IL_0879
 
-			IL_089d: ldloc.0
-			IL_089e: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_08a3: stloc.s 9
-			IL_08a5: ldloc.s 9
-			IL_08a7: brfalse IL_08e4
+			IL_0879: ldloc.0
+			IL_087a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_087f: stloc.s 8
+			IL_0881: ldloc.s 8
+			IL_0883: brfalse IL_08c0
 
-			IL_08ac: ldloc.0
-			IL_08ad: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_08b2: stloc.s 19
+			IL_0888: ldloc.0
+			IL_0889: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_088e: stloc.s 19
+			IL_0890: ldloc.0
+			IL_0891: ldc.i4.m1
+			IL_0892: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0897: ldloc.0
+			IL_0898: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_089d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_08a2: ldarg.0
+			IL_08a3: ldc.i4.1
+			IL_08a4: newarr [System.Runtime]System.Object
+			IL_08a9: dup
+			IL_08aa: ldc.i4.0
+			IL_08ab: ldloc.s 19
+			IL_08ad: stelem.ref
+			IL_08ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_08b3: pop
 			IL_08b4: ldloc.0
-			IL_08b5: ldc.i4.m1
-			IL_08b6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08bb: ldloc.0
-			IL_08bc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_08c6: ldarg.0
-			IL_08c7: ldc.i4.1
-			IL_08c8: newarr [System.Runtime]System.Object
-			IL_08cd: dup
-			IL_08ce: ldc.i4.0
-			IL_08cf: ldloc.s 19
-			IL_08d1: stelem.ref
-			IL_08d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_08d7: pop
-			IL_08d8: ldloc.0
-			IL_08d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08de: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08e3: ret
+			IL_08b5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08ba: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08bf: ret
 
-			IL_08e4: ldloc.0
-			IL_08e5: ldc.i4.m1
-			IL_08e6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08eb: ldloc.0
-			IL_08ec: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_08f6: ldarg.0
-			IL_08f7: ldc.i4.1
-			IL_08f8: newarr [System.Runtime]System.Object
-			IL_08fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0902: pop
-			IL_0903: ldloc.0
-			IL_0904: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0909: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_090e: ret
+			IL_08c0: ldloc.0
+			IL_08c1: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_08c6: stloc.s 9
+			IL_08c8: ldloc.s 9
+			IL_08ca: brfalse IL_0907
+
+			IL_08cf: ldloc.0
+			IL_08d0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_08d5: stloc.s 19
+			IL_08d7: ldloc.0
+			IL_08d8: ldc.i4.m1
+			IL_08d9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08de: ldloc.0
+			IL_08df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_08e9: ldarg.0
+			IL_08ea: ldc.i4.1
+			IL_08eb: newarr [System.Runtime]System.Object
+			IL_08f0: dup
+			IL_08f1: ldc.i4.0
+			IL_08f2: ldloc.s 19
+			IL_08f4: stelem.ref
+			IL_08f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_08fa: pop
+			IL_08fb: ldloc.0
+			IL_08fc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0901: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0906: ret
+
+			IL_0907: ldloc.0
+			IL_0908: ldc.i4.m1
+			IL_0909: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_090e: ldloc.0
+			IL_090f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0914: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0919: ldarg.0
+			IL_091a: ldc.i4.1
+			IL_091b: newarr [System.Runtime]System.Object
+			IL_0920: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0925: pop
+			IL_0926: ldloc.0
+			IL_0927: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_092c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0931: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1220,7 +1242,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a0b
+			// Method begins at RVA 0x2a2e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1321,7 +1343,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a38
+		// Method begins at RVA 0x2a5b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_MissingDir_Rejects.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_MissingDir_Rejects.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f9
+				// Method begins at RVA 0x21f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -77,7 +77,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2202
+				// Method begins at RVA 0x21fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,7 +103,7 @@
 			)
 			// Method begins at RVA 0x2190
 			// Header size: 12
-			// Code size: 84 (0x54)
+			// Code size: 79 (0x4f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -124,22 +124,21 @@
 			IL_001d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0022: stloc.2
 			IL_0023: ldloc.2
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0029: stloc.1
-			IL_002a: ldloc.1
-			IL_002b: castclass [System.Runtime]System.String
-			IL_0030: ldstr "ENOENT:"
-			IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-			IL_003a: stloc.3
-			IL_003b: ldloc.0
-			IL_003c: ldstr "log"
-			IL_0041: ldstr "Is ENOENT:"
-			IL_0046: ldloc.3
-			IL_0047: box [System.Runtime]System.Boolean
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0051: pop
-			IL_0052: ldnull
-			IL_0053: ret
+			IL_0024: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0029: stloc.2
+			IL_002a: ldloc.2
+			IL_002b: ldstr "ENOENT:"
+			IL_0030: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+			IL_0035: stloc.3
+			IL_0036: ldloc.0
+			IL_0037: ldstr "log"
+			IL_003c: ldstr "Is ENOENT:"
+			IL_0041: ldloc.3
+			IL_0042: box [System.Runtime]System.Boolean
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_004c: pop
+			IL_004d: ldnull
+			IL_004e: ret
 		} // end of method ArrowFunction_L12C12::__js_call__
 
 	} // end of class ArrowFunction_L12C12
@@ -151,7 +150,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21f0
+			// Method begins at RVA 0x21eb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -301,7 +300,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220b
+		// Method begins at RVA 0x2206
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Rename_ExistingDirectory_Rejects.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Rename_ExistingDirectory_Rejects.verified.txt
@@ -41,7 +41,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2822
+						// Method begins at RVA 0x2811
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -61,7 +61,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x282b
+						// Method begins at RVA 0x281a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -79,7 +79,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2819
+					// Method begins at RVA 0x2808
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -99,7 +99,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2834
+					// Method begins at RVA 0x2823
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -127,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2810
+				// Method begins at RVA 0x27ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -153,7 +153,7 @@
 			)
 			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 1803 (0x70b)
+			// Code size: 1786 (0x6fa)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope,
@@ -174,11 +174,10 @@
 				[15] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 				[16] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[17] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[18] object,
-				[19] bool,
+				[18] bool,
+				[19] object,
 				[20] object,
-				[21] object,
-				[22] object
+				[21] object
 			)
 
 			IL_0000: ldarg.0
@@ -211,14 +210,14 @@
 			IL_0042: brtrue IL_0054
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.s 22
+			IL_0048: ldc.i4.s 21
 			IL_004a: newarr [System.Runtime]System.Object
 			IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0054: ldloc.0
 			IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_005a: ldc.i4.0
-			IL_005b: ble IL_0116
+			IL_005b: ble IL_0110
 
 			IL_0060: ldloc.0
 			IL_0061: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -303,11 +302,11 @@
 			IL_00f2: dup
 			IL_00f3: ldc.i4.s 17
 			IL_00f5: ldelem.ref
-			IL_00f6: stloc.s 18
-			IL_00f8: dup
-			IL_00f9: ldc.i4.s 18
-			IL_00fb: ldelem.ref
-			IL_00fc: unbox.any [System.Runtime]System.Boolean
+			IL_00f6: unbox.any [System.Runtime]System.Boolean
+			IL_00fb: stloc.s 18
+			IL_00fd: dup
+			IL_00fe: ldc.i4.s 18
+			IL_0100: ldelem.ref
 			IL_0101: stloc.s 19
 			IL_0103: dup
 			IL_0104: ldc.i4.s 19
@@ -317,601 +316,592 @@
 			IL_010a: ldc.i4.s 20
 			IL_010c: ldelem.ref
 			IL_010d: stloc.s 21
-			IL_010f: dup
-			IL_0110: ldc.i4.s 21
-			IL_0112: ldelem.ref
-			IL_0113: stloc.s 22
-			IL_0115: pop
+			IL_010f: pop
 
-			IL_0116: ldloc.0
-			IL_0117: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_011c: switch (IL_0135, IL_05ef, IL_063f, IL_0478, IL_0440)
+			IL_0110: ldloc.0
+			IL_0111: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0116: switch (IL_012f, IL_05de, IL_062e, IL_046c, IL_0434)
 
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-			IL_013a: stloc.s 9
-			IL_013c: ldloc.s 9
-			IL_013e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0143: stloc.s 10
-			IL_0145: ldstr ""
-			IL_014a: ldloc.s 10
-			IL_014c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0151: ldstr "-"
-			IL_0156: call string [System.Runtime]System.String::Concat(string, string)
-			IL_015b: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-			IL_0160: stloc.s 11
-			IL_0162: ldloc.s 11
-			IL_0164: ldc.r8 1000000000
-			IL_016d: mul
-			IL_016e: stloc.s 11
-			IL_0170: ldloc.s 11
-			IL_0172: box [System.Runtime]System.Double
-			IL_0177: stloc.s 12
-			IL_0179: ldloc.s 12
-			IL_017b: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-			IL_0180: stloc.s 11
-			IL_0182: ldloc.s 11
-			IL_0184: box [System.Runtime]System.Double
-			IL_0189: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_018e: stloc.s 10
-			IL_0190: ldloc.s 10
-			IL_0192: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0197: stloc.1
-			IL_0198: ldarg.0
-			IL_0199: ldc.i4.1
-			IL_019a: ldelem.ref
-			IL_019b: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_01a0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_01a5: stloc.s 13
-			IL_01a7: ldarg.0
-			IL_01a8: ldc.i4.1
-			IL_01a9: ldelem.ref
-			IL_01aa: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_01af: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
-			IL_01b4: stloc.s 14
-			IL_01b6: ldloc.s 14
-			IL_01b8: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
-			IL_01bd: stloc.s 9
-			IL_01bf: ldloc.1
-			IL_01c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01c5: stloc.s 10
-			IL_01c7: ldstr "jroc-fs-rename-existing-dir-"
-			IL_01cc: ldloc.s 10
-			IL_01ce: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d3: stloc.s 10
-			IL_01d5: ldloc.s 13
-			IL_01d7: ldc.i4.2
-			IL_01d8: newarr [System.Runtime]System.Object
-			IL_01dd: dup
-			IL_01de: ldc.i4.0
-			IL_01df: ldloc.s 9
-			IL_01e1: stelem.ref
-			IL_01e2: dup
-			IL_01e3: ldc.i4.1
-			IL_01e4: ldloc.s 10
-			IL_01e6: stelem.ref
-			IL_01e7: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_01ec: stloc.2
-			IL_01ed: ldarg.0
-			IL_01ee: ldc.i4.1
-			IL_01ef: ldelem.ref
-			IL_01f0: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_01f5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_01fa: stloc.s 13
-			IL_01fc: ldloc.s 13
-			IL_01fe: ldc.i4.2
-			IL_01ff: newarr [System.Runtime]System.Object
-			IL_0204: dup
-			IL_0205: ldc.i4.0
-			IL_0206: ldloc.2
-			IL_0207: stelem.ref
-			IL_0208: dup
-			IL_0209: ldc.i4.1
-			IL_020a: ldstr "source"
-			IL_020f: stelem.ref
-			IL_0210: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0215: stloc.3
-			IL_0216: ldarg.0
-			IL_0217: ldc.i4.1
-			IL_0218: ldelem.ref
-			IL_0219: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_021e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_0223: stloc.s 13
-			IL_0225: ldloc.s 13
-			IL_0227: ldc.i4.2
-			IL_0228: newarr [System.Runtime]System.Object
-			IL_022d: dup
-			IL_022e: ldc.i4.0
-			IL_022f: ldloc.2
-			IL_0230: stelem.ref
-			IL_0231: dup
-			IL_0232: ldc.i4.1
-			IL_0233: ldstr "destination"
-			IL_0238: stelem.ref
-			IL_0239: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_023e: stloc.s 4
-			IL_0240: ldarg.0
-			IL_0241: ldc.i4.1
-			IL_0242: ldelem.ref
-			IL_0243: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0248: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_024d: stloc.s 13
-			IL_024f: ldloc.s 13
-			IL_0251: ldc.i4.2
-			IL_0252: newarr [System.Runtime]System.Object
-			IL_0257: dup
-			IL_0258: ldc.i4.0
-			IL_0259: ldloc.s 4
-			IL_025b: stelem.ref
-			IL_025c: dup
-			IL_025d: ldc.i4.1
-			IL_025e: ldstr "keep.txt"
-			IL_0263: stelem.ref
-			IL_0264: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0269: stloc.s 5
-			IL_026b: ldloc.0
-			IL_026c: ldc.i4.0
-			IL_026d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0272: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0277: ldloc.0
-			IL_0278: ldc.i4.0
-			IL_0279: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_027e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0283: ldloc.0
-			IL_0284: ldc.i4.0
-			IL_0285: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_028a: ldloc.0
-			IL_028b: ldc.i4.0
-			IL_028c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0291: ldarg.0
-			IL_0292: ldc.i4.1
-			IL_0293: ldelem.ref
-			IL_0294: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0299: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_029e: stloc.s 15
-			IL_02a0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02a5: dup
-			IL_02a6: ldstr "recursive"
-			IL_02ab: ldc.i4.1
-			IL_02ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02b1: dup
-			IL_02b2: ldstr "force"
-			IL_02b7: ldc.i4.1
-			IL_02b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02bd: stloc.s 16
-			IL_02bf: ldloc.s 15
-			IL_02c1: ldloc.2
-			IL_02c2: ldloc.s 16
-			IL_02c4: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_02c9: ldarg.0
-			IL_02ca: ldc.i4.1
-			IL_02cb: ldelem.ref
-			IL_02cc: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_02d1: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_02d6: stloc.s 15
-			IL_02d8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02dd: dup
-			IL_02de: ldstr "recursive"
-			IL_02e3: ldc.i4.1
-			IL_02e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02e9: stloc.s 16
-			IL_02eb: ldloc.s 15
-			IL_02ed: ldloc.3
-			IL_02ee: ldloc.s 16
-			IL_02f0: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
-			IL_02f5: pop
-			IL_02f6: ldarg.0
-			IL_02f7: ldc.i4.1
-			IL_02f8: ldelem.ref
-			IL_02f9: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_02fe: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0303: stloc.s 15
-			IL_0305: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_030a: dup
-			IL_030b: ldstr "recursive"
-			IL_0310: ldc.i4.1
-			IL_0311: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0316: stloc.s 16
-			IL_0318: ldloc.s 15
-			IL_031a: ldloc.s 4
-			IL_031c: ldloc.s 16
-			IL_031e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
-			IL_0323: pop
-			IL_0324: ldarg.0
-			IL_0325: ldc.i4.1
-			IL_0326: ldelem.ref
-			IL_0327: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_032c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0331: stloc.s 15
-			IL_0333: ldloc.s 15
-			IL_0335: ldloc.s 5
-			IL_0337: ldstr "keep"
-			IL_033c: ldstr "utf8"
-			IL_0341: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0346: ldloc.0
-			IL_0347: ldc.i4.0
-			IL_0348: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_034d: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0352: ldarg.0
-			IL_0353: ldc.i4.1
-			IL_0354: ldelem.ref
-			IL_0355: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_035a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_035f: stloc.s 15
-			IL_0361: ldloc.s 15
-			IL_0363: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
-			IL_0368: stloc.s 9
-			IL_036a: ldloc.s 9
-			IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0371: stloc.s 9
-			IL_0373: ldloc.s 9
-			IL_0375: ldstr "rename"
-			IL_037a: ldloc.3
-			IL_037b: ldloc.s 4
-			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0382: stloc.s 9
-			IL_0384: ldloc.0
-			IL_0385: ldc.i4.4
-			IL_0386: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_038b: ldloc.0
-			IL_038c: ldloc.s 9
-			IL_038e: ldarg.0
-			IL_038f: ldc.i4.1
-			IL_0390: ldloc.0
-			IL_0391: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0396: ldc.i4.3
-			IL_0397: ldstr "_pendingException"
-			IL_039c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_03a1: ldloc.0
-			IL_03a2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03a7: dup
-			IL_03a8: ldc.i4.0
-			IL_03a9: ldloc.1
-			IL_03aa: stelem.ref
-			IL_03ab: dup
-			IL_03ac: ldc.i4.1
-			IL_03ad: ldloc.2
-			IL_03ae: stelem.ref
-			IL_03af: dup
-			IL_03b0: ldc.i4.2
-			IL_03b1: ldloc.3
-			IL_03b2: stelem.ref
-			IL_03b3: dup
-			IL_03b4: ldc.i4.3
-			IL_03b5: ldloc.s 4
-			IL_03b7: stelem.ref
-			IL_03b8: dup
-			IL_03b9: ldc.i4.4
-			IL_03ba: ldloc.s 5
-			IL_03bc: stelem.ref
-			IL_03bd: dup
-			IL_03be: ldc.i4.5
-			IL_03bf: ldloc.s 6
-			IL_03c1: stelem.ref
-			IL_03c2: dup
-			IL_03c3: ldc.i4.6
-			IL_03c4: ldloc.s 7
-			IL_03c6: box [System.Runtime]System.Boolean
-			IL_03cb: stelem.ref
-			IL_03cc: dup
-			IL_03cd: ldc.i4.7
-			IL_03ce: ldloc.s 8
-			IL_03d0: box [System.Runtime]System.Boolean
-			IL_03d5: stelem.ref
-			IL_03d6: dup
-			IL_03d7: ldc.i4.8
-			IL_03d8: ldloc.s 9
+			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
+			IL_0134: stloc.s 9
+			IL_0136: ldloc.s 9
+			IL_0138: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_013d: stloc.s 10
+			IL_013f: ldstr ""
+			IL_0144: ldloc.s 10
+			IL_0146: call string [System.Runtime]System.String::Concat(string, string)
+			IL_014b: ldstr "-"
+			IL_0150: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0155: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+			IL_015a: stloc.s 11
+			IL_015c: ldloc.s 11
+			IL_015e: ldc.r8 1000000000
+			IL_0167: mul
+			IL_0168: stloc.s 11
+			IL_016a: ldloc.s 11
+			IL_016c: box [System.Runtime]System.Double
+			IL_0171: stloc.s 12
+			IL_0173: ldloc.s 12
+			IL_0175: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+			IL_017a: stloc.s 11
+			IL_017c: ldloc.s 11
+			IL_017e: box [System.Runtime]System.Double
+			IL_0183: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0188: stloc.s 10
+			IL_018a: ldloc.s 10
+			IL_018c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0191: stloc.1
+			IL_0192: ldarg.0
+			IL_0193: ldc.i4.1
+			IL_0194: ldelem.ref
+			IL_0195: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_019a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_019f: stloc.s 13
+			IL_01a1: ldarg.0
+			IL_01a2: ldc.i4.1
+			IL_01a3: ldelem.ref
+			IL_01a4: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_01a9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
+			IL_01ae: stloc.s 14
+			IL_01b0: ldloc.s 14
+			IL_01b2: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
+			IL_01b7: stloc.s 9
+			IL_01b9: ldloc.1
+			IL_01ba: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01bf: stloc.s 10
+			IL_01c1: ldstr "jroc-fs-rename-existing-dir-"
+			IL_01c6: ldloc.s 10
+			IL_01c8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01cd: stloc.s 10
+			IL_01cf: ldloc.s 13
+			IL_01d1: ldc.i4.2
+			IL_01d2: newarr [System.Runtime]System.Object
+			IL_01d7: dup
+			IL_01d8: ldc.i4.0
+			IL_01d9: ldloc.s 9
+			IL_01db: stelem.ref
+			IL_01dc: dup
+			IL_01dd: ldc.i4.1
+			IL_01de: ldloc.s 10
+			IL_01e0: stelem.ref
+			IL_01e1: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_01e6: stloc.2
+			IL_01e7: ldarg.0
+			IL_01e8: ldc.i4.1
+			IL_01e9: ldelem.ref
+			IL_01ea: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_01ef: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_01f4: stloc.s 13
+			IL_01f6: ldloc.s 13
+			IL_01f8: ldc.i4.2
+			IL_01f9: newarr [System.Runtime]System.Object
+			IL_01fe: dup
+			IL_01ff: ldc.i4.0
+			IL_0200: ldloc.2
+			IL_0201: stelem.ref
+			IL_0202: dup
+			IL_0203: ldc.i4.1
+			IL_0204: ldstr "source"
+			IL_0209: stelem.ref
+			IL_020a: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_020f: stloc.3
+			IL_0210: ldarg.0
+			IL_0211: ldc.i4.1
+			IL_0212: ldelem.ref
+			IL_0213: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0218: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_021d: stloc.s 13
+			IL_021f: ldloc.s 13
+			IL_0221: ldc.i4.2
+			IL_0222: newarr [System.Runtime]System.Object
+			IL_0227: dup
+			IL_0228: ldc.i4.0
+			IL_0229: ldloc.2
+			IL_022a: stelem.ref
+			IL_022b: dup
+			IL_022c: ldc.i4.1
+			IL_022d: ldstr "destination"
+			IL_0232: stelem.ref
+			IL_0233: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0238: stloc.s 4
+			IL_023a: ldarg.0
+			IL_023b: ldc.i4.1
+			IL_023c: ldelem.ref
+			IL_023d: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0242: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_0247: stloc.s 13
+			IL_0249: ldloc.s 13
+			IL_024b: ldc.i4.2
+			IL_024c: newarr [System.Runtime]System.Object
+			IL_0251: dup
+			IL_0252: ldc.i4.0
+			IL_0253: ldloc.s 4
+			IL_0255: stelem.ref
+			IL_0256: dup
+			IL_0257: ldc.i4.1
+			IL_0258: ldstr "keep.txt"
+			IL_025d: stelem.ref
+			IL_025e: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0263: stloc.s 5
+			IL_0265: ldloc.0
+			IL_0266: ldc.i4.0
+			IL_0267: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_026c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0271: ldloc.0
+			IL_0272: ldc.i4.0
+			IL_0273: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0278: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_027d: ldloc.0
+			IL_027e: ldc.i4.0
+			IL_027f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0284: ldloc.0
+			IL_0285: ldc.i4.0
+			IL_0286: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_028b: ldarg.0
+			IL_028c: ldc.i4.1
+			IL_028d: ldelem.ref
+			IL_028e: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0293: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0298: stloc.s 15
+			IL_029a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_029f: dup
+			IL_02a0: ldstr "recursive"
+			IL_02a5: ldc.i4.1
+			IL_02a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02ab: dup
+			IL_02ac: ldstr "force"
+			IL_02b1: ldc.i4.1
+			IL_02b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02b7: stloc.s 16
+			IL_02b9: ldloc.s 15
+			IL_02bb: ldloc.2
+			IL_02bc: ldloc.s 16
+			IL_02be: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_02c3: ldarg.0
+			IL_02c4: ldc.i4.1
+			IL_02c5: ldelem.ref
+			IL_02c6: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_02cb: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_02d0: stloc.s 15
+			IL_02d2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02d7: dup
+			IL_02d8: ldstr "recursive"
+			IL_02dd: ldc.i4.1
+			IL_02de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02e3: stloc.s 16
+			IL_02e5: ldloc.s 15
+			IL_02e7: ldloc.3
+			IL_02e8: ldloc.s 16
+			IL_02ea: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
+			IL_02ef: pop
+			IL_02f0: ldarg.0
+			IL_02f1: ldc.i4.1
+			IL_02f2: ldelem.ref
+			IL_02f3: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_02f8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_02fd: stloc.s 15
+			IL_02ff: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0304: dup
+			IL_0305: ldstr "recursive"
+			IL_030a: ldc.i4.1
+			IL_030b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0310: stloc.s 16
+			IL_0312: ldloc.s 15
+			IL_0314: ldloc.s 4
+			IL_0316: ldloc.s 16
+			IL_0318: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
+			IL_031d: pop
+			IL_031e: ldarg.0
+			IL_031f: ldc.i4.1
+			IL_0320: ldelem.ref
+			IL_0321: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0326: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_032b: stloc.s 15
+			IL_032d: ldloc.s 15
+			IL_032f: ldloc.s 5
+			IL_0331: ldstr "keep"
+			IL_0336: ldstr "utf8"
+			IL_033b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0340: ldloc.0
+			IL_0341: ldc.i4.0
+			IL_0342: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0347: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_034c: ldarg.0
+			IL_034d: ldc.i4.1
+			IL_034e: ldelem.ref
+			IL_034f: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0354: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0359: stloc.s 15
+			IL_035b: ldloc.s 15
+			IL_035d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
+			IL_0362: stloc.s 9
+			IL_0364: ldloc.s 9
+			IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_036b: stloc.s 9
+			IL_036d: ldloc.s 9
+			IL_036f: ldstr "rename"
+			IL_0374: ldloc.3
+			IL_0375: ldloc.s 4
+			IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_037c: stloc.s 9
+			IL_037e: ldloc.0
+			IL_037f: ldc.i4.4
+			IL_0380: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0385: ldloc.0
+			IL_0386: ldloc.s 9
+			IL_0388: ldarg.0
+			IL_0389: ldc.i4.1
+			IL_038a: ldloc.0
+			IL_038b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0390: ldc.i4.3
+			IL_0391: ldstr "_pendingException"
+			IL_0396: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_039b: ldloc.0
+			IL_039c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03a1: dup
+			IL_03a2: ldc.i4.0
+			IL_03a3: ldloc.1
+			IL_03a4: stelem.ref
+			IL_03a5: dup
+			IL_03a6: ldc.i4.1
+			IL_03a7: ldloc.2
+			IL_03a8: stelem.ref
+			IL_03a9: dup
+			IL_03aa: ldc.i4.2
+			IL_03ab: ldloc.3
+			IL_03ac: stelem.ref
+			IL_03ad: dup
+			IL_03ae: ldc.i4.3
+			IL_03af: ldloc.s 4
+			IL_03b1: stelem.ref
+			IL_03b2: dup
+			IL_03b3: ldc.i4.4
+			IL_03b4: ldloc.s 5
+			IL_03b6: stelem.ref
+			IL_03b7: dup
+			IL_03b8: ldc.i4.5
+			IL_03b9: ldloc.s 6
+			IL_03bb: stelem.ref
+			IL_03bc: dup
+			IL_03bd: ldc.i4.6
+			IL_03be: ldloc.s 7
+			IL_03c0: box [System.Runtime]System.Boolean
+			IL_03c5: stelem.ref
+			IL_03c6: dup
+			IL_03c7: ldc.i4.7
+			IL_03c8: ldloc.s 8
+			IL_03ca: box [System.Runtime]System.Boolean
+			IL_03cf: stelem.ref
+			IL_03d0: dup
+			IL_03d1: ldc.i4.8
+			IL_03d2: ldloc.s 9
+			IL_03d4: stelem.ref
+			IL_03d5: dup
+			IL_03d6: ldc.i4.s 9
+			IL_03d8: ldloc.s 10
 			IL_03da: stelem.ref
 			IL_03db: dup
-			IL_03dc: ldc.i4.s 9
-			IL_03de: ldloc.s 10
-			IL_03e0: stelem.ref
-			IL_03e1: dup
-			IL_03e2: ldc.i4.s 10
-			IL_03e4: ldloc.s 11
-			IL_03e6: box [System.Runtime]System.Double
+			IL_03dc: ldc.i4.s 10
+			IL_03de: ldloc.s 11
+			IL_03e0: box [System.Runtime]System.Double
+			IL_03e5: stelem.ref
+			IL_03e6: dup
+			IL_03e7: ldc.i4.s 11
+			IL_03e9: ldloc.s 12
 			IL_03eb: stelem.ref
 			IL_03ec: dup
-			IL_03ed: ldc.i4.s 11
-			IL_03ef: ldloc.s 12
+			IL_03ed: ldc.i4.s 12
+			IL_03ef: ldloc.s 13
 			IL_03f1: stelem.ref
 			IL_03f2: dup
-			IL_03f3: ldc.i4.s 12
-			IL_03f5: ldloc.s 13
+			IL_03f3: ldc.i4.s 13
+			IL_03f5: ldloc.s 14
 			IL_03f7: stelem.ref
 			IL_03f8: dup
-			IL_03f9: ldc.i4.s 13
-			IL_03fb: ldloc.s 14
+			IL_03f9: ldc.i4.s 14
+			IL_03fb: ldloc.s 15
 			IL_03fd: stelem.ref
 			IL_03fe: dup
-			IL_03ff: ldc.i4.s 14
-			IL_0401: ldloc.s 15
+			IL_03ff: ldc.i4.s 15
+			IL_0401: ldloc.s 16
 			IL_0403: stelem.ref
 			IL_0404: dup
-			IL_0405: ldc.i4.s 15
-			IL_0407: ldloc.s 16
+			IL_0405: ldc.i4.s 16
+			IL_0407: ldloc.s 17
 			IL_0409: stelem.ref
 			IL_040a: dup
-			IL_040b: ldc.i4.s 16
-			IL_040d: ldloc.s 17
-			IL_040f: stelem.ref
-			IL_0410: dup
-			IL_0411: ldc.i4.s 17
-			IL_0413: ldloc.s 18
-			IL_0415: stelem.ref
-			IL_0416: dup
-			IL_0417: ldc.i4.s 18
-			IL_0419: ldloc.s 19
-			IL_041b: box [System.Runtime]System.Boolean
+			IL_040b: ldc.i4.s 17
+			IL_040d: ldloc.s 18
+			IL_040f: box [System.Runtime]System.Boolean
+			IL_0414: stelem.ref
+			IL_0415: dup
+			IL_0416: ldc.i4.s 18
+			IL_0418: ldloc.s 19
+			IL_041a: stelem.ref
+			IL_041b: dup
+			IL_041c: ldc.i4.s 19
+			IL_041e: ldloc.s 20
 			IL_0420: stelem.ref
 			IL_0421: dup
-			IL_0422: ldc.i4.s 19
-			IL_0424: ldloc.s 20
+			IL_0422: ldc.i4.s 20
+			IL_0424: ldloc.s 21
 			IL_0426: stelem.ref
-			IL_0427: dup
-			IL_0428: ldc.i4.s 20
-			IL_042a: ldloc.s 21
-			IL_042c: stelem.ref
-			IL_042d: dup
-			IL_042e: ldc.i4.s 21
-			IL_0430: ldloc.s 22
-			IL_0432: stelem.ref
-			IL_0433: pop
+			IL_0427: pop
+			IL_0428: ldloc.0
+			IL_0429: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_042e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0433: ret
+
 			IL_0434: ldloc.0
-			IL_0435: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_043a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_043f: ret
+			IL_0435: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope::_awaited1
+			IL_043a: pop
+			IL_043b: ldstr "console"
+			IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0445: stloc.s 9
+			IL_0447: ldloc.s 9
+			IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_044e: stloc.s 9
+			IL_0450: ldloc.s 9
+			IL_0452: ldstr "log"
+			IL_0457: ldstr "RenameResult:"
+			IL_045c: ldstr "success"
+			IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0466: pop
+			IL_0467: br IL_0502
 
-			IL_0440: ldloc.0
-			IL_0441: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope::_awaited1
-			IL_0446: pop
-			IL_0447: ldstr "console"
-			IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0451: stloc.s 9
-			IL_0453: ldloc.s 9
-			IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_045a: stloc.s 9
-			IL_045c: ldloc.s 9
-			IL_045e: ldstr "log"
-			IL_0463: ldstr "RenameResult:"
-			IL_0468: ldstr "success"
-			IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0472: pop
-			IL_0473: br IL_0513
+			IL_046c: ldloc.0
+			IL_046d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0472: stloc.s 9
+			IL_0474: ldloc.0
+			IL_0475: ldc.i4.0
+			IL_0476: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_047b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0480: ldloc.s 9
+			IL_0482: stloc.s 6
+			IL_0484: ldstr "console"
+			IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_048e: stloc.s 9
+			IL_0490: ldloc.s 9
+			IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0497: stloc.s 9
+			IL_0499: ldstr "^EPERM: "
+			IL_049e: ldstr ""
+			IL_04a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_04a8: stloc.s 17
+			IL_04aa: ldloc.s 17
+			IL_04ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_04b1: stloc.s 17
+			IL_04b3: ldloc.s 6
+			IL_04b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04ba: stloc.s 18
+			IL_04bc: ldloc.s 18
+			IL_04be: brfalse IL_04da
 
-			IL_0478: ldloc.0
-			IL_0479: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_047e: stloc.s 9
-			IL_0480: ldloc.0
-			IL_0481: ldc.i4.0
-			IL_0482: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0487: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_048c: ldloc.s 9
-			IL_048e: stloc.s 6
-			IL_0490: ldstr "console"
-			IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_049a: stloc.s 9
-			IL_049c: ldloc.s 9
-			IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04a3: stloc.s 9
-			IL_04a5: ldstr "^EPERM: "
-			IL_04aa: ldstr ""
-			IL_04af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_04b4: stloc.s 17
-			IL_04b6: ldloc.s 17
-			IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04bd: stloc.s 18
-			IL_04bf: ldloc.s 6
-			IL_04c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04c6: stloc.s 19
-			IL_04c8: ldloc.s 19
-			IL_04ca: brfalse IL_04e6
+			IL_04c3: ldloc.s 6
+			IL_04c5: ldstr "message"
+			IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04cf: stloc.s 19
+			IL_04d1: ldloc.s 19
+			IL_04d3: stloc.s 21
+			IL_04d5: br IL_04de
 
-			IL_04cf: ldloc.s 6
-			IL_04d1: ldstr "message"
-			IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04db: stloc.s 20
-			IL_04dd: ldloc.s 20
-			IL_04df: stloc.s 22
-			IL_04e1: br IL_04ea
+			IL_04da: ldloc.s 6
+			IL_04dc: stloc.s 21
 
-			IL_04e6: ldloc.s 6
-			IL_04e8: stloc.s 22
+			IL_04de: ldloc.s 17
+			IL_04e0: ldloc.s 21
+			IL_04e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_04e7: stloc.s 19
+			IL_04e9: ldloc.s 9
+			IL_04eb: ldstr "log"
+			IL_04f0: ldstr "RenameStartsWithEPERM:"
+			IL_04f5: ldloc.s 19
+			IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_04fc: pop
+			IL_04fd: br IL_0502
 
-			IL_04ea: ldloc.s 18
-			IL_04ec: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-			IL_04f1: ldloc.s 22
-			IL_04f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_04f8: stloc.s 18
-			IL_04fa: ldloc.s 9
-			IL_04fc: ldstr "log"
-			IL_0501: ldstr "RenameStartsWithEPERM:"
-			IL_0506: ldloc.s 18
-			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_050d: pop
-			IL_050e: br IL_0513
+			IL_0502: ldstr "console"
+			IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_050c: stloc.s 19
+			IL_050e: ldloc.s 19
+			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0515: stloc.s 19
+			IL_0517: ldarg.0
+			IL_0518: ldc.i4.1
+			IL_0519: ldelem.ref
+			IL_051a: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_051f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0524: stloc.s 15
+			IL_0526: ldloc.s 15
+			IL_0528: ldloc.3
+			IL_0529: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_052e: box [System.Runtime]System.Boolean
+			IL_0533: stloc.s 9
+			IL_0535: ldloc.s 19
+			IL_0537: ldstr "log"
+			IL_053c: ldstr "SourceExists:"
+			IL_0541: ldloc.s 9
+			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0548: pop
+			IL_0549: ldstr "console"
+			IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0553: stloc.s 9
+			IL_0555: ldloc.s 9
+			IL_0557: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_055c: stloc.s 9
+			IL_055e: ldarg.0
+			IL_055f: ldc.i4.1
+			IL_0560: ldelem.ref
+			IL_0561: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0566: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_056b: stloc.s 15
+			IL_056d: ldloc.s 15
+			IL_056f: ldloc.s 4
+			IL_0571: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_0576: box [System.Runtime]System.Boolean
+			IL_057b: stloc.s 19
+			IL_057d: ldloc.s 9
+			IL_057f: ldstr "log"
+			IL_0584: ldstr "DestinationExists:"
+			IL_0589: ldloc.s 19
+			IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0590: pop
+			IL_0591: ldstr "console"
+			IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_059b: stloc.s 19
+			IL_059d: ldloc.s 19
+			IL_059f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05a4: stloc.s 19
+			IL_05a6: ldarg.0
+			IL_05a7: ldc.i4.1
+			IL_05a8: ldelem.ref
+			IL_05a9: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_05ae: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_05b3: stloc.s 15
+			IL_05b5: ldloc.s 15
+			IL_05b7: ldloc.s 5
+			IL_05b9: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_05be: box [System.Runtime]System.Boolean
+			IL_05c3: stloc.s 9
+			IL_05c5: ldloc.s 19
+			IL_05c7: ldstr "log"
+			IL_05cc: ldstr "SentinelExists:"
+			IL_05d1: ldloc.s 9
+			IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_05d8: pop
+			IL_05d9: br IL_05f1
 
-			IL_0513: ldstr "console"
-			IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_051d: stloc.s 18
-			IL_051f: ldloc.s 18
-			IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0526: stloc.s 18
-			IL_0528: ldarg.0
-			IL_0529: ldc.i4.1
-			IL_052a: ldelem.ref
-			IL_052b: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0530: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0535: stloc.s 15
-			IL_0537: ldloc.s 15
-			IL_0539: ldloc.3
-			IL_053a: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_053f: box [System.Runtime]System.Boolean
-			IL_0544: stloc.s 9
-			IL_0546: ldloc.s 18
-			IL_0548: ldstr "log"
-			IL_054d: ldstr "SourceExists:"
-			IL_0552: ldloc.s 9
-			IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0559: pop
-			IL_055a: ldstr "console"
-			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0564: stloc.s 9
-			IL_0566: ldloc.s 9
-			IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_056d: stloc.s 9
-			IL_056f: ldarg.0
-			IL_0570: ldc.i4.1
-			IL_0571: ldelem.ref
-			IL_0572: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0577: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_057c: stloc.s 15
-			IL_057e: ldloc.s 15
-			IL_0580: ldloc.s 4
-			IL_0582: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_0587: box [System.Runtime]System.Boolean
-			IL_058c: stloc.s 18
-			IL_058e: ldloc.s 9
-			IL_0590: ldstr "log"
-			IL_0595: ldstr "DestinationExists:"
-			IL_059a: ldloc.s 18
-			IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_05a1: pop
-			IL_05a2: ldstr "console"
-			IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05ac: stloc.s 18
-			IL_05ae: ldloc.s 18
-			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05b5: stloc.s 18
-			IL_05b7: ldarg.0
-			IL_05b8: ldc.i4.1
-			IL_05b9: ldelem.ref
-			IL_05ba: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_05bf: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_05c4: stloc.s 15
-			IL_05c6: ldloc.s 15
-			IL_05c8: ldloc.s 5
-			IL_05ca: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_05cf: box [System.Runtime]System.Boolean
-			IL_05d4: stloc.s 9
-			IL_05d6: ldloc.s 18
-			IL_05d8: ldstr "log"
-			IL_05dd: ldstr "SentinelExists:"
-			IL_05e2: ldloc.s 9
-			IL_05e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_05e9: pop
-			IL_05ea: br IL_0602
+			IL_05de: ldloc.0
+			IL_05df: ldc.i4.1
+			IL_05e0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_05e5: ldloc.0
+			IL_05e6: ldc.i4.0
+			IL_05e7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_05ec: br IL_05f1
 
-			IL_05ef: ldloc.0
-			IL_05f0: ldc.i4.1
-			IL_05f1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_05f6: ldloc.0
-			IL_05f7: ldc.i4.0
-			IL_05f8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_05fd: br IL_0602
+			IL_05f1: ldarg.0
+			IL_05f2: ldc.i4.1
+			IL_05f3: ldelem.ref
+			IL_05f4: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_05f9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_05fe: stloc.s 15
+			IL_0600: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0605: dup
+			IL_0606: ldstr "recursive"
+			IL_060b: ldc.i4.1
+			IL_060c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0611: dup
+			IL_0612: ldstr "force"
+			IL_0617: ldc.i4.1
+			IL_0618: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_061d: stloc.s 16
+			IL_061f: ldloc.s 15
+			IL_0621: ldloc.2
+			IL_0622: ldloc.s 16
+			IL_0624: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0629: br IL_0641
 
-			IL_0602: ldarg.0
-			IL_0603: ldc.i4.1
-			IL_0604: ldelem.ref
-			IL_0605: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_060a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_060f: stloc.s 15
-			IL_0611: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0616: dup
-			IL_0617: ldstr "recursive"
-			IL_061c: ldc.i4.1
-			IL_061d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0622: dup
-			IL_0623: ldstr "force"
-			IL_0628: ldc.i4.1
-			IL_0629: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_062e: stloc.s 16
-			IL_0630: ldloc.s 15
-			IL_0632: ldloc.2
-			IL_0633: ldloc.s 16
-			IL_0635: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_063a: br IL_0652
+			IL_062e: ldloc.0
+			IL_062f: ldc.i4.1
+			IL_0630: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0635: ldloc.0
+			IL_0636: ldc.i4.0
+			IL_0637: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_063c: br IL_0641
 
-			IL_063f: ldloc.0
-			IL_0640: ldc.i4.1
-			IL_0641: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0646: ldloc.0
-			IL_0647: ldc.i4.0
-			IL_0648: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_064d: br IL_0652
+			IL_0641: ldloc.0
+			IL_0642: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0647: stloc.s 7
+			IL_0649: ldloc.s 7
+			IL_064b: brfalse IL_0688
 
-			IL_0652: ldloc.0
-			IL_0653: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0658: stloc.s 7
-			IL_065a: ldloc.s 7
-			IL_065c: brfalse IL_0699
+			IL_0650: ldloc.0
+			IL_0651: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0656: stloc.s 9
+			IL_0658: ldloc.0
+			IL_0659: ldc.i4.m1
+			IL_065a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_065f: ldloc.0
+			IL_0660: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0665: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_066a: ldarg.0
+			IL_066b: ldc.i4.1
+			IL_066c: newarr [System.Runtime]System.Object
+			IL_0671: dup
+			IL_0672: ldc.i4.0
+			IL_0673: ldloc.s 9
+			IL_0675: stelem.ref
+			IL_0676: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_067b: pop
+			IL_067c: ldloc.0
+			IL_067d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0682: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0687: ret
 
-			IL_0661: ldloc.0
-			IL_0662: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0667: stloc.s 9
-			IL_0669: ldloc.0
-			IL_066a: ldc.i4.m1
-			IL_066b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0670: ldloc.0
-			IL_0671: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0676: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_067b: ldarg.0
-			IL_067c: ldc.i4.1
-			IL_067d: newarr [System.Runtime]System.Object
-			IL_0682: dup
-			IL_0683: ldc.i4.0
-			IL_0684: ldloc.s 9
-			IL_0686: stelem.ref
-			IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_068c: pop
-			IL_068d: ldloc.0
-			IL_068e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0693: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0698: ret
+			IL_0688: ldloc.0
+			IL_0689: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_068e: stloc.s 8
+			IL_0690: ldloc.s 8
+			IL_0692: brfalse IL_06cf
 
-			IL_0699: ldloc.0
-			IL_069a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_069f: stloc.s 8
-			IL_06a1: ldloc.s 8
-			IL_06a3: brfalse IL_06e0
+			IL_0697: ldloc.0
+			IL_0698: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_069d: stloc.s 9
+			IL_069f: ldloc.0
+			IL_06a0: ldc.i4.m1
+			IL_06a1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06a6: ldloc.0
+			IL_06a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06b1: ldarg.0
+			IL_06b2: ldc.i4.1
+			IL_06b3: newarr [System.Runtime]System.Object
+			IL_06b8: dup
+			IL_06b9: ldc.i4.0
+			IL_06ba: ldloc.s 9
+			IL_06bc: stelem.ref
+			IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06c2: pop
+			IL_06c3: ldloc.0
+			IL_06c4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06c9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06ce: ret
 
-			IL_06a8: ldloc.0
-			IL_06a9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_06ae: stloc.s 9
-			IL_06b0: ldloc.0
-			IL_06b1: ldc.i4.m1
-			IL_06b2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06b7: ldloc.0
-			IL_06b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_06c2: ldarg.0
-			IL_06c3: ldc.i4.1
-			IL_06c4: newarr [System.Runtime]System.Object
-			IL_06c9: dup
-			IL_06ca: ldc.i4.0
-			IL_06cb: ldloc.s 9
-			IL_06cd: stelem.ref
-			IL_06ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_06d3: pop
-			IL_06d4: ldloc.0
-			IL_06d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06da: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06df: ret
-
-			IL_06e0: ldloc.0
-			IL_06e1: ldc.i4.m1
-			IL_06e2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06e7: ldloc.0
-			IL_06e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_06f2: ldarg.0
-			IL_06f3: ldc.i4.1
-			IL_06f4: newarr [System.Runtime]System.Object
-			IL_06f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_06fe: pop
-			IL_06ff: ldloc.0
-			IL_0700: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0705: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_070a: ret
+			IL_06cf: ldloc.0
+			IL_06d0: ldc.i4.m1
+			IL_06d1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06d6: ldloc.0
+			IL_06d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06e1: ldarg.0
+			IL_06e2: ldc.i4.1
+			IL_06e3: newarr [System.Runtime]System.Object
+			IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06ed: pop
+			IL_06ee: ldloc.0
+			IL_06ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06f4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06f9: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -933,7 +923,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2807
+			// Method begins at RVA 0x27f6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1034,7 +1024,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x283d
+		// Method begins at RVA 0x282c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateReadStream_Missing_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateReadStream_Missing_Error.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22bc
+				// Method begins at RVA 0x22b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,16 +51,15 @@
 			)
 			// Method begins at RVA 0x2210
 			// Header size: 12
-			// Code size: 111 (0x6f)
+			// Code size: 104 (0x68)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[2] object,
-				[3] bool,
+				[2] bool,
+				[3] object,
 				[4] object,
-				[5] object,
-				[6] object
+				[5] object
 			)
 
 			IL_0000: ldstr "console"
@@ -72,38 +71,37 @@
 			IL_001a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_001f: stloc.1
 			IL_0020: ldloc.1
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0026: stloc.2
+			IL_0021: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_0026: stloc.1
 			IL_0027: ldarg.1
 			IL_0028: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_002d: stloc.3
-			IL_002e: ldloc.3
-			IL_002f: brfalse IL_004a
+			IL_002d: stloc.2
+			IL_002e: ldloc.2
+			IL_002f: brfalse IL_0048
 
 			IL_0034: ldarg.1
 			IL_0035: ldstr "message"
 			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003f: stloc.s 4
-			IL_0041: ldloc.s 4
-			IL_0043: stloc.s 6
-			IL_0045: br IL_004d
+			IL_003f: stloc.3
+			IL_0040: ldloc.3
+			IL_0041: stloc.s 5
+			IL_0043: br IL_004b
 
-			IL_004a: ldarg.1
-			IL_004b: stloc.s 6
+			IL_0048: ldarg.1
+			IL_0049: stloc.s 5
 
-			IL_004d: ldloc.2
-			IL_004e: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-			IL_0053: ldloc.s 6
-			IL_0055: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_005a: stloc.2
-			IL_005b: ldloc.0
-			IL_005c: ldstr "log"
-			IL_0061: ldstr "ErrorStartsWithENOENT:"
-			IL_0066: ldloc.2
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_006c: pop
-			IL_006d: ldnull
-			IL_006e: ret
+			IL_004b: ldloc.1
+			IL_004c: ldloc.s 5
+			IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0053: stloc.3
+			IL_0054: ldloc.0
+			IL_0055: ldstr "log"
+			IL_005a: ldstr "ErrorStartsWithENOENT:"
+			IL_005f: ldloc.3
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0065: pop
+			IL_0066: ldnull
+			IL_0067: ret
 		} // end of method ArrowFunction_L13C20::__js_call__
 
 	} // end of class ArrowFunction_L13C20
@@ -119,7 +117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c5
+				// Method begins at RVA 0x22be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -142,7 +140,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x228b
+			// Method begins at RVA 0x2284
 			// Header size: 1
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -169,7 +167,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22b3
+			// Method begins at RVA 0x22ac
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -367,7 +365,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22ce
+		// Method begins at RVA 0x22c7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Missing_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Missing_Error.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2330
+				// Method begins at RVA 0x2329
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,16 +51,15 @@
 			)
 			// Method begins at RVA 0x2284
 			// Header size: 12
-			// Code size: 111 (0x6f)
+			// Code size: 104 (0x68)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[2] object,
-				[3] bool,
+				[2] bool,
+				[3] object,
 				[4] object,
-				[5] object,
-				[6] object
+				[5] object
 			)
 
 			IL_0000: ldstr "console"
@@ -72,38 +71,37 @@
 			IL_001a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_001f: stloc.1
 			IL_0020: ldloc.1
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0026: stloc.2
+			IL_0021: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_0026: stloc.1
 			IL_0027: ldarg.1
 			IL_0028: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_002d: stloc.3
-			IL_002e: ldloc.3
-			IL_002f: brfalse IL_004a
+			IL_002d: stloc.2
+			IL_002e: ldloc.2
+			IL_002f: brfalse IL_0048
 
 			IL_0034: ldarg.1
 			IL_0035: ldstr "message"
 			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003f: stloc.s 4
-			IL_0041: ldloc.s 4
-			IL_0043: stloc.s 6
-			IL_0045: br IL_004d
+			IL_003f: stloc.3
+			IL_0040: ldloc.3
+			IL_0041: stloc.s 5
+			IL_0043: br IL_004b
 
-			IL_004a: ldarg.1
-			IL_004b: stloc.s 6
+			IL_0048: ldarg.1
+			IL_0049: stloc.s 5
 
-			IL_004d: ldloc.2
-			IL_004e: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-			IL_0053: ldloc.s 6
-			IL_0055: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_005a: stloc.2
-			IL_005b: ldloc.0
-			IL_005c: ldstr "log"
-			IL_0061: ldstr "ErrorStartsWithENOENT:"
-			IL_0066: ldloc.2
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_006c: pop
-			IL_006d: ldnull
-			IL_006e: ret
+			IL_004b: ldloc.1
+			IL_004c: ldloc.s 5
+			IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0053: stloc.3
+			IL_0054: ldloc.0
+			IL_0055: ldstr "log"
+			IL_005a: ldstr "ErrorStartsWithENOENT:"
+			IL_005f: ldloc.3
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0065: pop
+			IL_0066: ldnull
+			IL_0067: ret
 		} // end of method ArrowFunction_L14C20::__js_call__
 
 	} // end of class ArrowFunction_L14C20
@@ -119,7 +117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2339
+				// Method begins at RVA 0x2332
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -142,7 +140,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22ff
+			// Method begins at RVA 0x22f8
 			// Header size: 1
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -169,7 +167,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2327
+			// Method begins at RVA 0x2320
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -416,7 +414,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2342
+		// Method begins at RVA 0x233b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Unsupported_Connect_Fails_Clearly.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Unsupported_Connect_Fails_Clearly.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b1
+				// Method begins at RVA 0x21ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ba
+				// Method begins at RVA 0x21b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a8
+			// Method begins at RVA 0x21a4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 315 (0x13b)
+		// Code size: 310 (0x136)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_Request_Unsupported_Connect_Fails_Clearly/Scope,
@@ -96,8 +96,7 @@
 			[8] object,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[10] object,
-			[11] object,
-			[12] object
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.Http_Request_Unsupported_Connect_Fails_Clearly/Scope::.ctor()
@@ -144,7 +143,7 @@
 			IL_008d: ldstr "unexpected"
 			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_0097: pop
-			IL_0098: leave IL_0137
+			IL_0098: leave IL_0132
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -180,32 +179,31 @@
 			IL_00e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_00ec: stloc.s 9
 			IL_00ee: ldloc.s 9
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f5: stloc.s 10
+			IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_00f5: stloc.s 9
 			IL_00f7: ldloc.s 5
 			IL_00f9: ldstr "message"
 			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0103: stloc.s 11
-			IL_0105: ldloc.s 10
-			IL_0107: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-			IL_010c: ldloc.s 11
-			IL_010e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0113: stloc.s 11
-			IL_0115: ldstr "connect unsupported:"
-			IL_011a: ldloc.s 11
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0121: stloc.s 12
-			IL_0123: ldloc.s 8
-			IL_0125: ldstr "log"
-			IL_012a: ldloc.s 12
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0131: pop
-			IL_0132: leave IL_0137
+			IL_0103: stloc.s 10
+			IL_0105: ldloc.s 9
+			IL_0107: ldloc.s 10
+			IL_0109: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_010e: stloc.s 10
+			IL_0110: ldstr "connect unsupported:"
+			IL_0115: ldloc.s 10
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_011c: stloc.s 11
+			IL_011e: ldloc.s 8
+			IL_0120: ldstr "log"
+			IL_0125: ldloc.s 11
+			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_012c: pop
+			IL_012d: leave IL_0132
 		} // end handler
 
-		IL_0137: ldnull
-		IL_0138: stloc.s 6
-		IL_013a: ret
+		IL_0132: ldnull
+		IL_0133: stloc.s 6
+		IL_0135: ret
 	} // end of method Http_Request_Unsupported_Connect_Fails_Clearly::__js_module_init__
 
 } // end of class Modules.Http_Request_Unsupported_Connect_Fails_Clearly
@@ -217,7 +215,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c3
+		// Method begins at RVA 0x21bf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Parse_And_Format.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Parse_And_Format.verified.txt
@@ -62,7 +62,8 @@
 			[16] object,
 			[17] object,
 			[18] object,
-			[19] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[19] string,
+			[20] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
 		IL_0000: newobj instance void Modules.Require_Path_Parse_And_Format/Scope::.ctor()
@@ -237,8 +238,8 @@
 		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0210: stloc.s 11
 		IL_0212: ldloc.s 5
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0219: stloc.s 15
+		IL_0214: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0219: stloc.s 10
 		IL_021b: ldc.i4.3
 		IL_021c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 		IL_0221: dup
@@ -259,12 +260,12 @@
 		IL_024e: ldloc.2
 		IL_024f: stelem.ref
 		IL_0250: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0255: stloc.s 10
+		IL_0255: stloc.s 19
 		IL_0257: ldloc.2
-		IL_0258: ldloc.s 10
+		IL_0258: ldloc.s 19
 		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 		IL_025f: stloc.s 18
-		IL_0261: ldloc.s 15
+		IL_0261: ldloc.s 10
 		IL_0263: ldstr "endsWith"
 		IL_0268: ldloc.s 18
 		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
@@ -313,9 +314,9 @@
 		IL_02e8: ldstr "ext"
 		IL_02ed: ldstr ".tar"
 		IL_02f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_02f7: stloc.s 19
+		IL_02f7: stloc.s 20
 		IL_02f9: ldloc.1
-		IL_02fa: ldloc.s 19
+		IL_02fa: ldloc.s 20
 		IL_02fc: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::format(object)
 		IL_0301: stloc.s 7
 		IL_0303: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -327,9 +328,9 @@
 		IL_0315: ldstr "base"
 		IL_031a: ldstr "index.js"
 		IL_031f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0324: stloc.s 19
+		IL_0324: stloc.s 20
 		IL_0326: ldloc.1
-		IL_0327: ldloc.s 19
+		IL_0327: ldloc.s 20
 		IL_0329: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::format(object)
 		IL_032e: stloc.s 8
 		IL_0330: ldstr "console"

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Versions_Expanded.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Versions_Expanded.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24f6
+			// Method begins at RVA 0x24f5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1178 (0x49a)
+		// Code size: 1177 (0x499)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Process_Versions_Expanded/Scope,
@@ -401,18 +401,19 @@
 		IL_0469: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_046e: stloc.s 18
 		IL_0470: ldloc.s 18
-		IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0477: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_047c: ldloc.s 6
-		IL_047e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0483: stloc.s 19
-		IL_0485: ldloc.s 7
-		IL_0487: ldstr "log"
-		IL_048c: ldstr "node version format valid"
-		IL_0491: ldloc.s 19
-		IL_0493: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0498: pop
-		IL_0499: ret
+		IL_0472: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0477: stloc.s 18
+		IL_0479: ldloc.s 18
+		IL_047b: ldloc.s 6
+		IL_047d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0482: stloc.s 19
+		IL_0484: ldloc.s 7
+		IL_0486: ldstr "log"
+		IL_048b: ldstr "node version format valid"
+		IL_0490: ldloc.s 19
+		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0497: pop
+		IL_0498: ret
 	} // end of method Process_Versions_Expanded::__js_module_init__
 
 } // end of class Modules.Process_Versions_Expanded
@@ -424,7 +425,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24ff
+		// Method begins at RVA 0x24fe
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.GlobalTimers_AsValues_WindowLikeAssignment.verified.txt
+++ b/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.GlobalTimers_AsValues_WindowLikeAssignment.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x221f
+				// Method begins at RVA 0x2225
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2213
+			// Method begins at RVA 0x2219
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -59,7 +59,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2216
+			// Method begins at RVA 0x221c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -85,7 +85,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 439 (0x1b7)
+		// Code size: 445 (0x1bd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.GlobalTimers_AsValues_WindowLikeAssignment/Scope,
@@ -94,7 +94,8 @@
 			[3] object,
 			[4] object,
 			[5] string,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
 		)
 
 		IL_0000: newobj instance void Modules.GlobalTimers_AsValues_WindowLikeAssignment/Scope::.ctor()
@@ -203,40 +204,42 @@
 		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0140: pop
 		IL_0141: ldloc.1
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0147: stloc.3
-		IL_0148: ldnull
-		IL_0149: ldftn object Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id::__js_call__(object)
-		IL_014f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0154: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0159: ldc.i4.0
-		IL_015a: conv.r8
-		IL_015b: ldstr ""
-		IL_0160: ldc.i4.0
-		IL_0161: ldc.i4.1
-		IL_0162: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0167: stloc.s 6
-		IL_0169: ldloc.3
-		IL_016a: ldstr "setTimeout"
-		IL_016f: ldloc.s 6
-		IL_0171: ldc.r8 100000
-		IL_017a: box [System.Runtime]System.Double
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0184: stloc.2
-		IL_0185: ldloc.1
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018b: ldstr "clearTimeout"
-		IL_0190: ldloc.2
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0196: pop
-		IL_0197: ldstr "console"
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a6: ldstr "log"
-		IL_01ab: ldstr "ok"
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b5: pop
-		IL_01b6: ret
+		IL_0142: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
+		IL_0147: stloc.s 6
+		IL_0149: ldnull
+		IL_014a: ldftn object Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id::__js_call__(object)
+		IL_0150: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0155: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_015a: ldc.i4.0
+		IL_015b: conv.r8
+		IL_015c: ldstr ""
+		IL_0161: ldc.i4.0
+		IL_0162: ldc.i4.1
+		IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0168: stloc.s 7
+		IL_016a: ldloc.s 6
+		IL_016c: ldstr "setTimeout"
+		IL_0171: ldloc.s 7
+		IL_0173: ldc.r8 100000
+		IL_017c: box [System.Runtime]System.Double
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0186: stloc.2
+		IL_0187: ldloc.1
+		IL_0188: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
+		IL_018d: stloc.s 6
+		IL_018f: ldloc.s 6
+		IL_0191: ldstr "clearTimeout"
+		IL_0196: ldloc.2
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019c: pop
+		IL_019d: ldstr "console"
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ac: ldstr "log"
+		IL_01b1: ldstr "ok"
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bb: pop
+		IL_01bc: ret
 	} // end of method GlobalTimers_AsValues_WindowLikeAssignment::__js_module_init__
 
 } // end of class Modules.GlobalTimers_AsValues_WindowLikeAssignment
@@ -248,7 +251,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2228
+		// Method begins at RVA 0x222e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_Stream_RoundTrip.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_Stream_RoundTrip.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d2
+				// Method begins at RVA 0x24d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -75,7 +75,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24db
+				// Method begins at RVA 0x24dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24e4
+				// Method begins at RVA 0x24e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -189,7 +189,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ed
+				// Method begins at RVA 0x24ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -246,7 +246,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f6
+				// Method begins at RVA 0x24f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -305,7 +305,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ff
+				// Method begins at RVA 0x2501
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -333,8 +333,8 @@
 			)
 			// Method begins at RVA 0x2424
 			// Header size: 12
-			// Code size: 153 (0x99)
-			.maxstack 9
+			// Code size: 155 (0x9b)
+			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] object,
@@ -361,39 +361,41 @@
 			IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
 			IL_0030: stloc.2
 			IL_0031: ldloc.2
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0037: ldstr "toString"
-			IL_003c: ldstr "utf8"
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0046: stloc.3
-			IL_0047: ldloc.1
-			IL_0048: ldstr "log"
-			IL_004d: ldstr "output:"
-			IL_0052: ldloc.3
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0058: pop
-			IL_0059: ldstr "console"
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0068: stloc.3
-			IL_0069: ldarg.0
-			IL_006a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_006f: ldc.i4.1
-			IL_0070: newarr [System.Runtime]System.Object
-			IL_0075: dup
-			IL_0076: ldc.i4.0
-			IL_0077: ldstr ","
-			IL_007c: stelem.ref
-			IL_007d: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0082: stloc.s 4
-			IL_0084: ldloc.3
-			IL_0085: ldstr "log"
-			IL_008a: ldstr "events:"
-			IL_008f: ldloc.s 4
-			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0096: pop
-			IL_0097: ldnull
-			IL_0098: ret
+			IL_0032: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_0037: stloc.2
+			IL_0038: ldloc.2
+			IL_0039: ldstr "toString"
+			IL_003e: ldstr "utf8"
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0048: stloc.3
+			IL_0049: ldloc.1
+			IL_004a: ldstr "log"
+			IL_004f: ldstr "output:"
+			IL_0054: ldloc.3
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_005a: pop
+			IL_005b: ldstr "console"
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006a: stloc.3
+			IL_006b: ldarg.0
+			IL_006c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
+			IL_0071: ldc.i4.1
+			IL_0072: newarr [System.Runtime]System.Object
+			IL_0077: dup
+			IL_0078: ldc.i4.0
+			IL_0079: ldstr ","
+			IL_007e: stelem.ref
+			IL_007f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0084: stloc.s 4
+			IL_0086: ldloc.3
+			IL_0087: ldstr "log"
+			IL_008c: ldstr "events:"
+			IL_0091: ldloc.s 4
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0098: pop
+			IL_0099: ldnull
+			IL_009a: ret
 		} // end of method FunctionExpression_L23C22::__js_call__
 
 	} // end of class FunctionExpression_L23C22
@@ -414,7 +416,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24c9
+			// Method begins at RVA 0x24cb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -725,7 +727,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2508
+		// Method begins at RVA 0x250a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InferredConstruction_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InferredConstruction_Parity.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2447
+				// Method begins at RVA 0x244b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23ea
+			// Method begins at RVA 0x23ee
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2450
+				// Method begins at RVA 0x2454
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -86,7 +86,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f1
+			// Method begins at RVA 0x23f5
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -108,7 +108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2459
+				// Method begins at RVA 0x245d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -132,7 +132,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f8
+			// Method begins at RVA 0x23fc
 			// Header size: 12
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -177,7 +177,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x243e
+			// Method begins at RVA 0x2442
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -208,7 +208,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2462
+				// Method begins at RVA 0x2466
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -221,7 +221,7 @@
 			.method public hidebysig 
 				instance string get_text () cil managed 
 			{
-				// Method begins at RVA 0x246a
+				// Method begins at RVA 0x246e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -236,7 +236,7 @@
 					string ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x2472
+				// Method begins at RVA 0x2476
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -254,7 +254,7 @@
 			.method public hidebysig 
 				instance float64 get_n () cil managed 
 			{
-				// Method begins at RVA 0x2487
+				// Method begins at RVA 0x248b
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -269,7 +269,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x248f
+				// Method begins at RVA 0x2493
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -287,7 +287,7 @@
 			.method public hidebysig 
 				instance bool get_flag () cil managed 
 			{
-				// Method begins at RVA 0x24a4
+				// Method begins at RVA 0x24a8
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -302,7 +302,7 @@
 					bool ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x24ac
+				// Method begins at RVA 0x24b0
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -320,7 +320,7 @@
 			.method public hidebysig 
 				instance object get_boxed () cil managed 
 			{
-				// Method begins at RVA 0x24c1
+				// Method begins at RVA 0x24c5
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -335,7 +335,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x24c9
+				// Method begins at RVA 0x24cd
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -353,7 +353,7 @@
 			.method public hidebysig 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0 get_fn () cil managed 
 			{
-				// Method begins at RVA 0x24de
+				// Method begins at RVA 0x24e2
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -368,7 +368,7 @@
 					class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x24e6
+				// Method begins at RVA 0x24ea
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -401,7 +401,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 910 (0x38e)
+		// Code size: 914 (0x392)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_InferredConstruction_Parity/Scope,
@@ -422,7 +422,8 @@
 			[15] string,
 			[16] object,
 			[17] object,
-			[18] object
+			[18] object,
+			[19] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
 		IL_0000: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/Scope::.ctor()
@@ -623,111 +624,113 @@
 		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_023b: stloc.s 7
 		IL_023d: ldloc.3
-		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0243: ldstr "fn"
-		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_024d: stloc.s 17
-		IL_024f: ldloc.s 7
-		IL_0251: ldstr "log"
-		IL_0256: ldloc.s 17
-		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025d: pop
-		IL_025e: ldstr "console"
-		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026d: stloc.s 17
-		IL_026f: ldloc.3
-		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027a: ldstr "join"
-		IL_027f: ldstr ","
-		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0289: stloc.s 7
-		IL_028b: ldloc.s 17
-		IL_028d: ldstr "log"
-		IL_0292: ldloc.s 7
-		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0299: pop
-		IL_029a: ldstr "console"
-		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a9: ldloc.3
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_02af: stloc.s 7
-		IL_02b1: ldstr "log"
-		IL_02b6: ldloc.s 7
-		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02bd: pop
-		IL_02be: ldloc.3
-		IL_02bf: ldstr "n"
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_02c9: stloc.s 4
-		IL_02cb: ldstr "console"
-		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02da: stloc.s 7
-		IL_02dc: ldloc.s 4
-		IL_02de: ldstr "value"
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e8: stloc.s 17
-		IL_02ea: ldloc.s 4
-		IL_02ec: ldstr "writable"
-		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02f6: stloc.s 16
-		IL_02f8: ldloc.s 4
-		IL_02fa: ldstr "enumerable"
-		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0304: stloc.s 13
-		IL_0306: ldloc.s 4
-		IL_0308: ldstr "configurable"
-		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0312: stloc.s 18
-		IL_0314: ldloc.s 7
-		IL_0316: ldstr "log"
-		IL_031b: ldc.i4.4
-		IL_031c: newarr [System.Runtime]System.Object
-		IL_0321: dup
-		IL_0322: ldc.i4.0
-		IL_0323: ldloc.s 17
-		IL_0325: stelem.ref
-		IL_0326: dup
-		IL_0327: ldc.i4.1
-		IL_0328: ldloc.s 16
-		IL_032a: stelem.ref
-		IL_032b: dup
-		IL_032c: ldc.i4.2
-		IL_032d: ldloc.s 13
-		IL_032f: stelem.ref
-		IL_0330: dup
-		IL_0331: ldc.i4.3
-		IL_0332: ldloc.s 18
-		IL_0334: stelem.ref
-		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_033a: pop
-		IL_033b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0340: dup
-		IL_0341: ldstr "x"
-		IL_0346: ldc.r8 1
-		IL_034f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0354: stloc.s 5
-		IL_0356: ldnull
-		IL_0357: ldloc.s 5
-		IL_0359: call object Modules.ObjectLiteral_InferredConstruction_Parity/leak::__js_call__(object, object)
-		IL_035e: pop
-		IL_035f: ldstr "console"
-		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_036e: stloc.s 7
-		IL_0370: ldloc.s 5
-		IL_0372: ldstr "x"
-		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_037c: stloc.s 18
-		IL_037e: ldloc.s 7
-		IL_0380: ldstr "log"
-		IL_0385: ldloc.s 18
-		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_038c: pop
-		IL_038d: ret
+		IL_023e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
+		IL_0243: stloc.s 19
+		IL_0245: ldloc.s 19
+		IL_0247: ldstr "fn"
+		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0251: stloc.s 17
+		IL_0253: ldloc.s 7
+		IL_0255: ldstr "log"
+		IL_025a: ldloc.s 17
+		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0261: pop
+		IL_0262: ldstr "console"
+		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0271: stloc.s 17
+		IL_0273: ldloc.3
+		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_027e: ldstr "join"
+		IL_0283: ldstr ","
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028d: stloc.s 7
+		IL_028f: ldloc.s 17
+		IL_0291: ldstr "log"
+		IL_0296: ldloc.s 7
+		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029d: pop
+		IL_029e: ldstr "console"
+		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ad: ldloc.3
+		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_02b3: stloc.s 7
+		IL_02b5: ldstr "log"
+		IL_02ba: ldloc.s 7
+		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c1: pop
+		IL_02c2: ldloc.3
+		IL_02c3: ldstr "n"
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_02cd: stloc.s 4
+		IL_02cf: ldstr "console"
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02de: stloc.s 7
+		IL_02e0: ldloc.s 4
+		IL_02e2: ldstr "value"
+		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ec: stloc.s 17
+		IL_02ee: ldloc.s 4
+		IL_02f0: ldstr "writable"
+		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02fa: stloc.s 16
+		IL_02fc: ldloc.s 4
+		IL_02fe: ldstr "enumerable"
+		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0308: stloc.s 13
+		IL_030a: ldloc.s 4
+		IL_030c: ldstr "configurable"
+		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0316: stloc.s 18
+		IL_0318: ldloc.s 7
+		IL_031a: ldstr "log"
+		IL_031f: ldc.i4.4
+		IL_0320: newarr [System.Runtime]System.Object
+		IL_0325: dup
+		IL_0326: ldc.i4.0
+		IL_0327: ldloc.s 17
+		IL_0329: stelem.ref
+		IL_032a: dup
+		IL_032b: ldc.i4.1
+		IL_032c: ldloc.s 16
+		IL_032e: stelem.ref
+		IL_032f: dup
+		IL_0330: ldc.i4.2
+		IL_0331: ldloc.s 13
+		IL_0333: stelem.ref
+		IL_0334: dup
+		IL_0335: ldc.i4.3
+		IL_0336: ldloc.s 18
+		IL_0338: stelem.ref
+		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_033e: pop
+		IL_033f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0344: dup
+		IL_0345: ldstr "x"
+		IL_034a: ldc.r8 1
+		IL_0353: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0358: stloc.s 5
+		IL_035a: ldnull
+		IL_035b: ldloc.s 5
+		IL_035d: call object Modules.ObjectLiteral_InferredConstruction_Parity/leak::__js_call__(object, object)
+		IL_0362: pop
+		IL_0363: ldstr "console"
+		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0372: stloc.s 7
+		IL_0374: ldloc.s 5
+		IL_0376: ldstr "x"
+		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0380: stloc.s 18
+		IL_0382: ldloc.s 7
+		IL_0384: ldstr "log"
+		IL_0389: ldloc.s 18
+		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0390: pop
+		IL_0391: ret
 	} // end of method ObjectLiteral_InferredConstruction_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_InferredConstruction_Parity
@@ -739,7 +742,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24fb
+		// Method begins at RVA 0x24ff
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ShorthandAndMethod.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ShorthandAndMethod.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2157
+				// Method begins at RVA 0x215b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2130
+			// Method begins at RVA 0x2134
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -66,7 +66,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x214e
+			// Method begins at RVA 0x2152
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -92,7 +92,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 210 (0xd2)
+		// Code size: 214 (0xd6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_ShorthandAndMethod/Scope,
@@ -157,16 +157,18 @@
 		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00b0: stloc.s 5
 		IL_00b2: ldloc.2
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b8: ldstr "m"
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00c2: stloc.3
-		IL_00c3: ldloc.s 5
-		IL_00c5: ldstr "log"
-		IL_00ca: ldloc.3
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d0: pop
-		IL_00d1: ret
+		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
+		IL_00b8: stloc.s 4
+		IL_00ba: ldloc.s 4
+		IL_00bc: ldstr "m"
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00c6: stloc.3
+		IL_00c7: ldloc.s 5
+		IL_00c9: ldstr "log"
+		IL_00ce: ldloc.3
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d4: pop
+		IL_00d5: ret
 	} // end of method ObjectLiteral_ShorthandAndMethod::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_ShorthandAndMethod
@@ -178,7 +180,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2160
+		// Method begins at RVA 0x2164
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Executor_Rejected.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Executor_Rejected.verified.txt
@@ -173,7 +173,7 @@
 			[0] class Modules.Promise_Executor_Rejected/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[3] object,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		)
 
@@ -204,7 +204,7 @@
 		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
 		IL_0046: stloc.1
 		IL_0047: ldloc.1
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
 		IL_004d: stloc.3
 		IL_004e: ldnull
 		IL_004f: ldftn object Modules.Promise_Executor_Rejected/ArrowFunction_L7C14::__js_call__(object, object)

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Executor_Resolved.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Executor_Resolved.verified.txt
@@ -170,7 +170,7 @@
 			[0] class Modules.Promise_Executor_Resolved/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
-			[3] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.Promise
 		)
 
 		IL_0000: newobj instance void Modules.Promise_Executor_Resolved/Scope::.ctor()
@@ -200,7 +200,7 @@
 		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
 		IL_0046: stloc.1
 		IL_0047: ldloc.1
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
 		IL_004d: stloc.3
 		IL_004e: ldnull
 		IL_004f: ldftn object Modules.Promise_Executor_Resolved/ArrowFunction_L7C8::__js_call__(object, object)

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_WithResolvers_Idempotent.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_WithResolvers_Idempotent.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b4
+				// Method begins at RVA 0x21bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x213c
+			// Method begins at RVA 0x2144
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -95,7 +95,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21bd
+				// Method begins at RVA 0x21c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -119,7 +119,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2174
+			// Method begins at RVA 0x217c
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -154,7 +154,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ab
+			// Method begins at RVA 0x21b3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -180,14 +180,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 223 (0xdf)
+		// Code size: 231 (0xe7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_WithResolvers_Idempotent/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers
 		)
 
 		IL_0000: newobj instance void Modules.Promise_WithResolvers_Idempotent/Scope::.ctor()
@@ -255,18 +256,22 @@
 		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_00b1: pop
 		IL_00b2: ldloc.1
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b8: ldstr "resolve"
-		IL_00bd: ldstr "first"
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c7: pop
-		IL_00c8: ldloc.1
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ce: ldstr "reject"
-		IL_00d3: ldstr "second"
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00dd: pop
-		IL_00de: ret
+		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers>(!!0)
+		IL_00b8: stloc.s 5
+		IL_00ba: ldloc.s 5
+		IL_00bc: ldstr "resolve"
+		IL_00c1: ldstr "first"
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cb: pop
+		IL_00cc: ldloc.1
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers>(!!0)
+		IL_00d2: stloc.s 5
+		IL_00d4: ldloc.s 5
+		IL_00d6: ldstr "reject"
+		IL_00db: ldstr "second"
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e5: pop
+		IL_00e6: ret
 	} // end of method Promise_WithResolvers_Idempotent::__js_module_init__
 
 } // end of class Modules.Promise_WithResolvers_Idempotent
@@ -278,7 +283,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c6
+		// Method begins at RVA 0x21ce
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_WithResolvers_Reject.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_WithResolvers_Reject.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20fd
+				// Method begins at RVA 0x2101
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20d6
+			// Method begins at RVA 0x20da
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -74,7 +74,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f4
+			// Method begins at RVA 0x20f8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -100,14 +100,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 122 (0x7a)
+		// Code size: 126 (0x7e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_WithResolvers_Reject/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers
 		)
 
 		IL_0000: newobj instance void Modules.Promise_WithResolvers_Reject/Scope::.ctor()
@@ -147,12 +148,14 @@
 		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0062: pop
 		IL_0063: ldloc.1
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0069: ldstr "reject"
-		IL_006e: ldstr "rejected"
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0078: pop
-		IL_0079: ret
+		IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers>(!!0)
+		IL_0069: stloc.s 5
+		IL_006b: ldloc.s 5
+		IL_006d: ldstr "reject"
+		IL_0072: ldstr "rejected"
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007c: pop
+		IL_007d: ret
 	} // end of method Promise_WithResolvers_Reject::__js_module_init__
 
 } // end of class Modules.Promise_WithResolvers_Reject
@@ -164,7 +167,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2106
+		// Method begins at RVA 0x210a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_WithResolvers_Resolve.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_WithResolvers_Resolve.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20fd
+				// Method begins at RVA 0x2101
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20d6
+			// Method begins at RVA 0x20da
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -74,7 +74,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f4
+			// Method begins at RVA 0x20f8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -100,14 +100,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 122 (0x7a)
+		// Code size: 126 (0x7e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_WithResolvers_Resolve/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers
 		)
 
 		IL_0000: newobj instance void Modules.Promise_WithResolvers_Resolve/Scope::.ctor()
@@ -147,12 +148,14 @@
 		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0062: pop
 		IL_0063: ldloc.1
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0069: ldstr "resolve"
-		IL_006e: ldstr "resolved"
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0078: pop
-		IL_0079: ret
+		IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers>(!!0)
+		IL_0069: stloc.s 5
+		IL_006b: ldloc.s 5
+		IL_006d: ldstr "resolve"
+		IL_0072: ldstr "resolved"
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007c: pop
+		IL_007d: ret
 	} // end of method Promise_WithResolvers_Resolve::__js_module_init__
 
 } // end of class Modules.Promise_WithResolvers_Resolve
@@ -164,7 +167,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2106
+		// Method begins at RVA 0x210a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Algebra_Methods.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Algebra_Methods.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2721
+				// Method begins at RVA 0x273d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2578
+			// Method begins at RVA 0x2594
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x272a
+				// Method begins at RVA 0x2746
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -115,7 +115,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25cc
+			// Method begins at RVA 0x25e8
 			// Header size: 12
 			// Code size: 320 (0x140)
 			.maxstack 8
@@ -266,7 +266,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2733
+				// Method begins at RVA 0x274f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +286,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x273c
+				// Method begins at RVA 0x2758
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -304,7 +304,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2718
+			// Method begins at RVA 0x2734
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -330,7 +330,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1290 (0x50a)
+		// Code size: 1318 (0x526)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Algebra_Methods/Scope,
@@ -343,14 +343,15 @@
 			[7] object,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[9] object,
-			[10] object,
-			[11] string,
-			[12] class [JavaScriptRuntime]JavaScriptRuntime.Set,
-			[13] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
-			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
-			[15] object,
-			[16] bool,
-			[17] object
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.Set,
+			[11] object,
+			[12] string,
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.Set,
+			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[15] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+			[16] object,
+			[17] bool,
+			[18] object
 		)
 
 		IL_0000: newobj instance void Modules.Set_Algebra_Methods/Scope::.ctor()
@@ -388,365 +389,379 @@
 		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0081: stloc.s 9
 		IL_0083: ldloc.1
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0089: ldstr "difference"
-		IL_008e: ldloc.2
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0094: stloc.s 10
-		IL_0096: ldloc.s 10
-		IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_009d: ldc.i4.1
-		IL_009e: newarr [System.Runtime]System.Object
-		IL_00a3: dup
-		IL_00a4: ldc.i4.0
-		IL_00a5: ldstr ","
-		IL_00aa: stelem.ref
-		IL_00ab: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_00b0: stloc.s 11
-		IL_00b2: ldloc.s 9
-		IL_00b4: ldstr "log"
-		IL_00b9: ldloc.s 11
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c0: pop
-		IL_00c1: ldstr "console"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d0: stloc.s 9
-		IL_00d2: ldloc.1
-		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d8: ldstr "intersection"
-		IL_00dd: ldloc.2
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e3: stloc.s 10
-		IL_00e5: ldloc.s 10
-		IL_00e7: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_00ec: ldc.i4.1
-		IL_00ed: newarr [System.Runtime]System.Object
-		IL_00f2: dup
-		IL_00f3: ldc.i4.0
-		IL_00f4: ldstr ","
-		IL_00f9: stelem.ref
-		IL_00fa: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_00ff: stloc.s 11
-		IL_0101: ldloc.s 9
-		IL_0103: ldstr "log"
-		IL_0108: ldloc.s 11
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010f: pop
-		IL_0110: ldstr "console"
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011f: stloc.s 9
-		IL_0121: ldloc.1
+		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_0089: stloc.s 10
+		IL_008b: ldloc.s 10
+		IL_008d: ldstr "difference"
+		IL_0092: ldloc.2
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0098: stloc.s 11
+		IL_009a: ldloc.s 11
+		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_00a1: ldc.i4.1
+		IL_00a2: newarr [System.Runtime]System.Object
+		IL_00a7: dup
+		IL_00a8: ldc.i4.0
+		IL_00a9: ldstr ","
+		IL_00ae: stelem.ref
+		IL_00af: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_00b4: stloc.s 12
+		IL_00b6: ldloc.s 9
+		IL_00b8: ldstr "log"
+		IL_00bd: ldloc.s 12
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c4: pop
+		IL_00c5: ldstr "console"
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d4: stloc.s 9
+		IL_00d6: ldloc.1
+		IL_00d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_00dc: stloc.s 10
+		IL_00de: ldloc.s 10
+		IL_00e0: ldstr "intersection"
+		IL_00e5: ldloc.2
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00eb: stloc.s 11
+		IL_00ed: ldloc.s 11
+		IL_00ef: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_00f4: ldc.i4.1
+		IL_00f5: newarr [System.Runtime]System.Object
+		IL_00fa: dup
+		IL_00fb: ldc.i4.0
+		IL_00fc: ldstr ","
+		IL_0101: stelem.ref
+		IL_0102: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0107: stloc.s 12
+		IL_0109: ldloc.s 9
+		IL_010b: ldstr "log"
+		IL_0110: ldloc.s 12
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0117: pop
+		IL_0118: ldstr "console"
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0127: ldstr "union"
-		IL_012c: ldloc.2
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0132: stloc.s 10
-		IL_0134: ldloc.s 10
-		IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_013b: ldc.i4.1
-		IL_013c: newarr [System.Runtime]System.Object
-		IL_0141: dup
-		IL_0142: ldc.i4.0
-		IL_0143: ldstr ","
-		IL_0148: stelem.ref
-		IL_0149: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_014e: stloc.s 11
-		IL_0150: ldloc.s 9
-		IL_0152: ldstr "log"
-		IL_0157: ldloc.s 11
-		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015e: pop
-		IL_015f: ldstr "console"
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016e: stloc.s 9
-		IL_0170: ldloc.1
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0176: ldstr "symmetricDifference"
-		IL_017b: ldloc.2
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0181: stloc.s 10
-		IL_0183: ldloc.s 10
-		IL_0185: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_018a: ldc.i4.1
-		IL_018b: newarr [System.Runtime]System.Object
-		IL_0190: dup
-		IL_0191: ldc.i4.0
-		IL_0192: ldstr ","
-		IL_0197: stelem.ref
-		IL_0198: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_019d: stloc.s 11
-		IL_019f: ldloc.s 9
-		IL_01a1: ldstr "log"
-		IL_01a6: ldloc.s 11
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ad: pop
-		IL_01ae: ldstr "console"
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bd: stloc.s 9
-		IL_01bf: ldloc.1
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c5: stloc.s 10
-		IL_01c7: ldc.i4.2
-		IL_01c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01cd: dup
-		IL_01ce: ldc.r8 4
-		IL_01d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01dc: dup
-		IL_01dd: ldc.r8 5
-		IL_01e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01eb: stloc.s 8
-		IL_01ed: ldloc.s 8
-		IL_01ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_01f4: stloc.s 12
-		IL_01f6: ldloc.s 10
-		IL_01f8: ldstr "isDisjointFrom"
-		IL_01fd: ldloc.s 12
-		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0204: stloc.s 10
-		IL_0206: ldloc.s 9
-		IL_0208: ldstr "log"
-		IL_020d: ldloc.s 10
+		IL_0127: stloc.s 9
+		IL_0129: ldloc.1
+		IL_012a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_012f: stloc.s 10
+		IL_0131: ldloc.s 10
+		IL_0133: ldstr "union"
+		IL_0138: ldloc.2
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013e: stloc.s 11
+		IL_0140: ldloc.s 11
+		IL_0142: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0147: ldc.i4.1
+		IL_0148: newarr [System.Runtime]System.Object
+		IL_014d: dup
+		IL_014e: ldc.i4.0
+		IL_014f: ldstr ","
+		IL_0154: stelem.ref
+		IL_0155: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_015a: stloc.s 12
+		IL_015c: ldloc.s 9
+		IL_015e: ldstr "log"
+		IL_0163: ldloc.s 12
+		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016a: pop
+		IL_016b: ldstr "console"
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017a: stloc.s 9
+		IL_017c: ldloc.1
+		IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_0182: stloc.s 10
+		IL_0184: ldloc.s 10
+		IL_0186: ldstr "symmetricDifference"
+		IL_018b: ldloc.2
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0191: stloc.s 11
+		IL_0193: ldloc.s 11
+		IL_0195: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_019a: ldc.i4.1
+		IL_019b: newarr [System.Runtime]System.Object
+		IL_01a0: dup
+		IL_01a1: ldc.i4.0
+		IL_01a2: ldstr ","
+		IL_01a7: stelem.ref
+		IL_01a8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_01ad: stloc.s 12
+		IL_01af: ldloc.s 9
+		IL_01b1: ldstr "log"
+		IL_01b6: ldloc.s 12
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bd: pop
+		IL_01be: ldstr "console"
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01cd: stloc.s 9
+		IL_01cf: ldloc.1
+		IL_01d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_01d5: stloc.s 10
+		IL_01d7: ldc.i4.2
+		IL_01d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01dd: dup
+		IL_01de: ldc.r8 4
+		IL_01e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01ec: dup
+		IL_01ed: ldc.r8 5
+		IL_01f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01fb: stloc.s 8
+		IL_01fd: ldloc.s 8
+		IL_01ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_0204: stloc.s 13
+		IL_0206: ldloc.s 10
+		IL_0208: ldstr "isDisjointFrom"
+		IL_020d: ldloc.s 13
 		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0214: pop
-		IL_0215: ldstr "console"
-		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0224: stloc.s 10
-		IL_0226: ldloc.1
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022c: ldstr "isDisjointFrom"
-		IL_0231: ldloc.2
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0237: stloc.s 9
-		IL_0239: ldloc.s 10
-		IL_023b: ldstr "log"
-		IL_0240: ldloc.s 9
-		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0247: pop
-		IL_0248: ldstr "console"
-		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0257: stloc.s 9
-		IL_0259: ldc.i4.2
-		IL_025a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_025f: dup
-		IL_0260: ldc.r8 1
-		IL_0269: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_026e: dup
-		IL_026f: ldc.r8 2
-		IL_0278: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_027d: stloc.s 8
-		IL_027f: ldloc.s 8
-		IL_0281: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_0286: stloc.s 12
-		IL_0288: ldloc.s 12
-		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028f: stloc.s 10
-		IL_0291: ldc.i4.3
-		IL_0292: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0297: dup
-		IL_0298: ldc.r8 1
-		IL_02a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02a6: dup
-		IL_02a7: ldc.r8 2
-		IL_02b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02b5: dup
-		IL_02b6: ldc.r8 3
-		IL_02bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02c4: stloc.s 8
-		IL_02c6: ldloc.s 8
-		IL_02c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_02cd: stloc.s 12
-		IL_02cf: ldloc.s 10
-		IL_02d1: ldstr "isSubsetOf"
-		IL_02d6: ldloc.s 12
-		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02dd: stloc.s 10
-		IL_02df: ldloc.s 9
-		IL_02e1: ldstr "log"
-		IL_02e6: ldloc.s 10
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ed: pop
-		IL_02ee: ldstr "console"
-		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02fd: stloc.s 10
-		IL_02ff: ldloc.1
-		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0305: stloc.s 9
-		IL_0307: ldc.i4.2
-		IL_0308: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_030d: dup
-		IL_030e: ldc.r8 1
-		IL_0317: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_031c: dup
-		IL_031d: ldc.r8 3
-		IL_0326: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_032b: stloc.s 8
-		IL_032d: ldloc.s 8
-		IL_032f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_0334: stloc.s 12
-		IL_0336: ldloc.s 9
-		IL_0338: ldstr "isSupersetOf"
-		IL_033d: ldloc.s 12
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0344: stloc.s 9
-		IL_0346: ldloc.s 10
-		IL_0348: ldstr "log"
-		IL_034d: ldloc.s 9
-		IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0354: pop
-		IL_0355: ldnull
-		IL_0356: ldftn object Modules.Set_Algebra_Methods/FunctionExpression_setLike::__js_call__(object, object)
-		IL_035c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0361: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0366: ldc.i4.1
-		IL_0367: conv.r8
-		IL_0368: ldstr ""
-		IL_036d: ldc.i4.0
-		IL_036e: ldc.i4.1
-		IL_036f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0374: stloc.s 13
-		IL_0376: ldc.i4.1
-		IL_0377: newarr [System.Runtime]System.Object
-		IL_037c: dup
-		IL_037d: ldc.i4.0
-		IL_037e: ldloc.0
-		IL_037f: stelem.ref
-		IL_0380: ldftn object Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10::__js_call__(object[], object)
-		IL_0386: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_038b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0390: ldc.i4.0
-		IL_0391: conv.r8
-		IL_0392: ldstr ""
-		IL_0397: ldc.i4.0
-		IL_0398: ldc.i4.1
-		IL_0399: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_03a3: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_03a8: stloc.s 14
-		IL_03aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03af: dup
-		IL_03b0: ldstr "size"
-		IL_03b5: ldc.r8 2
-		IL_03be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0214: stloc.s 11
+		IL_0216: ldloc.s 9
+		IL_0218: ldstr "log"
+		IL_021d: ldloc.s 11
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0224: pop
+		IL_0225: ldstr "console"
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0234: stloc.s 11
+		IL_0236: ldloc.1
+		IL_0237: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_023c: stloc.s 13
+		IL_023e: ldloc.s 13
+		IL_0240: ldstr "isDisjointFrom"
+		IL_0245: ldloc.2
+		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024b: stloc.s 9
+		IL_024d: ldloc.s 11
+		IL_024f: ldstr "log"
+		IL_0254: ldloc.s 9
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025b: pop
+		IL_025c: ldstr "console"
+		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_026b: stloc.s 9
+		IL_026d: ldc.i4.2
+		IL_026e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0273: dup
+		IL_0274: ldc.r8 1
+		IL_027d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0282: dup
+		IL_0283: ldc.r8 2
+		IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0291: stloc.s 8
+		IL_0293: ldloc.s 8
+		IL_0295: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_029a: stloc.s 13
+		IL_029c: ldloc.s 13
+		IL_029e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_02a3: stloc.s 13
+		IL_02a5: ldc.i4.3
+		IL_02a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02ab: dup
+		IL_02ac: ldc.r8 1
+		IL_02b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02ba: dup
+		IL_02bb: ldc.r8 2
+		IL_02c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02c9: dup
+		IL_02ca: ldc.r8 3
+		IL_02d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02d8: stloc.s 8
+		IL_02da: ldloc.s 8
+		IL_02dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_02e1: stloc.s 10
+		IL_02e3: ldloc.s 13
+		IL_02e5: ldstr "isSubsetOf"
+		IL_02ea: ldloc.s 10
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02f1: stloc.s 11
+		IL_02f3: ldloc.s 9
+		IL_02f5: ldstr "log"
+		IL_02fa: ldloc.s 11
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0301: pop
+		IL_0302: ldstr "console"
+		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0311: stloc.s 11
+		IL_0313: ldloc.1
+		IL_0314: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_0319: stloc.s 10
+		IL_031b: ldc.i4.2
+		IL_031c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0321: dup
+		IL_0322: ldc.r8 1
+		IL_032b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0330: dup
+		IL_0331: ldc.r8 3
+		IL_033a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_033f: stloc.s 8
+		IL_0341: ldloc.s 8
+		IL_0343: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_0348: stloc.s 13
+		IL_034a: ldloc.s 10
+		IL_034c: ldstr "isSupersetOf"
+		IL_0351: ldloc.s 13
+		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0358: stloc.s 9
+		IL_035a: ldloc.s 11
+		IL_035c: ldstr "log"
+		IL_0361: ldloc.s 9
+		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0368: pop
+		IL_0369: ldnull
+		IL_036a: ldftn object Modules.Set_Algebra_Methods/FunctionExpression_setLike::__js_call__(object, object)
+		IL_0370: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0375: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_037a: ldc.i4.1
+		IL_037b: conv.r8
+		IL_037c: ldstr ""
+		IL_0381: ldc.i4.0
+		IL_0382: ldc.i4.1
+		IL_0383: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0388: stloc.s 14
+		IL_038a: ldc.i4.1
+		IL_038b: newarr [System.Runtime]System.Object
+		IL_0390: dup
+		IL_0391: ldc.i4.0
+		IL_0392: ldloc.0
+		IL_0393: stelem.ref
+		IL_0394: ldftn object Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10::__js_call__(object[], object)
+		IL_039a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_039f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_03a4: ldc.i4.0
+		IL_03a5: conv.r8
+		IL_03a6: ldstr ""
+		IL_03ab: ldc.i4.0
+		IL_03ac: ldc.i4.1
+		IL_03ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
+		IL_03b7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_03bc: stloc.s 15
+		IL_03be: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_03c3: dup
-		IL_03c4: ldstr "has"
-		IL_03c9: ldloc.s 13
-		IL_03cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03d0: dup
-		IL_03d1: ldstr "keys"
-		IL_03d6: ldloc.s 14
-		IL_03d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03dd: stloc.3
-		IL_03de: ldstr "console"
-		IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03ed: stloc.s 9
-		IL_03ef: ldloc.1
-		IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03f5: ldstr "union"
-		IL_03fa: ldloc.3
-		IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0400: stloc.s 10
-		IL_0402: ldloc.s 10
-		IL_0404: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0409: ldc.i4.1
-		IL_040a: newarr [System.Runtime]System.Object
-		IL_040f: dup
-		IL_0410: ldc.i4.0
-		IL_0411: ldstr ","
-		IL_0416: stelem.ref
-		IL_0417: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_041c: stloc.s 11
-		IL_041e: ldloc.s 9
-		IL_0420: ldstr "log"
-		IL_0425: ldloc.s 11
-		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_042c: pop
+		IL_03c4: ldstr "size"
+		IL_03c9: ldc.r8 2
+		IL_03d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_03d7: dup
+		IL_03d8: ldstr "has"
+		IL_03dd: ldloc.s 14
+		IL_03df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03e4: dup
+		IL_03e5: ldstr "keys"
+		IL_03ea: ldloc.s 15
+		IL_03ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03f1: stloc.3
+		IL_03f2: ldstr "console"
+		IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0401: stloc.s 9
+		IL_0403: ldloc.1
+		IL_0404: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_0409: stloc.s 13
+		IL_040b: ldloc.s 13
+		IL_040d: ldstr "union"
+		IL_0412: ldloc.3
+		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0418: stloc.s 11
+		IL_041a: ldloc.s 11
+		IL_041c: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0421: ldc.i4.1
+		IL_0422: newarr [System.Runtime]System.Object
+		IL_0427: dup
+		IL_0428: ldc.i4.0
+		IL_0429: ldstr ","
+		IL_042e: stelem.ref
+		IL_042f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0434: stloc.s 12
+		IL_0436: ldloc.s 9
+		IL_0438: ldstr "log"
+		IL_043d: ldloc.s 12
+		IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0444: pop
 		.try
 		{
-			IL_042d: nop
-			IL_042e: ldloc.1
-			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0434: ldc.i4.2
-			IL_0435: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_043a: dup
-			IL_043b: ldc.r8 3
-			IL_0444: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0449: dup
-			IL_044a: ldc.r8 4
-			IL_0453: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0458: stloc.s 8
-			IL_045a: ldstr "union"
-			IL_045f: ldloc.s 8
-			IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0466: pop
-			IL_0467: ldstr "console"
-			IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0476: ldstr "log"
-			IL_047b: ldstr "array did not throw"
-			IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0485: pop
-			IL_0486: leave IL_0506
+			IL_0445: nop
+			IL_0446: ldloc.1
+			IL_0447: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+			IL_044c: stloc.s 13
+			IL_044e: ldc.i4.2
+			IL_044f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0454: dup
+			IL_0455: ldc.r8 3
+			IL_045e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_0463: dup
+			IL_0464: ldc.r8 4
+			IL_046d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_0472: stloc.s 8
+			IL_0474: ldloc.s 13
+			IL_0476: ldstr "union"
+			IL_047b: ldloc.s 8
+			IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0482: pop
+			IL_0483: ldstr "console"
+			IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0492: ldstr "log"
+			IL_0497: ldstr "array did not throw"
+			IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04a1: pop
+			IL_04a2: leave IL_0522
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_048b: stloc.s 4
-			IL_048d: ldloc.s 4
-			IL_048f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0494: dup
-			IL_0495: brtrue IL_04ab
+			IL_04a7: stloc.s 4
+			IL_04a9: ldloc.s 4
+			IL_04ab: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_04b0: dup
+			IL_04b1: brtrue IL_04c7
 
-			IL_049a: pop
-			IL_049b: ldloc.s 4
-			IL_049d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_04a2: dup
-			IL_04a3: brtrue IL_04b7
+			IL_04b6: pop
+			IL_04b7: ldloc.s 4
+			IL_04b9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04be: dup
+			IL_04bf: brtrue IL_04d3
 
-			IL_04a8: pop
-			IL_04a9: rethrow
+			IL_04c4: pop
+			IL_04c5: rethrow
 
-			IL_04ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_04b0: stloc.s 5
-			IL_04b2: br IL_04b9
+			IL_04c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_04cc: stloc.s 5
+			IL_04ce: br IL_04d5
 
-			IL_04b7: stloc.s 5
+			IL_04d3: stloc.s 5
 
-			IL_04b9: ldloc.s 5
-			IL_04bb: stloc.s 6
-			IL_04bd: ldstr "console"
-			IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04cc: stloc.s 9
-			IL_04ce: ldloc.s 6
-			IL_04d0: stloc.s 10
-			IL_04d2: ldstr "TypeError"
-			IL_04d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04dc: stloc.s 15
-			IL_04de: ldloc.s 10
-			IL_04e0: ldloc.s 15
-			IL_04e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_04e7: stloc.s 16
-			IL_04e9: ldloc.s 16
-			IL_04eb: box [System.Runtime]System.Boolean
-			IL_04f0: stloc.s 17
-			IL_04f2: ldloc.s 9
-			IL_04f4: ldstr "log"
-			IL_04f9: ldloc.s 17
-			IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0500: pop
-			IL_0501: leave IL_0506
+			IL_04d5: ldloc.s 5
+			IL_04d7: stloc.s 6
+			IL_04d9: ldstr "console"
+			IL_04de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04e8: stloc.s 9
+			IL_04ea: ldloc.s 6
+			IL_04ec: stloc.s 11
+			IL_04ee: ldstr "TypeError"
+			IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04f8: stloc.s 16
+			IL_04fa: ldloc.s 11
+			IL_04fc: ldloc.s 16
+			IL_04fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0503: stloc.s 17
+			IL_0505: ldloc.s 17
+			IL_0507: box [System.Runtime]System.Boolean
+			IL_050c: stloc.s 18
+			IL_050e: ldloc.s 9
+			IL_0510: ldstr "log"
+			IL_0515: ldloc.s 18
+			IL_0517: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_051c: pop
+			IL_051d: leave IL_0522
 		} // end handler
 
-		IL_0506: ldnull
-		IL_0507: stloc.s 7
-		IL_0509: ret
+		IL_0522: ldnull
+		IL_0523: stloc.s 7
+		IL_0525: ret
 	} // end of method Set_Algebra_Methods::__js_module_init__
 
 } // end of class Modules.Set_Algebra_Methods
@@ -758,7 +773,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2745
+		// Method begins at RVA 0x2761
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2968
+						// Method begins at RVA 0x2978
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x295f
+					// Method begins at RVA 0x296f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2684
+				// Method begins at RVA 0x2694
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -178,7 +178,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2956
+				// Method begins at RVA 0x2966
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -204,7 +204,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x23c0
+			// Method begins at RVA 0x23d0
 			// Header size: 12
 			// Code size: 172 (0xac)
 			.maxstack 8
@@ -293,7 +293,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2983
+						// Method begins at RVA 0x2993
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -311,7 +311,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x297a
+					// Method begins at RVA 0x298a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -335,7 +335,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2758
+				// Method begins at RVA 0x2768
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -440,7 +440,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x298c
+					// Method begins at RVA 0x299c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -464,7 +464,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x282b
+				// Method begins at RVA 0x283b
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -502,7 +502,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2971
+				// Method begins at RVA 0x2981
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -528,7 +528,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2478
+			// Method begins at RVA 0x2488
 			// Header size: 12
 			// Code size: 208 (0xd0)
 			.maxstack 8
@@ -631,7 +631,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2995
+				// Method begins at RVA 0x29a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -655,7 +655,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2554
+			// Method begins at RVA 0x2564
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -712,7 +712,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x29b0
+						// Method begins at RVA 0x29c0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -730,7 +730,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29a7
+					// Method begins at RVA 0x29b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -754,7 +754,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2854
+				// Method begins at RVA 0x2864
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -859,7 +859,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29b9
+					// Method begins at RVA 0x29c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -883,7 +883,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2927
+				// Method begins at RVA 0x2937
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -921,7 +921,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x299e
+				// Method begins at RVA 0x29ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -947,7 +947,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x25a8
+			// Method begins at RVA 0x25b8
 			// Header size: 12
 			// Code size: 208 (0xd0)
 			.maxstack 8
@@ -1060,7 +1060,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x294d
+			// Method begins at RVA 0x295d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1086,7 +1086,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 865 (0x361)
+		// Code size: 881 (0x371)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Constructor_Iterable/Scope,
@@ -1100,7 +1100,8 @@
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[10] object,
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.Set,
+			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		)
 
 		IL_0000: newobj instance void Modules.Set_Constructor_Iterable/Scope::.ctor()
@@ -1154,206 +1155,214 @@
 		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_009b: stloc.s 10
 		IL_009d: ldloc.2
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a3: ldstr "has"
-		IL_00a8: ldc.r8 1
-		IL_00b1: box [System.Runtime]System.Double
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bb: stloc.s 7
-		IL_00bd: ldloc.s 10
-		IL_00bf: ldstr "log"
-		IL_00c4: ldloc.s 7
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cb: pop
-		IL_00cc: ldstr "console"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00db: stloc.s 7
-		IL_00dd: ldloc.2
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e3: ldstr "has"
-		IL_00e8: ldc.r8 3
-		IL_00f1: box [System.Runtime]System.Double
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fb: stloc.s 10
-		IL_00fd: ldloc.s 7
-		IL_00ff: ldstr "log"
-		IL_0104: ldloc.s 10
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010b: pop
-		IL_010c: ldstr "console"
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011b: stloc.s 10
-		IL_011d: ldloc.2
+		IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_00a3: stloc.s 11
+		IL_00a5: ldloc.s 11
+		IL_00a7: ldstr "has"
+		IL_00ac: ldc.r8 1
+		IL_00b5: box [System.Runtime]System.Double
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bf: stloc.s 7
+		IL_00c1: ldloc.s 10
+		IL_00c3: ldstr "log"
+		IL_00c8: ldloc.s 7
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cf: pop
+		IL_00d0: ldstr "console"
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00df: stloc.s 7
+		IL_00e1: ldloc.2
+		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_00e7: stloc.s 11
+		IL_00e9: ldloc.s 11
+		IL_00eb: ldstr "has"
+		IL_00f0: ldc.r8 3
+		IL_00f9: box [System.Runtime]System.Double
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0103: stloc.s 10
+		IL_0105: ldloc.s 7
+		IL_0107: ldstr "log"
+		IL_010c: ldloc.s 10
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0113: pop
+		IL_0114: ldstr "console"
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0123: ldstr "has"
-		IL_0128: ldc.r8 4
-		IL_0131: box [System.Runtime]System.Double
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013b: stloc.s 7
-		IL_013d: ldloc.s 10
-		IL_013f: ldstr "log"
-		IL_0144: ldloc.s 7
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014b: pop
-		IL_014c: ldloc.0
-		IL_014d: ldc.i4.0
-		IL_014e: box [System.Runtime]System.Boolean
-		IL_0153: stfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_0158: ldstr "iterator"
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0162: stloc.s 7
-		IL_0164: ldloc.0
-		IL_0165: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_016a: ldftn object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
-		IL_0170: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0175: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_017a: ldc.i4.0
-		IL_017b: conv.r8
-		IL_017c: ldstr ""
-		IL_0181: ldc.i4.0
-		IL_0182: ldc.i4.1
-		IL_0183: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0188: stloc.s 8
-		IL_018a: ldloc.s 8
-		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0191: stloc.s 8
-		IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0198: stloc.s 9
-		IL_019a: ldloc.s 9
-		IL_019c: ldloc.s 7
-		IL_019e: ldloc.s 8
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_01a5: pop
+		IL_0123: stloc.s 10
+		IL_0125: ldloc.2
+		IL_0126: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_012b: stloc.s 11
+		IL_012d: ldloc.s 11
+		IL_012f: ldstr "has"
+		IL_0134: ldc.r8 4
+		IL_013d: box [System.Runtime]System.Double
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0147: stloc.s 7
+		IL_0149: ldloc.s 10
+		IL_014b: ldstr "log"
+		IL_0150: ldloc.s 7
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0157: pop
+		IL_0158: ldloc.0
+		IL_0159: ldc.i4.0
+		IL_015a: box [System.Runtime]System.Boolean
+		IL_015f: stfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_0164: ldstr "iterator"
+		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_016e: stloc.s 7
+		IL_0170: ldloc.0
+		IL_0171: castclass Modules.Set_Constructor_Iterable/Scope
+		IL_0176: ldftn object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
+		IL_017c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0181: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0186: ldc.i4.0
+		IL_0187: conv.r8
+		IL_0188: ldstr ""
+		IL_018d: ldc.i4.0
+		IL_018e: ldc.i4.1
+		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0194: stloc.s 8
+		IL_0196: ldloc.s 8
+		IL_0198: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_019d: stloc.s 8
+		IL_019f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01a4: stloc.s 9
 		IL_01a6: ldloc.s 9
-		IL_01a8: stloc.3
-		IL_01a9: ldloc.3
-		IL_01aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_01af: stloc.s 4
-		IL_01b1: ldstr "console"
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c0: stloc.s 7
-		IL_01c2: ldloc.0
-		IL_01c3: ldfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_01c8: stloc.s 10
-		IL_01ca: ldloc.s 7
-		IL_01cc: ldstr "log"
-		IL_01d1: ldloc.s 10
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d8: pop
-		IL_01d9: ldstr "console"
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e8: stloc.s 10
-		IL_01ea: ldloc.s 4
-		IL_01ec: ldstr "size"
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01f6: stloc.s 7
-		IL_01f8: ldloc.s 10
-		IL_01fa: ldstr "log"
-		IL_01ff: ldloc.s 7
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0206: pop
-		IL_0207: ldloc.0
-		IL_0208: ldc.i4.0
-		IL_0209: box [System.Runtime]System.Boolean
-		IL_020e: stfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
-		IL_0213: ldnull
-		IL_0214: ldftn object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike::__js_call__(object, object)
-		IL_021a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_021f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0224: ldc.i4.1
-		IL_0225: conv.r8
-		IL_0226: ldstr ""
-		IL_022b: ldc.i4.0
-		IL_022c: ldc.i4.1
-		IL_022d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0232: stloc.s 11
-		IL_0234: ldloc.s 11
-		IL_0236: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_023b: stloc.s 11
-		IL_023d: ldloc.0
-		IL_023e: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_0243: ldftn object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
-		IL_0249: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_024e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0253: ldc.i4.0
-		IL_0254: conv.r8
-		IL_0255: ldstr ""
-		IL_025a: ldc.i4.0
-		IL_025b: ldc.i4.1
-		IL_025c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0261: stloc.s 8
-		IL_0263: ldloc.s 8
-		IL_0265: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_026a: stloc.s 8
-		IL_026c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0271: dup
-		IL_0272: ldstr "size"
-		IL_0277: ldc.r8 2
-		IL_0280: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0285: dup
-		IL_0286: ldstr "has"
-		IL_028b: ldloc.s 11
-		IL_028d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0292: dup
-		IL_0293: ldstr "keys"
-		IL_0298: ldloc.s 8
-		IL_029a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_029f: stloc.s 5
-		IL_02a1: ldloc.s 4
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a8: ldstr "union"
-		IL_02ad: ldloc.s 5
-		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b4: stloc.s 6
-		IL_02b6: ldstr "console"
-		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c5: stloc.s 7
-		IL_02c7: ldloc.0
-		IL_02c8: ldfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
-		IL_02cd: stloc.s 10
-		IL_02cf: ldloc.s 7
-		IL_02d1: ldstr "log"
-		IL_02d6: ldloc.s 10
-		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02dd: pop
-		IL_02de: ldstr "console"
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ed: stloc.s 10
-		IL_02ef: ldloc.s 6
-		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f6: ldstr "has"
-		IL_02fb: ldc.r8 4
-		IL_0304: box [System.Runtime]System.Double
-		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_030e: stloc.s 7
-		IL_0310: ldloc.s 10
-		IL_0312: ldstr "log"
-		IL_0317: ldloc.s 7
+		IL_01a8: ldloc.s 7
+		IL_01aa: ldloc.s 8
+		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_01b1: pop
+		IL_01b2: ldloc.s 9
+		IL_01b4: stloc.3
+		IL_01b5: ldloc.3
+		IL_01b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_01bb: stloc.s 4
+		IL_01bd: ldstr "console"
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01cc: stloc.s 7
+		IL_01ce: ldloc.0
+		IL_01cf: ldfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_01d4: stloc.s 10
+		IL_01d6: ldloc.s 7
+		IL_01d8: ldstr "log"
+		IL_01dd: ldloc.s 10
+		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e4: pop
+		IL_01e5: ldstr "console"
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f4: stloc.s 10
+		IL_01f6: ldloc.s 4
+		IL_01f8: ldstr "size"
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0202: stloc.s 7
+		IL_0204: ldloc.s 10
+		IL_0206: ldstr "log"
+		IL_020b: ldloc.s 7
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0212: pop
+		IL_0213: ldloc.0
+		IL_0214: ldc.i4.0
+		IL_0215: box [System.Runtime]System.Boolean
+		IL_021a: stfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
+		IL_021f: ldnull
+		IL_0220: ldftn object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike::__js_call__(object, object)
+		IL_0226: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_022b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0230: ldc.i4.1
+		IL_0231: conv.r8
+		IL_0232: ldstr ""
+		IL_0237: ldc.i4.0
+		IL_0238: ldc.i4.1
+		IL_0239: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_023e: stloc.s 12
+		IL_0240: ldloc.s 12
+		IL_0242: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_0247: stloc.s 12
+		IL_0249: ldloc.0
+		IL_024a: castclass Modules.Set_Constructor_Iterable/Scope
+		IL_024f: ldftn object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
+		IL_0255: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_025a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_025f: ldc.i4.0
+		IL_0260: conv.r8
+		IL_0261: ldstr ""
+		IL_0266: ldc.i4.0
+		IL_0267: ldc.i4.1
+		IL_0268: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_026d: stloc.s 8
+		IL_026f: ldloc.s 8
+		IL_0271: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0276: stloc.s 8
+		IL_0278: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_027d: dup
+		IL_027e: ldstr "size"
+		IL_0283: ldc.r8 2
+		IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0291: dup
+		IL_0292: ldstr "has"
+		IL_0297: ldloc.s 12
+		IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_029e: dup
+		IL_029f: ldstr "keys"
+		IL_02a4: ldloc.s 8
+		IL_02a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_02ab: stloc.s 5
+		IL_02ad: ldloc.s 4
+		IL_02af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_02b4: stloc.s 11
+		IL_02b6: ldloc.s 11
+		IL_02b8: ldstr "union"
+		IL_02bd: ldloc.s 5
+		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c4: stloc.s 6
+		IL_02c6: ldstr "console"
+		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d5: stloc.s 7
+		IL_02d7: ldloc.0
+		IL_02d8: ldfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
+		IL_02dd: stloc.s 10
+		IL_02df: ldloc.s 7
+		IL_02e1: ldstr "log"
+		IL_02e6: ldloc.s 10
+		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ed: pop
+		IL_02ee: ldstr "console"
+		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fd: stloc.s 10
+		IL_02ff: ldloc.s 6
+		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0306: ldstr "has"
+		IL_030b: ldc.r8 4
+		IL_0314: box [System.Runtime]System.Double
 		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_031e: pop
-		IL_031f: ldstr "console"
-		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_032e: stloc.s 7
-		IL_0330: ldloc.s 6
-		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0337: ldstr "has"
-		IL_033c: ldc.r8 6
-		IL_0345: box [System.Runtime]System.Double
-		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_034f: stloc.s 10
-		IL_0351: ldloc.s 7
-		IL_0353: ldstr "log"
-		IL_0358: ldloc.s 10
+		IL_031e: stloc.s 7
+		IL_0320: ldloc.s 10
+		IL_0322: ldstr "log"
+		IL_0327: ldloc.s 7
+		IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_032e: pop
+		IL_032f: ldstr "console"
+		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_033e: stloc.s 7
+		IL_0340: ldloc.s 6
+		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0347: ldstr "has"
+		IL_034c: ldc.r8 6
+		IL_0355: box [System.Runtime]System.Double
 		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_035f: pop
-		IL_0360: ret
+		IL_035f: stloc.s 10
+		IL_0361: ldloc.s 7
+		IL_0363: ldstr "log"
+		IL_0368: ldloc.s 10
+		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_036f: pop
+		IL_0370: ret
 	} // end of method Set_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Set_Constructor_Iterable
@@ -1365,7 +1374,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29c2
+		// Method begins at RVA 0x29d2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Core_Methods.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Core_Methods.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21cb
+			// Method begins at RVA 0x21e1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 367 (0x16f)
+		// Code size: 389 (0x185)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Core_Methods/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Set,
-			[2] object,
-			[3] object
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.Set,
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Set_Core_Methods/Scope::.ctor()
@@ -55,103 +56,115 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0013: ldstr "add"
-		IL_0018: ldc.r8 1
-		IL_0021: box [System.Runtime]System.Double
-		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_002b: pop
-		IL_002c: ldloc.1
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0032: ldstr "add"
-		IL_0037: ldc.r8 2
-		IL_0040: box [System.Runtime]System.Double
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004a: pop
-		IL_004b: ldloc.1
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0051: ldstr "add"
-		IL_0056: ldc.r8 2
-		IL_005f: box [System.Runtime]System.Double
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0069: pop
-		IL_006a: ldstr "console"
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0079: stloc.2
-		IL_007a: ldloc.1
-		IL_007b: ldstr "size"
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0085: stloc.3
-		IL_0086: ldloc.2
-		IL_0087: ldstr "log"
-		IL_008c: ldloc.3
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0092: pop
-		IL_0093: ldstr "console"
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a2: stloc.3
-		IL_00a3: ldloc.1
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a9: ldstr "delete"
-		IL_00ae: ldc.r8 2
-		IL_00b7: box [System.Runtime]System.Double
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c1: stloc.2
-		IL_00c2: ldloc.3
-		IL_00c3: ldstr "log"
-		IL_00c8: ldloc.2
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ce: pop
-		IL_00cf: ldstr "console"
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00de: stloc.2
-		IL_00df: ldloc.1
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e5: ldstr "has"
-		IL_00ea: ldc.r8 2
-		IL_00f3: box [System.Runtime]System.Double
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fd: stloc.3
-		IL_00fe: ldloc.2
-		IL_00ff: ldstr "log"
-		IL_0104: ldloc.3
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010a: pop
-		IL_010b: ldstr "console"
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011a: stloc.3
-		IL_011b: ldloc.1
-		IL_011c: ldstr "size"
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0126: stloc.2
-		IL_0127: ldloc.3
-		IL_0128: ldstr "log"
-		IL_012d: ldloc.2
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0133: pop
-		IL_0134: ldloc.1
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013a: ldstr "clear"
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0144: pop
-		IL_0145: ldstr "console"
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0154: stloc.2
-		IL_0155: ldloc.1
-		IL_0156: ldstr "size"
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0160: stloc.3
-		IL_0161: ldloc.2
-		IL_0162: ldstr "log"
-		IL_0167: ldloc.3
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016d: pop
-		IL_016e: ret
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_0013: stloc.2
+		IL_0014: ldloc.2
+		IL_0015: ldstr "add"
+		IL_001a: ldc.r8 1
+		IL_0023: box [System.Runtime]System.Double
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_002d: pop
+		IL_002e: ldloc.1
+		IL_002f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_0034: stloc.2
+		IL_0035: ldloc.2
+		IL_0036: ldstr "add"
+		IL_003b: ldc.r8 2
+		IL_0044: box [System.Runtime]System.Double
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004e: pop
+		IL_004f: ldloc.1
+		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_0055: stloc.2
+		IL_0056: ldloc.2
+		IL_0057: ldstr "add"
+		IL_005c: ldc.r8 2
+		IL_0065: box [System.Runtime]System.Double
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006f: pop
+		IL_0070: ldstr "console"
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007f: stloc.3
+		IL_0080: ldloc.1
+		IL_0081: ldstr "size"
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_008b: stloc.s 4
+		IL_008d: ldloc.3
+		IL_008e: ldstr "log"
+		IL_0093: ldloc.s 4
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009a: pop
+		IL_009b: ldstr "console"
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00aa: stloc.s 4
+		IL_00ac: ldloc.1
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_00b2: stloc.2
+		IL_00b3: ldloc.2
+		IL_00b4: ldstr "delete"
+		IL_00b9: ldc.r8 2
+		IL_00c2: box [System.Runtime]System.Double
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cc: stloc.3
+		IL_00cd: ldloc.s 4
+		IL_00cf: ldstr "log"
+		IL_00d4: ldloc.3
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00da: pop
+		IL_00db: ldstr "console"
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ea: stloc.3
+		IL_00eb: ldloc.1
+		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_00f1: stloc.2
+		IL_00f2: ldloc.2
+		IL_00f3: ldstr "has"
+		IL_00f8: ldc.r8 2
+		IL_0101: box [System.Runtime]System.Double
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010b: stloc.s 4
+		IL_010d: ldloc.3
+		IL_010e: ldstr "log"
+		IL_0113: ldloc.s 4
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011a: pop
+		IL_011b: ldstr "console"
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012a: stloc.s 4
+		IL_012c: ldloc.1
+		IL_012d: ldstr "size"
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0137: stloc.3
+		IL_0138: ldloc.s 4
+		IL_013a: ldstr "log"
+		IL_013f: ldloc.3
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0145: pop
+		IL_0146: ldloc.1
+		IL_0147: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_014c: stloc.2
+		IL_014d: ldloc.2
+		IL_014e: ldstr "clear"
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0158: pop
+		IL_0159: ldstr "console"
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0168: stloc.3
+		IL_0169: ldloc.1
+		IL_016a: ldstr "size"
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0174: stloc.s 4
+		IL_0176: ldloc.3
+		IL_0177: ldstr "log"
+		IL_017c: ldloc.s 4
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0183: pop
+		IL_0184: ret
 	} // end of method Set_Core_Methods::__js_module_init__
 
 } // end of class Modules.Set_Core_Methods
@@ -163,7 +176,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d4
+		// Method begins at RVA 0x21ea
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Entries_Keys_Values.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Entries_Keys_Values.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2311
+			// Method begins at RVA 0x231d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 693 (0x2b5)
+		// Code size: 705 (0x2c1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Entries_Keys_Values/Scope,
@@ -49,9 +49,10 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[6] object,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Set,
 			[7] object,
-			[8] object
+			[8] object,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.Set_Entries_Keys_Values/Scope::.ctor()
@@ -70,167 +71,173 @@
 		IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
 		IL_0034: stloc.1
 		IL_0035: ldloc.1
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003b: ldstr "keys"
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0045: stloc.s 6
-		IL_0047: ldloc.s 6
-		IL_0049: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_004e: stloc.2
-		IL_004f: ldloc.1
-		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0055: ldstr "values"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_005f: stloc.s 6
-		IL_0061: ldloc.s 6
-		IL_0063: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0068: stloc.3
-		IL_0069: ldloc.1
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: ldstr "entries"
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0079: stloc.s 6
-		IL_007b: ldloc.s 6
-		IL_007d: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0082: stloc.s 4
-		IL_0084: ldstr "console"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0093: ldloc.2
-		IL_0094: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0099: box [System.Runtime]System.Double
-		IL_009e: stloc.s 7
-		IL_00a0: ldstr "log"
-		IL_00a5: ldloc.s 7
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ac: pop
-		IL_00ad: ldstr "console"
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bc: ldloc.2
-		IL_00bd: ldc.r8 0.0
-		IL_00c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_00cb: stloc.s 6
-		IL_00cd: ldstr "log"
-		IL_00d2: ldloc.s 6
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d9: pop
-		IL_00da: ldstr "console"
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e9: ldloc.2
-		IL_00ea: ldc.r8 1
-		IL_00f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_00f8: stloc.s 6
-		IL_00fa: ldstr "log"
-		IL_00ff: ldloc.s 6
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0106: pop
-		IL_0107: ldstr "console"
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0116: ldloc.3
-		IL_0117: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_011c: box [System.Runtime]System.Double
-		IL_0121: stloc.s 7
-		IL_0123: ldstr "log"
-		IL_0128: ldloc.s 7
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012f: pop
-		IL_0130: ldstr "console"
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013f: ldloc.3
-		IL_0140: ldc.r8 0.0
-		IL_0149: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_014e: stloc.s 6
-		IL_0150: ldstr "log"
-		IL_0155: ldloc.s 6
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015c: pop
-		IL_015d: ldstr "console"
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016c: ldloc.3
-		IL_016d: ldc.r8 1
-		IL_0176: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_017b: stloc.s 6
-		IL_017d: ldstr "log"
-		IL_0182: ldloc.s 6
-		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0189: pop
-		IL_018a: ldstr "console"
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0199: ldloc.s 4
-		IL_019b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_01a0: box [System.Runtime]System.Double
-		IL_01a5: stloc.s 7
-		IL_01a7: ldstr "log"
-		IL_01ac: ldloc.s 7
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b3: pop
-		IL_01b4: ldstr "console"
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c3: stloc.s 6
-		IL_01c5: ldloc.s 4
-		IL_01c7: ldc.r8 0.0
-		IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01d5: ldc.r8 0.0
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01e3: stloc.s 8
-		IL_01e5: ldloc.s 6
-		IL_01e7: ldstr "log"
-		IL_01ec: ldloc.s 8
-		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f3: pop
-		IL_01f4: ldstr "console"
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0203: stloc.s 8
-		IL_0205: ldloc.s 4
-		IL_0207: ldc.r8 0.0
-		IL_0210: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0215: ldc.r8 1
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0223: stloc.s 6
-		IL_0225: ldloc.s 8
-		IL_0227: ldstr "log"
-		IL_022c: ldloc.s 6
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0233: pop
-		IL_0234: ldstr "console"
-		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0243: stloc.s 6
-		IL_0245: ldloc.s 4
-		IL_0247: ldc.r8 1
-		IL_0250: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0255: ldc.r8 0.0
-		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0263: stloc.s 8
-		IL_0265: ldloc.s 6
-		IL_0267: ldstr "log"
-		IL_026c: ldloc.s 8
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0273: pop
-		IL_0274: ldstr "console"
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0283: stloc.s 8
-		IL_0285: ldloc.s 4
-		IL_0287: ldc.r8 1
-		IL_0290: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0295: ldc.r8 1
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02a3: stloc.s 6
-		IL_02a5: ldloc.s 8
-		IL_02a7: ldstr "log"
-		IL_02ac: ldloc.s 6
-		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b3: pop
-		IL_02b4: ret
+		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_003b: stloc.s 6
+		IL_003d: ldloc.s 6
+		IL_003f: ldstr "keys"
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0049: stloc.s 7
+		IL_004b: ldloc.s 7
+		IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0052: stloc.2
+		IL_0053: ldloc.1
+		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_0059: stloc.s 6
+		IL_005b: ldloc.s 6
+		IL_005d: ldstr "values"
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0067: stloc.s 7
+		IL_0069: ldloc.s 7
+		IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0070: stloc.3
+		IL_0071: ldloc.1
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_0077: stloc.s 6
+		IL_0079: ldloc.s 6
+		IL_007b: ldstr "entries"
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0085: stloc.s 7
+		IL_0087: ldloc.s 7
+		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_008e: stloc.s 4
+		IL_0090: ldstr "console"
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009f: ldloc.2
+		IL_00a0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_00a5: box [System.Runtime]System.Double
+		IL_00aa: stloc.s 8
+		IL_00ac: ldstr "log"
+		IL_00b1: ldloc.s 8
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b8: pop
+		IL_00b9: ldstr "console"
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c8: ldloc.2
+		IL_00c9: ldc.r8 0.0
+		IL_00d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_00d7: stloc.s 7
+		IL_00d9: ldstr "log"
+		IL_00de: ldloc.s 7
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e5: pop
+		IL_00e6: ldstr "console"
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f5: ldloc.2
+		IL_00f6: ldc.r8 1
+		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0104: stloc.s 7
+		IL_0106: ldstr "log"
+		IL_010b: ldloc.s 7
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0112: pop
+		IL_0113: ldstr "console"
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0122: ldloc.3
+		IL_0123: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0128: box [System.Runtime]System.Double
+		IL_012d: stloc.s 8
+		IL_012f: ldstr "log"
+		IL_0134: ldloc.s 8
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013b: pop
+		IL_013c: ldstr "console"
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014b: ldloc.3
+		IL_014c: ldc.r8 0.0
+		IL_0155: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_015a: stloc.s 7
+		IL_015c: ldstr "log"
+		IL_0161: ldloc.s 7
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0168: pop
+		IL_0169: ldstr "console"
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0178: ldloc.3
+		IL_0179: ldc.r8 1
+		IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0187: stloc.s 7
+		IL_0189: ldstr "log"
+		IL_018e: ldloc.s 7
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0195: pop
+		IL_0196: ldstr "console"
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a5: ldloc.s 4
+		IL_01a7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_01ac: box [System.Runtime]System.Double
+		IL_01b1: stloc.s 8
+		IL_01b3: ldstr "log"
+		IL_01b8: ldloc.s 8
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bf: pop
+		IL_01c0: ldstr "console"
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01cf: stloc.s 7
+		IL_01d1: ldloc.s 4
+		IL_01d3: ldc.r8 0.0
+		IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01e1: ldc.r8 0.0
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01ef: stloc.s 9
+		IL_01f1: ldloc.s 7
+		IL_01f3: ldstr "log"
+		IL_01f8: ldloc.s 9
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ff: pop
+		IL_0200: ldstr "console"
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020f: stloc.s 9
+		IL_0211: ldloc.s 4
+		IL_0213: ldc.r8 0.0
+		IL_021c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0221: ldc.r8 1
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_022f: stloc.s 7
+		IL_0231: ldloc.s 9
+		IL_0233: ldstr "log"
+		IL_0238: ldloc.s 7
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023f: pop
+		IL_0240: ldstr "console"
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024f: stloc.s 7
+		IL_0251: ldloc.s 4
+		IL_0253: ldc.r8 1
+		IL_025c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0261: ldc.r8 0.0
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_026f: stloc.s 9
+		IL_0271: ldloc.s 7
+		IL_0273: ldstr "log"
+		IL_0278: ldloc.s 9
+		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027f: pop
+		IL_0280: ldstr "console"
+		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028f: stloc.s 9
+		IL_0291: ldloc.s 4
+		IL_0293: ldc.r8 1
+		IL_029c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_02a1: ldc.r8 1
+		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02af: stloc.s 7
+		IL_02b1: ldloc.s 9
+		IL_02b3: ldstr "log"
+		IL_02b8: ldloc.s 7
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02bf: pop
+		IL_02c0: ret
 	} // end of method Set_Entries_Keys_Values::__js_module_init__
 
 } // end of class Modules.Set_Entries_Keys_Values
@@ -242,7 +249,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x231a
+		// Method begins at RVA 0x2326
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Symbol_Iterator.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Symbol_Iterator.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c7
+			// Method begins at RVA 0x21d3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 363 (0x16b)
+		// Code size: 375 (0x177)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Symbol_Iterator/Scope,
@@ -50,8 +50,10 @@
 			[4] object,
 			[5] object,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[7] object,
-			[8] object
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.Set,
+			[8] object,
+			[9] object[],
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Set_Symbol_Iterator/Scope::.ctor()
@@ -70,94 +72,100 @@
 		IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
 		IL_0034: stloc.1
 		IL_0035: ldloc.1
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003b: ldstr "iterator"
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0045: ldc.i4.0
-		IL_0046: newarr [System.Runtime]System.Object
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0050: stloc.2
-		IL_0051: ldloc.2
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0057: ldstr "next"
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0061: stloc.3
-		IL_0062: ldloc.2
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0068: ldstr "next"
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0072: stloc.s 4
-		IL_0074: ldloc.2
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007a: ldstr "next"
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0084: stloc.s 5
-		IL_0086: ldstr "console"
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0095: stloc.s 7
-		IL_0097: ldloc.3
-		IL_0098: ldstr "done"
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a2: stloc.s 8
-		IL_00a4: ldloc.s 7
-		IL_00a6: ldstr "log"
-		IL_00ab: ldloc.s 8
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b2: pop
-		IL_00b3: ldstr "console"
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c2: stloc.s 8
-		IL_00c4: ldloc.3
-		IL_00c5: ldstr "value"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00cf: stloc.s 7
-		IL_00d1: ldloc.s 8
-		IL_00d3: ldstr "log"
-		IL_00d8: ldloc.s 7
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00df: pop
-		IL_00e0: ldstr "console"
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ef: stloc.s 7
-		IL_00f1: ldloc.s 4
-		IL_00f3: ldstr "done"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fd: stloc.s 8
-		IL_00ff: ldloc.s 7
-		IL_0101: ldstr "log"
-		IL_0106: ldloc.s 8
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010d: pop
-		IL_010e: ldstr "console"
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011d: stloc.s 8
-		IL_011f: ldloc.s 4
-		IL_0121: ldstr "value"
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012b: stloc.s 7
-		IL_012d: ldloc.s 8
-		IL_012f: ldstr "log"
-		IL_0134: ldloc.s 7
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013b: pop
-		IL_013c: ldstr "console"
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014b: stloc.s 7
-		IL_014d: ldloc.s 5
-		IL_014f: ldstr "done"
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0159: stloc.s 8
-		IL_015b: ldloc.s 7
-		IL_015d: ldstr "log"
-		IL_0162: ldloc.s 8
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0169: pop
-		IL_016a: ret
+		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
+		IL_003b: stloc.s 7
+		IL_003d: ldstr "iterator"
+		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0047: stloc.s 8
+		IL_0049: ldc.i4.0
+		IL_004a: newarr [System.Runtime]System.Object
+		IL_004f: stloc.s 9
+		IL_0051: ldloc.s 7
+		IL_0053: ldloc.s 8
+		IL_0055: ldloc.s 9
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_005c: stloc.2
+		IL_005d: ldloc.2
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0063: ldstr "next"
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_006d: stloc.3
+		IL_006e: ldloc.2
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0074: ldstr "next"
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_007e: stloc.s 4
+		IL_0080: ldloc.2
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0086: ldstr "next"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0090: stloc.s 5
+		IL_0092: ldstr "console"
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a1: stloc.s 8
+		IL_00a3: ldloc.3
+		IL_00a4: ldstr "done"
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ae: stloc.s 10
+		IL_00b0: ldloc.s 8
+		IL_00b2: ldstr "log"
+		IL_00b7: ldloc.s 10
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00be: pop
+		IL_00bf: ldstr "console"
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ce: stloc.s 10
+		IL_00d0: ldloc.3
+		IL_00d1: ldstr "value"
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00db: stloc.s 8
+		IL_00dd: ldloc.s 10
+		IL_00df: ldstr "log"
+		IL_00e4: ldloc.s 8
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00eb: pop
+		IL_00ec: ldstr "console"
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fb: stloc.s 8
+		IL_00fd: ldloc.s 4
+		IL_00ff: ldstr "done"
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0109: stloc.s 10
+		IL_010b: ldloc.s 8
+		IL_010d: ldstr "log"
+		IL_0112: ldloc.s 10
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0119: pop
+		IL_011a: ldstr "console"
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0129: stloc.s 10
+		IL_012b: ldloc.s 4
+		IL_012d: ldstr "value"
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0137: stloc.s 8
+		IL_0139: ldloc.s 10
+		IL_013b: ldstr "log"
+		IL_0140: ldloc.s 8
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0147: pop
+		IL_0148: ldstr "console"
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0157: stloc.s 8
+		IL_0159: ldloc.s 5
+		IL_015b: ldstr "done"
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0165: stloc.s 10
+		IL_0167: ldloc.s 8
+		IL_0169: ldstr "log"
+		IL_016e: ldloc.s 10
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0175: pop
+		IL_0176: ret
 	} // end of method Set_Symbol_Iterator::__js_module_init__
 
 } // end of class Modules.Set_Symbol_Iterator
@@ -169,7 +177,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d0
+		// Method begins at RVA 0x21dc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharAt_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharAt_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2385
+				// Method begins at RVA 0x2399
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x238e
+				// Method begins at RVA 0x23a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x237c
+			// Method begins at RVA 0x2390
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 782 (0x30e)
+		// Code size: 804 (0x324)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_CharAt_Basic/Scope,
@@ -92,11 +92,14 @@
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] string,
-			[8] object,
+			[7] object,
+			[8] string,
 			[9] bool,
 			[10] object,
-			[11] object
+			[11] float64,
+			[12] object,
+			[13] object,
+			[14] object
 		)
 
 		IL_0000: newobj instance void Modules.String_CharAt_Basic/Scope::.ctor()
@@ -107,222 +110,242 @@
 		IL_000d: ldstr "console"
 		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_001c: ldloc.1
-		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0022: castclass [System.Runtime]System.String
-		IL_0027: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string)
-		IL_002c: stloc.s 7
-		IL_002e: ldstr "log"
-		IL_0033: ldloc.s 7
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_003a: pop
-		IL_003b: ldstr "console"
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004a: ldloc.1
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0050: castclass [System.Runtime]System.String
-		IL_0055: ldc.r8 1
-		IL_005e: box [System.Runtime]System.Double
-		IL_0063: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_0068: stloc.s 7
-		IL_006a: ldstr "log"
-		IL_006f: ldloc.s 7
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0076: pop
-		IL_0077: ldstr "console"
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0086: ldloc.1
+		IL_001c: stloc.s 7
+		IL_001e: ldloc.1
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0024: stloc.s 8
+		IL_0026: ldloc.s 8
+		IL_0028: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string)
+		IL_002d: stloc.s 8
+		IL_002f: ldloc.s 7
+		IL_0031: ldstr "log"
+		IL_0036: ldloc.s 8
+		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_003d: pop
+		IL_003e: ldstr "console"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_004d: stloc.s 7
+		IL_004f: ldloc.1
+		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0055: stloc.s 8
+		IL_0057: ldloc.s 8
+		IL_0059: ldc.r8 1
+		IL_0062: box [System.Runtime]System.Double
+		IL_0067: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_006c: stloc.s 8
+		IL_006e: ldloc.s 7
+		IL_0070: ldstr "log"
+		IL_0075: ldloc.s 8
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007c: pop
+		IL_007d: ldstr "console"
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008c: castclass [System.Runtime]System.String
-		IL_0091: ldc.r8 4
-		IL_009a: box [System.Runtime]System.Double
-		IL_009f: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_00a4: stloc.s 7
-		IL_00a6: ldstr "log"
-		IL_00ab: ldloc.s 7
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b2: pop
-		IL_00b3: ldstr "console"
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c2: stloc.s 8
-		IL_00c4: ldloc.1
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ca: castclass [System.Runtime]System.String
-		IL_00cf: ldc.r8 5
-		IL_00d8: box [System.Runtime]System.Double
-		IL_00dd: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_00e2: stloc.s 7
-		IL_00e4: ldloc.s 7
-		IL_00e6: ldstr ""
-		IL_00eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f0: stloc.s 9
-		IL_00f2: ldloc.s 9
-		IL_00f4: box [System.Runtime]System.Boolean
-		IL_00f9: stloc.s 10
-		IL_00fb: ldloc.s 8
-		IL_00fd: ldstr "log"
-		IL_0102: ldloc.s 10
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0109: pop
-		IL_010a: ldstr "console"
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0119: stloc.s 8
-		IL_011b: ldloc.1
+		IL_008c: stloc.s 7
+		IL_008e: ldloc.1
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0094: stloc.s 8
+		IL_0096: ldloc.s 8
+		IL_0098: ldc.r8 4
+		IL_00a1: box [System.Runtime]System.Double
+		IL_00a6: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_00ab: stloc.s 8
+		IL_00ad: ldloc.s 7
+		IL_00af: ldstr "log"
+		IL_00b4: ldloc.s 8
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bb: pop
+		IL_00bc: ldstr "console"
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cb: stloc.s 7
+		IL_00cd: ldloc.1
+		IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_00d3: stloc.s 8
+		IL_00d5: ldloc.s 8
+		IL_00d7: ldc.r8 5
+		IL_00e0: box [System.Runtime]System.Double
+		IL_00e5: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_00ea: stloc.s 8
+		IL_00ec: ldloc.s 8
+		IL_00ee: ldstr ""
+		IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00f8: stloc.s 9
+		IL_00fa: ldloc.s 9
+		IL_00fc: box [System.Runtime]System.Boolean
+		IL_0101: stloc.s 10
+		IL_0103: ldloc.s 7
+		IL_0105: ldstr "log"
+		IL_010a: ldloc.s 10
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0111: pop
+		IL_0112: ldstr "console"
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0121: castclass [System.Runtime]System.String
-		IL_0126: ldc.r8 1
-		IL_012f: neg
-		IL_0130: box [System.Runtime]System.Double
-		IL_0135: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_013a: stloc.s 7
-		IL_013c: ldloc.s 7
-		IL_013e: ldstr ""
-		IL_0143: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0148: stloc.s 9
-		IL_014a: ldloc.s 9
-		IL_014c: box [System.Runtime]System.Boolean
-		IL_0151: stloc.s 10
-		IL_0153: ldloc.s 8
-		IL_0155: ldstr "log"
-		IL_015a: ldloc.s 10
-		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0161: pop
+		IL_0121: stloc.s 7
+		IL_0123: ldloc.1
+		IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0129: stloc.s 8
+		IL_012b: ldc.r8 1
+		IL_0134: neg
+		IL_0135: stloc.s 11
+		IL_0137: ldloc.s 11
+		IL_0139: box [System.Runtime]System.Double
+		IL_013e: stloc.s 12
+		IL_0140: ldloc.s 8
+		IL_0142: ldloc.s 12
+		IL_0144: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_0149: stloc.s 8
+		IL_014b: ldloc.s 8
+		IL_014d: ldstr ""
+		IL_0152: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0157: stloc.s 9
+		IL_0159: ldloc.s 9
+		IL_015b: box [System.Runtime]System.Boolean
+		IL_0160: stloc.s 10
+		IL_0162: ldloc.s 7
+		IL_0164: ldstr "log"
+		IL_0169: ldloc.s 10
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0170: pop
 		.try
 		{
-			IL_0162: nop
-			IL_0163: ldstr "console"
-			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0172: ldloc.1
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0178: castclass [System.Runtime]System.String
-			IL_017d: ldc.r8 1
-			IL_0186: box [System.Runtime]System.Double
-			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_0190: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-			IL_0195: stloc.s 7
-			IL_0197: ldstr "log"
-			IL_019c: ldloc.s 7
-			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01a3: pop
-			IL_01a4: leave IL_0265
+			IL_0171: nop
+			IL_0172: ldstr "console"
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0181: stloc.s 7
+			IL_0183: ldloc.1
+			IL_0184: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0189: stloc.s 8
+			IL_018b: ldc.r8 1
+			IL_0194: box [System.Runtime]System.Double
+			IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+			IL_019e: stloc.s 13
+			IL_01a0: ldloc.s 8
+			IL_01a2: ldloc.s 13
+			IL_01a4: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+			IL_01a9: stloc.s 8
+			IL_01ab: ldloc.s 7
+			IL_01ad: ldstr "log"
+			IL_01b2: ldloc.s 8
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01b9: pop
+			IL_01ba: leave IL_027b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01a9: stloc.2
-			IL_01aa: ldloc.2
-			IL_01ab: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_01b0: dup
-			IL_01b1: brtrue IL_01c6
+			IL_01bf: stloc.2
+			IL_01c0: ldloc.2
+			IL_01c1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_01c6: dup
+			IL_01c7: brtrue IL_01dc
 
-			IL_01b6: pop
-			IL_01b7: ldloc.2
-			IL_01b8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_01bd: dup
-			IL_01be: brtrue IL_01d1
+			IL_01cc: pop
+			IL_01cd: ldloc.2
+			IL_01ce: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_01d3: dup
+			IL_01d4: brtrue IL_01e7
 
-			IL_01c3: pop
-			IL_01c4: rethrow
+			IL_01d9: pop
+			IL_01da: rethrow
 
-			IL_01c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_01cb: stloc.3
-			IL_01cc: br IL_01d2
+			IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_01e1: stloc.3
+			IL_01e2: br IL_01e8
 
-			IL_01d1: stloc.3
+			IL_01e7: stloc.3
 
-			IL_01d2: ldloc.3
-			IL_01d3: stloc.s 4
-			IL_01d5: ldstr "console"
-			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e4: ldstr "log"
-			IL_01e9: ldstr "bigint threw:"
-			IL_01ee: ldc.i4.1
-			IL_01ef: box [System.Runtime]System.Boolean
-			IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01f9: pop
-			IL_01fa: ldstr "console"
-			IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0209: stloc.s 8
-			IL_020b: ldloc.s 4
-			IL_020d: ldstr "name"
-			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0217: stloc.s 11
-			IL_0219: ldloc.s 8
-			IL_021b: ldstr "log"
-			IL_0220: ldstr "bigint name:"
-			IL_0225: ldloc.s 11
-			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_022c: pop
-			IL_022d: ldstr "console"
-			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_023c: stloc.s 11
-			IL_023e: ldloc.s 4
-			IL_0240: ldstr "message"
-			IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_024a: stloc.s 8
-			IL_024c: ldloc.s 11
-			IL_024e: ldstr "log"
-			IL_0253: ldstr "bigint message:"
-			IL_0258: ldloc.s 8
-			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_025f: pop
-			IL_0260: leave IL_0265
+			IL_01e8: ldloc.3
+			IL_01e9: stloc.s 4
+			IL_01eb: ldstr "console"
+			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01fa: ldstr "log"
+			IL_01ff: ldstr "bigint threw:"
+			IL_0204: ldc.i4.1
+			IL_0205: box [System.Runtime]System.Boolean
+			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_020f: pop
+			IL_0210: ldstr "console"
+			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021f: stloc.s 7
+			IL_0221: ldloc.s 4
+			IL_0223: ldstr "name"
+			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_022d: stloc.s 14
+			IL_022f: ldloc.s 7
+			IL_0231: ldstr "log"
+			IL_0236: ldstr "bigint name:"
+			IL_023b: ldloc.s 14
+			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0242: pop
+			IL_0243: ldstr "console"
+			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0252: stloc.s 14
+			IL_0254: ldloc.s 4
+			IL_0256: ldstr "message"
+			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0260: stloc.s 7
+			IL_0262: ldloc.s 14
+			IL_0264: ldstr "log"
+			IL_0269: ldstr "bigint message:"
+			IL_026e: ldloc.s 7
+			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0275: pop
+			IL_0276: leave IL_027b
 		} // end handler
 
-		IL_0265: ldstr "String"
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_026f: stloc.s 8
-		IL_0271: ldloc.s 8
-		IL_0273: ldc.i4.1
-		IL_0274: newarr [System.Runtime]System.Object
-		IL_0279: dup
-		IL_027a: ldc.i4.0
-		IL_027b: ldstr "world"
-		IL_0280: stelem.ref
-		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_0286: stloc.s 5
-		IL_0288: ldstr "console"
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0297: stloc.s 8
-		IL_0299: ldloc.s 5
-		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a0: ldstr "charAt"
-		IL_02a5: ldc.r8 0.0
-		IL_02ae: box [System.Runtime]System.Double
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b8: stloc.s 11
-		IL_02ba: ldloc.s 8
-		IL_02bc: ldstr "log"
-		IL_02c1: ldloc.s 11
-		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c8: pop
-		IL_02c9: ldstr "console"
-		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d8: stloc.s 11
-		IL_02da: ldloc.s 5
-		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e1: ldstr "charAt"
-		IL_02e6: ldc.r8 2
-		IL_02ef: box [System.Runtime]System.Double
-		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02f9: stloc.s 8
-		IL_02fb: ldloc.s 11
-		IL_02fd: ldstr "log"
-		IL_0302: ldloc.s 8
-		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0309: pop
-		IL_030a: ldnull
-		IL_030b: stloc.s 6
-		IL_030d: ret
+		IL_027b: ldstr "String"
+		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0285: stloc.s 7
+		IL_0287: ldloc.s 7
+		IL_0289: ldc.i4.1
+		IL_028a: newarr [System.Runtime]System.Object
+		IL_028f: dup
+		IL_0290: ldc.i4.0
+		IL_0291: ldstr "world"
+		IL_0296: stelem.ref
+		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_029c: stloc.s 5
+		IL_029e: ldstr "console"
+		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ad: stloc.s 7
+		IL_02af: ldloc.s 5
+		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b6: ldstr "charAt"
+		IL_02bb: ldc.r8 0.0
+		IL_02c4: box [System.Runtime]System.Double
+		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ce: stloc.s 14
+		IL_02d0: ldloc.s 7
+		IL_02d2: ldstr "log"
+		IL_02d7: ldloc.s 14
+		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02de: pop
+		IL_02df: ldstr "console"
+		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ee: stloc.s 14
+		IL_02f0: ldloc.s 5
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f7: ldstr "charAt"
+		IL_02fc: ldc.r8 2
+		IL_0305: box [System.Runtime]System.Double
+		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_030f: stloc.s 7
+		IL_0311: ldloc.s 14
+		IL_0313: ldstr "log"
+		IL_0318: ldloc.s 7
+		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_031f: pop
+		IL_0320: ldnull
+		IL_0321: stloc.s 6
+		IL_0323: ret
 	} // end of method String_CharAt_Basic::__js_module_init__
 
 } // end of class Modules.String_CharAt_Basic
@@ -334,7 +357,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2397
+		// Method begins at RVA 0x23ab
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharCodeAt_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharCodeAt_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20e0
+			// Method begins at RVA 0x20de
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,11 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 132 (0x84)
+		// Code size: 130 (0x82)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_CharCodeAt_Basic/Scope,
-			[1] float64
+			[1] object,
+			[2] string,
+			[3] float64
 		)
 
 		IL_0000: newobj instance void Modules.String_CharCodeAt_Basic/Scope::.ctor()
@@ -53,32 +55,38 @@
 		IL_0007: ldstr "console"
 		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0016: ldstr "A"
-		IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0020: castclass [System.Runtime]System.String
-		IL_0025: ldc.r8 0.0
-		IL_002e: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
-		IL_0033: stloc.1
-		IL_0034: ldstr "log"
-		IL_0039: ldloc.1
-		IL_003a: box [System.Runtime]System.Double
-		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0044: pop
-		IL_0045: ldstr "console"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0016: stloc.1
+		IL_0017: ldstr "A"
+		IL_001c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0021: stloc.2
+		IL_0022: ldloc.2
+		IL_0023: ldc.r8 0.0
+		IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
+		IL_0031: stloc.3
+		IL_0032: ldloc.1
+		IL_0033: ldstr "log"
+		IL_0038: ldloc.3
+		IL_0039: box [System.Runtime]System.Double
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0043: pop
+		IL_0044: ldstr "console"
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0053: stloc.1
 		IL_0054: ldstr "ABC"
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005e: castclass [System.Runtime]System.String
-		IL_0063: ldc.r8 2
-		IL_006c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
-		IL_0071: stloc.1
-		IL_0072: ldstr "log"
-		IL_0077: ldloc.1
-		IL_0078: box [System.Runtime]System.Double
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0082: pop
-		IL_0083: ret
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_005e: stloc.2
+		IL_005f: ldloc.2
+		IL_0060: ldc.r8 2
+		IL_0069: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
+		IL_006e: stloc.3
+		IL_006f: ldloc.1
+		IL_0070: ldstr "log"
+		IL_0075: ldloc.3
+		IL_0076: box [System.Runtime]System.Double
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0080: pop
+		IL_0081: ret
 	} // end of method String_CharCodeAt_Basic::__js_module_init__
 
 } // end of class Modules.String_CharCodeAt_Basic
@@ -90,7 +98,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20e9
+		// Method begins at RVA 0x20e7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_FromCharCode_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_FromCharCode_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x221d
+			// Method begins at RVA 0x2223
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 449 (0x1c1)
-		.maxstack 11
+		// Code size: 455 (0x1c7)
+		.maxstack 10
 		.locals init (
 			[0] class Modules.String_FromCharCode_Basic/Scope,
 			[1] string,
 			[2] object,
 			[3] string,
-			[4] float64
+			[4] object,
+			[5] float64
 		)
 
 		IL_0000: newobj instance void Modules.String_FromCharCode_Basic/Scope::.ctor()
@@ -132,37 +133,47 @@
 		IL_0123: ldstr "console"
 		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0132: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_013b: box [System.Runtime]System.Double
-		IL_0140: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014a: castclass [System.Runtime]System.String
-		IL_014f: ldc.r8 0.0
-		IL_0158: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
-		IL_015d: stloc.s 4
-		IL_015f: ldstr "log"
-		IL_0164: ldloc.s 4
-		IL_0166: box [System.Runtime]System.Double
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0170: pop
-		IL_0171: ldstr "console"
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0180: ldc.r8 1
-		IL_0189: neg
-		IL_018a: box [System.Runtime]System.Double
-		IL_018f: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0199: castclass [System.Runtime]System.String
-		IL_019e: ldc.r8 0.0
-		IL_01a7: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
-		IL_01ac: stloc.s 4
-		IL_01ae: ldstr "log"
-		IL_01b3: ldloc.s 4
-		IL_01b5: box [System.Runtime]System.Double
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bf: pop
-		IL_01c0: ret
+		IL_0132: stloc.s 4
+		IL_0134: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_013d: box [System.Runtime]System.Double
+		IL_0142: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
+		IL_0147: stloc.3
+		IL_0148: ldloc.3
+		IL_0149: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_014e: stloc.3
+		IL_014f: ldloc.3
+		IL_0150: ldc.r8 0.0
+		IL_0159: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
+		IL_015e: stloc.s 5
+		IL_0160: ldloc.s 4
+		IL_0162: ldstr "log"
+		IL_0167: ldloc.s 5
+		IL_0169: box [System.Runtime]System.Double
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0173: pop
+		IL_0174: ldstr "console"
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0183: stloc.s 4
+		IL_0185: ldc.r8 1
+		IL_018e: neg
+		IL_018f: box [System.Runtime]System.Double
+		IL_0194: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
+		IL_0199: stloc.3
+		IL_019a: ldloc.3
+		IL_019b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_01a0: stloc.3
+		IL_01a1: ldloc.3
+		IL_01a2: ldc.r8 0.0
+		IL_01ab: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
+		IL_01b0: stloc.s 5
+		IL_01b2: ldloc.s 4
+		IL_01b4: ldstr "log"
+		IL_01b9: ldloc.s 5
+		IL_01bb: box [System.Runtime]System.Double
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c5: pop
+		IL_01c6: ret
 	} // end of method String_FromCharCode_Basic::__js_module_init__
 
 } // end of class Modules.String_FromCharCode_Basic
@@ -174,7 +185,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2226
+		// Method begins at RVA 0x222c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_LastIndexOf_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_LastIndexOf_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2261
+			// Method begins at RVA 0x2271
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,12 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 517 (0x205)
+		// Code size: 533 (0x215)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_LastIndexOf_Basic/Scope,
 			[1] string,
-			[2] float64
+			[2] object,
+			[3] string,
+			[4] float64,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.String_LastIndexOf_Basic/Scope::.ctor()
@@ -56,127 +59,155 @@
 		IL_000d: ldstr "console"
 		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_001c: ldloc.1
-		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0022: castclass [System.Runtime]System.String
-		IL_0027: ldstr "a"
-		IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
-		IL_0031: stloc.2
+		IL_001c: stloc.2
+		IL_001d: ldloc.1
+		IL_001e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0023: stloc.3
+		IL_0024: ldloc.3
+		IL_0025: ldstr "a"
+		IL_002a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+		IL_002f: stloc.s 4
+		IL_0031: ldloc.2
 		IL_0032: ldstr "log"
-		IL_0037: ldloc.2
-		IL_0038: box [System.Runtime]System.Double
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0042: pop
-		IL_0043: ldstr "console"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0052: ldloc.1
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0058: castclass [System.Runtime]System.String
-		IL_005d: ldstr "a"
-		IL_0062: ldc.r8 2
-		IL_006b: box [System.Runtime]System.Double
-		IL_0070: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
-		IL_0075: stloc.2
-		IL_0076: ldstr "log"
-		IL_007b: ldloc.2
-		IL_007c: box [System.Runtime]System.Double
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0086: pop
-		IL_0087: ldstr "console"
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0096: ldloc.1
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009c: castclass [System.Runtime]System.String
-		IL_00a1: ldstr "a"
-		IL_00a6: ldc.r8 1
-		IL_00af: neg
-		IL_00b0: box [System.Runtime]System.Double
-		IL_00b5: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
-		IL_00ba: stloc.2
-		IL_00bb: ldstr "log"
-		IL_00c0: ldloc.2
-		IL_00c1: box [System.Runtime]System.Double
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cb: pop
-		IL_00cc: ldstr "console"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00db: ldloc.1
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e1: castclass [System.Runtime]System.String
-		IL_00e6: ldstr "a"
-		IL_00eb: ldc.r8 99
-		IL_00f4: box [System.Runtime]System.Double
-		IL_00f9: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
-		IL_00fe: stloc.2
-		IL_00ff: ldstr "log"
-		IL_0104: ldloc.2
-		IL_0105: box [System.Runtime]System.Double
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010f: pop
-		IL_0110: ldstr "console"
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011f: ldloc.1
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0125: castclass [System.Runtime]System.String
-		IL_012a: ldstr ""
-		IL_012f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
-		IL_0134: stloc.2
-		IL_0135: ldstr "log"
-		IL_013a: ldloc.2
-		IL_013b: box [System.Runtime]System.Double
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0145: pop
-		IL_0146: ldstr "console"
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0155: ldloc.1
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015b: castclass [System.Runtime]System.String
-		IL_0160: ldstr ""
-		IL_0165: ldc.r8 2
-		IL_016e: box [System.Runtime]System.Double
-		IL_0173: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
-		IL_0178: stloc.2
-		IL_0179: ldstr "log"
-		IL_017e: ldloc.2
-		IL_017f: box [System.Runtime]System.Double
-		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0189: pop
-		IL_018a: ldstr "console"
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0199: ldloc.1
-		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019f: castclass [System.Runtime]System.String
-		IL_01a4: ldstr "ab"
-		IL_01a9: ldc.r8 1
-		IL_01b2: box [System.Runtime]System.Double
-		IL_01b7: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
-		IL_01bc: stloc.2
-		IL_01bd: ldstr "log"
-		IL_01c2: ldloc.2
-		IL_01c3: box [System.Runtime]System.Double
-		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01cd: pop
-		IL_01ce: ldstr "console"
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01dd: ldloc.1
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e3: castclass [System.Runtime]System.String
-		IL_01e8: ldstr "z"
-		IL_01ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
-		IL_01f2: stloc.2
-		IL_01f3: ldstr "log"
-		IL_01f8: ldloc.2
-		IL_01f9: box [System.Runtime]System.Double
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0203: pop
-		IL_0204: ret
+		IL_0037: ldloc.s 4
+		IL_0039: box [System.Runtime]System.Double
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0043: pop
+		IL_0044: ldstr "console"
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0053: stloc.2
+		IL_0054: ldloc.1
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_005a: stloc.3
+		IL_005b: ldloc.3
+		IL_005c: ldstr "a"
+		IL_0061: ldc.r8 2
+		IL_006a: box [System.Runtime]System.Double
+		IL_006f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_0074: stloc.s 4
+		IL_0076: ldloc.2
+		IL_0077: ldstr "log"
+		IL_007c: ldloc.s 4
+		IL_007e: box [System.Runtime]System.Double
+		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0088: pop
+		IL_0089: ldstr "console"
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0098: stloc.2
+		IL_0099: ldloc.1
+		IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_009f: stloc.3
+		IL_00a0: ldc.r8 1
+		IL_00a9: neg
+		IL_00aa: stloc.s 4
+		IL_00ac: ldloc.s 4
+		IL_00ae: box [System.Runtime]System.Double
+		IL_00b3: stloc.s 5
+		IL_00b5: ldloc.3
+		IL_00b6: ldstr "a"
+		IL_00bb: ldloc.s 5
+		IL_00bd: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_00c2: stloc.s 4
+		IL_00c4: ldloc.2
+		IL_00c5: ldstr "log"
+		IL_00ca: ldloc.s 4
+		IL_00cc: box [System.Runtime]System.Double
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d6: pop
+		IL_00d7: ldstr "console"
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e6: stloc.2
+		IL_00e7: ldloc.1
+		IL_00e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_00ed: stloc.3
+		IL_00ee: ldloc.3
+		IL_00ef: ldstr "a"
+		IL_00f4: ldc.r8 99
+		IL_00fd: box [System.Runtime]System.Double
+		IL_0102: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_0107: stloc.s 4
+		IL_0109: ldloc.2
+		IL_010a: ldstr "log"
+		IL_010f: ldloc.s 4
+		IL_0111: box [System.Runtime]System.Double
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011b: pop
+		IL_011c: ldstr "console"
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012b: stloc.2
+		IL_012c: ldloc.1
+		IL_012d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0132: stloc.3
+		IL_0133: ldloc.3
+		IL_0134: ldstr ""
+		IL_0139: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+		IL_013e: stloc.s 4
+		IL_0140: ldloc.2
+		IL_0141: ldstr "log"
+		IL_0146: ldloc.s 4
+		IL_0148: box [System.Runtime]System.Double
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0152: pop
+		IL_0153: ldstr "console"
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0162: stloc.2
+		IL_0163: ldloc.1
+		IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0169: stloc.3
+		IL_016a: ldloc.3
+		IL_016b: ldstr ""
+		IL_0170: ldc.r8 2
+		IL_0179: box [System.Runtime]System.Double
+		IL_017e: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_0183: stloc.s 4
+		IL_0185: ldloc.2
+		IL_0186: ldstr "log"
+		IL_018b: ldloc.s 4
+		IL_018d: box [System.Runtime]System.Double
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0197: pop
+		IL_0198: ldstr "console"
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a7: stloc.2
+		IL_01a8: ldloc.1
+		IL_01a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_01ae: stloc.3
+		IL_01af: ldloc.3
+		IL_01b0: ldstr "ab"
+		IL_01b5: ldc.r8 1
+		IL_01be: box [System.Runtime]System.Double
+		IL_01c3: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_01c8: stloc.s 4
+		IL_01ca: ldloc.2
+		IL_01cb: ldstr "log"
+		IL_01d0: ldloc.s 4
+		IL_01d2: box [System.Runtime]System.Double
+		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01dc: pop
+		IL_01dd: ldstr "console"
+		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ec: stloc.2
+		IL_01ed: ldloc.1
+		IL_01ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_01f3: stloc.3
+		IL_01f4: ldloc.3
+		IL_01f5: ldstr "z"
+		IL_01fa: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+		IL_01ff: stloc.s 4
+		IL_0201: ldloc.2
+		IL_0202: ldstr "log"
+		IL_0207: ldloc.s 4
+		IL_0209: box [System.Runtime]System.Double
+		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0213: pop
+		IL_0214: ret
 	} // end of method String_LastIndexOf_Basic::__js_module_init__
 
 } // end of class Modules.String_LastIndexOf_Basic
@@ -188,7 +219,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x226a
+		// Method begins at RVA 0x227a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MatchAll_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MatchAll_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2431
+				// Method begins at RVA 0x2435
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243a
+				// Method begins at RVA 0x243e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2428
+			// Method begins at RVA 0x242c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 956 (0x3bc)
+		// Code size: 960 (0x3c0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MatchAll_Basic/Scope,
@@ -92,17 +92,18 @@
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] object,
+			[7] string,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[9] object,
-			[10] object
+			[10] object,
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.String_MatchAll_Basic/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
 		IL_0007: ldstr "test1 test22"
-		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_000c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 		IL_0011: stloc.s 7
 		IL_0013: ldstr "t(e)(st\\d+)"
 		IL_0018: ldstr "g"
@@ -112,8 +113,8 @@
 		IL_0026: ldstr "matchAll"
 		IL_002b: ldloc.s 8
 		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0032: stloc.s 7
-		IL_0034: ldloc.s 7
+		IL_0032: stloc.s 9
+		IL_0034: ldloc.s 9
 		IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
 		IL_003b: stloc.1
 		IL_003c: ldstr "console"
@@ -122,245 +123,247 @@
 		IL_004b: ldloc.1
 		IL_004c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
 		IL_0051: box [System.Runtime]System.Double
-		IL_0056: stloc.s 9
+		IL_0056: stloc.s 10
 		IL_0058: ldstr "log"
-		IL_005d: ldloc.s 9
+		IL_005d: ldloc.s 10
 		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0064: pop
 		IL_0065: ldstr "console"
 		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0074: stloc.s 7
+		IL_0074: stloc.s 9
 		IL_0076: ldloc.1
 		IL_0077: ldc.r8 0.0
 		IL_0080: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 		IL_0085: ldc.r8 0.0
 		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0093: stloc.s 10
-		IL_0095: ldloc.s 7
+		IL_0093: stloc.s 11
+		IL_0095: ldloc.s 9
 		IL_0097: ldstr "log"
-		IL_009c: ldloc.s 10
+		IL_009c: ldloc.s 11
 		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_00a3: pop
 		IL_00a4: ldstr "console"
 		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b3: stloc.s 10
+		IL_00b3: stloc.s 11
 		IL_00b5: ldloc.1
 		IL_00b6: ldc.r8 0.0
 		IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 		IL_00c4: ldc.r8 1
 		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00d2: stloc.s 7
-		IL_00d4: ldloc.s 10
+		IL_00d2: stloc.s 9
+		IL_00d4: ldloc.s 11
 		IL_00d6: ldstr "log"
-		IL_00db: ldloc.s 7
+		IL_00db: ldloc.s 9
 		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_00e2: pop
 		IL_00e3: ldstr "console"
 		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f2: stloc.s 7
+		IL_00f2: stloc.s 9
 		IL_00f4: ldloc.1
 		IL_00f5: ldc.r8 0.0
 		IL_00fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 		IL_0103: ldc.r8 2
 		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0111: stloc.s 10
-		IL_0113: ldloc.s 7
+		IL_0111: stloc.s 11
+		IL_0113: ldloc.s 9
 		IL_0115: ldstr "log"
-		IL_011a: ldloc.s 10
+		IL_011a: ldloc.s 11
 		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0121: pop
 		IL_0122: ldstr "console"
 		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0131: stloc.s 10
+		IL_0131: stloc.s 11
 		IL_0133: ldloc.1
 		IL_0134: ldc.r8 0.0
 		IL_013d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 		IL_0142: ldstr "index"
 		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_014c: stloc.s 7
-		IL_014e: ldloc.s 10
+		IL_014c: stloc.s 9
+		IL_014e: ldloc.s 11
 		IL_0150: ldstr "log"
-		IL_0155: ldloc.s 7
+		IL_0155: ldloc.s 9
 		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_015c: pop
 		IL_015d: ldstr "console"
 		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016c: stloc.s 7
+		IL_016c: stloc.s 9
 		IL_016e: ldloc.1
 		IL_016f: ldc.r8 1
 		IL_0178: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 		IL_017d: ldc.r8 0.0
 		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_018b: stloc.s 10
-		IL_018d: ldloc.s 7
+		IL_018b: stloc.s 11
+		IL_018d: ldloc.s 9
 		IL_018f: ldstr "log"
-		IL_0194: ldloc.s 10
+		IL_0194: ldloc.s 11
 		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_019b: pop
 		IL_019c: ldstr "console"
 		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ab: stloc.s 10
+		IL_01ab: stloc.s 11
 		IL_01ad: ldloc.1
 		IL_01ae: ldc.r8 1
 		IL_01b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 		IL_01bc: ldc.r8 1
 		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01ca: stloc.s 7
-		IL_01cc: ldloc.s 10
+		IL_01ca: stloc.s 9
+		IL_01cc: ldloc.s 11
 		IL_01ce: ldstr "log"
-		IL_01d3: ldloc.s 7
+		IL_01d3: ldloc.s 9
 		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_01da: pop
 		IL_01db: ldstr "console"
 		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ea: stloc.s 7
+		IL_01ea: stloc.s 9
 		IL_01ec: ldloc.1
 		IL_01ed: ldc.r8 1
 		IL_01f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 		IL_01fb: ldc.r8 2
 		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0209: stloc.s 10
-		IL_020b: ldloc.s 7
+		IL_0209: stloc.s 11
+		IL_020b: ldloc.s 9
 		IL_020d: ldstr "log"
-		IL_0212: ldloc.s 10
+		IL_0212: ldloc.s 11
 		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0219: pop
 		IL_021a: ldstr "console"
 		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0229: stloc.s 10
+		IL_0229: stloc.s 11
 		IL_022b: ldloc.1
 		IL_022c: ldc.r8 1
 		IL_0235: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 		IL_023a: ldstr "index"
 		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0244: stloc.s 7
-		IL_0246: ldloc.s 10
+		IL_0244: stloc.s 9
+		IL_0246: ldloc.s 11
 		IL_0248: ldstr "log"
-		IL_024d: ldloc.s 7
+		IL_024d: ldloc.s 9
 		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0254: pop
 		IL_0255: ldstr "aba"
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025f: ldstr "matchAll"
-		IL_0264: ldstr "a"
-		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026e: stloc.s 7
-		IL_0270: ldloc.s 7
-		IL_0272: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0277: stloc.2
-		IL_0278: ldstr "console"
-		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0287: ldloc.2
-		IL_0288: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_028d: box [System.Runtime]System.Double
-		IL_0292: stloc.s 9
-		IL_0294: ldstr "log"
-		IL_0299: ldloc.s 9
-		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a0: pop
-		IL_02a1: ldstr "console"
-		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b0: stloc.s 7
-		IL_02b2: ldloc.2
-		IL_02b3: ldc.r8 0.0
-		IL_02bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_02c1: ldc.r8 0.0
-		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02cf: stloc.s 10
-		IL_02d1: ldloc.s 7
-		IL_02d3: ldstr "log"
-		IL_02d8: ldloc.s 10
-		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02df: pop
-		IL_02e0: ldstr "console"
-		IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ef: stloc.s 10
-		IL_02f1: ldloc.2
-		IL_02f2: ldc.r8 1
-		IL_02fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0300: ldstr "index"
-		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_030a: stloc.s 7
-		IL_030c: ldloc.s 10
-		IL_030e: ldstr "log"
-		IL_0313: ldloc.s 7
-		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_031a: pop
+		IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_025f: stloc.s 7
+		IL_0261: ldloc.s 7
+		IL_0263: ldstr "matchAll"
+		IL_0268: ldstr "a"
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0272: stloc.s 9
+		IL_0274: ldloc.s 9
+		IL_0276: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_027b: stloc.2
+		IL_027c: ldstr "console"
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028b: ldloc.2
+		IL_028c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0291: box [System.Runtime]System.Double
+		IL_0296: stloc.s 10
+		IL_0298: ldstr "log"
+		IL_029d: ldloc.s 10
+		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a4: pop
+		IL_02a5: ldstr "console"
+		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b4: stloc.s 9
+		IL_02b6: ldloc.2
+		IL_02b7: ldc.r8 0.0
+		IL_02c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_02c5: ldc.r8 0.0
+		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02d3: stloc.s 11
+		IL_02d5: ldloc.s 9
+		IL_02d7: ldstr "log"
+		IL_02dc: ldloc.s 11
+		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02e3: pop
+		IL_02e4: ldstr "console"
+		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f3: stloc.s 11
+		IL_02f5: ldloc.2
+		IL_02f6: ldc.r8 1
+		IL_02ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0304: ldstr "index"
+		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_030e: stloc.s 9
+		IL_0310: ldloc.s 11
+		IL_0312: ldstr "log"
+		IL_0317: ldloc.s 9
+		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_031e: pop
 		.try
 		{
-			IL_031b: nop
-			IL_031c: ldstr "aba"
-			IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0326: stloc.s 7
-			IL_0328: ldstr "a"
-			IL_032d: ldstr ""
-			IL_0332: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0337: stloc.s 8
-			IL_0339: ldloc.s 7
-			IL_033b: ldstr "matchAll"
-			IL_0340: ldloc.s 8
-			IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0347: stloc.s 7
-			IL_0349: ldloc.s 7
-			IL_034b: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0350: pop
-			IL_0351: leave IL_03b8
+			IL_031f: nop
+			IL_0320: ldstr "aba"
+			IL_0325: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_032a: stloc.s 7
+			IL_032c: ldstr "a"
+			IL_0331: ldstr ""
+			IL_0336: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_033b: stloc.s 8
+			IL_033d: ldloc.s 7
+			IL_033f: ldstr "matchAll"
+			IL_0344: ldloc.s 8
+			IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_034b: stloc.s 9
+			IL_034d: ldloc.s 9
+			IL_034f: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0354: pop
+			IL_0355: leave IL_03bc
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0356: stloc.3
-			IL_0357: ldloc.3
-			IL_0358: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_035d: dup
-			IL_035e: brtrue IL_0373
+			IL_035a: stloc.3
+			IL_035b: ldloc.3
+			IL_035c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0361: dup
+			IL_0362: brtrue IL_0377
 
-			IL_0363: pop
-			IL_0364: ldloc.3
-			IL_0365: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_036a: dup
-			IL_036b: brtrue IL_037f
+			IL_0367: pop
+			IL_0368: ldloc.3
+			IL_0369: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_036e: dup
+			IL_036f: brtrue IL_0383
 
-			IL_0370: pop
-			IL_0371: rethrow
+			IL_0374: pop
+			IL_0375: rethrow
 
-			IL_0373: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0378: stloc.s 4
-			IL_037a: br IL_0381
+			IL_0377: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_037c: stloc.s 4
+			IL_037e: br IL_0385
 
-			IL_037f: stloc.s 4
+			IL_0383: stloc.s 4
 
-			IL_0381: ldloc.s 4
-			IL_0383: stloc.s 5
-			IL_0385: ldstr "console"
-			IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0394: stloc.s 7
-			IL_0396: ldloc.s 5
-			IL_0398: ldstr "name"
-			IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03a2: stloc.s 10
-			IL_03a4: ldloc.s 7
-			IL_03a6: ldstr "log"
-			IL_03ab: ldloc.s 10
-			IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03b2: pop
-			IL_03b3: leave IL_03b8
+			IL_0385: ldloc.s 4
+			IL_0387: stloc.s 5
+			IL_0389: ldstr "console"
+			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0398: stloc.s 9
+			IL_039a: ldloc.s 5
+			IL_039c: ldstr "name"
+			IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a6: stloc.s 11
+			IL_03a8: ldloc.s 9
+			IL_03aa: ldstr "log"
+			IL_03af: ldloc.s 11
+			IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03b6: pop
+			IL_03b7: leave IL_03bc
 		} // end handler
 
-		IL_03b8: ldnull
-		IL_03b9: stloc.s 6
-		IL_03bb: ret
+		IL_03bc: ldnull
+		IL_03bd: stloc.s 6
+		IL_03bf: ret
 	} // end of method String_MatchAll_Basic::__js_module_init__
 
 } // end of class Modules.String_MatchAll_Basic
@@ -372,7 +375,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2443
+		// Method begins at RVA 0x2447
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Match_Global.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Match_Global.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2148
+			// Method begins at RVA 0x2150
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 236 (0xec)
+		// Code size: 244 (0xf4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Match_Global/Scope,
 			[1] string,
 			[2] object,
-			[3] object,
+			[3] string,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[5] object
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Match_Global/Scope::.ctor()
@@ -57,7 +58,7 @@
 		IL_0007: ldstr "baaa"
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 		IL_0013: stloc.3
 		IL_0014: ldstr "a"
 		IL_0019: ldstr "g"
@@ -71,56 +72,56 @@
 		IL_0033: ldstr "console"
 		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0042: stloc.3
-		IL_0043: ldloc.2
-		IL_0044: ldstr "length"
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_004e: stloc.s 5
-		IL_0050: ldloc.3
-		IL_0051: ldstr "log"
-		IL_0056: ldloc.s 5
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005d: pop
-		IL_005e: ldstr "console"
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006d: stloc.s 5
-		IL_006f: ldloc.2
-		IL_0070: ldc.r8 0.0
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_007e: stloc.3
-		IL_007f: ldloc.s 5
-		IL_0081: ldstr "log"
-		IL_0086: ldloc.3
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008c: pop
-		IL_008d: ldstr "console"
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009c: stloc.3
-		IL_009d: ldloc.2
-		IL_009e: ldc.r8 1
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00ac: stloc.s 5
-		IL_00ae: ldloc.3
-		IL_00af: ldstr "log"
-		IL_00b4: ldloc.s 5
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bb: pop
-		IL_00bc: ldstr "console"
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cb: stloc.s 5
-		IL_00cd: ldloc.2
-		IL_00ce: ldc.r8 2
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00dc: stloc.3
-		IL_00dd: ldloc.s 5
-		IL_00df: ldstr "log"
-		IL_00e4: ldloc.3
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ea: pop
-		IL_00eb: ret
+		IL_0042: stloc.s 5
+		IL_0044: ldloc.2
+		IL_0045: ldstr "length"
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_004f: stloc.s 6
+		IL_0051: ldloc.s 5
+		IL_0053: ldstr "log"
+		IL_0058: ldloc.s 6
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005f: pop
+		IL_0060: ldstr "console"
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006f: stloc.s 6
+		IL_0071: ldloc.2
+		IL_0072: ldc.r8 0.0
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0080: stloc.s 5
+		IL_0082: ldloc.s 6
+		IL_0084: ldstr "log"
+		IL_0089: ldloc.s 5
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0090: pop
+		IL_0091: ldstr "console"
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a0: stloc.s 5
+		IL_00a2: ldloc.2
+		IL_00a3: ldc.r8 1
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00b1: stloc.s 6
+		IL_00b3: ldloc.s 5
+		IL_00b5: ldstr "log"
+		IL_00ba: ldloc.s 6
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c1: pop
+		IL_00c2: ldstr "console"
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d1: stloc.s 6
+		IL_00d3: ldloc.2
+		IL_00d4: ldc.r8 2
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00e2: stloc.s 5
+		IL_00e4: ldloc.s 6
+		IL_00e6: ldstr "log"
+		IL_00eb: ldloc.s 5
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f2: pop
+		IL_00f3: ret
 	} // end of method String_Match_Global::__js_module_init__
 
 } // end of class Modules.String_Match_Global
@@ -132,7 +133,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2151
+		// Method begins at RVA 0x2159
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Match_NonGlobal.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Match_NonGlobal.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2173
+			// Method begins at RVA 0x217d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 279 (0x117)
+		// Code size: 289 (0x121)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Match_NonGlobal/Scope,
 			[1] string,
 			[2] object,
-			[3] object,
+			[3] string,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[5] object
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Match_NonGlobal/Scope::.ctor()
@@ -57,7 +58,7 @@
 		IL_0007: ldstr "  abc"
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 		IL_0013: stloc.3
 		IL_0014: ldstr "\\s+(a)(b)c"
 		IL_0019: ldstr ""
@@ -71,69 +72,69 @@
 		IL_0033: ldstr "console"
 		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0042: stloc.3
-		IL_0043: ldloc.2
-		IL_0044: ldc.r8 0.0
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0052: stloc.s 5
-		IL_0054: ldloc.3
-		IL_0055: ldstr "log"
-		IL_005a: ldloc.s 5
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0061: pop
-		IL_0062: ldstr "console"
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0071: stloc.s 5
-		IL_0073: ldloc.2
-		IL_0074: ldc.r8 1
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0082: stloc.3
-		IL_0083: ldloc.s 5
-		IL_0085: ldstr "log"
-		IL_008a: ldloc.3
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0090: pop
-		IL_0091: ldstr "console"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a0: stloc.3
-		IL_00a1: ldloc.2
-		IL_00a2: ldc.r8 2
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00b0: stloc.s 5
-		IL_00b2: ldloc.3
-		IL_00b3: ldstr "log"
-		IL_00b8: ldloc.s 5
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bf: pop
-		IL_00c0: ldstr "console"
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cf: stloc.s 5
-		IL_00d1: ldloc.2
-		IL_00d2: ldstr "index"
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00dc: stloc.3
-		IL_00dd: ldloc.s 5
-		IL_00df: ldstr "log"
-		IL_00e4: ldloc.3
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ea: pop
-		IL_00eb: ldstr "console"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fa: stloc.3
-		IL_00fb: ldloc.2
-		IL_00fc: ldstr "input"
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0106: stloc.s 5
-		IL_0108: ldloc.3
-		IL_0109: ldstr "log"
-		IL_010e: ldloc.s 5
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0115: pop
-		IL_0116: ret
+		IL_0042: stloc.s 5
+		IL_0044: ldloc.2
+		IL_0045: ldc.r8 0.0
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0053: stloc.s 6
+		IL_0055: ldloc.s 5
+		IL_0057: ldstr "log"
+		IL_005c: ldloc.s 6
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0063: pop
+		IL_0064: ldstr "console"
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0073: stloc.s 6
+		IL_0075: ldloc.2
+		IL_0076: ldc.r8 1
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0084: stloc.s 5
+		IL_0086: ldloc.s 6
+		IL_0088: ldstr "log"
+		IL_008d: ldloc.s 5
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0094: pop
+		IL_0095: ldstr "console"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a4: stloc.s 5
+		IL_00a6: ldloc.2
+		IL_00a7: ldc.r8 2
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00b5: stloc.s 6
+		IL_00b7: ldloc.s 5
+		IL_00b9: ldstr "log"
+		IL_00be: ldloc.s 6
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c5: pop
+		IL_00c6: ldstr "console"
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d5: stloc.s 6
+		IL_00d7: ldloc.2
+		IL_00d8: ldstr "index"
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e2: stloc.s 5
+		IL_00e4: ldloc.s 6
+		IL_00e6: ldstr "log"
+		IL_00eb: ldloc.s 5
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f2: pop
+		IL_00f3: ldstr "console"
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0102: stloc.s 5
+		IL_0104: ldloc.2
+		IL_0105: ldstr "input"
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010f: stloc.s 6
+		IL_0111: ldloc.s 5
+		IL_0113: ldstr "log"
+		IL_0118: ldloc.s 6
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011f: pop
+		IL_0120: ret
 	} // end of method String_Match_NonGlobal::__js_module_init__
 
 } // end of class Modules.String_Match_NonGlobal
@@ -145,7 +146,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x217c
+		// Method begins at RVA 0x2186
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_Arity3_Replace.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_Arity3_Replace.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20a5
+			// Method begins at RVA 0x20a7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,12 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 73 (0x49)
+		// Code size: 75 (0x4b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MemberCall_Arity3_Replace/Scope,
 			[1] string,
-			[2] object
+			[2] object,
+			[3] string
 		)
 
 		IL_0000: newobj instance void Modules.String_MemberCall_Arity3_Replace/Scope::.ctor()
@@ -54,21 +55,23 @@
 		IL_0007: ldstr "hello world"
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0013: ldstr "replace"
-		IL_0018: ldstr "world"
-		IL_001d: ldstr "JS"
-		IL_0022: ldstr "unused"
-		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_002c: stloc.2
-		IL_002d: ldstr "console"
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003c: ldstr "log"
-		IL_0041: ldloc.2
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0047: pop
-		IL_0048: ret
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0013: stloc.3
+		IL_0014: ldloc.3
+		IL_0015: ldstr "replace"
+		IL_001a: ldstr "world"
+		IL_001f: ldstr "JS"
+		IL_0024: ldstr "unused"
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_002e: stloc.2
+		IL_002f: ldstr "console"
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003e: ldstr "log"
+		IL_0043: ldloc.2
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0049: pop
+		IL_004a: ret
 	} // end of method String_MemberCall_Arity3_Replace::__js_module_init__
 
 } // end of class Modules.String_MemberCall_Arity3_Replace
@@ -80,7 +83,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20ae
+		// Method begins at RVA 0x20b0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f6
+				// Method begins at RVA 0x2501
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,209 +42,249 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21e8
+			// Method begins at RVA 0x2200
 			// Header size: 12
-			// Code size: 761 (0x2f9)
+			// Code size: 748 (0x2ec)
 			.maxstack 8
 			.locals init (
-				[0] float64,
+				[0] object,
 				[1] string,
-				[2] bool
+				[2] float64,
+				[3] bool
 			)
 
 			IL_0000: ldstr "console"
 			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000f: ldarg.1
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0015: castclass [System.Runtime]System.String
-			IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string)
-			IL_001f: stloc.0
-			IL_0020: ldstr "log"
-			IL_0025: ldloc.0
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0030: pop
-			IL_0031: ldstr "console"
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.1
+			IL_0011: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0016: stloc.1
+			IL_0017: ldloc.1
+			IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string)
+			IL_001d: stloc.2
+			IL_001e: ldloc.0
+			IL_001f: ldstr "log"
+			IL_0024: ldloc.2
+			IL_0025: box [System.Runtime]System.Double
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002f: pop
+			IL_0030: ldstr "console"
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003f: stloc.0
 			IL_0040: ldarg.1
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0046: castclass [System.Runtime]System.String
-			IL_004b: ldc.r8 1
-			IL_0054: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
-			IL_0059: stloc.0
-			IL_005a: ldstr "log"
-			IL_005f: ldloc.0
-			IL_0060: box [System.Runtime]System.Double
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_006a: pop
-			IL_006b: ldstr "console"
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007a: ldarg.1
-			IL_007b: ldc.r8 1
-			IL_0084: box [System.Runtime]System.Double
-			IL_0089: ldc.r8 4
-			IL_0092: box [System.Runtime]System.Double
-			IL_0097: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_009c: stloc.1
-			IL_009d: ldstr "log"
-			IL_00a2: ldloc.1
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00a8: pop
-			IL_00a9: ldstr "console"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b8: ldarg.1
-			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00be: castclass [System.Runtime]System.String
-			IL_00c3: ldc.r8 2
-			IL_00cc: box [System.Runtime]System.Double
-			IL_00d1: ldc.r8 5
-			IL_00da: box [System.Runtime]System.Double
-			IL_00df: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
-			IL_00e4: stloc.1
-			IL_00e5: ldstr "log"
-			IL_00ea: ldloc.1
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00f0: pop
-			IL_00f1: ldstr "console"
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0100: ldarg.1
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0106: castclass [System.Runtime]System.String
-			IL_010b: ldstr "cd"
-			IL_0110: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0115: stloc.0
-			IL_0116: ldstr "log"
-			IL_011b: ldloc.0
-			IL_011c: box [System.Runtime]System.Double
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0126: pop
-			IL_0127: ldstr "console"
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0136: ldarg.1
-			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013c: castclass [System.Runtime]System.String
-			IL_0141: ldstr "cd"
-			IL_0146: ldc.r8 3
-			IL_014f: box [System.Runtime]System.Double
-			IL_0154: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string, object)
-			IL_0159: stloc.0
-			IL_015a: ldstr "log"
-			IL_015f: ldloc.0
-			IL_0160: box [System.Runtime]System.Double
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_016a: pop
-			IL_016b: ldstr "console"
-			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_017a: ldarg.1
-			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0180: castclass [System.Runtime]System.String
-			IL_0185: ldstr "ab"
-			IL_018a: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-			IL_018f: stloc.2
-			IL_0190: ldstr "log"
-			IL_0195: ldloc.2
-			IL_0196: box [System.Runtime]System.Boolean
-			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01a0: pop
-			IL_01a1: ldstr "console"
-			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b0: ldarg.1
-			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b6: castclass [System.Runtime]System.String
-			IL_01bb: ldstr "bc"
-			IL_01c0: ldc.r8 1
-			IL_01c9: box [System.Runtime]System.Double
-			IL_01ce: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, object, object)
-			IL_01d3: stloc.2
-			IL_01d4: ldstr "log"
-			IL_01d9: ldloc.2
-			IL_01da: box [System.Runtime]System.Boolean
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01e4: pop
-			IL_01e5: ldstr "console"
-			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f4: ldarg.1
-			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01fa: castclass [System.Runtime]System.String
-			IL_01ff: ldstr "de"
-			IL_0204: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_0209: stloc.2
-			IL_020a: ldstr "log"
-			IL_020f: ldloc.2
-			IL_0210: box [System.Runtime]System.Boolean
-			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_021a: pop
-			IL_021b: ldstr "console"
-			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_022a: ldarg.1
-			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0230: castclass [System.Runtime]System.String
-			IL_0235: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_023a: stloc.1
-			IL_023b: ldstr "log"
-			IL_0240: ldloc.1
-			IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0246: pop
-			IL_0247: ldstr "console"
-			IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0256: ldarg.1
-			IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_025c: castclass [System.Runtime]System.String
-			IL_0261: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimStart(string)
-			IL_0266: stloc.1
-			IL_0267: ldstr "log"
-			IL_026c: ldloc.1
-			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0272: pop
-			IL_0273: ldstr "console"
-			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0282: ldarg.1
-			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0288: castclass [System.Runtime]System.String
-			IL_028d: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimEnd(string)
-			IL_0292: stloc.1
-			IL_0293: ldstr "log"
-			IL_0298: ldloc.1
-			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_029e: pop
-			IL_029f: ldstr "console"
-			IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ae: ldarg.1
-			IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02b4: castclass [System.Runtime]System.String
-			IL_02b9: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimLeft(string)
-			IL_02be: stloc.1
-			IL_02bf: ldstr "log"
-			IL_02c4: ldloc.1
-			IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02ca: pop
-			IL_02cb: ldstr "console"
-			IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02da: ldarg.1
-			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e0: castclass [System.Runtime]System.String
-			IL_02e5: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimRight(string)
-			IL_02ea: stloc.1
-			IL_02eb: ldstr "log"
-			IL_02f0: ldloc.1
-			IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02f6: pop
-			IL_02f7: ldnull
-			IL_02f8: ret
+			IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0046: stloc.1
+			IL_0047: ldloc.1
+			IL_0048: ldc.r8 1
+			IL_0051: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
+			IL_0056: stloc.2
+			IL_0057: ldloc.0
+			IL_0058: ldstr "log"
+			IL_005d: ldloc.2
+			IL_005e: box [System.Runtime]System.Double
+			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0068: pop
+			IL_0069: ldstr "console"
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0078: ldarg.1
+			IL_0079: ldc.r8 1
+			IL_0082: box [System.Runtime]System.Double
+			IL_0087: ldc.r8 4
+			IL_0090: box [System.Runtime]System.Double
+			IL_0095: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_009a: stloc.1
+			IL_009b: ldstr "log"
+			IL_00a0: ldloc.1
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00a6: pop
+			IL_00a7: ldstr "console"
+			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b6: stloc.0
+			IL_00b7: ldarg.1
+			IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_00bd: stloc.1
+			IL_00be: ldloc.1
+			IL_00bf: ldc.r8 2
+			IL_00c8: box [System.Runtime]System.Double
+			IL_00cd: ldc.r8 5
+			IL_00d6: box [System.Runtime]System.Double
+			IL_00db: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+			IL_00e0: stloc.1
+			IL_00e1: ldloc.0
+			IL_00e2: ldstr "log"
+			IL_00e7: ldloc.1
+			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ed: pop
+			IL_00ee: ldstr "console"
+			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00fd: stloc.0
+			IL_00fe: ldarg.1
+			IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0104: stloc.1
+			IL_0105: ldloc.1
+			IL_0106: ldstr "cd"
+			IL_010b: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0110: stloc.2
+			IL_0111: ldloc.0
+			IL_0112: ldstr "log"
+			IL_0117: ldloc.2
+			IL_0118: box [System.Runtime]System.Double
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0122: pop
+			IL_0123: ldstr "console"
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0132: stloc.0
+			IL_0133: ldarg.1
+			IL_0134: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0139: stloc.1
+			IL_013a: ldloc.1
+			IL_013b: ldstr "cd"
+			IL_0140: ldc.r8 3
+			IL_0149: box [System.Runtime]System.Double
+			IL_014e: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string, object)
+			IL_0153: stloc.2
+			IL_0154: ldloc.0
+			IL_0155: ldstr "log"
+			IL_015a: ldloc.2
+			IL_015b: box [System.Runtime]System.Double
+			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0165: pop
+			IL_0166: ldstr "console"
+			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0175: stloc.0
+			IL_0176: ldarg.1
+			IL_0177: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_017c: stloc.1
+			IL_017d: ldloc.1
+			IL_017e: ldstr "ab"
+			IL_0183: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+			IL_0188: stloc.3
+			IL_0189: ldloc.0
+			IL_018a: ldstr "log"
+			IL_018f: ldloc.3
+			IL_0190: box [System.Runtime]System.Boolean
+			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_019a: pop
+			IL_019b: ldstr "console"
+			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01aa: stloc.0
+			IL_01ab: ldarg.1
+			IL_01ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_01b1: stloc.1
+			IL_01b2: ldloc.1
+			IL_01b3: ldstr "bc"
+			IL_01b8: ldc.r8 1
+			IL_01c1: box [System.Runtime]System.Double
+			IL_01c6: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string, object)
+			IL_01cb: stloc.3
+			IL_01cc: ldloc.0
+			IL_01cd: ldstr "log"
+			IL_01d2: ldloc.3
+			IL_01d3: box [System.Runtime]System.Boolean
+			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01dd: pop
+			IL_01de: ldstr "console"
+			IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ed: stloc.0
+			IL_01ee: ldarg.1
+			IL_01ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_01f4: stloc.1
+			IL_01f5: ldloc.1
+			IL_01f6: ldstr "de"
+			IL_01fb: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_0200: stloc.3
+			IL_0201: ldloc.0
+			IL_0202: ldstr "log"
+			IL_0207: ldloc.3
+			IL_0208: box [System.Runtime]System.Boolean
+			IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0212: pop
+			IL_0213: ldstr "console"
+			IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0222: stloc.0
+			IL_0223: ldarg.1
+			IL_0224: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0229: stloc.1
+			IL_022a: ldloc.1
+			IL_022b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0230: stloc.1
+			IL_0231: ldloc.0
+			IL_0232: ldstr "log"
+			IL_0237: ldloc.1
+			IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_023d: pop
+			IL_023e: ldstr "console"
+			IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_024d: stloc.0
+			IL_024e: ldarg.1
+			IL_024f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0254: stloc.1
+			IL_0255: ldloc.1
+			IL_0256: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimStart(string)
+			IL_025b: stloc.1
+			IL_025c: ldloc.0
+			IL_025d: ldstr "log"
+			IL_0262: ldloc.1
+			IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0268: pop
+			IL_0269: ldstr "console"
+			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0278: stloc.0
+			IL_0279: ldarg.1
+			IL_027a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_027f: stloc.1
+			IL_0280: ldloc.1
+			IL_0281: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimEnd(string)
+			IL_0286: stloc.1
+			IL_0287: ldloc.0
+			IL_0288: ldstr "log"
+			IL_028d: ldloc.1
+			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0293: pop
+			IL_0294: ldstr "console"
+			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02a3: stloc.0
+			IL_02a4: ldarg.1
+			IL_02a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_02aa: stloc.1
+			IL_02ab: ldloc.1
+			IL_02ac: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimLeft(string)
+			IL_02b1: stloc.1
+			IL_02b2: ldloc.0
+			IL_02b3: ldstr "log"
+			IL_02b8: ldloc.1
+			IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02be: pop
+			IL_02bf: ldstr "console"
+			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ce: stloc.0
+			IL_02cf: ldarg.1
+			IL_02d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_02d5: stloc.1
+			IL_02d6: ldloc.1
+			IL_02d7: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimRight(string)
+			IL_02dc: stloc.1
+			IL_02dd: ldloc.0
+			IL_02de: ldstr "log"
+			IL_02e3: ldloc.1
+			IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02e9: pop
+			IL_02ea: ldnull
+			IL_02eb: ret
 		} // end of method runCommon::__js_call__
 
 	} // end of class runCommon
@@ -263,7 +303,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24ed
+			// Method begins at RVA 0x24f8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -289,13 +329,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 396 (0x18c)
+		// Code size: 417 (0x1a1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MemberCall_FastPath_CommonMethods/Scope,
 			[1] class [System.Runtime]System.Func`3<object, string, object>,
 			[2] object[],
-			[3] string
+			[3] object,
+			[4] string
 		)
 
 		IL_0000: newobj instance void Modules.String_MemberCall_FastPath_CommonMethods/Scope::.ctor()
@@ -323,88 +364,109 @@
 		IL_003b: ldstr "console"
 		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004a: ldstr "  x  "
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0054: castclass [System.Runtime]System.String
+		IL_004a: stloc.3
+		IL_004b: ldstr "  x  "
+		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0055: stloc.s 4
+		IL_0057: ldloc.s 4
 		IL_0059: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-		IL_005e: stloc.3
-		IL_005f: ldstr "log"
-		IL_0064: ldloc.3
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006a: pop
-		IL_006b: ldstr "console"
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007a: ldstr "  x  "
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0084: castclass [System.Runtime]System.String
-		IL_0089: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimStart(string)
-		IL_008e: stloc.3
-		IL_008f: ldstr "log"
-		IL_0094: ldloc.3
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009a: pop
-		IL_009b: ldstr "console"
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00aa: ldstr "x  "
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b4: castclass [System.Runtime]System.String
-		IL_00b9: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimEnd(string)
-		IL_00be: stloc.3
-		IL_00bf: ldstr "log"
-		IL_00c4: ldloc.3
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ca: pop
-		IL_00cb: ldstr "console"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00da: ldstr "  x  "
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e4: castclass [System.Runtime]System.String
-		IL_00e9: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimLeft(string)
-		IL_00ee: stloc.3
-		IL_00ef: ldstr "log"
-		IL_00f4: ldloc.3
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fa: pop
-		IL_00fb: ldstr "console"
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010a: ldstr "x  "
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0114: castclass [System.Runtime]System.String
-		IL_0119: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimRight(string)
-		IL_011e: stloc.3
-		IL_011f: ldstr "log"
-		IL_0124: ldloc.3
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012a: pop
-		IL_012b: ldstr "console"
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013a: ldstr "A"
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0144: castclass [System.Runtime]System.String
-		IL_0149: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
-		IL_014e: stloc.3
-		IL_014f: ldstr "log"
-		IL_0154: ldloc.3
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015a: pop
-		IL_015b: ldstr "console"
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016a: ldstr "a"
-		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0174: castclass [System.Runtime]System.String
-		IL_0179: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-		IL_017e: stloc.3
-		IL_017f: ldstr "log"
-		IL_0184: ldloc.3
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018a: pop
-		IL_018b: ret
+		IL_005e: stloc.s 4
+		IL_0060: ldloc.3
+		IL_0061: ldstr "log"
+		IL_0066: ldloc.s 4
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006d: pop
+		IL_006e: ldstr "console"
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007d: stloc.3
+		IL_007e: ldstr "  x  "
+		IL_0083: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0088: stloc.s 4
+		IL_008a: ldloc.s 4
+		IL_008c: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimStart(string)
+		IL_0091: stloc.s 4
+		IL_0093: ldloc.3
+		IL_0094: ldstr "log"
+		IL_0099: ldloc.s 4
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a0: pop
+		IL_00a1: ldstr "console"
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b0: stloc.3
+		IL_00b1: ldstr "x  "
+		IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_00bb: stloc.s 4
+		IL_00bd: ldloc.s 4
+		IL_00bf: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimEnd(string)
+		IL_00c4: stloc.s 4
+		IL_00c6: ldloc.3
+		IL_00c7: ldstr "log"
+		IL_00cc: ldloc.s 4
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d3: pop
+		IL_00d4: ldstr "console"
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e3: stloc.3
+		IL_00e4: ldstr "  x  "
+		IL_00e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_00ee: stloc.s 4
+		IL_00f0: ldloc.s 4
+		IL_00f2: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimLeft(string)
+		IL_00f7: stloc.s 4
+		IL_00f9: ldloc.3
+		IL_00fa: ldstr "log"
+		IL_00ff: ldloc.s 4
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0106: pop
+		IL_0107: ldstr "console"
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0116: stloc.3
+		IL_0117: ldstr "x  "
+		IL_011c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0121: stloc.s 4
+		IL_0123: ldloc.s 4
+		IL_0125: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimRight(string)
+		IL_012a: stloc.s 4
+		IL_012c: ldloc.3
+		IL_012d: ldstr "log"
+		IL_0132: ldloc.s 4
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0139: pop
+		IL_013a: ldstr "console"
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0149: stloc.3
+		IL_014a: ldstr "A"
+		IL_014f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0154: stloc.s 4
+		IL_0156: ldloc.s 4
+		IL_0158: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
+		IL_015d: stloc.s 4
+		IL_015f: ldloc.3
+		IL_0160: ldstr "log"
+		IL_0165: ldloc.s 4
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016c: pop
+		IL_016d: ldstr "console"
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017c: stloc.3
+		IL_017d: ldstr "a"
+		IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0187: stloc.s 4
+		IL_0189: ldloc.s 4
+		IL_018b: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+		IL_0190: stloc.s 4
+		IL_0192: ldloc.3
+		IL_0193: ldstr "log"
+		IL_0198: ldloc.s 4
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019f: pop
+		IL_01a0: ret
 	} // end of method String_MemberCall_FastPath_CommonMethods::__js_module_init__
 
 } // end of class Modules.String_MemberCall_FastPath_CommonMethods
@@ -416,7 +478,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24ff
+		// Method begins at RVA 0x250a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_NewApis_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_NewApis_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24e4
+			// Method begins at RVA 0x24fc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1160 (0x488)
+		// Code size: 1184 (0x4a0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_NewApis_Basic/Scope,
@@ -150,208 +150,232 @@
 		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0170: stloc.2
 		IL_0171: ldstr "abc"
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017b: ldstr "at"
-		IL_0180: ldc.r8 0.0
-		IL_0189: box [System.Runtime]System.Double
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0193: stloc.s 4
-		IL_0195: ldloc.2
-		IL_0196: ldstr "log"
-		IL_019b: ldloc.s 4
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a2: pop
-		IL_01a3: ldstr "console"
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b2: stloc.s 4
-		IL_01b4: ldstr "abc"
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01be: ldc.r8 1
-		IL_01c7: neg
-		IL_01c8: stloc.s 5
-		IL_01ca: ldloc.s 5
-		IL_01cc: box [System.Runtime]System.Double
-		IL_01d1: stloc.s 6
-		IL_01d3: ldstr "at"
-		IL_01d8: ldloc.s 6
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01df: stloc.2
-		IL_01e0: ldloc.s 4
-		IL_01e2: ldstr "log"
-		IL_01e7: ldloc.2
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ed: pop
-		IL_01ee: ldstr "console"
-		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01fd: stloc.2
-		IL_01fe: ldstr "abc"
-		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0208: ldstr "at"
-		IL_020d: ldc.r8 99
-		IL_0216: box [System.Runtime]System.Double
-		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0220: stloc.s 4
-		IL_0222: ldloc.s 4
-		IL_0224: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0229: stloc.1
-		IL_022a: ldloc.2
-		IL_022b: ldstr "log"
-		IL_0230: ldloc.1
-		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0236: pop
-		IL_0237: ldstr "console"
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0246: stloc.2
-		IL_0247: ldstr "A\ud83d\ude00B"
-		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0251: ldstr "codePointAt"
-		IL_0256: ldc.r8 1
-		IL_025f: box [System.Runtime]System.Double
-		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0269: stloc.s 4
-		IL_026b: ldloc.2
-		IL_026c: ldstr "log"
-		IL_0271: ldloc.s 4
-		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0278: pop
-		IL_0279: ldstr "console"
-		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0288: stloc.s 4
-		IL_028a: ldstr "A\ud83d\ude00B"
-		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0294: ldstr "codePointAt"
-		IL_0299: ldc.r8 20
-		IL_02a2: box [System.Runtime]System.Double
-		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ac: stloc.2
-		IL_02ad: ldloc.2
-		IL_02ae: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_02b3: stloc.1
-		IL_02b4: ldloc.s 4
-		IL_02b6: ldstr "log"
-		IL_02bb: ldloc.1
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c1: pop
-		IL_02c2: ldstr "console"
-		IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d1: stloc.s 4
-		IL_02d3: ldstr "5"
-		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02dd: ldstr "padStart"
-		IL_02e2: ldc.r8 3
-		IL_02eb: box [System.Runtime]System.Double
-		IL_02f0: ldstr "0"
-		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02fa: stloc.2
-		IL_02fb: ldloc.s 4
-		IL_02fd: ldstr "log"
-		IL_0302: ldloc.2
-		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0308: pop
-		IL_0309: ldstr "console"
-		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0318: stloc.2
-		IL_0319: ldstr "5"
-		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0323: ldstr "padEnd"
-		IL_0328: ldc.r8 4
-		IL_0331: box [System.Runtime]System.Double
-		IL_0336: ldstr "xy"
-		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0340: stloc.s 4
-		IL_0342: ldloc.2
-		IL_0343: ldstr "log"
-		IL_0348: ldloc.s 4
-		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_034f: pop
-		IL_0350: ldstr "console"
-		IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_035f: stloc.s 4
-		IL_0361: ldstr "foofoo"
-		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_036b: ldstr "replaceAll"
-		IL_0370: ldstr "oo"
-		IL_0375: ldstr "ar"
-		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_037f: stloc.2
-		IL_0380: ldloc.s 4
-		IL_0382: ldstr "log"
-		IL_0387: ldloc.2
-		IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_038d: pop
-		IL_038e: ldstr "console"
-		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_039d: stloc.2
-		IL_039e: ldstr "aba"
-		IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03a8: ldstr "replaceAll"
-		IL_03ad: ldstr ""
-		IL_03b2: ldstr "-"
-		IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03bc: stloc.s 4
-		IL_03be: ldloc.2
-		IL_03bf: ldstr "log"
-		IL_03c4: ldloc.s 4
-		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03cb: pop
-		IL_03cc: ldstr "console"
-		IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03db: stloc.s 4
-		IL_03dd: ldstr "\ud83d\ude00"
-		IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03e7: ldstr "isWellFormed"
-		IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_03f1: stloc.2
-		IL_03f2: ldloc.s 4
-		IL_03f4: ldstr "log"
-		IL_03f9: ldloc.2
-		IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03ff: pop
-		IL_0400: ldstr "console"
-		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_040f: stloc.2
-		IL_0410: ldstr "\ud83d"
-		IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_041a: ldstr "isWellFormed"
-		IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0424: stloc.s 4
-		IL_0426: ldloc.2
-		IL_0427: ldstr "log"
-		IL_042c: ldloc.s 4
-		IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0433: pop
-		IL_0434: ldstr "console"
-		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0443: stloc.s 4
-		IL_0445: ldstr "A\ud83d"
-		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_044f: ldstr "toWellFormed"
-		IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0459: stloc.2
-		IL_045a: ldloc.2
-		IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0460: ldstr "charCodeAt"
-		IL_0465: ldc.r8 1
-		IL_046e: box [System.Runtime]System.Double
-		IL_0473: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0478: stloc.2
-		IL_0479: ldloc.s 4
-		IL_047b: ldstr "log"
-		IL_0480: ldloc.2
-		IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0486: pop
-		IL_0487: ret
+		IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_017b: stloc.1
+		IL_017c: ldloc.1
+		IL_017d: ldstr "at"
+		IL_0182: ldc.r8 0.0
+		IL_018b: box [System.Runtime]System.Double
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0195: stloc.s 4
+		IL_0197: ldloc.2
+		IL_0198: ldstr "log"
+		IL_019d: ldloc.s 4
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a4: pop
+		IL_01a5: ldstr "console"
+		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b4: stloc.s 4
+		IL_01b6: ldstr "abc"
+		IL_01bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_01c0: stloc.1
+		IL_01c1: ldc.r8 1
+		IL_01ca: neg
+		IL_01cb: stloc.s 5
+		IL_01cd: ldloc.s 5
+		IL_01cf: box [System.Runtime]System.Double
+		IL_01d4: stloc.s 6
+		IL_01d6: ldloc.1
+		IL_01d7: ldstr "at"
+		IL_01dc: ldloc.s 6
+		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e3: stloc.2
+		IL_01e4: ldloc.s 4
+		IL_01e6: ldstr "log"
+		IL_01eb: ldloc.2
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f1: pop
+		IL_01f2: ldstr "console"
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0201: stloc.2
+		IL_0202: ldstr "abc"
+		IL_0207: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_020c: stloc.1
+		IL_020d: ldloc.1
+		IL_020e: ldstr "at"
+		IL_0213: ldc.r8 99
+		IL_021c: box [System.Runtime]System.Double
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0226: stloc.s 4
+		IL_0228: ldloc.s 4
+		IL_022a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_022f: stloc.1
+		IL_0230: ldloc.2
+		IL_0231: ldstr "log"
+		IL_0236: ldloc.1
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023c: pop
+		IL_023d: ldstr "console"
+		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024c: stloc.2
+		IL_024d: ldstr "A\ud83d\ude00B"
+		IL_0252: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0257: stloc.1
+		IL_0258: ldloc.1
+		IL_0259: ldstr "codePointAt"
+		IL_025e: ldc.r8 1
+		IL_0267: box [System.Runtime]System.Double
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0271: stloc.s 4
+		IL_0273: ldloc.2
+		IL_0274: ldstr "log"
+		IL_0279: ldloc.s 4
+		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0280: pop
+		IL_0281: ldstr "console"
+		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0290: stloc.s 4
+		IL_0292: ldstr "A\ud83d\ude00B"
+		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_029c: stloc.1
+		IL_029d: ldloc.1
+		IL_029e: ldstr "codePointAt"
+		IL_02a3: ldc.r8 20
+		IL_02ac: box [System.Runtime]System.Double
+		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b6: stloc.2
+		IL_02b7: ldloc.2
+		IL_02b8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_02bd: stloc.1
+		IL_02be: ldloc.s 4
+		IL_02c0: ldstr "log"
+		IL_02c5: ldloc.1
+		IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02cb: pop
+		IL_02cc: ldstr "console"
+		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02db: stloc.s 4
+		IL_02dd: ldstr "5"
+		IL_02e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_02e7: stloc.1
+		IL_02e8: ldloc.1
+		IL_02e9: ldstr "padStart"
+		IL_02ee: ldc.r8 3
+		IL_02f7: box [System.Runtime]System.Double
+		IL_02fc: ldstr "0"
+		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0306: stloc.2
+		IL_0307: ldloc.s 4
+		IL_0309: ldstr "log"
+		IL_030e: ldloc.2
+		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0314: pop
+		IL_0315: ldstr "console"
+		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0324: stloc.2
+		IL_0325: ldstr "5"
+		IL_032a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_032f: stloc.1
+		IL_0330: ldloc.1
+		IL_0331: ldstr "padEnd"
+		IL_0336: ldc.r8 4
+		IL_033f: box [System.Runtime]System.Double
+		IL_0344: ldstr "xy"
+		IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_034e: stloc.s 4
+		IL_0350: ldloc.2
+		IL_0351: ldstr "log"
+		IL_0356: ldloc.s 4
+		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_035d: pop
+		IL_035e: ldstr "console"
+		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_036d: stloc.s 4
+		IL_036f: ldstr "foofoo"
+		IL_0374: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0379: stloc.1
+		IL_037a: ldloc.1
+		IL_037b: ldstr "replaceAll"
+		IL_0380: ldstr "oo"
+		IL_0385: ldstr "ar"
+		IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_038f: stloc.2
+		IL_0390: ldloc.s 4
+		IL_0392: ldstr "log"
+		IL_0397: ldloc.2
+		IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_039d: pop
+		IL_039e: ldstr "console"
+		IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03ad: stloc.2
+		IL_03ae: ldstr "aba"
+		IL_03b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_03b8: stloc.1
+		IL_03b9: ldloc.1
+		IL_03ba: ldstr "replaceAll"
+		IL_03bf: ldstr ""
+		IL_03c4: ldstr "-"
+		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03ce: stloc.s 4
+		IL_03d0: ldloc.2
+		IL_03d1: ldstr "log"
+		IL_03d6: ldloc.s 4
+		IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03dd: pop
+		IL_03de: ldstr "console"
+		IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03ed: stloc.s 4
+		IL_03ef: ldstr "\ud83d\ude00"
+		IL_03f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_03f9: stloc.1
+		IL_03fa: ldloc.1
+		IL_03fb: ldstr "isWellFormed"
+		IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0405: stloc.2
+		IL_0406: ldloc.s 4
+		IL_0408: ldstr "log"
+		IL_040d: ldloc.2
+		IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0413: pop
+		IL_0414: ldstr "console"
+		IL_0419: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0423: stloc.2
+		IL_0424: ldstr "\ud83d"
+		IL_0429: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_042e: stloc.1
+		IL_042f: ldloc.1
+		IL_0430: ldstr "isWellFormed"
+		IL_0435: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_043a: stloc.s 4
+		IL_043c: ldloc.2
+		IL_043d: ldstr "log"
+		IL_0442: ldloc.s 4
+		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0449: pop
+		IL_044a: ldstr "console"
+		IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0459: stloc.s 4
+		IL_045b: ldstr "A\ud83d"
+		IL_0460: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0465: stloc.1
+		IL_0466: ldloc.1
+		IL_0467: ldstr "toWellFormed"
+		IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0471: stloc.2
+		IL_0472: ldloc.2
+		IL_0473: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0478: ldstr "charCodeAt"
+		IL_047d: ldc.r8 1
+		IL_0486: box [System.Runtime]System.Double
+		IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0490: stloc.2
+		IL_0491: ldloc.s 4
+		IL_0493: ldstr "log"
+		IL_0498: ldloc.2
+		IL_0499: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_049e: pop
+		IL_049f: ret
 	} // end of method String_NewApis_Basic::__js_module_init__
 
 } // end of class Modules.String_NewApis_Basic
@@ -363,7 +387,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24ed
+		// Method begins at RVA 0x2505
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_EmptyMatch_Global.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_EmptyMatch_Global.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2221
+			// Method begins at RVA 0x222d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 453 (0x1c5)
+		// Code size: 465 (0x1d1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global/Scope,
@@ -51,8 +51,9 @@
 			[5] object,
 			[6] object,
 			[7] object,
-			[8] bool,
-			[9] object
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[9] bool,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global/Scope::.ctor()
@@ -78,116 +79,122 @@
 		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0049: pop
 		IL_004a: ldloc.1
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0050: ldstr "exec"
-		IL_0055: ldloc.2
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005b: stloc.3
-		IL_005c: ldstr "console"
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006b: stloc.s 7
-		IL_006d: ldloc.3
-		IL_006e: ldc.r8 0.0
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_007c: stloc.s 6
-		IL_007e: ldloc.s 6
-		IL_0080: ldstr "length"
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_008a: stloc.s 6
-		IL_008c: ldloc.s 7
-		IL_008e: ldstr "log"
-		IL_0093: ldloc.s 6
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009a: pop
-		IL_009b: ldstr "console"
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00aa: stloc.s 6
-		IL_00ac: ldloc.1
-		IL_00ad: ldstr "lastIndex"
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b7: stloc.s 7
-		IL_00b9: ldloc.s 6
-		IL_00bb: ldstr "log"
-		IL_00c0: ldloc.s 7
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c7: pop
-		IL_00c8: ldloc.1
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ce: ldstr "exec"
-		IL_00d3: ldloc.2
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d9: stloc.s 4
-		IL_00db: ldstr "console"
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ea: stloc.s 7
-		IL_00ec: ldloc.s 4
-		IL_00ee: ldc.r8 0.0
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00fc: stloc.s 6
-		IL_00fe: ldloc.s 6
-		IL_0100: ldstr "length"
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010a: stloc.s 6
-		IL_010c: ldloc.s 7
-		IL_010e: ldstr "log"
-		IL_0113: ldloc.s 6
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011a: pop
-		IL_011b: ldstr "console"
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012a: stloc.s 6
-		IL_012c: ldloc.1
-		IL_012d: ldstr "lastIndex"
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0137: stloc.s 7
-		IL_0139: ldloc.s 6
-		IL_013b: ldstr "log"
-		IL_0140: ldloc.s 7
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0147: pop
-		IL_0148: ldloc.1
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014e: ldstr "exec"
-		IL_0153: ldloc.2
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0159: stloc.s 5
-		IL_015b: ldstr "console"
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016a: stloc.s 7
-		IL_016c: ldloc.s 5
-		IL_016e: stloc.s 6
-		IL_0170: ldloc.s 6
-		IL_0172: ldc.i4.0
-		IL_0173: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0178: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_017d: stloc.s 8
-		IL_017f: ldloc.s 8
-		IL_0181: box [System.Runtime]System.Boolean
-		IL_0186: stloc.s 9
-		IL_0188: ldloc.s 7
-		IL_018a: ldstr "log"
-		IL_018f: ldloc.s 9
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0196: pop
-		IL_0197: ldstr "console"
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a6: stloc.s 7
-		IL_01a8: ldloc.1
-		IL_01a9: ldstr "lastIndex"
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b3: stloc.s 6
-		IL_01b5: ldloc.s 7
-		IL_01b7: ldstr "log"
-		IL_01bc: ldloc.s 6
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c3: pop
-		IL_01c4: ret
+		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0050: stloc.s 8
+		IL_0052: ldloc.s 8
+		IL_0054: ldstr "exec"
+		IL_0059: ldloc.2
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005f: stloc.3
+		IL_0060: ldstr "console"
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006f: stloc.s 7
+		IL_0071: ldloc.3
+		IL_0072: ldc.r8 0.0
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0080: stloc.s 6
+		IL_0082: ldloc.s 6
+		IL_0084: ldstr "length"
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_008e: stloc.s 6
+		IL_0090: ldloc.s 7
+		IL_0092: ldstr "log"
+		IL_0097: ldloc.s 6
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009e: pop
+		IL_009f: ldstr "console"
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ae: stloc.s 6
+		IL_00b0: ldloc.1
+		IL_00b1: ldstr "lastIndex"
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00bb: stloc.s 7
+		IL_00bd: ldloc.s 6
+		IL_00bf: ldstr "log"
+		IL_00c4: ldloc.s 7
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cb: pop
+		IL_00cc: ldloc.1
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_00d2: stloc.s 8
+		IL_00d4: ldloc.s 8
+		IL_00d6: ldstr "exec"
+		IL_00db: ldloc.2
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e1: stloc.s 4
+		IL_00e3: ldstr "console"
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f2: stloc.s 7
+		IL_00f4: ldloc.s 4
+		IL_00f6: ldc.r8 0.0
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0104: stloc.s 6
+		IL_0106: ldloc.s 6
+		IL_0108: ldstr "length"
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0112: stloc.s 6
+		IL_0114: ldloc.s 7
+		IL_0116: ldstr "log"
+		IL_011b: ldloc.s 6
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0122: pop
+		IL_0123: ldstr "console"
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0132: stloc.s 6
+		IL_0134: ldloc.1
+		IL_0135: ldstr "lastIndex"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013f: stloc.s 7
+		IL_0141: ldloc.s 6
+		IL_0143: ldstr "log"
+		IL_0148: ldloc.s 7
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014f: pop
+		IL_0150: ldloc.1
+		IL_0151: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0156: stloc.s 8
+		IL_0158: ldloc.s 8
+		IL_015a: ldstr "exec"
+		IL_015f: ldloc.2
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0165: stloc.s 5
+		IL_0167: ldstr "console"
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0176: stloc.s 7
+		IL_0178: ldloc.s 5
+		IL_017a: stloc.s 6
+		IL_017c: ldloc.s 6
+		IL_017e: ldc.i4.0
+		IL_017f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0189: stloc.s 9
+		IL_018b: ldloc.s 9
+		IL_018d: box [System.Runtime]System.Boolean
+		IL_0192: stloc.s 10
+		IL_0194: ldloc.s 7
+		IL_0196: ldstr "log"
+		IL_019b: ldloc.s 10
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a2: pop
+		IL_01a3: ldstr "console"
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b2: stloc.s 7
+		IL_01b4: ldloc.1
+		IL_01b5: ldstr "lastIndex"
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01bf: stloc.s 6
+		IL_01c1: ldloc.s 7
+		IL_01c3: ldstr "log"
+		IL_01c8: ldloc.s 6
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01cf: pop
+		IL_01d0: ret
 	} // end of method String_RegExp_Exec_LastIndex_EmptyMatch_Global::__js_module_init__
 
 } // end of class Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global
@@ -199,7 +206,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x222a
+		// Method begins at RVA 0x2236
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_Global.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_Global.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2211
+			// Method begins at RVA 0x2219
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 437 (0x1b5)
+		// Code size: 445 (0x1bd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_Exec_LastIndex_Global/Scope,
@@ -49,7 +49,8 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] object
+			[6] object,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		)
 
 		IL_0000: newobj instance void Modules.String_RegExp_Exec_LastIndex_Global/Scope::.ctor()
@@ -75,109 +76,113 @@
 		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0049: pop
 		IL_004a: ldloc.1
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0050: ldstr "exec"
-		IL_0055: ldloc.2
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005b: stloc.3
-		IL_005c: ldstr "console"
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006b: stloc.s 6
-		IL_006d: ldloc.3
-		IL_006e: ldc.r8 0.0
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_007c: stloc.s 5
-		IL_007e: ldloc.s 6
-		IL_0080: ldstr "log"
-		IL_0085: ldloc.s 5
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008c: pop
-		IL_008d: ldstr "console"
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009c: stloc.s 5
-		IL_009e: ldloc.3
-		IL_009f: ldstr "index"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a9: stloc.s 6
-		IL_00ab: ldloc.s 5
-		IL_00ad: ldstr "log"
-		IL_00b2: ldloc.s 6
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b9: pop
-		IL_00ba: ldstr "console"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c9: stloc.s 6
-		IL_00cb: ldloc.3
-		IL_00cc: ldstr "input"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d6: stloc.s 5
-		IL_00d8: ldloc.s 6
-		IL_00da: ldstr "log"
-		IL_00df: ldloc.s 5
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e6: pop
-		IL_00e7: ldstr "console"
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f6: stloc.s 5
-		IL_00f8: ldloc.1
-		IL_00f9: ldstr "lastIndex"
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0103: stloc.s 6
-		IL_0105: ldloc.s 5
-		IL_0107: ldstr "log"
-		IL_010c: ldloc.s 6
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0113: pop
-		IL_0114: ldloc.1
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011a: ldstr "exec"
-		IL_011f: ldloc.2
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0125: stloc.s 4
-		IL_0127: ldstr "console"
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0136: stloc.s 6
-		IL_0138: ldloc.s 4
-		IL_013a: ldc.r8 0.0
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0148: stloc.s 5
-		IL_014a: ldloc.s 6
-		IL_014c: ldstr "log"
-		IL_0151: ldloc.s 5
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0158: pop
-		IL_0159: ldstr "console"
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0168: stloc.s 5
-		IL_016a: ldloc.s 4
-		IL_016c: ldstr "index"
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0176: stloc.s 6
-		IL_0178: ldloc.s 5
-		IL_017a: ldstr "log"
-		IL_017f: ldloc.s 6
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0186: pop
-		IL_0187: ldstr "console"
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0196: stloc.s 6
-		IL_0198: ldloc.1
-		IL_0199: ldstr "lastIndex"
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a3: stloc.s 5
-		IL_01a5: ldloc.s 6
-		IL_01a7: ldstr "log"
-		IL_01ac: ldloc.s 5
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b3: pop
-		IL_01b4: ret
+		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0050: stloc.s 7
+		IL_0052: ldloc.s 7
+		IL_0054: ldstr "exec"
+		IL_0059: ldloc.2
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005f: stloc.3
+		IL_0060: ldstr "console"
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006f: stloc.s 6
+		IL_0071: ldloc.3
+		IL_0072: ldc.r8 0.0
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0080: stloc.s 5
+		IL_0082: ldloc.s 6
+		IL_0084: ldstr "log"
+		IL_0089: ldloc.s 5
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0090: pop
+		IL_0091: ldstr "console"
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a0: stloc.s 5
+		IL_00a2: ldloc.3
+		IL_00a3: ldstr "index"
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ad: stloc.s 6
+		IL_00af: ldloc.s 5
+		IL_00b1: ldstr "log"
+		IL_00b6: ldloc.s 6
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bd: pop
+		IL_00be: ldstr "console"
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cd: stloc.s 6
+		IL_00cf: ldloc.3
+		IL_00d0: ldstr "input"
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00da: stloc.s 5
+		IL_00dc: ldloc.s 6
+		IL_00de: ldstr "log"
+		IL_00e3: ldloc.s 5
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ea: pop
+		IL_00eb: ldstr "console"
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fa: stloc.s 5
+		IL_00fc: ldloc.1
+		IL_00fd: ldstr "lastIndex"
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0107: stloc.s 6
+		IL_0109: ldloc.s 5
+		IL_010b: ldstr "log"
+		IL_0110: ldloc.s 6
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0117: pop
+		IL_0118: ldloc.1
+		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_011e: stloc.s 7
+		IL_0120: ldloc.s 7
+		IL_0122: ldstr "exec"
+		IL_0127: ldloc.2
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012d: stloc.s 4
+		IL_012f: ldstr "console"
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013e: stloc.s 6
+		IL_0140: ldloc.s 4
+		IL_0142: ldc.r8 0.0
+		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0150: stloc.s 5
+		IL_0152: ldloc.s 6
+		IL_0154: ldstr "log"
+		IL_0159: ldloc.s 5
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0160: pop
+		IL_0161: ldstr "console"
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0170: stloc.s 5
+		IL_0172: ldloc.s 4
+		IL_0174: ldstr "index"
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_017e: stloc.s 6
+		IL_0180: ldloc.s 5
+		IL_0182: ldstr "log"
+		IL_0187: ldloc.s 6
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018e: pop
+		IL_018f: ldstr "console"
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019e: stloc.s 6
+		IL_01a0: ldloc.1
+		IL_01a1: ldstr "lastIndex"
+		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ab: stloc.s 5
+		IL_01ad: ldloc.s 6
+		IL_01af: ldstr "log"
+		IL_01b4: ldloc.s 5
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bb: pop
+		IL_01bc: ret
 	} // end of method String_RegExp_Exec_LastIndex_Global::__js_module_init__
 
 } // end of class Modules.String_RegExp_Exec_LastIndex_Global
@@ -189,7 +194,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x221a
+		// Method begins at RVA 0x2222
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_Sticky.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_Sticky.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x235a
+			// Method begins at RVA 0x236a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 766 (0x2fe)
+		// Code size: 782 (0x30e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_Exec_LastIndex_Sticky/Scope,
@@ -50,8 +50,9 @@
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] bool,
-			[8] object
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[8] bool,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.String_RegExp_Exec_LastIndex_Sticky/Scope::.ctor()
@@ -94,189 +95,197 @@
 		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0086: stloc.s 5
 		IL_0088: ldloc.1
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008e: ldstr "exec"
-		IL_0093: ldloc.2
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0099: stloc.s 6
-		IL_009b: ldloc.s 6
-		IL_009d: ldc.i4.0
-		IL_009e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_00a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00a8: stloc.s 7
-		IL_00aa: ldloc.s 7
-		IL_00ac: box [System.Runtime]System.Boolean
-		IL_00b1: stloc.s 8
-		IL_00b3: ldloc.s 5
-		IL_00b5: ldstr "log"
-		IL_00ba: ldloc.s 8
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c1: pop
-		IL_00c2: ldstr "console"
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d1: stloc.s 5
-		IL_00d3: ldloc.1
-		IL_00d4: ldstr "lastIndex"
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00de: stloc.s 6
-		IL_00e0: ldloc.s 5
-		IL_00e2: ldstr "log"
-		IL_00e7: ldloc.s 6
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ee: pop
-		IL_00ef: ldloc.1
-		IL_00f0: ldstr "lastIndex"
-		IL_00f5: ldc.r8 1
-		IL_00fe: ldc.i4.1
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0104: pop
-		IL_0105: ldloc.1
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010b: ldstr "exec"
-		IL_0110: ldloc.2
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0116: stloc.3
-		IL_0117: ldstr "console"
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0126: stloc.s 6
-		IL_0128: ldloc.3
-		IL_0129: ldc.r8 0.0
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0137: stloc.s 5
-		IL_0139: ldloc.s 6
-		IL_013b: ldstr "log"
-		IL_0140: ldloc.s 5
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0147: pop
-		IL_0148: ldstr "console"
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0157: stloc.s 5
-		IL_0159: ldloc.3
-		IL_015a: ldstr "index"
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0164: stloc.s 6
-		IL_0166: ldloc.s 5
-		IL_0168: ldstr "log"
-		IL_016d: ldloc.s 6
-		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0174: pop
-		IL_0175: ldstr "console"
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0184: stloc.s 6
-		IL_0186: ldloc.3
-		IL_0187: ldstr "input"
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0191: stloc.s 5
-		IL_0193: ldloc.s 6
-		IL_0195: ldstr "log"
-		IL_019a: ldloc.s 5
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a1: pop
-		IL_01a2: ldstr "console"
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b1: stloc.s 5
-		IL_01b3: ldloc.1
-		IL_01b4: ldstr "lastIndex"
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01be: stloc.s 6
-		IL_01c0: ldloc.s 5
-		IL_01c2: ldstr "log"
-		IL_01c7: ldloc.s 6
-		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ce: pop
-		IL_01cf: ldloc.1
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d5: ldstr "exec"
-		IL_01da: ldloc.2
-		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e0: stloc.s 4
-		IL_01e2: ldstr "console"
-		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f1: stloc.s 6
-		IL_01f3: ldloc.s 4
-		IL_01f5: ldc.r8 0.0
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0203: stloc.s 5
-		IL_0205: ldloc.s 6
-		IL_0207: ldstr "log"
-		IL_020c: ldloc.s 5
-		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0213: pop
-		IL_0214: ldstr "console"
-		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0223: stloc.s 5
-		IL_0225: ldloc.s 4
-		IL_0227: ldstr "index"
-		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0231: stloc.s 6
-		IL_0233: ldloc.s 5
-		IL_0235: ldstr "log"
-		IL_023a: ldloc.s 6
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0241: pop
-		IL_0242: ldstr "console"
-		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0251: stloc.s 6
-		IL_0253: ldloc.1
-		IL_0254: ldstr "lastIndex"
-		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_025e: stloc.s 5
-		IL_0260: ldloc.s 6
-		IL_0262: ldstr "log"
-		IL_0267: ldloc.s 5
-		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026e: pop
-		IL_026f: ldloc.1
-		IL_0270: ldstr "lastIndex"
-		IL_0275: ldc.r8 10
-		IL_027e: ldc.i4.1
-		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0284: pop
-		IL_0285: ldstr "console"
-		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0294: stloc.s 5
-		IL_0296: ldloc.1
-		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_029c: ldstr "exec"
-		IL_02a1: ldloc.2
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a7: stloc.s 6
-		IL_02a9: ldloc.s 6
-		IL_02ab: ldc.i4.0
-		IL_02ac: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_02b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02b6: stloc.s 7
-		IL_02b8: ldloc.s 7
-		IL_02ba: box [System.Runtime]System.Boolean
-		IL_02bf: stloc.s 8
-		IL_02c1: ldloc.s 5
-		IL_02c3: ldstr "log"
+		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_008e: stloc.s 7
+		IL_0090: ldloc.s 7
+		IL_0092: ldstr "exec"
+		IL_0097: ldloc.2
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009d: stloc.s 6
+		IL_009f: ldloc.s 6
+		IL_00a1: ldc.i4.0
+		IL_00a2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00a7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00ac: stloc.s 8
+		IL_00ae: ldloc.s 8
+		IL_00b0: box [System.Runtime]System.Boolean
+		IL_00b5: stloc.s 9
+		IL_00b7: ldloc.s 5
+		IL_00b9: ldstr "log"
+		IL_00be: ldloc.s 9
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c5: pop
+		IL_00c6: ldstr "console"
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d5: stloc.s 5
+		IL_00d7: ldloc.1
+		IL_00d8: ldstr "lastIndex"
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e2: stloc.s 6
+		IL_00e4: ldloc.s 5
+		IL_00e6: ldstr "log"
+		IL_00eb: ldloc.s 6
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f2: pop
+		IL_00f3: ldloc.1
+		IL_00f4: ldstr "lastIndex"
+		IL_00f9: ldc.r8 1
+		IL_0102: ldc.i4.1
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0108: pop
+		IL_0109: ldloc.1
+		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_010f: stloc.s 7
+		IL_0111: ldloc.s 7
+		IL_0113: ldstr "exec"
+		IL_0118: ldloc.2
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011e: stloc.3
+		IL_011f: ldstr "console"
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012e: stloc.s 6
+		IL_0130: ldloc.3
+		IL_0131: ldc.r8 0.0
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_013f: stloc.s 5
+		IL_0141: ldloc.s 6
+		IL_0143: ldstr "log"
+		IL_0148: ldloc.s 5
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014f: pop
+		IL_0150: ldstr "console"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015f: stloc.s 5
+		IL_0161: ldloc.3
+		IL_0162: ldstr "index"
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_016c: stloc.s 6
+		IL_016e: ldloc.s 5
+		IL_0170: ldstr "log"
+		IL_0175: ldloc.s 6
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017c: pop
+		IL_017d: ldstr "console"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018c: stloc.s 6
+		IL_018e: ldloc.3
+		IL_018f: ldstr "input"
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0199: stloc.s 5
+		IL_019b: ldloc.s 6
+		IL_019d: ldstr "log"
+		IL_01a2: ldloc.s 5
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a9: pop
+		IL_01aa: ldstr "console"
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b9: stloc.s 5
+		IL_01bb: ldloc.1
+		IL_01bc: ldstr "lastIndex"
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c6: stloc.s 6
+		IL_01c8: ldloc.s 5
+		IL_01ca: ldstr "log"
+		IL_01cf: ldloc.s 6
+		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d6: pop
+		IL_01d7: ldloc.1
+		IL_01d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_01dd: stloc.s 7
+		IL_01df: ldloc.s 7
+		IL_01e1: ldstr "exec"
+		IL_01e6: ldloc.2
+		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ec: stloc.s 4
+		IL_01ee: ldstr "console"
+		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01fd: stloc.s 6
+		IL_01ff: ldloc.s 4
+		IL_0201: ldc.r8 0.0
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_020f: stloc.s 5
+		IL_0211: ldloc.s 6
+		IL_0213: ldstr "log"
+		IL_0218: ldloc.s 5
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_021f: pop
+		IL_0220: ldstr "console"
+		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_022f: stloc.s 5
+		IL_0231: ldloc.s 4
+		IL_0233: ldstr "index"
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023d: stloc.s 6
+		IL_023f: ldloc.s 5
+		IL_0241: ldstr "log"
+		IL_0246: ldloc.s 6
+		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024d: pop
+		IL_024e: ldstr "console"
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025d: stloc.s 6
+		IL_025f: ldloc.1
+		IL_0260: ldstr "lastIndex"
+		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_026a: stloc.s 5
+		IL_026c: ldloc.s 6
+		IL_026e: ldstr "log"
+		IL_0273: ldloc.s 5
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027a: pop
+		IL_027b: ldloc.1
+		IL_027c: ldstr "lastIndex"
+		IL_0281: ldc.r8 10
+		IL_028a: ldc.i4.1
+		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0290: pop
+		IL_0291: ldstr "console"
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a0: stloc.s 5
+		IL_02a2: ldloc.1
+		IL_02a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_02a8: stloc.s 7
+		IL_02aa: ldloc.s 7
+		IL_02ac: ldstr "exec"
+		IL_02b1: ldloc.2
+		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b7: stloc.s 6
+		IL_02b9: ldloc.s 6
+		IL_02bb: ldc.i4.0
+		IL_02bc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_02c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02c6: stloc.s 8
 		IL_02c8: ldloc.s 8
-		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02cf: pop
-		IL_02d0: ldstr "console"
-		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02df: stloc.s 5
-		IL_02e1: ldloc.1
-		IL_02e2: ldstr "lastIndex"
-		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ec: stloc.s 6
-		IL_02ee: ldloc.s 5
-		IL_02f0: ldstr "log"
-		IL_02f5: ldloc.s 6
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02fc: pop
-		IL_02fd: ret
+		IL_02ca: box [System.Runtime]System.Boolean
+		IL_02cf: stloc.s 9
+		IL_02d1: ldloc.s 5
+		IL_02d3: ldstr "log"
+		IL_02d8: ldloc.s 9
+		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02df: pop
+		IL_02e0: ldstr "console"
+		IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ef: stloc.s 5
+		IL_02f1: ldloc.1
+		IL_02f2: ldstr "lastIndex"
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02fc: stloc.s 6
+		IL_02fe: ldloc.s 5
+		IL_0300: ldstr "log"
+		IL_0305: ldloc.s 6
+		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_030c: pop
+		IL_030d: ret
 	} // end of method String_RegExp_Exec_LastIndex_Sticky::__js_module_init__
 
 } // end of class Modules.String_RegExp_Exec_LastIndex_Sticky
@@ -288,7 +297,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2363
+		// Method begins at RVA 0x2373
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_NamedGroups_Indices.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_NamedGroups_Indices.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2888
+			// Method begins at RVA 0x2890
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2092 (0x82c)
+		// Code size: 2100 (0x834)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_NamedGroups_Indices/Scope,
@@ -54,7 +54,8 @@
 			[8] bool,
 			[9] object,
 			[10] object,
-			[11] object
+			[11] string,
+			[12] object
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -66,602 +67,606 @@
 		IL_0016: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_001b: stloc.s 5
 		IL_001d: ldloc.s 5
-		IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0024: ldstr "exec"
-		IL_0029: ldstr "a"
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0033: stloc.1
-		IL_0034: ldstr "console"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0043: stloc.s 6
-		IL_0045: ldloc.1
-		IL_0046: ldstr "groups"
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0050: stloc.s 7
-		IL_0052: ldloc.s 7
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0059: stloc.s 7
-		IL_005b: ldloc.s 7
-		IL_005d: ldc.i4.0
-		IL_005e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0068: stloc.s 8
-		IL_006a: ldloc.s 8
-		IL_006c: box [System.Runtime]System.Boolean
-		IL_0071: stloc.s 9
-		IL_0073: ldloc.s 6
-		IL_0075: ldstr "log"
-		IL_007a: ldloc.s 9
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0081: pop
-		IL_0082: ldstr "console"
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0091: ldloc.1
-		IL_0092: ldstr "groups"
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_00a1: stloc.s 6
-		IL_00a3: ldstr "log"
-		IL_00a8: ldloc.s 6
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00af: pop
-		IL_00b0: ldstr "console"
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bf: stloc.s 6
-		IL_00c1: ldloc.1
-		IL_00c2: ldstr "groups"
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00cc: stloc.s 7
-		IL_00ce: ldloc.s 7
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_00d5: stloc.s 7
-		IL_00d7: ldloc.s 7
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_00de: stloc.s 7
-		IL_00e0: ldloc.s 6
-		IL_00e2: ldstr "log"
-		IL_00e7: ldloc.s 7
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ee: pop
-		IL_00ef: ldstr "console"
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fe: stloc.s 7
-		IL_0100: ldloc.1
-		IL_0101: ldstr "groups"
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010b: stloc.s 6
-		IL_010d: ldloc.s 6
-		IL_010f: ldstr "word"
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0119: stloc.s 6
-		IL_011b: ldloc.s 7
-		IL_011d: ldstr "log"
-		IL_0122: ldloc.s 6
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0129: pop
-		IL_012a: ldstr "console"
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0139: stloc.s 6
-		IL_013b: ldloc.1
-		IL_013c: ldstr "groups"
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0146: stloc.s 7
-		IL_0148: ldloc.s 7
-		IL_014a: ldstr "optional"
-		IL_014f: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0154: box [System.Runtime]System.Boolean
-		IL_0159: stloc.s 9
-		IL_015b: ldloc.s 6
-		IL_015d: ldstr "log"
-		IL_0162: ldloc.s 9
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0169: pop
-		IL_016a: ldstr "console"
-		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0179: stloc.s 6
-		IL_017b: ldloc.1
-		IL_017c: ldstr "groups"
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0186: stloc.s 7
-		IL_0188: ldloc.s 7
-		IL_018a: ldstr "optional"
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0194: stloc.s 7
-		IL_0196: ldloc.s 7
-		IL_0198: ldnull
-		IL_0199: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_019e: stloc.s 8
-		IL_01a0: ldloc.s 8
-		IL_01a2: box [System.Runtime]System.Boolean
-		IL_01a7: stloc.s 9
-		IL_01a9: ldloc.s 6
-		IL_01ab: ldstr "log"
-		IL_01b0: ldloc.s 9
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b7: pop
-		IL_01b8: ldstr "console"
-		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c7: stloc.s 6
-		IL_01c9: ldloc.1
-		IL_01ca: ldstr "groups"
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01d4: stloc.s 7
-		IL_01d6: ldloc.s 7
-		IL_01d8: ldstr "word"
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_01e2: stloc.s 7
-		IL_01e4: ldloc.s 7
-		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_01eb: stloc.s 7
-		IL_01ed: ldloc.s 6
-		IL_01ef: ldstr "log"
-		IL_01f4: ldloc.s 7
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fb: pop
-		IL_01fc: ldstr "console"
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020b: stloc.s 7
-		IL_020d: ldloc.1
-		IL_020e: ldstr "groups"
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0218: stloc.s 6
-		IL_021a: ldloc.s 6
-		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0221: stloc.s 6
-		IL_0223: ldloc.s 7
-		IL_0225: ldstr "log"
-		IL_022a: ldloc.s 6
-		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0231: pop
-		IL_0232: ldstr "console"
-		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0241: stloc.s 6
-		IL_0243: ldloc.1
-		IL_0244: ldstr "indices"
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_024e: stloc.s 7
-		IL_0250: ldloc.s 7
-		IL_0252: ldc.r8 0.0
-		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0260: stloc.s 7
-		IL_0262: ldloc.s 7
-		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0269: stloc.s 7
-		IL_026b: ldloc.s 6
-		IL_026d: ldstr "log"
-		IL_0272: ldloc.s 7
-		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0279: pop
-		IL_027a: ldstr "console"
-		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0289: stloc.s 7
-		IL_028b: ldloc.1
-		IL_028c: ldstr "indices"
-		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0296: stloc.s 6
-		IL_0298: ldloc.s 6
-		IL_029a: ldc.r8 1
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02a8: stloc.s 6
-		IL_02aa: ldloc.s 6
-		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_02b1: stloc.s 6
-		IL_02b3: ldloc.s 7
-		IL_02b5: ldstr "log"
-		IL_02ba: ldloc.s 6
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c1: pop
-		IL_02c2: ldstr "console"
-		IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d1: stloc.s 6
-		IL_02d3: ldloc.1
-		IL_02d4: ldstr "indices"
-		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02de: stloc.s 7
-		IL_02e0: ldloc.s 7
-		IL_02e2: ldc.r8 2
-		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02f0: stloc.s 7
-		IL_02f2: ldloc.s 7
-		IL_02f4: ldnull
-		IL_02f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02fa: stloc.s 8
-		IL_02fc: ldloc.s 8
-		IL_02fe: box [System.Runtime]System.Boolean
-		IL_0303: stloc.s 9
-		IL_0305: ldloc.s 6
-		IL_0307: ldstr "log"
-		IL_030c: ldloc.s 9
-		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0313: pop
-		IL_0314: ldstr "console"
-		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0323: stloc.s 6
-		IL_0325: ldloc.1
-		IL_0326: ldstr "indices"
-		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0330: stloc.s 7
-		IL_0332: ldloc.s 7
-		IL_0334: ldstr "groups"
-		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_033e: stloc.s 7
-		IL_0340: ldloc.s 7
-		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0347: stloc.s 7
-		IL_0349: ldloc.s 7
-		IL_034b: ldc.i4.0
-		IL_034c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0351: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0356: stloc.s 8
-		IL_0358: ldloc.s 8
-		IL_035a: box [System.Runtime]System.Boolean
-		IL_035f: stloc.s 9
-		IL_0361: ldloc.s 6
-		IL_0363: ldstr "log"
-		IL_0368: ldloc.s 9
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_036f: pop
-		IL_0370: ldstr "console"
-		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_037f: stloc.s 6
-		IL_0381: ldloc.1
-		IL_0382: ldstr "indices"
-		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_038c: stloc.s 7
-		IL_038e: ldloc.s 7
-		IL_0390: ldstr "groups"
-		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_039a: stloc.s 7
-		IL_039c: ldloc.s 7
-		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_03a3: stloc.s 7
-		IL_03a5: ldloc.s 6
-		IL_03a7: ldstr "log"
-		IL_03ac: ldloc.s 7
-		IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03b3: pop
-		IL_03b4: ldstr "console"
-		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03c3: stloc.s 7
-		IL_03c5: ldloc.1
-		IL_03c6: ldstr "indices"
-		IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03d0: stloc.s 6
-		IL_03d2: ldloc.s 6
-		IL_03d4: ldstr "groups"
-		IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03de: stloc.s 6
-		IL_03e0: ldloc.s 6
-		IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_03e7: stloc.s 6
-		IL_03e9: ldloc.s 6
-		IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_03f0: stloc.s 6
-		IL_03f2: ldloc.s 7
-		IL_03f4: ldstr "log"
-		IL_03f9: ldloc.s 6
-		IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0400: pop
-		IL_0401: ldstr "console"
-		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0410: stloc.s 6
-		IL_0412: ldloc.1
-		IL_0413: ldstr "indices"
-		IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_041d: stloc.s 7
-		IL_041f: ldloc.s 7
-		IL_0421: ldstr "groups"
-		IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_042b: stloc.s 7
-		IL_042d: ldloc.s 7
-		IL_042f: ldstr "word"
-		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0439: stloc.s 7
-		IL_043b: ldloc.s 7
-		IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0442: stloc.s 7
-		IL_0444: ldloc.s 6
-		IL_0446: ldstr "log"
-		IL_044b: ldloc.s 7
-		IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0452: pop
-		IL_0453: ldstr "console"
-		IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0462: stloc.s 7
-		IL_0464: ldloc.1
-		IL_0465: ldstr "indices"
-		IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_046f: stloc.s 6
-		IL_0471: ldloc.s 6
-		IL_0473: ldstr "groups"
-		IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_047d: stloc.s 6
-		IL_047f: ldloc.s 6
-		IL_0481: ldstr "optional"
-		IL_0486: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_048b: box [System.Runtime]System.Boolean
-		IL_0490: stloc.s 9
-		IL_0492: ldloc.s 7
-		IL_0494: ldstr "log"
-		IL_0499: ldloc.s 9
-		IL_049b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04a0: pop
-		IL_04a1: ldstr "console"
-		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b0: stloc.s 7
-		IL_04b2: ldloc.1
-		IL_04b3: ldstr "indices"
-		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04bd: stloc.s 6
-		IL_04bf: ldloc.s 6
-		IL_04c1: ldstr "groups"
-		IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04cb: stloc.s 6
-		IL_04cd: ldloc.s 6
-		IL_04cf: ldstr "optional"
-		IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04d9: stloc.s 6
-		IL_04db: ldloc.s 6
-		IL_04dd: ldnull
-		IL_04de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04e3: stloc.s 8
-		IL_04e5: ldloc.s 8
-		IL_04e7: box [System.Runtime]System.Boolean
-		IL_04ec: stloc.s 9
-		IL_04ee: ldloc.s 7
-		IL_04f0: ldstr "log"
-		IL_04f5: ldloc.s 9
-		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04fc: pop
-		IL_04fd: ldstr "console"
-		IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_050c: stloc.s 7
-		IL_050e: ldloc.1
-		IL_050f: ldstr "groups"
-		IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0519: stloc.s 6
-		IL_051b: ldloc.1
-		IL_051c: ldstr "indices"
-		IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0526: stloc.s 10
-		IL_0528: ldloc.s 10
-		IL_052a: ldstr "groups"
-		IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0534: stloc.s 10
-		IL_0536: ldloc.s 6
-		IL_0538: ldloc.s 10
-		IL_053a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_053f: stloc.s 8
-		IL_0541: ldloc.s 8
-		IL_0543: box [System.Runtime]System.Boolean
-		IL_0548: stloc.s 9
-		IL_054a: ldloc.s 7
-		IL_054c: ldstr "log"
-		IL_0551: ldloc.s 9
-		IL_0553: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0558: pop
-		IL_0559: ldstr "a"
-		IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0563: stloc.s 7
-		IL_0565: ldstr "(?<letter>a)"
-		IL_056a: ldstr ""
-		IL_056f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0574: stloc.s 5
-		IL_0576: ldloc.s 7
-		IL_0578: ldstr "match"
-		IL_057d: ldloc.s 5
-		IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0584: stloc.2
-		IL_0585: ldstr "console"
-		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0594: stloc.s 7
-		IL_0596: ldloc.2
-		IL_0597: ldstr "groups"
-		IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05a1: stloc.s 10
-		IL_05a3: ldloc.s 10
-		IL_05a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_05aa: stloc.s 10
-		IL_05ac: ldloc.s 10
-		IL_05ae: ldc.i4.0
-		IL_05af: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_05b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_05b9: stloc.s 8
-		IL_05bb: ldloc.s 8
-		IL_05bd: box [System.Runtime]System.Boolean
-		IL_05c2: stloc.s 9
-		IL_05c4: ldloc.s 7
-		IL_05c6: ldstr "log"
-		IL_05cb: ldloc.s 9
-		IL_05cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05d2: pop
-		IL_05d3: ldstr "console"
-		IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05e2: stloc.s 7
-		IL_05e4: ldloc.2
-		IL_05e5: ldstr "groups"
-		IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05ef: stloc.s 10
-		IL_05f1: ldloc.s 10
-		IL_05f3: ldstr "letter"
-		IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05fd: stloc.s 10
-		IL_05ff: ldloc.s 7
-		IL_0601: ldstr "log"
-		IL_0606: ldloc.s 10
-		IL_0608: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_060d: pop
-		IL_060e: ldstr "a a"
-		IL_0613: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0618: stloc.s 10
-		IL_061a: ldstr "(?<letter>a)"
-		IL_061f: ldstr "g"
-		IL_0624: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0629: stloc.s 5
-		IL_062b: ldloc.s 10
-		IL_062d: ldstr "matchAll"
-		IL_0632: ldloc.s 5
-		IL_0634: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0639: stloc.s 10
-		IL_063b: ldloc.s 10
-		IL_063d: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0642: stloc.3
-		IL_0643: ldstr "console"
-		IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_064d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0652: ldloc.3
-		IL_0653: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0658: box [System.Runtime]System.Double
-		IL_065d: stloc.s 11
-		IL_065f: ldstr "log"
-		IL_0664: ldloc.s 11
-		IL_0666: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_066b: pop
-		IL_066c: ldstr "console"
-		IL_0671: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0676: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_067b: stloc.s 10
-		IL_067d: ldloc.3
-		IL_067e: ldc.r8 0.0
-		IL_0687: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_068c: ldstr "groups"
-		IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0696: stloc.s 7
-		IL_0698: ldloc.s 7
-		IL_069a: ldstr "letter"
-		IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06a4: stloc.s 7
-		IL_06a6: ldloc.s 10
-		IL_06a8: ldstr "log"
-		IL_06ad: ldloc.s 7
-		IL_06af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06b4: pop
-		IL_06b5: ldstr "console"
-		IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06c4: stloc.s 7
-		IL_06c6: ldloc.3
-		IL_06c7: ldc.r8 1
-		IL_06d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_06d5: ldstr "groups"
-		IL_06da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06df: stloc.s 10
-		IL_06e1: ldloc.s 10
-		IL_06e3: ldstr "letter"
-		IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06ed: stloc.s 10
-		IL_06ef: ldloc.s 7
-		IL_06f1: ldstr "log"
-		IL_06f6: ldloc.s 10
-		IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06fd: pop
-		IL_06fe: ldstr "a"
-		IL_0703: ldstr "d"
-		IL_0708: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_070d: stloc.s 5
-		IL_070f: ldloc.s 5
-		IL_0711: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0716: ldstr "exec"
-		IL_071b: ldstr "a"
-		IL_0720: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0725: stloc.s 4
-		IL_0727: ldstr "console"
-		IL_072c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0731: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0736: stloc.s 10
-		IL_0738: ldloc.s 4
-		IL_073a: ldstr "groups"
-		IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0744: stloc.s 7
-		IL_0746: ldloc.s 7
-		IL_0748: ldnull
-		IL_0749: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_074e: stloc.s 8
-		IL_0750: ldloc.s 8
-		IL_0752: box [System.Runtime]System.Boolean
-		IL_0757: stloc.s 9
-		IL_0759: ldloc.s 10
-		IL_075b: ldstr "log"
-		IL_0760: ldloc.s 9
-		IL_0762: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0767: pop
-		IL_0768: ldstr "console"
-		IL_076d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0772: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0777: stloc.s 10
-		IL_0779: ldloc.s 4
-		IL_077b: ldstr "indices"
-		IL_0780: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0785: stloc.s 7
-		IL_0787: ldloc.s 7
-		IL_0789: ldstr "groups"
-		IL_078e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0793: stloc.s 7
-		IL_0795: ldloc.s 7
-		IL_0797: ldnull
-		IL_0798: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_079d: stloc.s 8
-		IL_079f: ldloc.s 8
-		IL_07a1: box [System.Runtime]System.Boolean
-		IL_07a6: stloc.s 9
-		IL_07a8: ldloc.s 10
-		IL_07aa: ldstr "log"
-		IL_07af: ldloc.s 9
-		IL_07b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07b6: pop
-		IL_07b7: ldstr "console"
-		IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07c6: ldloc.s 4
-		IL_07c8: ldstr "groups"
-		IL_07cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_07d7: stloc.s 10
-		IL_07d9: ldstr "log"
-		IL_07de: ldloc.s 10
-		IL_07e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07e5: pop
-		IL_07e6: ldstr "console"
-		IL_07eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07f5: stloc.s 10
-		IL_07f7: ldloc.s 4
-		IL_07f9: ldstr "indices"
-		IL_07fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0803: stloc.s 7
-		IL_0805: ldloc.s 7
-		IL_0807: ldstr "groups"
-		IL_080c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0811: stloc.s 7
-		IL_0813: ldloc.s 7
-		IL_0815: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_081a: stloc.s 7
-		IL_081c: ldloc.s 10
-		IL_081e: ldstr "log"
-		IL_0823: ldloc.s 7
-		IL_0825: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_082a: pop
-		IL_082b: ret
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_0024: stloc.s 5
+		IL_0026: ldloc.s 5
+		IL_0028: ldstr "exec"
+		IL_002d: ldstr "a"
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0037: stloc.1
+		IL_0038: ldstr "console"
+		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0047: stloc.s 6
+		IL_0049: ldloc.1
+		IL_004a: ldstr "groups"
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0054: stloc.s 7
+		IL_0056: ldloc.s 7
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_005d: stloc.s 7
+		IL_005f: ldloc.s 7
+		IL_0061: ldc.i4.0
+		IL_0062: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0067: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_006c: stloc.s 8
+		IL_006e: ldloc.s 8
+		IL_0070: box [System.Runtime]System.Boolean
+		IL_0075: stloc.s 9
+		IL_0077: ldloc.s 6
+		IL_0079: ldstr "log"
+		IL_007e: ldloc.s 9
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0085: pop
+		IL_0086: ldstr "console"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0095: ldloc.1
+		IL_0096: ldstr "groups"
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_00a5: stloc.s 6
+		IL_00a7: ldstr "log"
+		IL_00ac: ldloc.s 6
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b3: pop
+		IL_00b4: ldstr "console"
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c3: stloc.s 6
+		IL_00c5: ldloc.1
+		IL_00c6: ldstr "groups"
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d0: stloc.s 7
+		IL_00d2: ldloc.s 7
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_00d9: stloc.s 7
+		IL_00db: ldloc.s 7
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_00e2: stloc.s 7
+		IL_00e4: ldloc.s 6
+		IL_00e6: ldstr "log"
+		IL_00eb: ldloc.s 7
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f2: pop
+		IL_00f3: ldstr "console"
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0102: stloc.s 7
+		IL_0104: ldloc.1
+		IL_0105: ldstr "groups"
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010f: stloc.s 6
+		IL_0111: ldloc.s 6
+		IL_0113: ldstr "word"
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011d: stloc.s 6
+		IL_011f: ldloc.s 7
+		IL_0121: ldstr "log"
+		IL_0126: ldloc.s 6
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012d: pop
+		IL_012e: ldstr "console"
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013d: stloc.s 6
+		IL_013f: ldloc.1
+		IL_0140: ldstr "groups"
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_014a: stloc.s 7
+		IL_014c: ldloc.s 7
+		IL_014e: ldstr "optional"
+		IL_0153: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0158: box [System.Runtime]System.Boolean
+		IL_015d: stloc.s 9
+		IL_015f: ldloc.s 6
+		IL_0161: ldstr "log"
+		IL_0166: ldloc.s 9
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016d: pop
+		IL_016e: ldstr "console"
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017d: stloc.s 6
+		IL_017f: ldloc.1
+		IL_0180: ldstr "groups"
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018a: stloc.s 7
+		IL_018c: ldloc.s 7
+		IL_018e: ldstr "optional"
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0198: stloc.s 7
+		IL_019a: ldloc.s 7
+		IL_019c: ldnull
+		IL_019d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01a2: stloc.s 8
+		IL_01a4: ldloc.s 8
+		IL_01a6: box [System.Runtime]System.Boolean
+		IL_01ab: stloc.s 9
+		IL_01ad: ldloc.s 6
+		IL_01af: ldstr "log"
+		IL_01b4: ldloc.s 9
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bb: pop
+		IL_01bc: ldstr "console"
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01cb: stloc.s 6
+		IL_01cd: ldloc.1
+		IL_01ce: ldstr "groups"
+		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d8: stloc.s 7
+		IL_01da: ldloc.s 7
+		IL_01dc: ldstr "word"
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_01e6: stloc.s 7
+		IL_01e8: ldloc.s 7
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_01ef: stloc.s 7
+		IL_01f1: ldloc.s 6
+		IL_01f3: ldstr "log"
+		IL_01f8: ldloc.s 7
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ff: pop
+		IL_0200: ldstr "console"
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020f: stloc.s 7
+		IL_0211: ldloc.1
+		IL_0212: ldstr "groups"
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_021c: stloc.s 6
+		IL_021e: ldloc.s 6
+		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0225: stloc.s 6
+		IL_0227: ldloc.s 7
+		IL_0229: ldstr "log"
+		IL_022e: ldloc.s 6
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0235: pop
+		IL_0236: ldstr "console"
+		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0245: stloc.s 6
+		IL_0247: ldloc.1
+		IL_0248: ldstr "indices"
+		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0252: stloc.s 7
+		IL_0254: ldloc.s 7
+		IL_0256: ldc.r8 0.0
+		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0264: stloc.s 7
+		IL_0266: ldloc.s 7
+		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_026d: stloc.s 7
+		IL_026f: ldloc.s 6
+		IL_0271: ldstr "log"
+		IL_0276: ldloc.s 7
+		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027d: pop
+		IL_027e: ldstr "console"
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028d: stloc.s 7
+		IL_028f: ldloc.1
+		IL_0290: ldstr "indices"
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_029a: stloc.s 6
+		IL_029c: ldloc.s 6
+		IL_029e: ldc.r8 1
+		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02ac: stloc.s 6
+		IL_02ae: ldloc.s 6
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_02b5: stloc.s 6
+		IL_02b7: ldloc.s 7
+		IL_02b9: ldstr "log"
+		IL_02be: ldloc.s 6
+		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c5: pop
+		IL_02c6: ldstr "console"
+		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d5: stloc.s 6
+		IL_02d7: ldloc.1
+		IL_02d8: ldstr "indices"
+		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02e2: stloc.s 7
+		IL_02e4: ldloc.s 7
+		IL_02e6: ldc.r8 2
+		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02f4: stloc.s 7
+		IL_02f6: ldloc.s 7
+		IL_02f8: ldnull
+		IL_02f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02fe: stloc.s 8
+		IL_0300: ldloc.s 8
+		IL_0302: box [System.Runtime]System.Boolean
+		IL_0307: stloc.s 9
+		IL_0309: ldloc.s 6
+		IL_030b: ldstr "log"
+		IL_0310: ldloc.s 9
+		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0317: pop
+		IL_0318: ldstr "console"
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0327: stloc.s 6
+		IL_0329: ldloc.1
+		IL_032a: ldstr "indices"
+		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0334: stloc.s 7
+		IL_0336: ldloc.s 7
+		IL_0338: ldstr "groups"
+		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0342: stloc.s 7
+		IL_0344: ldloc.s 7
+		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_034b: stloc.s 7
+		IL_034d: ldloc.s 7
+		IL_034f: ldc.i4.0
+		IL_0350: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0355: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_035a: stloc.s 8
+		IL_035c: ldloc.s 8
+		IL_035e: box [System.Runtime]System.Boolean
+		IL_0363: stloc.s 9
+		IL_0365: ldloc.s 6
+		IL_0367: ldstr "log"
+		IL_036c: ldloc.s 9
+		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0373: pop
+		IL_0374: ldstr "console"
+		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0383: stloc.s 6
+		IL_0385: ldloc.1
+		IL_0386: ldstr "indices"
+		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0390: stloc.s 7
+		IL_0392: ldloc.s 7
+		IL_0394: ldstr "groups"
+		IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_039e: stloc.s 7
+		IL_03a0: ldloc.s 7
+		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_03a7: stloc.s 7
+		IL_03a9: ldloc.s 6
+		IL_03ab: ldstr "log"
+		IL_03b0: ldloc.s 7
+		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03b7: pop
+		IL_03b8: ldstr "console"
+		IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03c7: stloc.s 7
+		IL_03c9: ldloc.1
+		IL_03ca: ldstr "indices"
+		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03d4: stloc.s 6
+		IL_03d6: ldloc.s 6
+		IL_03d8: ldstr "groups"
+		IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03e2: stloc.s 6
+		IL_03e4: ldloc.s 6
+		IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_03eb: stloc.s 6
+		IL_03ed: ldloc.s 6
+		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_03f4: stloc.s 6
+		IL_03f6: ldloc.s 7
+		IL_03f8: ldstr "log"
+		IL_03fd: ldloc.s 6
+		IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0404: pop
+		IL_0405: ldstr "console"
+		IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0414: stloc.s 6
+		IL_0416: ldloc.1
+		IL_0417: ldstr "indices"
+		IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0421: stloc.s 7
+		IL_0423: ldloc.s 7
+		IL_0425: ldstr "groups"
+		IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_042f: stloc.s 7
+		IL_0431: ldloc.s 7
+		IL_0433: ldstr "word"
+		IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_043d: stloc.s 7
+		IL_043f: ldloc.s 7
+		IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0446: stloc.s 7
+		IL_0448: ldloc.s 6
+		IL_044a: ldstr "log"
+		IL_044f: ldloc.s 7
+		IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0456: pop
+		IL_0457: ldstr "console"
+		IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0466: stloc.s 7
+		IL_0468: ldloc.1
+		IL_0469: ldstr "indices"
+		IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0473: stloc.s 6
+		IL_0475: ldloc.s 6
+		IL_0477: ldstr "groups"
+		IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0481: stloc.s 6
+		IL_0483: ldloc.s 6
+		IL_0485: ldstr "optional"
+		IL_048a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_048f: box [System.Runtime]System.Boolean
+		IL_0494: stloc.s 9
+		IL_0496: ldloc.s 7
+		IL_0498: ldstr "log"
+		IL_049d: ldloc.s 9
+		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04a4: pop
+		IL_04a5: ldstr "console"
+		IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04b4: stloc.s 7
+		IL_04b6: ldloc.1
+		IL_04b7: ldstr "indices"
+		IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04c1: stloc.s 6
+		IL_04c3: ldloc.s 6
+		IL_04c5: ldstr "groups"
+		IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04cf: stloc.s 6
+		IL_04d1: ldloc.s 6
+		IL_04d3: ldstr "optional"
+		IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04dd: stloc.s 6
+		IL_04df: ldloc.s 6
+		IL_04e1: ldnull
+		IL_04e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04e7: stloc.s 8
+		IL_04e9: ldloc.s 8
+		IL_04eb: box [System.Runtime]System.Boolean
+		IL_04f0: stloc.s 9
+		IL_04f2: ldloc.s 7
+		IL_04f4: ldstr "log"
+		IL_04f9: ldloc.s 9
+		IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0500: pop
+		IL_0501: ldstr "console"
+		IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0510: stloc.s 7
+		IL_0512: ldloc.1
+		IL_0513: ldstr "groups"
+		IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_051d: stloc.s 6
+		IL_051f: ldloc.1
+		IL_0520: ldstr "indices"
+		IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_052a: stloc.s 10
+		IL_052c: ldloc.s 10
+		IL_052e: ldstr "groups"
+		IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0538: stloc.s 10
+		IL_053a: ldloc.s 6
+		IL_053c: ldloc.s 10
+		IL_053e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0543: stloc.s 8
+		IL_0545: ldloc.s 8
+		IL_0547: box [System.Runtime]System.Boolean
+		IL_054c: stloc.s 9
+		IL_054e: ldloc.s 7
+		IL_0550: ldstr "log"
+		IL_0555: ldloc.s 9
+		IL_0557: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_055c: pop
+		IL_055d: ldstr "a"
+		IL_0562: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0567: stloc.s 11
+		IL_0569: ldstr "(?<letter>a)"
+		IL_056e: ldstr ""
+		IL_0573: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0578: stloc.s 5
+		IL_057a: ldloc.s 11
+		IL_057c: ldstr "match"
+		IL_0581: ldloc.s 5
+		IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0588: stloc.2
+		IL_0589: ldstr "console"
+		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0598: stloc.s 7
+		IL_059a: ldloc.2
+		IL_059b: ldstr "groups"
+		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05a5: stloc.s 10
+		IL_05a7: ldloc.s 10
+		IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_05ae: stloc.s 10
+		IL_05b0: ldloc.s 10
+		IL_05b2: ldc.i4.0
+		IL_05b3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_05b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05bd: stloc.s 8
+		IL_05bf: ldloc.s 8
+		IL_05c1: box [System.Runtime]System.Boolean
+		IL_05c6: stloc.s 9
+		IL_05c8: ldloc.s 7
+		IL_05ca: ldstr "log"
+		IL_05cf: ldloc.s 9
+		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05d6: pop
+		IL_05d7: ldstr "console"
+		IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05e6: stloc.s 7
+		IL_05e8: ldloc.2
+		IL_05e9: ldstr "groups"
+		IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05f3: stloc.s 10
+		IL_05f5: ldloc.s 10
+		IL_05f7: ldstr "letter"
+		IL_05fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0601: stloc.s 10
+		IL_0603: ldloc.s 7
+		IL_0605: ldstr "log"
+		IL_060a: ldloc.s 10
+		IL_060c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0611: pop
+		IL_0612: ldstr "a a"
+		IL_0617: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_061c: stloc.s 11
+		IL_061e: ldstr "(?<letter>a)"
+		IL_0623: ldstr "g"
+		IL_0628: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_062d: stloc.s 5
+		IL_062f: ldloc.s 11
+		IL_0631: ldstr "matchAll"
+		IL_0636: ldloc.s 5
+		IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_063d: stloc.s 10
+		IL_063f: ldloc.s 10
+		IL_0641: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0646: stloc.3
+		IL_0647: ldstr "console"
+		IL_064c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0656: ldloc.3
+		IL_0657: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_065c: box [System.Runtime]System.Double
+		IL_0661: stloc.s 12
+		IL_0663: ldstr "log"
+		IL_0668: ldloc.s 12
+		IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_066f: pop
+		IL_0670: ldstr "console"
+		IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_067f: stloc.s 10
+		IL_0681: ldloc.3
+		IL_0682: ldc.r8 0.0
+		IL_068b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0690: ldstr "groups"
+		IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_069a: stloc.s 7
+		IL_069c: ldloc.s 7
+		IL_069e: ldstr "letter"
+		IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06a8: stloc.s 7
+		IL_06aa: ldloc.s 10
+		IL_06ac: ldstr "log"
+		IL_06b1: ldloc.s 7
+		IL_06b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06b8: pop
+		IL_06b9: ldstr "console"
+		IL_06be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06c8: stloc.s 7
+		IL_06ca: ldloc.3
+		IL_06cb: ldc.r8 1
+		IL_06d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_06d9: ldstr "groups"
+		IL_06de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06e3: stloc.s 10
+		IL_06e5: ldloc.s 10
+		IL_06e7: ldstr "letter"
+		IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06f1: stloc.s 10
+		IL_06f3: ldloc.s 7
+		IL_06f5: ldstr "log"
+		IL_06fa: ldloc.s 10
+		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0701: pop
+		IL_0702: ldstr "a"
+		IL_0707: ldstr "d"
+		IL_070c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0711: stloc.s 5
+		IL_0713: ldloc.s 5
+		IL_0715: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+		IL_071a: stloc.s 5
+		IL_071c: ldloc.s 5
+		IL_071e: ldstr "exec"
+		IL_0723: ldstr "a"
+		IL_0728: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_072d: stloc.s 4
+		IL_072f: ldstr "console"
+		IL_0734: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_073e: stloc.s 10
+		IL_0740: ldloc.s 4
+		IL_0742: ldstr "groups"
+		IL_0747: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_074c: stloc.s 7
+		IL_074e: ldloc.s 7
+		IL_0750: ldnull
+		IL_0751: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0756: stloc.s 8
+		IL_0758: ldloc.s 8
+		IL_075a: box [System.Runtime]System.Boolean
+		IL_075f: stloc.s 9
+		IL_0761: ldloc.s 10
+		IL_0763: ldstr "log"
+		IL_0768: ldloc.s 9
+		IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_076f: pop
+		IL_0770: ldstr "console"
+		IL_0775: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_077a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_077f: stloc.s 10
+		IL_0781: ldloc.s 4
+		IL_0783: ldstr "indices"
+		IL_0788: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_078d: stloc.s 7
+		IL_078f: ldloc.s 7
+		IL_0791: ldstr "groups"
+		IL_0796: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_079b: stloc.s 7
+		IL_079d: ldloc.s 7
+		IL_079f: ldnull
+		IL_07a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_07a5: stloc.s 8
+		IL_07a7: ldloc.s 8
+		IL_07a9: box [System.Runtime]System.Boolean
+		IL_07ae: stloc.s 9
+		IL_07b0: ldloc.s 10
+		IL_07b2: ldstr "log"
+		IL_07b7: ldloc.s 9
+		IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07be: pop
+		IL_07bf: ldstr "console"
+		IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07ce: ldloc.s 4
+		IL_07d0: ldstr "groups"
+		IL_07d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_07da: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_07df: stloc.s 10
+		IL_07e1: ldstr "log"
+		IL_07e6: ldloc.s 10
+		IL_07e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07ed: pop
+		IL_07ee: ldstr "console"
+		IL_07f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07fd: stloc.s 10
+		IL_07ff: ldloc.s 4
+		IL_0801: ldstr "indices"
+		IL_0806: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_080b: stloc.s 7
+		IL_080d: ldloc.s 7
+		IL_080f: ldstr "groups"
+		IL_0814: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0819: stloc.s 7
+		IL_081b: ldloc.s 7
+		IL_081d: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0822: stloc.s 7
+		IL_0824: ldloc.s 10
+		IL_0826: ldstr "log"
+		IL_082b: ldloc.s 7
+		IL_082d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0832: pop
+		IL_0833: ret
 	} // end of method String_RegExp_NamedGroups_Indices::__js_module_init__
 
 } // end of class Modules.String_RegExp_NamedGroups_Indices
@@ -673,7 +678,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2891
+		// Method begins at RVA 0x2899
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2620
+				// Method begins at RVA 0x2624
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x242c
+			// Method begins at RVA 0x2430
 			// Header size: 12
 			// Code size: 100 (0x64)
 			.maxstack 8
@@ -103,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2629
+				// Method begins at RVA 0x262d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,7 +131,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x249c
+			// Method begins at RVA 0x24a0
 			// Header size: 12
 			// Code size: 124 (0x7c)
 			.maxstack 8
@@ -193,7 +193,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2632
+				// Method begins at RVA 0x2636
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -220,7 +220,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2524
+			// Method begins at RVA 0x2528
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -274,7 +274,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x263b
+				// Method begins at RVA 0x263f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -302,7 +302,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2588
+			// Method begins at RVA 0x258c
 			// Header size: 12
 			// Code size: 131 (0x83)
 			.maxstack 8
@@ -371,7 +371,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2644
+				// Method begins at RVA 0x2648
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -391,7 +391,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x264d
+				// Method begins at RVA 0x2651
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -412,7 +412,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2617
+			// Method begins at RVA 0x261b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -438,7 +438,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 960 (0x3c0)
+		// Code size: 964 (0x3c4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_SymbolDispatch_Custom/Scope,
@@ -564,36 +564,36 @@
 		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
 		IL_0131: pop
 		IL_0132: ldstr "abc"
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013c: stloc.s 11
+		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_013c: stloc.s 15
 		IL_013e: ldloc.0
 		IL_013f: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0144: stloc.s 12
-		IL_0146: ldloc.s 11
+		IL_0144: stloc.s 11
+		IL_0146: ldloc.s 15
 		IL_0148: ldstr "match"
-		IL_014d: ldloc.s 12
+		IL_014d: ldloc.s 11
 		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0154: stloc.1
 		IL_0155: ldstr "console"
 		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0164: stloc.s 12
+		IL_0164: stloc.s 11
 		IL_0166: ldloc.1
 		IL_0167: ldc.r8 0.0
 		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0175: stloc.s 11
-		IL_0177: ldloc.s 12
+		IL_0175: stloc.s 12
+		IL_0177: ldloc.s 11
 		IL_0179: ldstr "log"
-		IL_017e: ldloc.s 11
+		IL_017e: ldloc.s 12
 		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0185: pop
 		IL_0186: ldstr "abc"
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0190: stloc.s 11
+		IL_018b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0190: stloc.s 15
 		IL_0192: ldloc.0
 		IL_0193: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
 		IL_0198: stloc.s 12
-		IL_019a: ldloc.s 11
+		IL_019a: ldloc.s 15
 		IL_019c: ldstr "replace"
 		IL_01a1: ldloc.s 12
 		IL_01a3: ldstr "x"
@@ -619,24 +619,24 @@
 		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_01f0: pop
 		IL_01f1: ldstr "abc"
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01fb: stloc.s 12
+		IL_01f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_01fb: stloc.s 15
 		IL_01fd: ldloc.0
 		IL_01fe: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0203: stloc.s 11
-		IL_0205: ldloc.s 12
+		IL_0203: stloc.s 12
+		IL_0205: ldloc.s 15
 		IL_0207: ldstr "search"
-		IL_020c: ldloc.s 11
+		IL_020c: ldloc.s 12
 		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0213: stloc.3
 		IL_0214: ldstr "console"
 		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0223: stloc.s 11
+		IL_0223: stloc.s 12
 		IL_0225: ldloc.3
 		IL_0226: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 		IL_022b: stloc.s 15
-		IL_022d: ldloc.s 11
+		IL_022d: ldloc.s 12
 		IL_022f: ldstr "log"
 		IL_0234: ldloc.s 15
 		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
@@ -649,12 +649,12 @@
 		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0256: pop
 		IL_0257: ldstr "abc"
-		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0261: stloc.s 11
+		IL_025c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0261: stloc.s 15
 		IL_0263: ldloc.0
 		IL_0264: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
 		IL_0269: stloc.s 12
-		IL_026b: ldloc.s 11
+		IL_026b: ldloc.s 15
 		IL_026d: ldstr "split"
 		IL_0272: ldloc.s 12
 		IL_0274: ldc.r8 5
@@ -702,70 +702,72 @@
 		{
 			IL_030c: nop
 			IL_030d: ldstr "abc"
-			IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0317: ldstr "match"
-			IL_031c: ldloc.s 5
-			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0323: pop
-			IL_0324: leave IL_03bc
+			IL_0312: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0317: stloc.s 15
+			IL_0319: ldloc.s 15
+			IL_031b: ldstr "match"
+			IL_0320: ldloc.s 5
+			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0327: pop
+			IL_0328: leave IL_03c0
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0329: stloc.s 6
-			IL_032b: ldloc.s 6
-			IL_032d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0332: dup
-			IL_0333: brtrue IL_0349
+			IL_032d: stloc.s 6
+			IL_032f: ldloc.s 6
+			IL_0331: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0336: dup
+			IL_0337: brtrue IL_034d
 
-			IL_0338: pop
-			IL_0339: ldloc.s 6
-			IL_033b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0340: dup
-			IL_0341: brtrue IL_0355
+			IL_033c: pop
+			IL_033d: ldloc.s 6
+			IL_033f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0344: dup
+			IL_0345: brtrue IL_0359
 
-			IL_0346: pop
-			IL_0347: rethrow
+			IL_034a: pop
+			IL_034b: rethrow
 
-			IL_0349: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_034e: stloc.s 7
-			IL_0350: br IL_0357
+			IL_034d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0352: stloc.s 7
+			IL_0354: br IL_035b
 
-			IL_0355: stloc.s 7
+			IL_0359: stloc.s 7
 
-			IL_0357: ldloc.s 7
-			IL_0359: stloc.s 8
-			IL_035b: ldstr "console"
-			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_036a: stloc.s 11
-			IL_036c: ldloc.s 8
-			IL_036e: ldstr "name"
-			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0378: stloc.s 12
-			IL_037a: ldloc.s 11
-			IL_037c: ldstr "log"
-			IL_0381: ldloc.s 12
-			IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0388: pop
-			IL_0389: ldstr "console"
-			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0398: stloc.s 12
-			IL_039a: ldloc.s 8
-			IL_039c: ldstr "message"
-			IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03a6: stloc.s 11
-			IL_03a8: ldloc.s 12
-			IL_03aa: ldstr "log"
-			IL_03af: ldloc.s 11
-			IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03b6: pop
-			IL_03b7: leave IL_03bc
+			IL_035b: ldloc.s 7
+			IL_035d: stloc.s 8
+			IL_035f: ldstr "console"
+			IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_036e: stloc.s 11
+			IL_0370: ldloc.s 8
+			IL_0372: ldstr "name"
+			IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_037c: stloc.s 12
+			IL_037e: ldloc.s 11
+			IL_0380: ldstr "log"
+			IL_0385: ldloc.s 12
+			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_038c: pop
+			IL_038d: ldstr "console"
+			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_039c: stloc.s 12
+			IL_039e: ldloc.s 8
+			IL_03a0: ldstr "message"
+			IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03aa: stloc.s 11
+			IL_03ac: ldloc.s 12
+			IL_03ae: ldstr "log"
+			IL_03b3: ldloc.s 11
+			IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03ba: pop
+			IL_03bb: leave IL_03c0
 		} // end handler
 
-		IL_03bc: ldnull
-		IL_03bd: stloc.s 9
-		IL_03bf: ret
+		IL_03c0: ldnull
+		IL_03c1: stloc.s 9
+		IL_03c3: ret
 	} // end of method String_RegExp_SymbolDispatch_Custom::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_Custom
@@ -777,7 +779,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2656
+		// Method begins at RVA 0x265a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpOverride.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpOverride.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x256e
+				// Method begins at RVA 0x2572
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x22f8
+			// Method begins at RVA 0x22fc
 			// Header size: 12
 			// Code size: 131 (0x83)
 			.maxstack 8
@@ -110,7 +110,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2577
+				// Method begins at RVA 0x257b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2388
+			// Method begins at RVA 0x238c
 			// Header size: 12
 			// Code size: 146 (0x92)
 			.maxstack 8
@@ -206,7 +206,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2580
+				// Method begins at RVA 0x2584
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -233,7 +233,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2428
+			// Method begins at RVA 0x242c
 			// Header size: 12
 			// Code size: 128 (0x80)
 			.maxstack 8
@@ -295,7 +295,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2589
+				// Method begins at RVA 0x258d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -323,7 +323,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x24b4
+			// Method begins at RVA 0x24b8
 			// Header size: 12
 			// Code size: 165 (0xa5)
 			.maxstack 8
@@ -401,7 +401,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2565
+			// Method begins at RVA 0x2569
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -427,7 +427,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 667 (0x29b)
+		// Code size: 669 (0x29d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope,
@@ -437,7 +437,7 @@
 			[4] object,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[7] object
+			[7] string
 		)
 
 		IL_0000: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::.ctor()
@@ -551,106 +551,106 @@
 		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0141: stloc.3
 		IL_0142: ldstr "aba"
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014c: stloc.s 4
+		IL_0147: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_014c: stloc.s 7
 		IL_014e: ldloc.0
 		IL_014f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-		IL_0154: stloc.s 7
-		IL_0156: ldloc.s 4
+		IL_0154: stloc.s 4
+		IL_0156: ldloc.s 7
 		IL_0158: ldstr "match"
-		IL_015d: ldloc.s 7
+		IL_015d: ldloc.s 4
 		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0164: stloc.s 7
-		IL_0166: ldloc.s 7
+		IL_0164: stloc.s 4
+		IL_0166: ldloc.s 4
 		IL_0168: ldc.r8 0.0
 		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0176: stloc.s 7
+		IL_0176: stloc.s 4
 		IL_0178: ldloc.3
 		IL_0179: ldstr "log"
-		IL_017e: ldloc.s 7
+		IL_017e: ldloc.s 4
 		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0185: pop
 		IL_0186: ldstr "console"
 		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0195: stloc.s 7
+		IL_0195: stloc.s 4
 		IL_0197: ldstr "aba"
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a1: stloc.3
-		IL_01a2: ldloc.0
-		IL_01a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-		IL_01a8: stloc.s 4
-		IL_01aa: ldloc.3
-		IL_01ab: ldstr "replace"
-		IL_01b0: ldloc.s 4
+		IL_019c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_01a1: stloc.s 7
+		IL_01a3: ldloc.0
+		IL_01a4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+		IL_01a9: stloc.3
+		IL_01aa: ldloc.s 7
+		IL_01ac: ldstr "replace"
+		IL_01b1: ldloc.3
 		IL_01b2: ldstr "x"
 		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01bc: stloc.s 4
-		IL_01be: ldloc.s 7
-		IL_01c0: ldstr "log"
-		IL_01c5: ldloc.s 4
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01cc: pop
-		IL_01cd: ldstr "console"
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01dc: stloc.s 4
-		IL_01de: ldstr "aba"
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e8: stloc.s 7
-		IL_01ea: ldloc.0
-		IL_01eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-		IL_01f0: stloc.3
-		IL_01f1: ldloc.s 7
-		IL_01f3: ldstr "search"
-		IL_01f8: ldloc.3
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fe: stloc.3
-		IL_01ff: ldloc.s 4
-		IL_0201: ldstr "log"
-		IL_0206: ldloc.3
+		IL_01bc: stloc.3
+		IL_01bd: ldloc.s 4
+		IL_01bf: ldstr "log"
+		IL_01c4: ldloc.3
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ca: pop
+		IL_01cb: ldstr "console"
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01da: stloc.3
+		IL_01db: ldstr "aba"
+		IL_01e0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_01e5: stloc.s 7
+		IL_01e7: ldloc.0
+		IL_01e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+		IL_01ed: stloc.s 4
+		IL_01ef: ldloc.s 7
+		IL_01f1: ldstr "search"
+		IL_01f6: ldloc.s 4
+		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01fd: stloc.s 4
+		IL_01ff: ldloc.3
+		IL_0200: ldstr "log"
+		IL_0205: ldloc.s 4
 		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_020c: pop
 		IL_020d: ldstr "aba"
-		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0217: stloc.3
-		IL_0218: ldloc.0
-		IL_0219: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-		IL_021e: stloc.s 4
-		IL_0220: ldloc.3
-		IL_0221: ldstr "split"
-		IL_0226: ldloc.s 4
-		IL_0228: ldc.r8 3
-		IL_0231: box [System.Runtime]System.Double
-		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_023b: stloc.1
-		IL_023c: ldstr "console"
-		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024b: stloc.s 4
-		IL_024d: ldloc.1
-		IL_024e: ldc.r8 0.0
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_025c: stloc.3
-		IL_025d: ldloc.s 4
-		IL_025f: ldstr "log"
-		IL_0264: ldloc.3
-		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026a: pop
-		IL_026b: ldstr "console"
-		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027a: stloc.3
-		IL_027b: ldloc.1
-		IL_027c: ldc.r8 1
-		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_028a: stloc.s 4
-		IL_028c: ldloc.3
-		IL_028d: ldstr "log"
-		IL_0292: ldloc.s 4
-		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0299: pop
-		IL_029a: ret
+		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0217: stloc.s 7
+		IL_0219: ldloc.0
+		IL_021a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+		IL_021f: stloc.s 4
+		IL_0221: ldloc.s 7
+		IL_0223: ldstr "split"
+		IL_0228: ldloc.s 4
+		IL_022a: ldc.r8 3
+		IL_0233: box [System.Runtime]System.Double
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_023d: stloc.1
+		IL_023e: ldstr "console"
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024d: stloc.s 4
+		IL_024f: ldloc.1
+		IL_0250: ldc.r8 0.0
+		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_025e: stloc.3
+		IL_025f: ldloc.s 4
+		IL_0261: ldstr "log"
+		IL_0266: ldloc.3
+		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_026c: pop
+		IL_026d: ldstr "console"
+		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_027c: stloc.3
+		IL_027d: ldloc.1
+		IL_027e: ldc.r8 1
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_028c: stloc.s 4
+		IL_028e: ldloc.3
+		IL_028f: ldstr "log"
+		IL_0294: ldloc.s 4
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029b: pop
+		IL_029c: ret
 	} // end of method String_RegExp_SymbolDispatch_RegExpOverride::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_RegExpOverride
@@ -662,7 +662,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2592
+		// Method begins at RVA 0x2596
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpPrototypeOverride.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpPrototypeOverride.verified.txt
@@ -441,7 +441,7 @@
 			[8] object,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[11] object,
+			[11] string,
 			[12] object
 		)
 
@@ -579,7 +579,7 @@
 		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0192: stloc.s 8
 		IL_0194: ldstr "aba"
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0199: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 		IL_019e: stloc.s 11
 		IL_01a0: ldloc.0
 		IL_01a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
@@ -603,51 +603,51 @@
 		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_01e8: stloc.s 12
 		IL_01ea: ldstr "aba"
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f4: stloc.s 8
+		IL_01ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_01f4: stloc.s 11
 		IL_01f6: ldloc.0
 		IL_01f7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-		IL_01fc: stloc.s 11
-		IL_01fe: ldloc.s 8
+		IL_01fc: stloc.s 8
+		IL_01fe: ldloc.s 11
 		IL_0200: ldstr "replace"
-		IL_0205: ldloc.s 11
+		IL_0205: ldloc.s 8
 		IL_0207: ldstr "x"
 		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0211: stloc.s 11
+		IL_0211: stloc.s 8
 		IL_0213: ldloc.s 12
 		IL_0215: ldstr "log"
-		IL_021a: ldloc.s 11
+		IL_021a: ldloc.s 8
 		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0221: pop
 		IL_0222: ldstr "console"
 		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0231: stloc.s 11
+		IL_0231: stloc.s 8
 		IL_0233: ldstr "aba"
-		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023d: stloc.s 12
+		IL_0238: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_023d: stloc.s 11
 		IL_023f: ldloc.0
 		IL_0240: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-		IL_0245: stloc.s 8
-		IL_0247: ldloc.s 12
+		IL_0245: stloc.s 12
+		IL_0247: ldloc.s 11
 		IL_0249: ldstr "search"
-		IL_024e: ldloc.s 8
+		IL_024e: ldloc.s 12
 		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0255: stloc.s 8
-		IL_0257: ldloc.s 11
+		IL_0255: stloc.s 12
+		IL_0257: ldloc.s 8
 		IL_0259: ldstr "log"
-		IL_025e: ldloc.s 8
+		IL_025e: ldloc.s 12
 		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0265: pop
 		IL_0266: ldstr "aba"
-		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0270: stloc.s 8
+		IL_026b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0270: stloc.s 11
 		IL_0272: ldloc.0
 		IL_0273: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-		IL_0278: stloc.s 11
-		IL_027a: ldloc.s 8
+		IL_0278: stloc.s 12
+		IL_027a: ldloc.s 11
 		IL_027c: ldstr "split"
-		IL_0281: ldloc.s 11
+		IL_0281: ldloc.s 12
 		IL_0283: ldc.r8 3
 		IL_028c: box [System.Runtime]System.Double
 		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
@@ -655,12 +655,12 @@
 		IL_0298: ldstr "console"
 		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a7: stloc.s 11
+		IL_02a7: stloc.s 12
 		IL_02a9: ldloc.s 6
 		IL_02ab: ldc.r8 0.0
 		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 		IL_02b9: stloc.s 8
-		IL_02bb: ldloc.s 11
+		IL_02bb: ldloc.s 12
 		IL_02bd: ldstr "log"
 		IL_02c2: ldloc.s 8
 		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
@@ -672,44 +672,44 @@
 		IL_02db: ldloc.s 6
 		IL_02dd: ldc.r8 1
 		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02eb: stloc.s 11
+		IL_02eb: stloc.s 12
 		IL_02ed: ldloc.s 8
 		IL_02ef: ldstr "log"
-		IL_02f4: ldloc.s 11
+		IL_02f4: ldloc.s 12
 		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_02fb: pop
 		IL_02fc: ldstr "match"
 		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0306: stloc.s 11
+		IL_0306: stloc.s 12
 		IL_0308: ldloc.1
-		IL_0309: ldloc.s 11
+		IL_0309: ldloc.s 12
 		IL_030b: ldloc.2
 		IL_030c: ldc.i4.1
 		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
 		IL_0312: pop
 		IL_0313: ldstr "replace"
 		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_031d: stloc.s 11
+		IL_031d: stloc.s 12
 		IL_031f: ldloc.1
-		IL_0320: ldloc.s 11
+		IL_0320: ldloc.s 12
 		IL_0322: ldloc.3
 		IL_0323: ldc.i4.1
 		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
 		IL_0329: pop
 		IL_032a: ldstr "search"
 		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0334: stloc.s 11
+		IL_0334: stloc.s 12
 		IL_0336: ldloc.1
-		IL_0337: ldloc.s 11
+		IL_0337: ldloc.s 12
 		IL_0339: ldloc.s 4
 		IL_033b: ldc.i4.1
 		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
 		IL_0341: pop
 		IL_0342: ldstr "split"
 		IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_034c: stloc.s 11
+		IL_034c: stloc.s 12
 		IL_034e: ldloc.1
-		IL_034f: ldloc.s 11
+		IL_034f: ldloc.s 12
 		IL_0351: ldloc.s 5
 		IL_0353: ldc.i4.1
 		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x228a
+					// Method begins at RVA 0x228e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2293
+					// Method begins at RVA 0x2297
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2281
+				// Method begins at RVA 0x2285
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -90,7 +90,7 @@
 			)
 			// Method begins at RVA 0x2158
 			// Header size: 12
-			// Code size: 259 (0x103)
+			// Code size: 263 (0x107)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -99,120 +99,122 @@
 				[3] object,
 				[4] object,
 				[5] object,
-				[6] object,
+				[6] string,
 				[7] object,
-				[8] bool,
-				[9] object,
+				[8] object,
+				[9] bool,
 				[10] object,
-				[11] string
+				[11] object
 			)
 
 			.try
 			{
 				IL_0000: nop
 				IL_0001: ldarg.2
-				IL_0002: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0007: ldstr "repeat"
-				IL_000c: ldarg.3
-				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0012: stloc.0
-				IL_0013: ldstr "console"
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0022: stloc.s 6
-				IL_0024: ldstr "["
-				IL_0029: ldloc.0
-				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_002f: stloc.s 7
-				IL_0031: ldloc.s 7
-				IL_0033: ldstr "]"
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_003d: stloc.s 7
-				IL_003f: ldloc.s 6
-				IL_0041: ldstr "log"
-				IL_0046: ldloc.s 7
-				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004d: pop
-				IL_004e: leave IL_00fd
+				IL_0002: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_0007: stloc.s 6
+				IL_0009: ldloc.s 6
+				IL_000b: ldstr "repeat"
+				IL_0010: ldarg.3
+				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0016: stloc.0
+				IL_0017: ldstr "console"
+				IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0026: stloc.s 7
+				IL_0028: ldstr "["
+				IL_002d: ldloc.0
+				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0033: stloc.s 8
+				IL_0035: ldloc.s 8
+				IL_0037: ldstr "]"
+				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0041: stloc.s 8
+				IL_0043: ldloc.s 7
+				IL_0045: ldstr "log"
+				IL_004a: ldloc.s 8
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0051: pop
+				IL_0052: leave IL_0101
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0053: stloc.1
-				IL_0054: ldloc.1
-				IL_0055: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_005a: dup
-				IL_005b: brtrue IL_0070
+				IL_0057: stloc.1
+				IL_0058: ldloc.1
+				IL_0059: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_005e: dup
+				IL_005f: brtrue IL_0074
 
-				IL_0060: pop
-				IL_0061: ldloc.1
-				IL_0062: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0067: dup
-				IL_0068: brtrue IL_007b
+				IL_0064: pop
+				IL_0065: ldloc.1
+				IL_0066: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_006b: dup
+				IL_006c: brtrue IL_007f
 
-				IL_006d: pop
-				IL_006e: rethrow
+				IL_0071: pop
+				IL_0072: rethrow
 
-				IL_0070: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0075: stloc.2
-				IL_0076: br IL_007c
+				IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0079: stloc.2
+				IL_007a: br IL_0080
 
-				IL_007b: stloc.2
+				IL_007f: stloc.2
 
-				IL_007c: ldloc.2
-				IL_007d: stloc.3
-				IL_007e: ldstr "console"
-				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_008d: stloc.s 6
-				IL_008f: ldloc.3
-				IL_0090: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0095: stloc.s 8
-				IL_0097: ldloc.s 8
-				IL_0099: brfalse IL_00b4
+				IL_0080: ldloc.2
+				IL_0081: stloc.3
+				IL_0082: ldstr "console"
+				IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0091: stloc.s 7
+				IL_0093: ldloc.3
+				IL_0094: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0099: stloc.s 9
+				IL_009b: ldloc.s 9
+				IL_009d: brfalse IL_00b8
 
-				IL_009e: ldloc.3
-				IL_009f: ldstr "name"
-				IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00a9: stloc.s 9
-				IL_00ab: ldloc.s 9
+				IL_00a2: ldloc.3
+				IL_00a3: ldstr "name"
+				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 				IL_00ad: stloc.s 10
-				IL_00af: br IL_00b7
+				IL_00af: ldloc.s 10
+				IL_00b1: stloc.s 11
+				IL_00b3: br IL_00bb
 
-				IL_00b4: ldloc.3
-				IL_00b5: stloc.s 10
+				IL_00b8: ldloc.3
+				IL_00b9: stloc.s 11
 
-				IL_00b7: ldloc.s 10
-				IL_00b9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00be: stloc.s 8
-				IL_00c0: ldloc.s 8
-				IL_00c2: brfalse IL_00dd
+				IL_00bb: ldloc.s 11
+				IL_00bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00c2: stloc.s 9
+				IL_00c4: ldloc.s 9
+				IL_00c6: brfalse IL_00e1
 
-				IL_00c7: ldloc.3
-				IL_00c8: ldstr "name"
-				IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00d2: stloc.s 9
-				IL_00d4: ldloc.s 9
-				IL_00d6: stloc.s 4
-				IL_00d8: br IL_00e9
+				IL_00cb: ldloc.3
+				IL_00cc: ldstr "name"
+				IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00d6: stloc.s 10
+				IL_00d8: ldloc.s 10
+				IL_00da: stloc.s 4
+				IL_00dc: br IL_00ed
 
-				IL_00dd: ldloc.3
-				IL_00de: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_00e3: stloc.s 11
-				IL_00e5: ldloc.s 11
-				IL_00e7: stloc.s 4
-
+				IL_00e1: ldloc.3
+				IL_00e2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_00e7: stloc.s 6
 				IL_00e9: ldloc.s 6
-				IL_00eb: ldstr "log"
-				IL_00f0: ldloc.s 4
-				IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00f7: pop
-				IL_00f8: leave IL_00fd
+				IL_00eb: stloc.s 4
+
+				IL_00ed: ldloc.s 7
+				IL_00ef: ldstr "log"
+				IL_00f4: ldloc.s 4
+				IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00fb: pop
+				IL_00fc: leave IL_0101
 			} // end handler
 
-			IL_00fd: ldnull
-			IL_00fe: stloc.s 5
-			IL_0100: ldloc.s 5
-			IL_0102: ret
+			IL_0101: ldnull
+			IL_0102: stloc.s 5
+			IL_0104: ldloc.s 5
+			IL_0106: ret
 		} // end of method logRepeat::__js_call__
 
 	} // end of class logRepeat
@@ -231,7 +233,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2278
+			// Method begins at RVA 0x227c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -354,7 +356,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x229c
+		// Method begins at RVA 0x22a0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Replace_CallOnExpression.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Replace_CallOnExpression.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20ea
+			// Method begins at RVA 0x20ee
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 142 (0x8e)
+		// Code size: 146 (0x92)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Replace_CallOnExpression/Scope,
 			[1] object,
-			[2] object,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			[2] string,
+			[3] object,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		)
 
 		IL_0000: newobj instance void Modules.String_Replace_CallOnExpression/Scope::.ctor()
@@ -57,40 +58,42 @@
 		IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0016: stloc.1
 		IL_0017: ldstr "abc"
-		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0021: ldstr "replace"
-		IL_0026: ldstr "b"
-		IL_002b: ldstr "x"
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0035: stloc.2
-		IL_0036: ldloc.1
-		IL_0037: ldstr "log"
-		IL_003c: ldloc.2
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0042: pop
-		IL_0043: ldstr "console"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0052: stloc.2
-		IL_0053: ldstr "abc"
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005d: stloc.1
-		IL_005e: ldstr "b"
-		IL_0063: ldstr "g"
-		IL_0068: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_006d: stloc.3
-		IL_006e: ldloc.1
-		IL_006f: ldstr "replace"
-		IL_0074: ldloc.3
-		IL_0075: ldstr "x"
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_007f: stloc.1
-		IL_0080: ldloc.2
-		IL_0081: ldstr "log"
-		IL_0086: ldloc.1
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008c: pop
-		IL_008d: ret
+		IL_001c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0021: stloc.2
+		IL_0022: ldloc.2
+		IL_0023: ldstr "replace"
+		IL_0028: ldstr "b"
+		IL_002d: ldstr "x"
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0037: stloc.3
+		IL_0038: ldloc.1
+		IL_0039: ldstr "log"
+		IL_003e: ldloc.3
+		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0044: pop
+		IL_0045: ldstr "console"
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0054: stloc.3
+		IL_0055: ldstr "abc"
+		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_005f: stloc.2
+		IL_0060: ldstr "b"
+		IL_0065: ldstr "g"
+		IL_006a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_006f: stloc.s 4
+		IL_0071: ldloc.2
+		IL_0072: ldstr "replace"
+		IL_0077: ldloc.s 4
+		IL_0079: ldstr "x"
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0083: stloc.1
+		IL_0084: ldloc.3
+		IL_0085: ldstr "log"
+		IL_008a: ldloc.1
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0090: pop
+		IL_0091: ret
 	} // end of method String_Replace_CallOnExpression::__js_module_init__
 
 } // end of class Modules.String_Replace_CallOnExpression
@@ -102,7 +105,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f3
+		// Method begins at RVA 0x20f7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Replace_Regex_Global.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Replace_Regex_Global.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20b2
+			// Method begins at RVA 0x20b4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 86 (0x56)
+		// Code size: 88 (0x58)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Replace_Regex_Global/Scope,
 			[1] string,
 			[2] object,
-			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			[3] string,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Replace_Regex_Global/Scope::.ctor()
@@ -60,7 +61,7 @@
 		IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_001c: stloc.2
 		IL_001d: ldloc.1
-		IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_001e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 		IL_0023: stloc.3
 		IL_0024: ldstr "b"
 		IL_0029: ldstr "g"
@@ -71,13 +72,13 @@
 		IL_003b: ldloc.s 4
 		IL_003d: ldstr "x"
 		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0047: stloc.3
-		IL_0048: ldloc.2
-		IL_0049: ldstr "log"
-		IL_004e: ldloc.3
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0054: pop
-		IL_0055: ret
+		IL_0047: stloc.s 5
+		IL_0049: ldloc.2
+		IL_004a: ldstr "log"
+		IL_004f: ldloc.s 5
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0056: pop
+		IL_0057: ret
 	} // end of method String_Replace_Regex_Global::__js_module_init__
 
 } // end of class Modules.String_Replace_Regex_Global
@@ -89,7 +90,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20bb
+		// Method begins at RVA 0x20bd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Search_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Search_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e7
+			// Method begins at RVA 0x21f3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 395 (0x18b)
+		// Code size: 407 (0x197)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Search_Basic/Scope,
 			[1] string,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[3] object,
-			[4] object,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			[4] string,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Search_Basic/Scope::.ctor()
@@ -61,7 +62,7 @@
 		IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_001c: stloc.3
 		IL_001d: ldloc.1
-		IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_001e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 		IL_0023: stloc.s 4
 		IL_0025: ldstr "\\d+"
 		IL_002a: ldstr ""
@@ -71,101 +72,107 @@
 		IL_0038: ldstr "search"
 		IL_003d: ldloc.s 5
 		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0044: stloc.s 4
+		IL_0044: stloc.s 6
 		IL_0046: ldloc.3
 		IL_0047: ldstr "log"
-		IL_004c: ldloc.s 4
+		IL_004c: ldloc.s 6
 		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0053: pop
 		IL_0054: ldstr "console"
 		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0063: stloc.s 4
+		IL_0063: stloc.s 6
 		IL_0065: ldloc.1
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006b: ldstr "search"
-		IL_0070: ldstr "123"
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007a: stloc.3
-		IL_007b: ldloc.s 4
-		IL_007d: ldstr "log"
-		IL_0082: ldloc.3
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0088: pop
-		IL_0089: ldstr "console"
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0098: stloc.3
-		IL_0099: ldloc.1
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009f: stloc.s 4
-		IL_00a1: ldstr "xyz"
-		IL_00a6: ldstr ""
-		IL_00ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00b0: stloc.s 5
-		IL_00b2: ldloc.s 4
-		IL_00b4: ldstr "search"
-		IL_00b9: ldloc.s 5
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c0: stloc.s 4
-		IL_00c2: ldloc.3
-		IL_00c3: ldstr "log"
-		IL_00c8: ldloc.s 4
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cf: pop
-		IL_00d0: ldstr "console"
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00df: stloc.s 4
-		IL_00e1: ldstr "undefined-value"
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00eb: ldstr "search"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00f5: stloc.3
-		IL_00f6: ldloc.s 4
-		IL_00f8: ldstr "log"
-		IL_00fd: ldloc.3
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0103: pop
-		IL_0104: ldstr "a"
-		IL_0109: ldstr "g"
-		IL_010e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0113: stloc.2
-		IL_0114: ldloc.2
-		IL_0115: ldstr "lastIndex"
-		IL_011a: ldc.r8 2
-		IL_0123: ldc.i4.1
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0129: pop
-		IL_012a: ldstr "console"
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0139: stloc.3
-		IL_013a: ldstr "baaa"
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0144: ldstr "search"
-		IL_0149: ldloc.2
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014f: stloc.s 4
-		IL_0151: ldloc.3
-		IL_0152: ldstr "log"
-		IL_0157: ldloc.s 4
-		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015e: pop
-		IL_015f: ldstr "console"
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016e: stloc.s 4
-		IL_0170: ldloc.2
-		IL_0171: ldstr "lastIndex"
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017b: stloc.3
-		IL_017c: ldloc.s 4
-		IL_017e: ldstr "log"
-		IL_0183: ldloc.3
-		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0189: pop
-		IL_018a: ret
+		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_006b: stloc.s 4
+		IL_006d: ldloc.s 4
+		IL_006f: ldstr "search"
+		IL_0074: ldstr "123"
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: stloc.3
+		IL_007f: ldloc.s 6
+		IL_0081: ldstr "log"
+		IL_0086: ldloc.3
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008c: pop
+		IL_008d: ldstr "console"
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009c: stloc.3
+		IL_009d: ldloc.1
+		IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_00a3: stloc.s 4
+		IL_00a5: ldstr "xyz"
+		IL_00aa: ldstr ""
+		IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00b4: stloc.s 5
+		IL_00b6: ldloc.s 4
+		IL_00b8: ldstr "search"
+		IL_00bd: ldloc.s 5
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c4: stloc.s 6
+		IL_00c6: ldloc.3
+		IL_00c7: ldstr "log"
+		IL_00cc: ldloc.s 6
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d3: pop
+		IL_00d4: ldstr "console"
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e3: stloc.s 6
+		IL_00e5: ldstr "undefined-value"
+		IL_00ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_00ef: stloc.s 4
+		IL_00f1: ldloc.s 4
+		IL_00f3: ldstr "search"
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00fd: stloc.3
+		IL_00fe: ldloc.s 6
+		IL_0100: ldstr "log"
+		IL_0105: ldloc.3
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010b: pop
+		IL_010c: ldstr "a"
+		IL_0111: ldstr "g"
+		IL_0116: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_011b: stloc.2
+		IL_011c: ldloc.2
+		IL_011d: ldstr "lastIndex"
+		IL_0122: ldc.r8 2
+		IL_012b: ldc.i4.1
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0131: pop
+		IL_0132: ldstr "console"
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0141: stloc.3
+		IL_0142: ldstr "baaa"
+		IL_0147: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_014c: stloc.s 4
+		IL_014e: ldloc.s 4
+		IL_0150: ldstr "search"
+		IL_0155: ldloc.2
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015b: stloc.s 6
+		IL_015d: ldloc.3
+		IL_015e: ldstr "log"
+		IL_0163: ldloc.s 6
+		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016a: pop
+		IL_016b: ldstr "console"
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017a: stloc.s 6
+		IL_017c: ldloc.2
+		IL_017d: ldstr "lastIndex"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0187: stloc.3
+		IL_0188: ldloc.s 6
+		IL_018a: ldstr "log"
+		IL_018f: ldloc.3
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0195: pop
+		IL_0196: ret
 	} // end of method String_Search_Basic::__js_module_init__
 
 } // end of class Modules.String_Search_Basic
@@ -177,7 +184,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f0
+		// Method begins at RVA 0x21fc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2138
+			// Method begins at RVA 0x2142
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 220 (0xdc)
+		// Code size: 230 (0xe6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Split_Basic/Scope,
 			[1] string,
 			[2] object,
-			[3] object,
-			[4] object
+			[3] string,
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Split_Basic/Scope::.ctor()
@@ -56,64 +57,66 @@
 		IL_0007: ldstr "a,b,c"
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0013: ldstr "split"
-		IL_0018: ldstr ","
-		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0022: stloc.2
-		IL_0023: ldstr "console"
-		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0032: stloc.3
-		IL_0033: ldloc.2
-		IL_0034: ldstr "length"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: stloc.s 4
-		IL_0040: ldloc.3
-		IL_0041: ldstr "log"
-		IL_0046: ldloc.s 4
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004d: pop
-		IL_004e: ldstr "console"
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005d: stloc.s 4
-		IL_005f: ldloc.2
-		IL_0060: ldc.r8 0.0
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_006e: stloc.3
-		IL_006f: ldloc.s 4
-		IL_0071: ldstr "log"
-		IL_0076: ldloc.3
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007c: pop
-		IL_007d: ldstr "console"
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008c: stloc.3
-		IL_008d: ldloc.2
-		IL_008e: ldc.r8 1
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_009c: stloc.s 4
-		IL_009e: ldloc.3
-		IL_009f: ldstr "log"
-		IL_00a4: ldloc.s 4
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ab: pop
-		IL_00ac: ldstr "console"
-		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bb: stloc.s 4
-		IL_00bd: ldloc.2
-		IL_00be: ldc.r8 2
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00cc: stloc.3
-		IL_00cd: ldloc.s 4
-		IL_00cf: ldstr "log"
-		IL_00d4: ldloc.3
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00da: pop
-		IL_00db: ret
+		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0013: stloc.3
+		IL_0014: ldloc.3
+		IL_0015: ldstr "split"
+		IL_001a: ldstr ","
+		IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0024: stloc.2
+		IL_0025: ldstr "console"
+		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0034: stloc.s 4
+		IL_0036: ldloc.2
+		IL_0037: ldstr "length"
+		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0041: stloc.s 5
+		IL_0043: ldloc.s 4
+		IL_0045: ldstr "log"
+		IL_004a: ldloc.s 5
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0051: pop
+		IL_0052: ldstr "console"
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0061: stloc.s 5
+		IL_0063: ldloc.2
+		IL_0064: ldc.r8 0.0
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0072: stloc.s 4
+		IL_0074: ldloc.s 5
+		IL_0076: ldstr "log"
+		IL_007b: ldloc.s 4
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0082: pop
+		IL_0083: ldstr "console"
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0092: stloc.s 4
+		IL_0094: ldloc.2
+		IL_0095: ldc.r8 1
+		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00a3: stloc.s 5
+		IL_00a5: ldloc.s 4
+		IL_00a7: ldstr "log"
+		IL_00ac: ldloc.s 5
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b3: pop
+		IL_00b4: ldstr "console"
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c3: stloc.s 5
+		IL_00c5: ldloc.2
+		IL_00c6: ldc.r8 2
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00d4: stloc.s 4
+		IL_00d6: ldloc.s 5
+		IL_00d8: ldstr "log"
+		IL_00dd: ldloc.s 4
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e4: pop
+		IL_00e5: ret
 	} // end of method String_Split_Basic::__js_module_init__
 
 } // end of class Modules.String_Split_Basic
@@ -125,7 +128,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2141
+		// Method begins at RVA 0x214b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2207
+			// Method begins at RVA 0x2215
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,22 +40,23 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 427 (0x1ab)
+		// Code size: 441 (0x1b9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Split_Regex_Basic/Scope,
 			[1] object,
 			[2] object,
-			[3] object,
+			[3] string,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[5] object
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Split_Regex_Basic/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
 		IL_0007: ldstr "a,b,c"
-		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_000c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 		IL_0011: stloc.3
 		IL_0012: ldstr ","
 		IL_0017: ldstr ""
@@ -69,109 +70,109 @@
 		IL_0031: ldstr "console"
 		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0040: stloc.3
-		IL_0041: ldloc.1
-		IL_0042: ldstr "length"
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_004c: stloc.s 5
-		IL_004e: ldloc.3
-		IL_004f: ldstr "log"
-		IL_0054: ldloc.s 5
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005b: pop
-		IL_005c: ldstr "console"
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006b: stloc.s 5
-		IL_006d: ldloc.1
-		IL_006e: ldc.r8 0.0
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_007c: stloc.3
-		IL_007d: ldloc.s 5
-		IL_007f: ldstr "log"
-		IL_0084: ldloc.3
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008a: pop
-		IL_008b: ldstr "console"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009a: stloc.3
-		IL_009b: ldloc.1
-		IL_009c: ldc.r8 1
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00aa: stloc.s 5
-		IL_00ac: ldloc.3
-		IL_00ad: ldstr "log"
-		IL_00b2: ldloc.s 5
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b9: pop
-		IL_00ba: ldstr "console"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c9: stloc.s 5
-		IL_00cb: ldloc.1
-		IL_00cc: ldc.r8 2
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00da: stloc.3
-		IL_00db: ldloc.s 5
-		IL_00dd: ldstr "log"
-		IL_00e2: ldloc.3
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e8: pop
-		IL_00e9: ldstr "a,b,c"
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f3: stloc.3
-		IL_00f4: ldstr ","
-		IL_00f9: ldstr ""
-		IL_00fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0103: stloc.s 4
-		IL_0105: ldloc.3
-		IL_0106: ldstr "split"
-		IL_010b: ldloc.s 4
-		IL_010d: ldc.r8 2
-		IL_0116: box [System.Runtime]System.Double
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0120: stloc.2
-		IL_0121: ldstr "console"
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0130: stloc.3
-		IL_0131: ldloc.2
-		IL_0132: ldstr "length"
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013c: stloc.s 5
-		IL_013e: ldloc.3
-		IL_013f: ldstr "log"
-		IL_0144: ldloc.s 5
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014b: pop
-		IL_014c: ldstr "console"
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015b: stloc.s 5
-		IL_015d: ldloc.2
-		IL_015e: ldc.r8 0.0
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_016c: stloc.3
-		IL_016d: ldloc.s 5
-		IL_016f: ldstr "log"
-		IL_0174: ldloc.3
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017a: pop
-		IL_017b: ldstr "console"
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018a: stloc.3
-		IL_018b: ldloc.2
-		IL_018c: ldc.r8 1
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_019a: stloc.s 5
-		IL_019c: ldloc.3
-		IL_019d: ldstr "log"
-		IL_01a2: ldloc.s 5
-		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a9: pop
-		IL_01aa: ret
+		IL_0040: stloc.s 5
+		IL_0042: ldloc.1
+		IL_0043: ldstr "length"
+		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_004d: stloc.s 6
+		IL_004f: ldloc.s 5
+		IL_0051: ldstr "log"
+		IL_0056: ldloc.s 6
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005d: pop
+		IL_005e: ldstr "console"
+		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006d: stloc.s 6
+		IL_006f: ldloc.1
+		IL_0070: ldc.r8 0.0
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_007e: stloc.s 5
+		IL_0080: ldloc.s 6
+		IL_0082: ldstr "log"
+		IL_0087: ldloc.s 5
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008e: pop
+		IL_008f: ldstr "console"
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009e: stloc.s 5
+		IL_00a0: ldloc.1
+		IL_00a1: ldc.r8 1
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00af: stloc.s 6
+		IL_00b1: ldloc.s 5
+		IL_00b3: ldstr "log"
+		IL_00b8: ldloc.s 6
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bf: pop
+		IL_00c0: ldstr "console"
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cf: stloc.s 6
+		IL_00d1: ldloc.1
+		IL_00d2: ldc.r8 2
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00e0: stloc.s 5
+		IL_00e2: ldloc.s 6
+		IL_00e4: ldstr "log"
+		IL_00e9: ldloc.s 5
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f0: pop
+		IL_00f1: ldstr "a,b,c"
+		IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_00fb: stloc.3
+		IL_00fc: ldstr ","
+		IL_0101: ldstr ""
+		IL_0106: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_010b: stloc.s 4
+		IL_010d: ldloc.3
+		IL_010e: ldstr "split"
+		IL_0113: ldloc.s 4
+		IL_0115: ldc.r8 2
+		IL_011e: box [System.Runtime]System.Double
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0128: stloc.2
+		IL_0129: ldstr "console"
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0138: stloc.s 5
+		IL_013a: ldloc.2
+		IL_013b: ldstr "length"
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0145: stloc.s 6
+		IL_0147: ldloc.s 5
+		IL_0149: ldstr "log"
+		IL_014e: ldloc.s 6
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0155: pop
+		IL_0156: ldstr "console"
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0165: stloc.s 6
+		IL_0167: ldloc.2
+		IL_0168: ldc.r8 0.0
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0176: stloc.s 5
+		IL_0178: ldloc.s 6
+		IL_017a: ldstr "log"
+		IL_017f: ldloc.s 5
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0186: pop
+		IL_0187: ldstr "console"
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0196: stloc.s 5
+		IL_0198: ldloc.2
+		IL_0199: ldc.r8 1
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01a7: stloc.s 6
+		IL_01a9: ldloc.s 5
+		IL_01ab: ldstr "log"
+		IL_01b0: ldloc.s 6
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b7: pop
+		IL_01b8: ret
 	} // end of method String_Split_Regex_Basic::__js_module_init__
 
 } // end of class Modules.String_Split_Regex_Basic
@@ -183,7 +184,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2210
+		// Method begins at RVA 0x221e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Empty.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Empty.verified.txt
@@ -49,16 +49,17 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] object,
+			[6] string,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[8] object
+			[8] object,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Split_Regex_Empty/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
 		IL_0007: ldstr "abc"
-		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_000c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 		IL_0011: stloc.s 6
 		IL_0013: ldstr "(?:)"
 		IL_0018: ldstr ""
@@ -72,57 +73,57 @@
 		IL_0033: ldstr "console"
 		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0042: stloc.s 6
+		IL_0042: stloc.s 8
 		IL_0044: ldloc.1
 		IL_0045: ldstr "length"
 		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_004f: stloc.s 8
-		IL_0051: ldloc.s 6
+		IL_004f: stloc.s 9
+		IL_0051: ldloc.s 8
 		IL_0053: ldstr "log"
-		IL_0058: ldloc.s 8
+		IL_0058: ldloc.s 9
 		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_005f: pop
 		IL_0060: ldstr "console"
 		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: stloc.s 8
+		IL_006f: stloc.s 9
 		IL_0071: ldloc.1
 		IL_0072: ldc.r8 0.0
 		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0080: stloc.s 6
-		IL_0082: ldloc.s 8
+		IL_0080: stloc.s 8
+		IL_0082: ldloc.s 9
 		IL_0084: ldstr "log"
-		IL_0089: ldloc.s 6
+		IL_0089: ldloc.s 8
 		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0090: pop
 		IL_0091: ldstr "console"
 		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a0: stloc.s 6
+		IL_00a0: stloc.s 8
 		IL_00a2: ldloc.1
 		IL_00a3: ldc.r8 1
 		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00b1: stloc.s 8
-		IL_00b3: ldloc.s 6
+		IL_00b1: stloc.s 9
+		IL_00b3: ldloc.s 8
 		IL_00b5: ldstr "log"
-		IL_00ba: ldloc.s 8
+		IL_00ba: ldloc.s 9
 		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_00c1: pop
 		IL_00c2: ldstr "console"
 		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d1: stloc.s 8
+		IL_00d1: stloc.s 9
 		IL_00d3: ldloc.1
 		IL_00d4: ldc.r8 2
 		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00e2: stloc.s 6
-		IL_00e4: ldloc.s 8
+		IL_00e2: stloc.s 8
+		IL_00e4: ldloc.s 9
 		IL_00e6: ldstr "log"
-		IL_00eb: ldloc.s 6
+		IL_00eb: ldloc.s 8
 		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_00f2: pop
 		IL_00f3: ldstr "abc"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 		IL_00fd: stloc.s 6
 		IL_00ff: ldstr "(?:)"
 		IL_0104: ldstr ""
@@ -138,50 +139,50 @@
 		IL_012d: ldstr "console"
 		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013c: stloc.s 6
+		IL_013c: stloc.s 8
 		IL_013e: ldloc.2
 		IL_013f: ldstr "length"
 		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0149: stloc.s 8
-		IL_014b: ldloc.s 6
+		IL_0149: stloc.s 9
+		IL_014b: ldloc.s 8
 		IL_014d: ldstr "log"
-		IL_0152: ldloc.s 8
+		IL_0152: ldloc.s 9
 		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0159: pop
 		IL_015a: ldstr "console"
 		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0169: stloc.s 8
+		IL_0169: stloc.s 9
 		IL_016b: ldloc.2
 		IL_016c: ldc.r8 0.0
 		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_017a: stloc.s 6
-		IL_017c: ldloc.s 8
+		IL_017a: stloc.s 8
+		IL_017c: ldloc.s 9
 		IL_017e: ldstr "log"
-		IL_0183: ldloc.s 6
+		IL_0183: ldloc.s 8
 		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_018a: pop
 		IL_018b: ldstr "console"
 		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019a: stloc.s 6
+		IL_019a: stloc.s 8
 		IL_019c: ldloc.2
 		IL_019d: ldc.r8 1
 		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01ab: stloc.s 8
-		IL_01ad: ldloc.s 6
+		IL_01ab: stloc.s 9
+		IL_01ad: ldloc.s 8
 		IL_01af: ldstr "log"
-		IL_01b4: ldloc.s 8
+		IL_01b4: ldloc.s 9
 		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_01bb: pop
 		IL_01bc: ldstr ""
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c6: stloc.s 8
+		IL_01c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_01c6: stloc.s 6
 		IL_01c8: ldstr "(?:)"
 		IL_01cd: ldstr ""
 		IL_01d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_01d7: stloc.s 7
-		IL_01d9: ldloc.s 8
+		IL_01d9: ldloc.s 6
 		IL_01db: ldstr "split"
 		IL_01e0: ldloc.s 7
 		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
@@ -189,18 +190,18 @@
 		IL_01e8: ldstr "console"
 		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f7: stloc.s 8
+		IL_01f7: stloc.s 9
 		IL_01f9: ldloc.3
 		IL_01fa: ldstr "length"
 		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0204: stloc.s 6
-		IL_0206: ldloc.s 8
+		IL_0204: stloc.s 8
+		IL_0206: ldloc.s 9
 		IL_0208: ldstr "log"
-		IL_020d: ldloc.s 6
+		IL_020d: ldloc.s 8
 		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0214: pop
 		IL_0215: ldstr "\ud83d\ude00a"
-		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 		IL_021f: stloc.s 6
 		IL_0221: ldstr "(?:)"
 		IL_0226: ldstr ""
@@ -214,71 +215,71 @@
 		IL_0242: ldstr "console"
 		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0251: stloc.s 6
+		IL_0251: stloc.s 8
 		IL_0253: ldloc.s 4
 		IL_0255: ldstr "length"
 		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_025f: stloc.s 8
-		IL_0261: ldloc.s 6
+		IL_025f: stloc.s 9
+		IL_0261: ldloc.s 8
 		IL_0263: ldstr "log"
-		IL_0268: ldloc.s 8
+		IL_0268: ldloc.s 9
 		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_026f: pop
 		IL_0270: ldstr "console"
 		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027f: stloc.s 8
+		IL_027f: stloc.s 9
 		IL_0281: ldloc.s 4
 		IL_0283: ldc.r8 0.0
 		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0291: stloc.s 6
-		IL_0293: ldloc.s 6
+		IL_0291: stloc.s 8
+		IL_0293: ldloc.s 8
 		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_029a: ldstr "charCodeAt"
 		IL_029f: ldc.r8 0.0
 		IL_02a8: box [System.Runtime]System.Double
 		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b2: stloc.s 6
-		IL_02b4: ldloc.s 8
+		IL_02b2: stloc.s 8
+		IL_02b4: ldloc.s 9
 		IL_02b6: ldstr "log"
-		IL_02bb: ldloc.s 6
+		IL_02bb: ldloc.s 8
 		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_02c2: pop
 		IL_02c3: ldstr "console"
 		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d2: stloc.s 6
+		IL_02d2: stloc.s 8
 		IL_02d4: ldloc.s 4
 		IL_02d6: ldc.r8 1
 		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02e4: stloc.s 8
-		IL_02e6: ldloc.s 8
+		IL_02e4: stloc.s 9
+		IL_02e6: ldloc.s 9
 		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_02ed: ldstr "charCodeAt"
 		IL_02f2: ldc.r8 0.0
 		IL_02fb: box [System.Runtime]System.Double
 		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0305: stloc.s 8
-		IL_0307: ldloc.s 6
+		IL_0305: stloc.s 9
+		IL_0307: ldloc.s 8
 		IL_0309: ldstr "log"
-		IL_030e: ldloc.s 8
+		IL_030e: ldloc.s 9
 		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0315: pop
 		IL_0316: ldstr "console"
 		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0325: stloc.s 8
+		IL_0325: stloc.s 9
 		IL_0327: ldloc.s 4
 		IL_0329: ldc.r8 2
 		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0337: stloc.s 6
-		IL_0339: ldloc.s 8
+		IL_0337: stloc.s 8
+		IL_0339: ldloc.s 9
 		IL_033b: ldstr "log"
-		IL_0340: ldloc.s 6
+		IL_0340: ldloc.s 8
 		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0347: pop
 		IL_0348: ldstr "\ud83d\ude00a"
-		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_034d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 		IL_0352: stloc.s 6
 		IL_0354: ldstr "(?:)"
 		IL_0359: ldstr "u"
@@ -292,40 +293,40 @@
 		IL_0375: ldstr "console"
 		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0384: stloc.s 6
+		IL_0384: stloc.s 8
 		IL_0386: ldloc.s 5
 		IL_0388: ldstr "length"
 		IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0392: stloc.s 8
-		IL_0394: ldloc.s 6
+		IL_0392: stloc.s 9
+		IL_0394: ldloc.s 8
 		IL_0396: ldstr "log"
-		IL_039b: ldloc.s 8
+		IL_039b: ldloc.s 9
 		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_03a2: pop
 		IL_03a3: ldstr "console"
 		IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b2: stloc.s 8
+		IL_03b2: stloc.s 9
 		IL_03b4: ldloc.s 5
 		IL_03b6: ldc.r8 0.0
 		IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03c4: stloc.s 6
-		IL_03c6: ldloc.s 8
+		IL_03c4: stloc.s 8
+		IL_03c6: ldloc.s 9
 		IL_03c8: ldstr "log"
-		IL_03cd: ldloc.s 6
+		IL_03cd: ldloc.s 8
 		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_03d4: pop
 		IL_03d5: ldstr "console"
 		IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03e4: stloc.s 6
+		IL_03e4: stloc.s 8
 		IL_03e6: ldloc.s 5
 		IL_03e8: ldc.r8 1
 		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03f6: stloc.s 8
-		IL_03f8: ldloc.s 6
+		IL_03f6: stloc.s 9
+		IL_03f8: ldloc.s 8
 		IL_03fa: ldstr "log"
-		IL_03ff: ldloc.s 8
+		IL_03ff: ldloc.s 9
 		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0406: pop
 		IL_0407: ret

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x209e
+			// Method begins at RVA 0x209d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,11 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 66 (0x42)
+		// Code size: 65 (0x41)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_StartsWith_Basic/Scope,
-			[1] bool
+			[1] object,
+			[2] string,
+			[3] bool
 		)
 
 		IL_0000: newobj instance void Modules.String_StartsWith_Basic/Scope::.ctor()
@@ -53,18 +55,21 @@
 		IL_0007: ldstr "console"
 		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0016: ldstr "abc"
-		IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0020: castclass [System.Runtime]System.String
-		IL_0025: ldstr "ab"
-		IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-		IL_002f: stloc.1
-		IL_0030: ldstr "log"
-		IL_0035: ldloc.1
-		IL_0036: box [System.Runtime]System.Boolean
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0040: pop
-		IL_0041: ret
+		IL_0016: stloc.1
+		IL_0017: ldstr "abc"
+		IL_001c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0021: stloc.2
+		IL_0022: ldloc.2
+		IL_0023: ldstr "ab"
+		IL_0028: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_002d: stloc.3
+		IL_002e: ldloc.1
+		IL_002f: ldstr "log"
+		IL_0034: ldloc.3
+		IL_0035: box [System.Runtime]System.Boolean
+		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_003f: pop
+		IL_0040: ret
 	} // end of method String_StartsWith_Basic::__js_module_init__
 
 } // end of class Modules.String_StartsWith_Basic
@@ -76,7 +81,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20a7
+		// Method begins at RVA 0x20a6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ToLowerCase_ToUpperCase_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ToLowerCase_ToUpperCase_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20c4
+			// Method begins at RVA 0x20c2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,11 +40,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 104 (0x68)
+		// Code size: 102 (0x66)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_ToLowerCase_ToUpperCase_Basic/Scope,
-			[1] string
+			[1] object,
+			[2] string
 		)
 
 		IL_0000: newobj instance void Modules.String_ToLowerCase_ToUpperCase_Basic/Scope::.ctor()
@@ -53,28 +54,34 @@
 		IL_0007: ldstr "console"
 		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0016: ldstr "AbC"
-		IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0020: castclass [System.Runtime]System.String
-		IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
-		IL_002a: stloc.1
-		IL_002b: ldstr "log"
-		IL_0030: ldloc.1
-		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0036: pop
-		IL_0037: ldstr "console"
-		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0016: stloc.1
+		IL_0017: ldstr "AbC"
+		IL_001c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0021: stloc.2
+		IL_0022: ldloc.2
+		IL_0023: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
+		IL_0028: stloc.2
+		IL_0029: ldloc.1
+		IL_002a: ldstr "log"
+		IL_002f: ldloc.2
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0035: pop
+		IL_0036: ldstr "console"
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0045: stloc.1
 		IL_0046: ldstr "AbC"
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0050: castclass [System.Runtime]System.String
-		IL_0055: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-		IL_005a: stloc.1
-		IL_005b: ldstr "log"
-		IL_0060: ldloc.1
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0066: pop
-		IL_0067: ret
+		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0050: stloc.2
+		IL_0051: ldloc.2
+		IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+		IL_0057: stloc.2
+		IL_0058: ldloc.1
+		IL_0059: ldstr "log"
+		IL_005e: ldloc.2
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0064: pop
+		IL_0065: ret
 	} // end of method String_ToLowerCase_ToUpperCase_Basic::__js_module_init__
 
 } // end of class Modules.String_ToLowerCase_ToUpperCase_Basic
@@ -86,7 +93,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20cd
+		// Method begins at RVA 0x20cb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.ArrayBuffer_Construct_ByteLength.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.ArrayBuffer_Construct_ByteLength.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20fb
+			// Method begins at RVA 0x2101
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 159 (0x9f)
+		// Code size: 165 (0xa5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrayBuffer_Construct_ByteLength/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
 			[2] object,
-			[3] object,
-			[4] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrayBuffer_Construct_ByteLength/Scope::.ctor()
@@ -58,41 +59,43 @@
 		IL_0015: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer::.ctor(object)
 		IL_001a: stloc.1
 		IL_001b: ldloc.1
-		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0021: ldstr "slice"
-		IL_0026: ldc.r8 2
-		IL_002f: box [System.Runtime]System.Double
-		IL_0034: ldc.r8 6
-		IL_003d: box [System.Runtime]System.Double
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0047: stloc.2
-		IL_0048: ldstr "console"
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0057: stloc.3
-		IL_0058: ldloc.1
-		IL_0059: ldstr "byteLength"
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0063: stloc.s 4
-		IL_0065: ldloc.3
-		IL_0066: ldstr "log"
-		IL_006b: ldloc.s 4
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: pop
-		IL_0073: ldstr "console"
-		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0082: stloc.s 4
-		IL_0084: ldloc.2
-		IL_0085: ldstr "byteLength"
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_008f: stloc.3
-		IL_0090: ldloc.s 4
-		IL_0092: ldstr "log"
-		IL_0097: ldloc.3
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009d: pop
-		IL_009e: ret
+		IL_001c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer>(!!0)
+		IL_0021: stloc.3
+		IL_0022: ldloc.3
+		IL_0023: ldstr "slice"
+		IL_0028: ldc.r8 2
+		IL_0031: box [System.Runtime]System.Double
+		IL_0036: ldc.r8 6
+		IL_003f: box [System.Runtime]System.Double
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0049: stloc.2
+		IL_004a: ldstr "console"
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0059: stloc.s 4
+		IL_005b: ldloc.1
+		IL_005c: ldstr "byteLength"
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0066: stloc.s 5
+		IL_0068: ldloc.s 4
+		IL_006a: ldstr "log"
+		IL_006f: ldloc.s 5
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0076: pop
+		IL_0077: ldstr "console"
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0086: stloc.s 5
+		IL_0088: ldloc.2
+		IL_0089: ldstr "byteLength"
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0093: stloc.s 4
+		IL_0095: ldloc.s 5
+		IL_0097: ldstr "log"
+		IL_009c: ldloc.s 4
+		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a3: pop
+		IL_00a4: ret
 	} // end of method ArrayBuffer_Construct_ByteLength::__js_module_init__
 
 } // end of class Modules.ArrayBuffer_Construct_ByteLength
@@ -104,7 +107,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2104
+		// Method begins at RVA 0x210a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_BoundsChecks_RangeError.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_BoundsChecks_RangeError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cd
+				// Method begins at RVA 0x21d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d6
+				// Method begins at RVA 0x21da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21df
+				// Method begins at RVA 0x21e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e8
+				// Method begins at RVA 0x21ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21c8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 329 (0x149)
+		// Code size: 333 (0x14d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_BoundsChecks_RangeError/Scope,
@@ -135,8 +135,9 @@
 			[7] object,
 			[8] object,
 			[9] object,
-			[10] object,
-			[11] object
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[11] object,
+			[12] object
 		)
 
 		IL_0000: newobj instance void Modules.DataView_BoundsChecks_RangeError/Scope::.ctor()
@@ -157,108 +158,110 @@
 		{
 			IL_003e: nop
 			IL_003f: ldloc.2
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0045: ldstr "getUint32"
-			IL_004a: ldc.r8 0.0
-			IL_0053: box [System.Runtime]System.Double
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_005d: pop
-			IL_005e: leave IL_00c5
+			IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+			IL_0045: stloc.s 10
+			IL_0047: ldloc.s 10
+			IL_0049: ldstr "getUint32"
+			IL_004e: ldc.r8 0.0
+			IL_0057: box [System.Runtime]System.Double
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0061: pop
+			IL_0062: leave IL_00c9
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0063: stloc.3
-			IL_0064: ldloc.3
-			IL_0065: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_006a: dup
-			IL_006b: brtrue IL_0080
+			IL_0067: stloc.3
+			IL_0068: ldloc.3
+			IL_0069: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_006e: dup
+			IL_006f: brtrue IL_0084
 
-			IL_0070: pop
-			IL_0071: ldloc.3
-			IL_0072: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0077: dup
-			IL_0078: brtrue IL_008c
+			IL_0074: pop
+			IL_0075: ldloc.3
+			IL_0076: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_007b: dup
+			IL_007c: brtrue IL_0090
 
-			IL_007d: pop
-			IL_007e: rethrow
+			IL_0081: pop
+			IL_0082: rethrow
 
-			IL_0080: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0085: stloc.s 4
-			IL_0087: br IL_008e
+			IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0089: stloc.s 4
+			IL_008b: br IL_0092
 
-			IL_008c: stloc.s 4
+			IL_0090: stloc.s 4
 
-			IL_008e: ldloc.s 4
-			IL_0090: stloc.s 5
-			IL_0092: ldstr "console"
-			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a1: stloc.s 10
-			IL_00a3: ldloc.s 5
-			IL_00a5: ldstr "name"
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00af: stloc.s 11
-			IL_00b1: ldloc.s 10
-			IL_00b3: ldstr "log"
-			IL_00b8: ldloc.s 11
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00bf: pop
-			IL_00c0: leave IL_00c5
+			IL_0092: ldloc.s 4
+			IL_0094: stloc.s 5
+			IL_0096: ldstr "console"
+			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a5: stloc.s 11
+			IL_00a7: ldloc.s 5
+			IL_00a9: ldstr "name"
+			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b3: stloc.s 12
+			IL_00b5: ldloc.s 11
+			IL_00b7: ldstr "log"
+			IL_00bc: ldloc.s 12
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00c3: pop
+			IL_00c4: leave IL_00c9
 		} // end handler
 		.try
 		{
-			IL_00c5: nop
-			IL_00c6: ldloc.1
-			IL_00c7: ldc.r8 5
-			IL_00d0: box [System.Runtime]System.Double
-			IL_00d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object)
-			IL_00da: pop
-			IL_00db: leave IL_0145
+			IL_00c9: nop
+			IL_00ca: ldloc.1
+			IL_00cb: ldc.r8 5
+			IL_00d4: box [System.Runtime]System.Double
+			IL_00d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object)
+			IL_00de: pop
+			IL_00df: leave IL_0149
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00e0: stloc.s 6
-			IL_00e2: ldloc.s 6
-			IL_00e4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00e9: dup
-			IL_00ea: brtrue IL_0100
+			IL_00e4: stloc.s 6
+			IL_00e6: ldloc.s 6
+			IL_00e8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00ed: dup
+			IL_00ee: brtrue IL_0104
 
-			IL_00ef: pop
-			IL_00f0: ldloc.s 6
-			IL_00f2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00f7: dup
-			IL_00f8: brtrue IL_010c
+			IL_00f3: pop
+			IL_00f4: ldloc.s 6
+			IL_00f6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00fb: dup
+			IL_00fc: brtrue IL_0110
 
-			IL_00fd: pop
-			IL_00fe: rethrow
+			IL_0101: pop
+			IL_0102: rethrow
 
-			IL_0100: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0105: stloc.s 7
-			IL_0107: br IL_010e
+			IL_0104: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0109: stloc.s 7
+			IL_010b: br IL_0112
 
-			IL_010c: stloc.s 7
+			IL_0110: stloc.s 7
 
-			IL_010e: ldloc.s 7
-			IL_0110: stloc.s 8
-			IL_0112: ldstr "console"
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0121: stloc.s 11
-			IL_0123: ldloc.s 8
-			IL_0125: ldstr "name"
-			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_012f: stloc.s 10
-			IL_0131: ldloc.s 11
-			IL_0133: ldstr "log"
-			IL_0138: ldloc.s 10
-			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_013f: pop
-			IL_0140: leave IL_0145
+			IL_0112: ldloc.s 7
+			IL_0114: stloc.s 8
+			IL_0116: ldstr "console"
+			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0125: stloc.s 12
+			IL_0127: ldloc.s 8
+			IL_0129: ldstr "name"
+			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0133: stloc.s 11
+			IL_0135: ldloc.s 12
+			IL_0137: ldstr "log"
+			IL_013c: ldloc.s 11
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0143: pop
+			IL_0144: leave IL_0149
 		} // end handler
 
-		IL_0145: ldnull
-		IL_0146: stloc.s 9
-		IL_0148: ret
+		IL_0149: ldnull
+		IL_014a: stloc.s 9
+		IL_014c: ret
 	} // end of method DataView_BoundsChecks_RangeError::__js_module_init__
 
 } // end of class Modules.DataView_BoundsChecks_RangeError
@@ -270,7 +273,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f1
+		// Method begins at RVA 0x21f5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_ByteOffset_ByteLength.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_ByteOffset_ByteLength.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2211
+			// Method begins at RVA 0x2221
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 437 (0x1b5)
+		// Code size: 453 (0x1c5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_ByteOffset_ByteLength/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[4] object,
-			[5] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.DataView_ByteOffset_ByteLength/Scope::.ctor()
@@ -69,99 +70,107 @@
 		IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object)
 		IL_0044: stloc.3
 		IL_0045: ldloc.2
-		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004b: ldstr "setUint8"
-		IL_0050: ldc.r8 0.0
-		IL_0059: box [System.Runtime]System.Double
-		IL_005e: ldc.r8 10
-		IL_0067: box [System.Runtime]System.Double
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0071: pop
-		IL_0072: ldloc.2
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0078: ldstr "setUint8"
-		IL_007d: ldc.r8 3
-		IL_0086: box [System.Runtime]System.Double
-		IL_008b: ldc.r8 20
-		IL_0094: box [System.Runtime]System.Double
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_009e: pop
-		IL_009f: ldstr "console"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ae: stloc.s 4
-		IL_00b0: ldloc.2
-		IL_00b1: ldstr "byteOffset"
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00bb: stloc.s 5
-		IL_00bd: ldloc.s 4
-		IL_00bf: ldstr "log"
-		IL_00c4: ldloc.s 5
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cb: pop
-		IL_00cc: ldstr "console"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00db: stloc.s 5
-		IL_00dd: ldloc.2
-		IL_00de: ldstr "byteLength"
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e8: stloc.s 4
-		IL_00ea: ldloc.s 5
-		IL_00ec: ldstr "log"
-		IL_00f1: ldloc.s 4
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f8: pop
-		IL_00f9: ldstr "console"
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0108: stloc.s 4
-		IL_010a: ldloc.2
-		IL_010b: ldstr "buffer"
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0115: stloc.s 5
-		IL_0117: ldloc.s 5
-		IL_0119: ldstr "byteLength"
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0123: stloc.s 5
-		IL_0125: ldloc.s 4
-		IL_0127: ldstr "log"
-		IL_012c: ldloc.s 5
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0133: pop
-		IL_0134: ldstr "console"
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0143: stloc.s 5
-		IL_0145: ldloc.3
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_004b: stloc.s 4
+		IL_004d: ldloc.s 4
+		IL_004f: ldstr "setUint8"
+		IL_0054: ldc.r8 0.0
+		IL_005d: box [System.Runtime]System.Double
+		IL_0062: ldc.r8 10
+		IL_006b: box [System.Runtime]System.Double
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0075: pop
+		IL_0076: ldloc.2
+		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_007c: stloc.s 4
+		IL_007e: ldloc.s 4
+		IL_0080: ldstr "setUint8"
+		IL_0085: ldc.r8 3
+		IL_008e: box [System.Runtime]System.Double
+		IL_0093: ldc.r8 20
+		IL_009c: box [System.Runtime]System.Double
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00a6: pop
+		IL_00a7: ldstr "console"
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b6: stloc.s 5
+		IL_00b8: ldloc.2
+		IL_00b9: ldstr "byteOffset"
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c3: stloc.s 6
+		IL_00c5: ldloc.s 5
+		IL_00c7: ldstr "log"
+		IL_00cc: ldloc.s 6
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d3: pop
+		IL_00d4: ldstr "console"
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e3: stloc.s 6
+		IL_00e5: ldloc.2
+		IL_00e6: ldstr "byteLength"
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f0: stloc.s 5
+		IL_00f2: ldloc.s 6
+		IL_00f4: ldstr "log"
+		IL_00f9: ldloc.s 5
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0100: pop
+		IL_0101: ldstr "console"
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0110: stloc.s 5
+		IL_0112: ldloc.2
+		IL_0113: ldstr "buffer"
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011d: stloc.s 6
+		IL_011f: ldloc.s 6
+		IL_0121: ldstr "byteLength"
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012b: stloc.s 6
+		IL_012d: ldloc.s 5
+		IL_012f: ldstr "log"
+		IL_0134: ldloc.s 6
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013b: pop
+		IL_013c: ldstr "console"
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014b: ldstr "getUint8"
-		IL_0150: ldc.r8 2
-		IL_0159: box [System.Runtime]System.Double
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0163: stloc.s 4
-		IL_0165: ldloc.s 5
-		IL_0167: ldstr "log"
-		IL_016c: ldloc.s 4
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0173: pop
-		IL_0174: ldstr "console"
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0183: stloc.s 4
-		IL_0185: ldloc.3
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018b: ldstr "getUint8"
-		IL_0190: ldc.r8 5
-		IL_0199: box [System.Runtime]System.Double
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a3: stloc.s 5
-		IL_01a5: ldloc.s 4
-		IL_01a7: ldstr "log"
-		IL_01ac: ldloc.s 5
+		IL_014b: stloc.s 6
+		IL_014d: ldloc.3
+		IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0153: stloc.s 4
+		IL_0155: ldloc.s 4
+		IL_0157: ldstr "getUint8"
+		IL_015c: ldc.r8 2
+		IL_0165: box [System.Runtime]System.Double
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016f: stloc.s 5
+		IL_0171: ldloc.s 6
+		IL_0173: ldstr "log"
+		IL_0178: ldloc.s 5
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017f: pop
+		IL_0180: ldstr "console"
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018f: stloc.s 5
+		IL_0191: ldloc.3
+		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0197: stloc.s 4
+		IL_0199: ldloc.s 4
+		IL_019b: ldstr "getUint8"
+		IL_01a0: ldc.r8 5
+		IL_01a9: box [System.Runtime]System.Double
 		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b3: pop
-		IL_01b4: ret
+		IL_01b3: stloc.s 6
+		IL_01b5: ldloc.s 5
+		IL_01b7: ldstr "log"
+		IL_01bc: ldloc.s 6
+		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c3: pop
+		IL_01c4: ret
 	} // end of method DataView_ByteOffset_ByteLength::__js_module_init__
 
 } // end of class Modules.DataView_ByteOffset_ByteLength
@@ -173,7 +182,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x221a
+		// Method begins at RVA 0x222a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_Float32_Float64_RoundTrip.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_Float32_Float64_RoundTrip.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2161
+			// Method begins at RVA 0x216d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 261 (0x105)
+		// Code size: 273 (0x111)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_Float32_Float64_RoundTrip/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[3] object,
-			[4] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.DataView_Float32_Float64_RoundTrip/Scope::.ctor()
@@ -61,60 +62,68 @@
 		IL_001c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object)
 		IL_0021: stloc.2
 		IL_0022: ldloc.2
-		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0028: ldstr "setFloat32"
-		IL_002d: ldc.r8 0.0
-		IL_0036: box [System.Runtime]System.Double
-		IL_003b: ldc.r8 1.25
-		IL_0044: box [System.Runtime]System.Double
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_004e: pop
-		IL_004f: ldloc.2
-		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0055: ldstr "setFloat64"
-		IL_005a: ldc.r8 8
-		IL_0063: box [System.Runtime]System.Double
-		IL_0068: ldc.r8 3.141592653589793
-		IL_0071: box [System.Runtime]System.Double
-		IL_0076: ldc.i4.1
-		IL_0077: box [System.Runtime]System.Boolean
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0081: pop
-		IL_0082: ldstr "console"
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0091: stloc.3
-		IL_0092: ldloc.2
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0098: ldstr "getFloat32"
-		IL_009d: ldc.r8 0.0
-		IL_00a6: box [System.Runtime]System.Double
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b0: stloc.s 4
-		IL_00b2: ldloc.3
-		IL_00b3: ldstr "log"
-		IL_00b8: ldloc.s 4
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bf: pop
-		IL_00c0: ldstr "console"
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cf: stloc.s 4
-		IL_00d1: ldloc.2
+		IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0028: stloc.3
+		IL_0029: ldloc.3
+		IL_002a: ldstr "setFloat32"
+		IL_002f: ldc.r8 0.0
+		IL_0038: box [System.Runtime]System.Double
+		IL_003d: ldc.r8 1.25
+		IL_0046: box [System.Runtime]System.Double
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0050: pop
+		IL_0051: ldloc.2
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0057: stloc.3
+		IL_0058: ldloc.3
+		IL_0059: ldstr "setFloat64"
+		IL_005e: ldc.r8 8
+		IL_0067: box [System.Runtime]System.Double
+		IL_006c: ldc.r8 3.141592653589793
+		IL_0075: box [System.Runtime]System.Double
+		IL_007a: ldc.i4.1
+		IL_007b: box [System.Runtime]System.Boolean
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0085: pop
+		IL_0086: ldstr "console"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0095: stloc.s 4
+		IL_0097: ldloc.2
+		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_009d: stloc.3
+		IL_009e: ldloc.3
+		IL_009f: ldstr "getFloat32"
+		IL_00a4: ldc.r8 0.0
+		IL_00ad: box [System.Runtime]System.Double
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b7: stloc.s 5
+		IL_00b9: ldloc.s 4
+		IL_00bb: ldstr "log"
+		IL_00c0: ldloc.s 5
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c7: pop
+		IL_00c8: ldstr "console"
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d7: ldstr "getFloat64"
-		IL_00dc: ldc.r8 8
-		IL_00e5: box [System.Runtime]System.Double
-		IL_00ea: ldc.i4.1
-		IL_00eb: box [System.Runtime]System.Boolean
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00f5: stloc.3
-		IL_00f6: ldloc.s 4
-		IL_00f8: ldstr "log"
-		IL_00fd: ldloc.3
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0103: pop
-		IL_0104: ret
+		IL_00d7: stloc.s 5
+		IL_00d9: ldloc.2
+		IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_00df: stloc.3
+		IL_00e0: ldloc.3
+		IL_00e1: ldstr "getFloat64"
+		IL_00e6: ldc.r8 8
+		IL_00ef: box [System.Runtime]System.Double
+		IL_00f4: ldc.i4.1
+		IL_00f5: box [System.Runtime]System.Boolean
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00ff: stloc.s 4
+		IL_0101: ldloc.s 5
+		IL_0103: ldstr "log"
+		IL_0108: ldloc.s 4
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010f: pop
+		IL_0110: ret
 	} // end of method DataView_Float32_Float64_RoundTrip::__js_module_init__
 
 } // end of class Modules.DataView_Float32_Float64_RoundTrip
@@ -126,7 +135,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x216a
+		// Method begins at RVA 0x2176
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_SetGet_UintAndEndian.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_SetGet_UintAndEndian.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22c6
+			// Method begins at RVA 0x22dc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 618 (0x26a)
+		// Code size: 640 (0x280)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_SetGet_UintAndEndian/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[3] float64,
-			[4] object,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[4] float64,
 			[5] object,
-			[6] object
+			[6] object,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.DataView_SetGet_UintAndEndian/Scope::.ctor()
@@ -63,147 +64,167 @@
 		IL_001c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object)
 		IL_0021: stloc.2
 		IL_0022: ldloc.2
-		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0028: ldstr "setUint8"
-		IL_002d: ldc.r8 0.0
-		IL_0036: box [System.Runtime]System.Double
-		IL_003b: ldc.r8 255
-		IL_0044: box [System.Runtime]System.Double
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_004e: pop
-		IL_004f: ldloc.2
-		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0055: ldstr "setUint16"
-		IL_005a: ldc.r8 1
-		IL_0063: box [System.Runtime]System.Double
-		IL_0068: ldc.r8 4660
-		IL_0071: box [System.Runtime]System.Double
-		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_007b: pop
-		IL_007c: ldloc.2
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0082: ldstr "setUint16"
-		IL_0087: ldc.r8 3
-		IL_0090: box [System.Runtime]System.Double
-		IL_0095: ldc.r8 4660
-		IL_009e: box [System.Runtime]System.Double
-		IL_00a3: ldc.i4.1
-		IL_00a4: box [System.Runtime]System.Boolean
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00ae: pop
-		IL_00af: ldloc.2
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b5: ldc.r8 1
-		IL_00be: neg
-		IL_00bf: stloc.3
-		IL_00c0: ldloc.3
-		IL_00c1: box [System.Runtime]System.Double
+		IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0028: stloc.3
+		IL_0029: ldloc.3
+		IL_002a: ldstr "setUint8"
+		IL_002f: ldc.r8 0.0
+		IL_0038: box [System.Runtime]System.Double
+		IL_003d: ldc.r8 255
+		IL_0046: box [System.Runtime]System.Double
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0050: pop
+		IL_0051: ldloc.2
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0057: stloc.3
+		IL_0058: ldloc.3
+		IL_0059: ldstr "setUint16"
+		IL_005e: ldc.r8 1
+		IL_0067: box [System.Runtime]System.Double
+		IL_006c: ldc.r8 4660
+		IL_0075: box [System.Runtime]System.Double
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_007f: pop
+		IL_0080: ldloc.2
+		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0086: stloc.3
+		IL_0087: ldloc.3
+		IL_0088: ldstr "setUint16"
+		IL_008d: ldc.r8 3
+		IL_0096: box [System.Runtime]System.Double
+		IL_009b: ldc.r8 4660
+		IL_00a4: box [System.Runtime]System.Double
+		IL_00a9: ldc.i4.1
+		IL_00aa: box [System.Runtime]System.Boolean
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00b4: pop
+		IL_00b5: ldloc.2
+		IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_00bb: stloc.3
+		IL_00bc: ldc.r8 1
+		IL_00c5: neg
 		IL_00c6: stloc.s 4
-		IL_00c8: ldstr "setInt32"
-		IL_00cd: ldc.r8 4
-		IL_00d6: box [System.Runtime]System.Double
-		IL_00db: ldloc.s 4
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00e2: pop
-		IL_00e3: ldstr "console"
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f2: stloc.s 5
-		IL_00f4: ldloc.2
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fa: ldstr "getUint8"
-		IL_00ff: ldc.r8 0.0
-		IL_0108: box [System.Runtime]System.Double
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0112: stloc.s 6
-		IL_0114: ldloc.s 5
-		IL_0116: ldstr "log"
-		IL_011b: ldloc.s 6
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0122: pop
-		IL_0123: ldstr "console"
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0132: stloc.s 6
-		IL_0134: ldloc.2
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013a: ldstr "getUint16"
-		IL_013f: ldc.r8 1
-		IL_0148: box [System.Runtime]System.Double
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0152: stloc.s 5
-		IL_0154: ldloc.s 6
-		IL_0156: ldstr "log"
-		IL_015b: ldloc.s 5
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0162: pop
-		IL_0163: ldstr "console"
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0172: stloc.s 5
-		IL_0174: ldloc.2
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017a: ldstr "getUint16"
-		IL_017f: ldc.r8 3
-		IL_0188: box [System.Runtime]System.Double
-		IL_018d: ldc.i4.1
-		IL_018e: box [System.Runtime]System.Boolean
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0198: stloc.s 6
-		IL_019a: ldloc.s 5
-		IL_019c: ldstr "log"
-		IL_01a1: ldloc.s 6
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a8: pop
-		IL_01a9: ldstr "console"
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b8: stloc.s 6
-		IL_01ba: ldloc.2
-		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c0: ldstr "getUint16"
-		IL_01c5: ldc.r8 3
-		IL_01ce: box [System.Runtime]System.Double
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d8: stloc.s 5
-		IL_01da: ldloc.s 6
-		IL_01dc: ldstr "log"
-		IL_01e1: ldloc.s 5
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e8: pop
-		IL_01e9: ldstr "console"
-		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f8: stloc.s 5
-		IL_01fa: ldloc.2
-		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0200: ldstr "getInt32"
-		IL_0205: ldc.r8 4
-		IL_020e: box [System.Runtime]System.Double
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0218: stloc.s 6
-		IL_021a: ldloc.s 5
-		IL_021c: ldstr "log"
-		IL_0221: ldloc.s 6
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0228: pop
-		IL_0229: ldstr "console"
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0238: stloc.s 6
-		IL_023a: ldloc.2
-		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0240: ldstr "getUint32"
-		IL_0245: ldc.r8 4
-		IL_024e: box [System.Runtime]System.Double
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0258: stloc.s 5
-		IL_025a: ldloc.s 6
-		IL_025c: ldstr "log"
-		IL_0261: ldloc.s 5
-		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0268: pop
-		IL_0269: ret
+		IL_00c8: ldloc.s 4
+		IL_00ca: box [System.Runtime]System.Double
+		IL_00cf: stloc.s 5
+		IL_00d1: ldloc.3
+		IL_00d2: ldstr "setInt32"
+		IL_00d7: ldc.r8 4
+		IL_00e0: box [System.Runtime]System.Double
+		IL_00e5: ldloc.s 5
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00ec: pop
+		IL_00ed: ldstr "console"
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fc: stloc.s 6
+		IL_00fe: ldloc.2
+		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0104: stloc.3
+		IL_0105: ldloc.3
+		IL_0106: ldstr "getUint8"
+		IL_010b: ldc.r8 0.0
+		IL_0114: box [System.Runtime]System.Double
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011e: stloc.s 7
+		IL_0120: ldloc.s 6
+		IL_0122: ldstr "log"
+		IL_0127: ldloc.s 7
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012e: pop
+		IL_012f: ldstr "console"
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013e: stloc.s 7
+		IL_0140: ldloc.2
+		IL_0141: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0146: stloc.3
+		IL_0147: ldloc.3
+		IL_0148: ldstr "getUint16"
+		IL_014d: ldc.r8 1
+		IL_0156: box [System.Runtime]System.Double
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0160: stloc.s 6
+		IL_0162: ldloc.s 7
+		IL_0164: ldstr "log"
+		IL_0169: ldloc.s 6
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0170: pop
+		IL_0171: ldstr "console"
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0180: stloc.s 6
+		IL_0182: ldloc.2
+		IL_0183: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0188: stloc.3
+		IL_0189: ldloc.3
+		IL_018a: ldstr "getUint16"
+		IL_018f: ldc.r8 3
+		IL_0198: box [System.Runtime]System.Double
+		IL_019d: ldc.i4.1
+		IL_019e: box [System.Runtime]System.Boolean
+		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01a8: stloc.s 7
+		IL_01aa: ldloc.s 6
+		IL_01ac: ldstr "log"
+		IL_01b1: ldloc.s 7
+		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b8: pop
+		IL_01b9: ldstr "console"
+		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c8: stloc.s 7
+		IL_01ca: ldloc.2
+		IL_01cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_01d0: stloc.3
+		IL_01d1: ldloc.3
+		IL_01d2: ldstr "getUint16"
+		IL_01d7: ldc.r8 3
+		IL_01e0: box [System.Runtime]System.Double
+		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ea: stloc.s 6
+		IL_01ec: ldloc.s 7
+		IL_01ee: ldstr "log"
+		IL_01f3: ldloc.s 6
+		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01fa: pop
+		IL_01fb: ldstr "console"
+		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020a: stloc.s 6
+		IL_020c: ldloc.2
+		IL_020d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0212: stloc.3
+		IL_0213: ldloc.3
+		IL_0214: ldstr "getInt32"
+		IL_0219: ldc.r8 4
+		IL_0222: box [System.Runtime]System.Double
+		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_022c: stloc.s 7
+		IL_022e: ldloc.s 6
+		IL_0230: ldstr "log"
+		IL_0235: ldloc.s 7
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023c: pop
+		IL_023d: ldstr "console"
+		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024c: stloc.s 7
+		IL_024e: ldloc.2
+		IL_024f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0254: stloc.3
+		IL_0255: ldloc.3
+		IL_0256: ldstr "getUint32"
+		IL_025b: ldc.r8 4
+		IL_0264: box [System.Runtime]System.Double
+		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_026e: stloc.s 6
+		IL_0270: ldloc.s 7
+		IL_0272: ldstr "log"
+		IL_0277: ldloc.s 6
+		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027e: pop
+		IL_027f: ret
 	} // end of method DataView_SetGet_UintAndEndian::__js_module_init__
 
 } // end of class Modules.DataView_SetGet_UintAndEndian
@@ -215,7 +236,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22cf
+		// Method begins at RVA 0x22e5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Callback_Methods.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Callback_Methods.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x247f
+				// Method begins at RVA 0x2487
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23ac
+			// Method begins at RVA 0x23b4
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -72,7 +72,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2488
+				// Method begins at RVA 0x2490
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23c2
+			// Method begins at RVA 0x23ca
 			// Header size: 1
 			// Code size: 23 (0x17)
 			.maxstack 8
@@ -122,7 +122,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2491
+				// Method begins at RVA 0x2499
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -146,7 +146,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23da
+			// Method begins at RVA 0x23e2
 			// Header size: 1
 			// Code size: 23 (0x17)
 			.maxstack 8
@@ -172,7 +172,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x249a
+				// Method begins at RVA 0x24a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +196,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f2
+			// Method begins at RVA 0x23fa
 			// Header size: 1
 			// Code size: 23 (0x17)
 			.maxstack 8
@@ -222,7 +222,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a3
+				// Method begins at RVA 0x24ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -246,7 +246,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x240a
+			// Method begins at RVA 0x2412
 			// Header size: 1
 			// Code size: 23 (0x17)
 			.maxstack 8
@@ -272,7 +272,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ac
+				// Method begins at RVA 0x24b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -296,7 +296,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2422
+			// Method begins at RVA 0x242a
 			// Header size: 1
 			// Code size: 23 (0x17)
 			.maxstack 8
@@ -322,7 +322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b5
+				// Method begins at RVA 0x24bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -349,7 +349,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x243c
+			// Method begins at RVA 0x2444
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -385,7 +385,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24be
+				// Method begins at RVA 0x24c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -410,7 +410,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2460
+			// Method begins at RVA 0x2468
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -442,7 +442,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2476
+			// Method begins at RVA 0x247e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -468,16 +468,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 845 (0x34d)
+		// Code size: 855 (0x357)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Float64Array_Callback_Methods/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Float64Array,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object,
-			[4] object,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Float64Array,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[6] object,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		)
 
 		IL_0000: newobj instance void Modules.Float64Array_Callback_Methods/Scope::.ctor()
@@ -503,7 +504,7 @@
 		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0051: stloc.3
 		IL_0052: ldloc.1
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
 		IL_0058: stloc.s 4
 		IL_005a: ldnull
 		IL_005b: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23::__js_call__(object, object, object)
@@ -520,231 +521,231 @@
 		IL_007d: ldstr "map"
 		IL_0082: ldloc.s 5
 		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0089: stloc.s 4
-		IL_008b: ldloc.s 4
+		IL_0089: stloc.s 6
+		IL_008b: ldloc.s 6
 		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0092: ldstr "join"
 		IL_0097: ldstr "|"
 		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a1: stloc.s 4
+		IL_00a1: stloc.s 6
 		IL_00a3: ldloc.3
 		IL_00a4: ldstr "log"
-		IL_00a9: ldloc.s 4
+		IL_00a9: ldloc.s 6
 		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_00b0: pop
 		IL_00b1: ldstr "console"
 		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c0: stloc.s 4
+		IL_00c0: stloc.s 6
 		IL_00c2: ldloc.1
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c8: stloc.3
-		IL_00c9: ldnull
-		IL_00ca: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26::__js_call__(object, object)
-		IL_00d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00d5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_00da: ldc.i4.1
-		IL_00db: conv.r8
-		IL_00dc: ldstr ""
-		IL_00e1: ldc.i4.0
-		IL_00e2: ldc.i4.1
-		IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_00e8: stloc.s 6
-		IL_00ea: ldloc.3
-		IL_00eb: ldstr "filter"
-		IL_00f0: ldloc.s 6
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f7: stloc.3
-		IL_00f8: ldloc.3
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fe: ldstr "join"
-		IL_0103: ldstr "|"
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010d: stloc.3
-		IL_010e: ldloc.s 4
-		IL_0110: ldstr "log"
-		IL_0115: ldloc.3
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011b: pop
-		IL_011c: ldstr "console"
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012b: stloc.3
-		IL_012c: ldloc.1
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0132: stloc.s 4
-		IL_0134: ldnull
-		IL_0135: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25::__js_call__(object, object)
-		IL_013b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0140: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0145: ldc.i4.1
-		IL_0146: conv.r8
-		IL_0147: ldstr ""
-		IL_014c: ldc.i4.0
-		IL_014d: ldc.i4.1
-		IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0153: stloc.s 6
-		IL_0155: ldloc.s 4
-		IL_0157: ldstr "every"
-		IL_015c: ldloc.s 6
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0163: stloc.s 4
-		IL_0165: ldloc.3
-		IL_0166: ldstr "log"
-		IL_016b: ldloc.s 4
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0172: pop
-		IL_0173: ldstr "console"
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0182: stloc.s 4
-		IL_0184: ldloc.1
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018a: stloc.3
-		IL_018b: ldnull
-		IL_018c: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24::__js_call__(object, object)
-		IL_0192: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0197: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_019c: ldc.i4.1
-		IL_019d: conv.r8
-		IL_019e: ldstr ""
-		IL_01a3: ldc.i4.0
-		IL_01a4: ldc.i4.1
-		IL_01a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_01aa: stloc.s 6
-		IL_01ac: ldloc.3
-		IL_01ad: ldstr "some"
-		IL_01b2: ldloc.s 6
-		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b9: stloc.3
-		IL_01ba: ldloc.s 4
-		IL_01bc: ldstr "log"
-		IL_01c1: ldloc.3
-		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c7: pop
-		IL_01c8: ldstr "console"
-		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d7: stloc.3
-		IL_01d8: ldloc.1
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01de: stloc.s 4
-		IL_01e0: ldnull
-		IL_01e1: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24::__js_call__(object, object)
-		IL_01e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01ec: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_01f1: ldc.i4.1
-		IL_01f2: conv.r8
-		IL_01f3: ldstr ""
-		IL_01f8: ldc.i4.0
-		IL_01f9: ldc.i4.1
-		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_01ff: stloc.s 6
-		IL_0201: ldloc.s 4
-		IL_0203: ldstr "find"
-		IL_0208: ldloc.s 6
-		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020f: stloc.s 4
-		IL_0211: ldloc.3
-		IL_0212: ldstr "log"
-		IL_0217: ldloc.s 4
-		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_021e: pop
-		IL_021f: ldstr "console"
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022e: stloc.s 4
-		IL_0230: ldloc.1
-		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0236: stloc.3
-		IL_0237: ldnull
-		IL_0238: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29::__js_call__(object, object)
-		IL_023e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0243: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0248: ldc.i4.1
-		IL_0249: conv.r8
-		IL_024a: ldstr ""
-		IL_024f: ldc.i4.0
-		IL_0250: ldc.i4.1
-		IL_0251: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0256: stloc.s 6
-		IL_0258: ldloc.3
-		IL_0259: ldstr "findIndex"
-		IL_025e: ldloc.s 6
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0265: stloc.3
-		IL_0266: ldloc.s 4
-		IL_0268: ldstr "log"
-		IL_026d: ldloc.3
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0273: pop
-		IL_0274: ldloc.0
-		IL_0275: ldc.r8 0.0
-		IL_027e: box [System.Runtime]System.Double
-		IL_0283: stfld object Modules.Float64Array_Callback_Methods/Scope::total
-		IL_0288: ldloc.1
-		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028e: stloc.3
-		IL_028f: ldloc.0
-		IL_0290: castclass Modules.Float64Array_Callback_Methods/Scope
-		IL_0295: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15::__js_call__(class Modules.Float64Array_Callback_Methods/Scope, object, object)
-		IL_029b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_02a0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_02a5: ldc.i4.1
-		IL_02a6: conv.r8
-		IL_02a7: ldstr ""
-		IL_02ac: ldc.i4.0
-		IL_02ad: ldc.i4.1
-		IL_02ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_02b3: stloc.s 6
-		IL_02b5: ldloc.3
-		IL_02b6: ldstr "forEach"
-		IL_02bb: ldloc.s 6
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c2: pop
-		IL_02c3: ldstr "console"
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d2: stloc.3
-		IL_02d3: ldloc.0
-		IL_02d4: ldfld object Modules.Float64Array_Callback_Methods/Scope::total
-		IL_02d9: stloc.s 4
-		IL_02db: ldloc.3
-		IL_02dc: ldstr "log"
-		IL_02e1: ldloc.s 4
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e8: pop
-		IL_02e9: ldstr "console"
-		IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f8: stloc.s 4
-		IL_02fa: ldloc.1
+		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_00c8: stloc.s 4
+		IL_00ca: ldnull
+		IL_00cb: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26::__js_call__(object, object)
+		IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00d6: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_00db: ldc.i4.1
+		IL_00dc: conv.r8
+		IL_00dd: ldstr ""
+		IL_00e2: ldc.i4.0
+		IL_00e3: ldc.i4.1
+		IL_00e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_00e9: stloc.s 7
+		IL_00eb: ldloc.s 4
+		IL_00ed: ldstr "filter"
+		IL_00f2: ldloc.s 7
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f9: stloc.3
+		IL_00fa: ldloc.3
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0100: ldstr "join"
+		IL_0105: ldstr "|"
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010f: stloc.3
+		IL_0110: ldloc.s 6
+		IL_0112: ldstr "log"
+		IL_0117: ldloc.3
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011d: pop
+		IL_011e: ldstr "console"
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012d: stloc.3
+		IL_012e: ldloc.1
+		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_0134: stloc.s 4
+		IL_0136: ldnull
+		IL_0137: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25::__js_call__(object, object)
+		IL_013d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0142: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0147: ldc.i4.1
+		IL_0148: conv.r8
+		IL_0149: ldstr ""
+		IL_014e: ldc.i4.0
+		IL_014f: ldc.i4.1
+		IL_0150: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0155: stloc.s 7
+		IL_0157: ldloc.s 4
+		IL_0159: ldstr "every"
+		IL_015e: ldloc.s 7
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0165: stloc.s 6
+		IL_0167: ldloc.3
+		IL_0168: ldstr "log"
+		IL_016d: ldloc.s 6
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0174: pop
+		IL_0175: ldstr "console"
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0184: stloc.s 6
+		IL_0186: ldloc.1
+		IL_0187: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_018c: stloc.s 4
+		IL_018e: ldnull
+		IL_018f: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24::__js_call__(object, object)
+		IL_0195: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_019a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_019f: ldc.i4.1
+		IL_01a0: conv.r8
+		IL_01a1: ldstr ""
+		IL_01a6: ldc.i4.0
+		IL_01a7: ldc.i4.1
+		IL_01a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_01ad: stloc.s 7
+		IL_01af: ldloc.s 4
+		IL_01b1: ldstr "some"
+		IL_01b6: ldloc.s 7
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bd: stloc.3
+		IL_01be: ldloc.s 6
+		IL_01c0: ldstr "log"
+		IL_01c5: ldloc.3
+		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01cb: pop
+		IL_01cc: ldstr "console"
+		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01db: stloc.3
+		IL_01dc: ldloc.1
+		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_01e2: stloc.s 4
+		IL_01e4: ldnull
+		IL_01e5: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24::__js_call__(object, object)
+		IL_01eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01f0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_01f5: ldc.i4.1
+		IL_01f6: conv.r8
+		IL_01f7: ldstr ""
+		IL_01fc: ldc.i4.0
+		IL_01fd: ldc.i4.1
+		IL_01fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0203: stloc.s 7
+		IL_0205: ldloc.s 4
+		IL_0207: ldstr "find"
+		IL_020c: ldloc.s 7
+		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0213: stloc.s 6
+		IL_0215: ldloc.3
+		IL_0216: ldstr "log"
+		IL_021b: ldloc.s 6
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0222: pop
+		IL_0223: ldstr "console"
+		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0232: stloc.s 6
+		IL_0234: ldloc.1
+		IL_0235: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_023a: stloc.s 4
+		IL_023c: ldnull
+		IL_023d: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29::__js_call__(object, object)
+		IL_0243: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0248: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_024d: ldc.i4.1
+		IL_024e: conv.r8
+		IL_024f: ldstr ""
+		IL_0254: ldc.i4.0
+		IL_0255: ldc.i4.1
+		IL_0256: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_025b: stloc.s 7
+		IL_025d: ldloc.s 4
+		IL_025f: ldstr "findIndex"
+		IL_0264: ldloc.s 7
+		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_026b: stloc.3
+		IL_026c: ldloc.s 6
+		IL_026e: ldstr "log"
+		IL_0273: ldloc.3
+		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0279: pop
+		IL_027a: ldloc.0
+		IL_027b: ldc.r8 0.0
+		IL_0284: box [System.Runtime]System.Double
+		IL_0289: stfld object Modules.Float64Array_Callback_Methods/Scope::total
+		IL_028e: ldloc.1
+		IL_028f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_0294: stloc.s 4
+		IL_0296: ldloc.0
+		IL_0297: castclass Modules.Float64Array_Callback_Methods/Scope
+		IL_029c: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15::__js_call__(class Modules.Float64Array_Callback_Methods/Scope, object, object)
+		IL_02a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_02a7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_02ac: ldc.i4.1
+		IL_02ad: conv.r8
+		IL_02ae: ldstr ""
+		IL_02b3: ldc.i4.0
+		IL_02b4: ldc.i4.1
+		IL_02b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_02ba: stloc.s 7
+		IL_02bc: ldloc.s 4
+		IL_02be: ldstr "forEach"
+		IL_02c3: ldloc.s 7
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ca: pop
+		IL_02cb: ldstr "console"
+		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02da: stloc.3
+		IL_02db: ldloc.0
+		IL_02dc: ldfld object Modules.Float64Array_Callback_Methods/Scope::total
+		IL_02e1: stloc.s 6
+		IL_02e3: ldloc.3
+		IL_02e4: ldstr "log"
+		IL_02e9: ldloc.s 6
+		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02f0: pop
+		IL_02f1: ldstr "console"
+		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0300: stloc.3
-		IL_0301: ldnull
-		IL_0302: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26::__js_call__(object, object, object)
-		IL_0308: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_030d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_0312: ldc.i4.2
-		IL_0313: conv.r8
-		IL_0314: ldstr ""
-		IL_0319: ldc.i4.0
-		IL_031a: ldc.i4.1
-		IL_031b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_0320: stloc.s 5
-		IL_0322: ldloc.3
-		IL_0323: ldstr "reduce"
-		IL_0328: ldloc.s 5
-		IL_032a: ldc.r8 1
-		IL_0333: box [System.Runtime]System.Double
-		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_033d: stloc.3
-		IL_033e: ldloc.s 4
-		IL_0340: ldstr "log"
-		IL_0345: ldloc.3
-		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_034b: pop
-		IL_034c: ret
+		IL_0300: stloc.s 6
+		IL_0302: ldloc.1
+		IL_0303: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_0308: stloc.s 4
+		IL_030a: ldnull
+		IL_030b: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26::__js_call__(object, object, object)
+		IL_0311: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0316: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_031b: ldc.i4.2
+		IL_031c: conv.r8
+		IL_031d: ldstr ""
+		IL_0322: ldc.i4.0
+		IL_0323: ldc.i4.1
+		IL_0324: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_0329: stloc.s 5
+		IL_032b: ldloc.s 4
+		IL_032d: ldstr "reduce"
+		IL_0332: ldloc.s 5
+		IL_0334: ldc.r8 1
+		IL_033d: box [System.Runtime]System.Double
+		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0347: stloc.3
+		IL_0348: ldloc.s 6
+		IL_034a: ldstr "log"
+		IL_034f: ldloc.3
+		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0355: pop
+		IL_0356: ret
 	} // end of method Float64Array_Callback_Methods::__js_module_init__
 
 } // end of class Modules.Float64Array_Callback_Methods
@@ -756,7 +757,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24c7
+		// Method begins at RVA 0x24cf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Construct_ArrayBuffer_Search.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Construct_ArrayBuffer_Search.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23ce
+			// Method begins at RVA 0x23de
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 882 (0x372)
+		// Code size: 898 (0x382)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Float64Array_Construct_ArrayBuffer_Search/Scope,
@@ -53,7 +53,8 @@
 			[7] object,
 			[8] object,
 			[9] bool,
-			[10] object
+			[10] object,
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.Float64Array
 		)
 
 		IL_0000: newobj instance void Modules.Float64Array_Construct_ArrayBuffer_Search/Scope::.ctor()
@@ -188,110 +189,118 @@
 		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_01e4: stloc.s 8
 		IL_01e6: ldloc.3
-		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ec: ldstr "includes"
-		IL_01f1: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_01fa: box [System.Runtime]System.Double
-		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0204: stloc.s 5
-		IL_0206: ldloc.s 8
-		IL_0208: ldstr "log"
-		IL_020d: ldloc.s 5
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0214: pop
-		IL_0215: ldstr "console"
-		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0224: stloc.s 5
-		IL_0226: ldloc.3
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022c: ldstr "indexOf"
-		IL_0231: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_023a: box [System.Runtime]System.Double
-		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0244: stloc.s 8
-		IL_0246: ldloc.s 5
-		IL_0248: ldstr "log"
-		IL_024d: ldloc.s 8
-		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0254: pop
-		IL_0255: ldstr "console"
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0264: stloc.s 8
-		IL_0266: ldloc.2
+		IL_01e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_01ec: stloc.s 11
+		IL_01ee: ldloc.s 11
+		IL_01f0: ldstr "includes"
+		IL_01f5: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_01fe: box [System.Runtime]System.Double
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0208: stloc.s 5
+		IL_020a: ldloc.s 8
+		IL_020c: ldstr "log"
+		IL_0211: ldloc.s 5
+		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0218: pop
+		IL_0219: ldstr "console"
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0228: stloc.s 5
+		IL_022a: ldloc.3
+		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_0230: stloc.s 11
+		IL_0232: ldloc.s 11
+		IL_0234: ldstr "indexOf"
+		IL_0239: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_0242: box [System.Runtime]System.Double
+		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024c: stloc.s 8
+		IL_024e: ldloc.s 5
+		IL_0250: ldstr "log"
+		IL_0255: ldloc.s 8
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025c: pop
+		IL_025d: ldstr "console"
+		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026c: ldc.r8 1
-		IL_0275: neg
-		IL_0276: stloc.s 6
-		IL_0278: ldloc.s 6
-		IL_027a: box [System.Runtime]System.Double
-		IL_027f: stloc.s 7
-		IL_0281: ldstr "at"
-		IL_0286: ldloc.s 7
-		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_028d: stloc.s 5
-		IL_028f: ldloc.s 8
-		IL_0291: ldstr "log"
-		IL_0296: ldloc.s 5
-		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_029d: pop
-		IL_029e: ldloc.3
-		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a4: ldstr "slice"
-		IL_02a9: ldc.r8 1
-		IL_02b2: box [System.Runtime]System.Double
-		IL_02b7: ldc.r8 3
-		IL_02c0: box [System.Runtime]System.Double
-		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02ca: stloc.s 4
-		IL_02cc: ldstr "console"
-		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02db: stloc.s 5
-		IL_02dd: ldloc.s 4
-		IL_02df: ldstr "buffer"
-		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e9: stloc.s 8
-		IL_02eb: ldloc.s 8
-		IL_02ed: ldloc.1
-		IL_02ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02f3: stloc.s 9
-		IL_02f5: ldloc.s 9
-		IL_02f7: box [System.Runtime]System.Boolean
-		IL_02fc: stloc.s 10
-		IL_02fe: ldloc.s 5
-		IL_0300: ldstr "log"
-		IL_0305: ldloc.s 10
-		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_030c: pop
-		IL_030d: ldstr "console"
-		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_031c: stloc.s 5
-		IL_031e: ldloc.s 4
-		IL_0320: ldc.r8 0.0
-		IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_032e: stloc.s 8
-		IL_0330: ldloc.s 5
-		IL_0332: ldstr "log"
-		IL_0337: ldloc.s 8
-		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_033e: pop
-		IL_033f: ldstr "console"
-		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_034e: stloc.s 8
-		IL_0350: ldloc.s 4
-		IL_0352: ldc.r8 1
-		IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0360: stloc.s 5
-		IL_0362: ldloc.s 8
-		IL_0364: ldstr "log"
-		IL_0369: ldloc.s 5
-		IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0370: pop
-		IL_0371: ret
+		IL_026c: stloc.s 8
+		IL_026e: ldloc.2
+		IL_026f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_0274: stloc.s 11
+		IL_0276: ldc.r8 1
+		IL_027f: neg
+		IL_0280: stloc.s 6
+		IL_0282: ldloc.s 6
+		IL_0284: box [System.Runtime]System.Double
+		IL_0289: stloc.s 7
+		IL_028b: ldloc.s 11
+		IL_028d: ldstr "at"
+		IL_0292: ldloc.s 7
+		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0299: stloc.s 5
+		IL_029b: ldloc.s 8
+		IL_029d: ldstr "log"
+		IL_02a2: ldloc.s 5
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a9: pop
+		IL_02aa: ldloc.3
+		IL_02ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_02b0: stloc.s 11
+		IL_02b2: ldloc.s 11
+		IL_02b4: ldstr "slice"
+		IL_02b9: ldc.r8 1
+		IL_02c2: box [System.Runtime]System.Double
+		IL_02c7: ldc.r8 3
+		IL_02d0: box [System.Runtime]System.Double
+		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02da: stloc.s 4
+		IL_02dc: ldstr "console"
+		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02eb: stloc.s 5
+		IL_02ed: ldloc.s 4
+		IL_02ef: ldstr "buffer"
+		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02f9: stloc.s 8
+		IL_02fb: ldloc.s 8
+		IL_02fd: ldloc.1
+		IL_02fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0303: stloc.s 9
+		IL_0305: ldloc.s 9
+		IL_0307: box [System.Runtime]System.Boolean
+		IL_030c: stloc.s 10
+		IL_030e: ldloc.s 5
+		IL_0310: ldstr "log"
+		IL_0315: ldloc.s 10
+		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_031c: pop
+		IL_031d: ldstr "console"
+		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_032c: stloc.s 5
+		IL_032e: ldloc.s 4
+		IL_0330: ldc.r8 0.0
+		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_033e: stloc.s 8
+		IL_0340: ldloc.s 5
+		IL_0342: ldstr "log"
+		IL_0347: ldloc.s 8
+		IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_034e: pop
+		IL_034f: ldstr "console"
+		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_035e: stloc.s 8
+		IL_0360: ldloc.s 4
+		IL_0362: ldc.r8 1
+		IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0370: stloc.s 5
+		IL_0372: ldloc.s 8
+		IL_0374: ldstr "log"
+		IL_0379: ldloc.s 5
+		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0380: pop
+		IL_0381: ret
 	} // end of method Float64Array_Construct_ArrayBuffer_Search::__js_module_init__
 
 } // end of class Modules.Float64Array_Construct_ArrayBuffer_Search
@@ -303,7 +312,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23d7
+		// Method begins at RVA 0x23e7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Construct_ArrayBuffer_ViewProperties.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Construct_ArrayBuffer_ViewProperties.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2289
+			// Method begins at RVA 0x2299
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,19 +40,20 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 557 (0x22d)
+		// Code size: 573 (0x23d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Construct_ArrayBuffer_ViewProperties/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
-			[4] float64,
-			[5] object,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[5] float64,
 			[6] object,
 			[7] object,
-			[8] bool,
-			[9] object
+			[8] object,
+			[9] bool,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Construct_ArrayBuffer_ViewProperties/Scope::.ctor()
@@ -66,140 +67,148 @@
 		IL_001c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object)
 		IL_0021: stloc.2
 		IL_0022: ldloc.2
-		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0028: ldstr "setInt32"
-		IL_002d: ldc.r8 0.0
-		IL_0036: box [System.Runtime]System.Double
-		IL_003b: ldc.r8 11
-		IL_0044: box [System.Runtime]System.Double
-		IL_0049: ldc.i4.1
-		IL_004a: box [System.Runtime]System.Boolean
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0054: pop
-		IL_0055: ldloc.2
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005b: ldc.r8 22
-		IL_0064: neg
-		IL_0065: stloc.s 4
-		IL_0067: ldloc.s 4
-		IL_0069: box [System.Runtime]System.Double
-		IL_006e: stloc.s 5
-		IL_0070: ldstr "setInt32"
-		IL_0075: ldc.r8 4
-		IL_007e: box [System.Runtime]System.Double
-		IL_0083: ldloc.s 5
-		IL_0085: ldc.i4.1
-		IL_0086: box [System.Runtime]System.Boolean
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0090: pop
-		IL_0091: ldloc.2
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0097: ldstr "setInt32"
-		IL_009c: ldc.r8 8
-		IL_00a5: box [System.Runtime]System.Double
-		IL_00aa: ldc.r8 33
-		IL_00b3: box [System.Runtime]System.Double
-		IL_00b8: ldc.i4.1
-		IL_00b9: box [System.Runtime]System.Boolean
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00c3: pop
-		IL_00c4: ldloc.1
-		IL_00c5: ldc.r8 4
-		IL_00ce: box [System.Runtime]System.Double
-		IL_00d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object, object)
-		IL_00d8: stloc.3
-		IL_00d9: ldstr "console"
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e8: ldloc.3
-		IL_00e9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-		IL_00ee: box [System.Runtime]System.Double
-		IL_00f3: stloc.s 5
-		IL_00f5: ldstr "log"
-		IL_00fa: ldloc.s 5
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0101: pop
-		IL_0102: ldstr "console"
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0111: stloc.s 6
-		IL_0113: ldloc.3
-		IL_0114: ldstr "byteOffset"
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_011e: stloc.s 7
-		IL_0120: ldloc.s 6
-		IL_0122: ldstr "log"
-		IL_0127: ldloc.s 7
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012e: pop
-		IL_012f: ldstr "console"
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013e: stloc.s 7
-		IL_0140: ldloc.3
-		IL_0141: ldstr "byteLength"
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_014b: stloc.s 6
-		IL_014d: ldloc.s 7
-		IL_014f: ldstr "log"
-		IL_0154: ldloc.s 6
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015b: pop
-		IL_015c: ldstr "console"
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016b: stloc.s 6
-		IL_016d: ldloc.3
-		IL_016e: ldstr "buffer"
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0178: stloc.s 7
-		IL_017a: ldloc.s 7
-		IL_017c: ldloc.1
-		IL_017d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0182: stloc.s 8
-		IL_0184: ldloc.s 8
-		IL_0186: box [System.Runtime]System.Boolean
-		IL_018b: stloc.s 9
-		IL_018d: ldloc.s 6
-		IL_018f: ldstr "log"
-		IL_0194: ldloc.s 9
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019b: pop
-		IL_019c: ldstr "console"
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ab: ldloc.3
-		IL_01ac: ldc.r8 0.0
-		IL_01b5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_01ba: box [System.Runtime]System.Double
-		IL_01bf: stloc.s 5
-		IL_01c1: ldstr "log"
-		IL_01c6: ldloc.s 5
-		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01cd: pop
-		IL_01ce: ldloc.3
-		IL_01cf: ldc.r8 1
-		IL_01d8: ldc.r8 44
-		IL_01e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-		IL_01e6: ldstr "console"
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f5: stloc.s 6
-		IL_01f7: ldloc.2
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01fd: ldstr "getInt32"
-		IL_0202: ldc.r8 8
-		IL_020b: box [System.Runtime]System.Double
-		IL_0210: ldc.i4.1
-		IL_0211: box [System.Runtime]System.Boolean
-		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_021b: stloc.s 7
-		IL_021d: ldloc.s 6
-		IL_021f: ldstr "log"
-		IL_0224: ldloc.s 7
-		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_022b: pop
-		IL_022c: ret
+		IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0028: stloc.s 4
+		IL_002a: ldloc.s 4
+		IL_002c: ldstr "setInt32"
+		IL_0031: ldc.r8 0.0
+		IL_003a: box [System.Runtime]System.Double
+		IL_003f: ldc.r8 11
+		IL_0048: box [System.Runtime]System.Double
+		IL_004d: ldc.i4.1
+		IL_004e: box [System.Runtime]System.Boolean
+		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0058: pop
+		IL_0059: ldloc.2
+		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_005f: stloc.s 4
+		IL_0061: ldc.r8 22
+		IL_006a: neg
+		IL_006b: stloc.s 5
+		IL_006d: ldloc.s 5
+		IL_006f: box [System.Runtime]System.Double
+		IL_0074: stloc.s 6
+		IL_0076: ldloc.s 4
+		IL_0078: ldstr "setInt32"
+		IL_007d: ldc.r8 4
+		IL_0086: box [System.Runtime]System.Double
+		IL_008b: ldloc.s 6
+		IL_008d: ldc.i4.1
+		IL_008e: box [System.Runtime]System.Boolean
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0098: pop
+		IL_0099: ldloc.2
+		IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_009f: stloc.s 4
+		IL_00a1: ldloc.s 4
+		IL_00a3: ldstr "setInt32"
+		IL_00a8: ldc.r8 8
+		IL_00b1: box [System.Runtime]System.Double
+		IL_00b6: ldc.r8 33
+		IL_00bf: box [System.Runtime]System.Double
+		IL_00c4: ldc.i4.1
+		IL_00c5: box [System.Runtime]System.Boolean
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00cf: pop
+		IL_00d0: ldloc.1
+		IL_00d1: ldc.r8 4
+		IL_00da: box [System.Runtime]System.Double
+		IL_00df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object, object)
+		IL_00e4: stloc.3
+		IL_00e5: ldstr "console"
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f4: ldloc.3
+		IL_00f5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+		IL_00fa: box [System.Runtime]System.Double
+		IL_00ff: stloc.s 6
+		IL_0101: ldstr "log"
+		IL_0106: ldloc.s 6
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010d: pop
+		IL_010e: ldstr "console"
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011d: stloc.s 7
+		IL_011f: ldloc.3
+		IL_0120: ldstr "byteOffset"
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012a: stloc.s 8
+		IL_012c: ldloc.s 7
+		IL_012e: ldstr "log"
+		IL_0133: ldloc.s 8
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013a: pop
+		IL_013b: ldstr "console"
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014a: stloc.s 8
+		IL_014c: ldloc.3
+		IL_014d: ldstr "byteLength"
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0157: stloc.s 7
+		IL_0159: ldloc.s 8
+		IL_015b: ldstr "log"
+		IL_0160: ldloc.s 7
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0167: pop
+		IL_0168: ldstr "console"
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0177: stloc.s 7
+		IL_0179: ldloc.3
+		IL_017a: ldstr "buffer"
+		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0184: stloc.s 8
+		IL_0186: ldloc.s 8
+		IL_0188: ldloc.1
+		IL_0189: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_018e: stloc.s 9
+		IL_0190: ldloc.s 9
+		IL_0192: box [System.Runtime]System.Boolean
+		IL_0197: stloc.s 10
+		IL_0199: ldloc.s 7
+		IL_019b: ldstr "log"
+		IL_01a0: ldloc.s 10
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a7: pop
+		IL_01a8: ldstr "console"
+		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b7: ldloc.3
+		IL_01b8: ldc.r8 0.0
+		IL_01c1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_01c6: box [System.Runtime]System.Double
+		IL_01cb: stloc.s 6
+		IL_01cd: ldstr "log"
+		IL_01d2: ldloc.s 6
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d9: pop
+		IL_01da: ldloc.3
+		IL_01db: ldc.r8 1
+		IL_01e4: ldc.r8 44
+		IL_01ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+		IL_01f2: ldstr "console"
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0201: stloc.s 7
+		IL_0203: ldloc.2
+		IL_0204: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
+		IL_0209: stloc.s 4
+		IL_020b: ldloc.s 4
+		IL_020d: ldstr "getInt32"
+		IL_0212: ldc.r8 8
+		IL_021b: box [System.Runtime]System.Double
+		IL_0220: ldc.i4.1
+		IL_0221: box [System.Runtime]System.Boolean
+		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_022b: stloc.s 8
+		IL_022d: ldloc.s 7
+		IL_022f: ldstr "log"
+		IL_0234: ldloc.s 8
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023b: pop
+		IL_023c: ret
 	} // end of method Int32Array_Construct_ArrayBuffer_ViewProperties::__js_module_init__
 
 } // end of class Modules.Int32Array_Construct_ArrayBuffer_ViewProperties
@@ -211,7 +220,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2292
+		// Method begins at RVA 0x22a2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Fill_Reverse_Join_LastIndexOf.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Fill_Reverse_Join_LastIndexOf.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2204
+			// Method begins at RVA 0x2218
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 424 (0x1a8)
+		// Code size: 444 (0x1bc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Fill_Reverse_Join_LastIndexOf/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object,
-			[4] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Fill_Reverse_Join_LastIndexOf/Scope::.ctor()
@@ -76,92 +77,102 @@
 		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0060: stloc.3
 		IL_0061: ldloc.1
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0067: ldstr "lastIndexOf"
-		IL_006c: ldc.r8 2
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007f: stloc.s 4
-		IL_0081: ldloc.3
-		IL_0082: ldstr "log"
-		IL_0087: ldloc.s 4
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008e: pop
-		IL_008f: ldstr "console"
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009e: stloc.s 4
-		IL_00a0: ldloc.1
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a6: ldstr "fill"
-		IL_00ab: ldc.r8 9
-		IL_00b4: box [System.Runtime]System.Double
-		IL_00b9: ldc.r8 1
-		IL_00c2: box [System.Runtime]System.Double
-		IL_00c7: ldc.r8 3
-		IL_00d0: box [System.Runtime]System.Double
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00da: stloc.3
-		IL_00db: ldloc.3
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e1: ldstr "join"
-		IL_00e6: ldstr "|"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f0: stloc.3
-		IL_00f1: ldloc.s 4
-		IL_00f3: ldstr "log"
-		IL_00f8: ldloc.3
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fe: pop
-		IL_00ff: ldstr "console"
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010e: stloc.3
-		IL_010f: ldloc.1
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0115: ldstr "reverse"
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_011f: stloc.s 4
-		IL_0121: ldloc.s 4
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0128: ldstr "toString"
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0132: stloc.s 4
-		IL_0134: ldloc.3
-		IL_0135: ldstr "log"
-		IL_013a: ldloc.s 4
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0141: pop
-		IL_0142: ldstr "console"
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0151: stloc.s 4
-		IL_0153: ldloc.1
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0159: ldstr "toString"
-		IL_015e: ldstr "|"
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0168: stloc.3
-		IL_0169: ldloc.s 4
-		IL_016b: ldstr "log"
-		IL_0170: ldloc.3
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0176: pop
-		IL_0177: ldstr "console"
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0186: stloc.3
-		IL_0187: ldloc.1
-		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018d: ldstr "toLocaleString"
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0197: stloc.s 4
-		IL_0199: ldloc.3
-		IL_019a: ldstr "log"
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0067: stloc.s 4
+		IL_0069: ldloc.s 4
+		IL_006b: ldstr "lastIndexOf"
+		IL_0070: ldc.r8 2
+		IL_0079: box [System.Runtime]System.Double
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0083: stloc.s 5
+		IL_0085: ldloc.3
+		IL_0086: ldstr "log"
+		IL_008b: ldloc.s 5
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0092: pop
+		IL_0093: ldstr "console"
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a2: stloc.s 5
+		IL_00a4: ldloc.1
+		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_00aa: stloc.s 4
+		IL_00ac: ldloc.s 4
+		IL_00ae: ldstr "fill"
+		IL_00b3: ldc.r8 9
+		IL_00bc: box [System.Runtime]System.Double
+		IL_00c1: ldc.r8 1
+		IL_00ca: box [System.Runtime]System.Double
+		IL_00cf: ldc.r8 3
+		IL_00d8: box [System.Runtime]System.Double
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00e2: stloc.3
+		IL_00e3: ldloc.3
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e9: ldstr "join"
+		IL_00ee: ldstr "|"
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f8: stloc.3
+		IL_00f9: ldloc.s 5
+		IL_00fb: ldstr "log"
+		IL_0100: ldloc.3
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0106: pop
+		IL_0107: ldstr "console"
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0116: stloc.3
+		IL_0117: ldloc.1
+		IL_0118: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_011d: stloc.s 4
+		IL_011f: ldloc.s 4
+		IL_0121: ldstr "reverse"
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_012b: stloc.s 5
+		IL_012d: ldloc.s 5
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0134: ldstr "toString"
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_013e: stloc.s 5
+		IL_0140: ldloc.3
+		IL_0141: ldstr "log"
+		IL_0146: ldloc.s 5
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014d: pop
+		IL_014e: ldstr "console"
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015d: stloc.s 5
+		IL_015f: ldloc.1
+		IL_0160: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0165: stloc.s 4
+		IL_0167: ldloc.s 4
+		IL_0169: ldstr "toString"
+		IL_016e: ldstr "|"
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0178: stloc.3
+		IL_0179: ldloc.s 5
+		IL_017b: ldstr "log"
+		IL_0180: ldloc.3
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0186: pop
+		IL_0187: ldstr "console"
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0196: stloc.3
+		IL_0197: ldloc.1
+		IL_0198: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_019d: stloc.s 4
 		IL_019f: ldloc.s 4
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a6: pop
-		IL_01a7: ret
+		IL_01a1: ldstr "toLocaleString"
+		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01ab: stloc.s 5
+		IL_01ad: ldloc.3
+		IL_01ae: ldstr "log"
+		IL_01b3: ldloc.s 5
+		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ba: pop
+		IL_01bb: ret
 	} // end of method Int32Array_Fill_Reverse_Join_LastIndexOf::__js_module_init__
 
 } // end of class Modules.Int32Array_Fill_Reverse_Join_LastIndexOf
@@ -173,7 +184,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220d
+		// Method begins at RVA 0x2221
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_BoundsChecks.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_BoundsChecks.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2415
+				// Method begins at RVA 0x2429
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x241e
+				// Method begins at RVA 0x2432
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2427
+				// Method begins at RVA 0x243b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2430
+				// Method begins at RVA 0x2444
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23e8
+			// Method begins at RVA 0x23fc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23fa
+				// Method begins at RVA 0x240e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23f1
+			// Method begins at RVA 0x2405
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x240c
+				// Method begins at RVA 0x2420
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +180,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2403
+			// Method begins at RVA 0x2417
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -206,7 +206,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 879 (0x36f)
+		// Code size: 899 (0x383)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Set_BoundsChecks/Scope,
@@ -222,11 +222,12 @@
 			[10] object,
 			[11] object,
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[13] float64,
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[14] float64,
-			[15] object,
+			[15] float64,
 			[16] object,
-			[17] object
+			[17] object,
+			[18] object
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope::.ctor()
@@ -251,261 +252,271 @@
 		IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
 		IL_0052: stloc.1
 		IL_0053: ldloc.1
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0059: ldc.i4.2
-		IL_005a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_005f: dup
-		IL_0060: ldc.r8 9
-		IL_0069: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_006e: dup
-		IL_006f: ldc.r8 8
-		IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_007d: stloc.s 12
-		IL_007f: ldstr "set"
-		IL_0084: ldloc.s 12
-		IL_0086: ldc.r8 2
-		IL_008f: box [System.Runtime]System.Double
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0099: pop
-		IL_009a: ldc.r8 0.0
-		IL_00a3: stloc.2
-		// loop start (head: IL_00a4)
-			IL_00a4: ldloc.2
-			IL_00a5: stloc.s 13
-			IL_00a7: ldloc.1
-			IL_00a8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-			IL_00ad: stloc.s 14
-			IL_00af: ldloc.s 13
-			IL_00b1: ldloc.s 14
-			IL_00b3: clt
-			IL_00b5: brfalse IL_00f5
+		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0059: stloc.s 13
+		IL_005b: ldc.i4.2
+		IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0061: dup
+		IL_0062: ldc.r8 9
+		IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0070: dup
+		IL_0071: ldc.r8 8
+		IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_007f: stloc.s 12
+		IL_0081: ldloc.s 13
+		IL_0083: ldstr "set"
+		IL_0088: ldloc.s 12
+		IL_008a: ldc.r8 2
+		IL_0093: box [System.Runtime]System.Double
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_009d: pop
+		IL_009e: ldc.r8 0.0
+		IL_00a7: stloc.2
+		// loop start (head: IL_00a8)
+			IL_00a8: ldloc.2
+			IL_00a9: stloc.s 14
+			IL_00ab: ldloc.1
+			IL_00ac: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+			IL_00b1: stloc.s 15
+			IL_00b3: ldloc.s 14
+			IL_00b5: ldloc.s 15
+			IL_00b7: clt
+			IL_00b9: brfalse IL_00f9
 
-			IL_00ba: ldstr "console"
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c9: ldloc.1
-			IL_00ca: ldloc.2
-			IL_00cb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_00d0: box [System.Runtime]System.Double
-			IL_00d5: stloc.s 15
-			IL_00d7: ldstr "log"
-			IL_00dc: ldloc.s 15
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00e3: pop
-			IL_00e4: ldloc.2
-			IL_00e5: ldc.r8 1
-			IL_00ee: add
-			IL_00ef: stloc.2
-			IL_00f0: br IL_00a4
+			IL_00be: ldstr "console"
+			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00cd: ldloc.1
+			IL_00ce: ldloc.2
+			IL_00cf: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_00d4: box [System.Runtime]System.Double
+			IL_00d9: stloc.s 16
+			IL_00db: ldstr "log"
+			IL_00e0: ldloc.s 16
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00e7: pop
+			IL_00e8: ldloc.2
+			IL_00e9: ldc.r8 1
+			IL_00f2: add
+			IL_00f3: stloc.2
+			IL_00f4: br IL_00a8
 		// end loop
 
-		IL_00f5: ldloc.1
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fb: ldstr "subarray"
-		IL_0100: ldc.r8 1
-		IL_0109: box [System.Runtime]System.Double
-		IL_010e: ldc.r8 3
-		IL_0117: box [System.Runtime]System.Double
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0121: stloc.3
-		IL_0122: ldloc.1
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0128: ldstr "set"
-		IL_012d: ldloc.3
-		IL_012e: ldc.r8 0.0
-		IL_0137: box [System.Runtime]System.Double
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0141: pop
-		IL_0142: ldc.r8 0.0
-		IL_014b: stloc.s 4
-		// loop start (head: IL_014d)
-			IL_014d: ldloc.s 4
-			IL_014f: stloc.s 14
-			IL_0151: ldloc.1
-			IL_0152: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-			IL_0157: stloc.s 13
-			IL_0159: ldloc.s 14
-			IL_015b: ldloc.s 13
-			IL_015d: clt
-			IL_015f: brfalse IL_01a2
+		IL_00f9: ldloc.1
+		IL_00fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_00ff: stloc.s 13
+		IL_0101: ldloc.s 13
+		IL_0103: ldstr "subarray"
+		IL_0108: ldc.r8 1
+		IL_0111: box [System.Runtime]System.Double
+		IL_0116: ldc.r8 3
+		IL_011f: box [System.Runtime]System.Double
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0129: stloc.3
+		IL_012a: ldloc.1
+		IL_012b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0130: stloc.s 13
+		IL_0132: ldloc.s 13
+		IL_0134: ldstr "set"
+		IL_0139: ldloc.3
+		IL_013a: ldc.r8 0.0
+		IL_0143: box [System.Runtime]System.Double
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_014d: pop
+		IL_014e: ldc.r8 0.0
+		IL_0157: stloc.s 4
+		// loop start (head: IL_0159)
+			IL_0159: ldloc.s 4
+			IL_015b: stloc.s 15
+			IL_015d: ldloc.1
+			IL_015e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+			IL_0163: stloc.s 14
+			IL_0165: ldloc.s 15
+			IL_0167: ldloc.s 14
+			IL_0169: clt
+			IL_016b: brfalse IL_01ae
 
-			IL_0164: ldstr "console"
-			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0173: ldloc.1
-			IL_0174: ldloc.s 4
-			IL_0176: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_017b: box [System.Runtime]System.Double
-			IL_0180: stloc.s 15
-			IL_0182: ldstr "log"
-			IL_0187: ldloc.s 15
-			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_018e: pop
-			IL_018f: ldloc.s 4
-			IL_0191: ldc.r8 1
-			IL_019a: add
-			IL_019b: stloc.s 4
-			IL_019d: br IL_014d
+			IL_0170: ldstr "console"
+			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_017f: ldloc.1
+			IL_0180: ldloc.s 4
+			IL_0182: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_0187: box [System.Runtime]System.Double
+			IL_018c: stloc.s 16
+			IL_018e: ldstr "log"
+			IL_0193: ldloc.s 16
+			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_019a: pop
+			IL_019b: ldloc.s 4
+			IL_019d: ldc.r8 1
+			IL_01a6: add
+			IL_01a7: stloc.s 4
+			IL_01a9: br IL_0159
 		// end loop
 		.try
 		{
-			IL_01a2: nop
-			IL_01a3: ldloc.1
-			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a9: ldc.i4.3
-			IL_01aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_01af: dup
-			IL_01b0: ldc.r8 7
-			IL_01b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_01be: dup
-			IL_01bf: ldc.r8 6
-			IL_01c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_01cd: dup
-			IL_01ce: ldc.r8 5
-			IL_01d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_01dc: stloc.s 12
-			IL_01de: ldstr "set"
-			IL_01e3: ldloc.s 12
-			IL_01e5: ldc.r8 2
-			IL_01ee: box [System.Runtime]System.Double
-			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01f8: pop
-			IL_01f9: leave IL_0291
+			IL_01ae: nop
+			IL_01af: ldloc.1
+			IL_01b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+			IL_01b5: stloc.s 13
+			IL_01b7: ldc.i4.3
+			IL_01b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01bd: dup
+			IL_01be: ldc.r8 7
+			IL_01c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_01cc: dup
+			IL_01cd: ldc.r8 6
+			IL_01d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_01db: dup
+			IL_01dc: ldc.r8 5
+			IL_01e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_01ea: stloc.s 12
+			IL_01ec: ldloc.s 13
+			IL_01ee: ldstr "set"
+			IL_01f3: ldloc.s 12
+			IL_01f5: ldc.r8 2
+			IL_01fe: box [System.Runtime]System.Double
+			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0208: pop
+			IL_0209: leave IL_02a1
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01fe: stloc.s 5
-			IL_0200: ldloc.s 5
-			IL_0202: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0207: dup
-			IL_0208: brtrue IL_021e
+			IL_020e: stloc.s 5
+			IL_0210: ldloc.s 5
+			IL_0212: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0217: dup
+			IL_0218: brtrue IL_022e
 
-			IL_020d: pop
-			IL_020e: ldloc.s 5
-			IL_0210: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0215: dup
-			IL_0216: brtrue IL_022a
+			IL_021d: pop
+			IL_021e: ldloc.s 5
+			IL_0220: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0225: dup
+			IL_0226: brtrue IL_023a
 
-			IL_021b: pop
-			IL_021c: rethrow
+			IL_022b: pop
+			IL_022c: rethrow
 
-			IL_021e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0223: stloc.s 6
-			IL_0225: br IL_022c
+			IL_022e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0233: stloc.s 6
+			IL_0235: br IL_023c
 
-			IL_022a: stloc.s 6
+			IL_023a: stloc.s 6
 
-			IL_022c: ldloc.s 6
-			IL_022e: stloc.s 7
-			IL_0230: ldstr "console"
-			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_023f: stloc.s 16
-			IL_0241: ldloc.s 7
-			IL_0243: ldstr "name"
-			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_024d: stloc.s 17
-			IL_024f: ldloc.s 16
-			IL_0251: ldstr "log"
-			IL_0256: ldloc.s 17
-			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_025d: pop
-			IL_025e: ldstr "console"
-			IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_026d: stloc.s 17
-			IL_026f: ldloc.s 7
-			IL_0271: ldstr "message"
-			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_027b: stloc.s 16
-			IL_027d: ldloc.s 17
-			IL_027f: ldstr "log"
-			IL_0284: ldloc.s 16
-			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_028b: pop
-			IL_028c: leave IL_0291
+			IL_023c: ldloc.s 6
+			IL_023e: stloc.s 7
+			IL_0240: ldstr "console"
+			IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_024f: stloc.s 17
+			IL_0251: ldloc.s 7
+			IL_0253: ldstr "name"
+			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_025d: stloc.s 18
+			IL_025f: ldloc.s 17
+			IL_0261: ldstr "log"
+			IL_0266: ldloc.s 18
+			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_026d: pop
+			IL_026e: ldstr "console"
+			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_027d: stloc.s 18
+			IL_027f: ldloc.s 7
+			IL_0281: ldstr "message"
+			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_028b: stloc.s 17
+			IL_028d: ldloc.s 18
+			IL_028f: ldstr "log"
+			IL_0294: ldloc.s 17
+			IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_029b: pop
+			IL_029c: leave IL_02a1
 		} // end handler
 		.try
 		{
-			IL_0291: nop
-			IL_0292: ldloc.1
-			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0298: ldc.i4.1
-			IL_0299: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_029e: dup
-			IL_029f: ldc.r8 1
-			IL_02a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_02ad: stloc.s 12
-			IL_02af: ldc.r8 1
-			IL_02b8: neg
-			IL_02b9: stloc.s 13
-			IL_02bb: ldloc.s 13
-			IL_02bd: box [System.Runtime]System.Double
-			IL_02c2: stloc.s 15
-			IL_02c4: ldstr "set"
-			IL_02c9: ldloc.s 12
-			IL_02cb: ldloc.s 15
-			IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_02d2: pop
-			IL_02d3: leave IL_036b
+			IL_02a1: nop
+			IL_02a2: ldloc.1
+			IL_02a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+			IL_02a8: stloc.s 13
+			IL_02aa: ldc.i4.1
+			IL_02ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02b0: dup
+			IL_02b1: ldc.r8 1
+			IL_02ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_02bf: stloc.s 12
+			IL_02c1: ldc.r8 1
+			IL_02ca: neg
+			IL_02cb: stloc.s 14
+			IL_02cd: ldloc.s 14
+			IL_02cf: box [System.Runtime]System.Double
+			IL_02d4: stloc.s 16
+			IL_02d6: ldloc.s 13
+			IL_02d8: ldstr "set"
+			IL_02dd: ldloc.s 12
+			IL_02df: ldloc.s 16
+			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_02e6: pop
+			IL_02e7: leave IL_037f
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02d8: stloc.s 8
-			IL_02da: ldloc.s 8
-			IL_02dc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02e1: dup
-			IL_02e2: brtrue IL_02f8
+			IL_02ec: stloc.s 8
+			IL_02ee: ldloc.s 8
+			IL_02f0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02f5: dup
+			IL_02f6: brtrue IL_030c
 
-			IL_02e7: pop
-			IL_02e8: ldloc.s 8
-			IL_02ea: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02ef: dup
-			IL_02f0: brtrue IL_0304
+			IL_02fb: pop
+			IL_02fc: ldloc.s 8
+			IL_02fe: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0303: dup
+			IL_0304: brtrue IL_0318
 
-			IL_02f5: pop
-			IL_02f6: rethrow
+			IL_0309: pop
+			IL_030a: rethrow
 
-			IL_02f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02fd: stloc.s 9
-			IL_02ff: br IL_0306
+			IL_030c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0311: stloc.s 9
+			IL_0313: br IL_031a
 
-			IL_0304: stloc.s 9
+			IL_0318: stloc.s 9
 
-			IL_0306: ldloc.s 9
-			IL_0308: stloc.s 10
-			IL_030a: ldstr "console"
-			IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0319: stloc.s 16
-			IL_031b: ldloc.s 10
-			IL_031d: ldstr "name"
-			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0327: stloc.s 17
-			IL_0329: ldloc.s 16
-			IL_032b: ldstr "log"
-			IL_0330: ldloc.s 17
-			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0337: pop
-			IL_0338: ldstr "console"
-			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0347: stloc.s 17
-			IL_0349: ldloc.s 10
-			IL_034b: ldstr "message"
-			IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0355: stloc.s 16
-			IL_0357: ldloc.s 17
-			IL_0359: ldstr "log"
-			IL_035e: ldloc.s 16
-			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0365: pop
-			IL_0366: leave IL_036b
+			IL_031a: ldloc.s 9
+			IL_031c: stloc.s 10
+			IL_031e: ldstr "console"
+			IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_032d: stloc.s 17
+			IL_032f: ldloc.s 10
+			IL_0331: ldstr "name"
+			IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_033b: stloc.s 18
+			IL_033d: ldloc.s 17
+			IL_033f: ldstr "log"
+			IL_0344: ldloc.s 18
+			IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_034b: pop
+			IL_034c: ldstr "console"
+			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_035b: stloc.s 18
+			IL_035d: ldloc.s 10
+			IL_035f: ldstr "message"
+			IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0369: stloc.s 17
+			IL_036b: ldloc.s 18
+			IL_036d: ldstr "log"
+			IL_0372: ldloc.s 17
+			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0379: pop
+			IL_037a: leave IL_037f
 		} // end handler
 
-		IL_036b: ldnull
-		IL_036c: stloc.s 11
-		IL_036e: ret
+		IL_037f: ldnull
+		IL_0380: stloc.s 11
+		IL_0382: ret
 	} // end of method Int32Array_Set_BoundsChecks::__js_module_init__
 
 } // end of class Modules.Int32Array_Set_BoundsChecks
@@ -517,7 +528,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2439
+		// Method begins at RVA 0x244d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_FromArray_WithOffset.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_FromArray_WithOffset.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2128
+			// Method begins at RVA 0x212c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -34,7 +34,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2131
+			// Method begins at RVA 0x2135
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -60,16 +60,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 204 (0xcc)
+		// Code size: 208 (0xd0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Set_FromArray_WithOffset/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] float64,
-			[4] float64,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[5] float64,
-			[6] object
+			[6] float64,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Set_FromArray_WithOffset/Scope::.ctor()
@@ -93,46 +94,48 @@
 		IL_004a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_004f: stloc.2
 		IL_0050: ldloc.1
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0056: ldstr "set"
-		IL_005b: ldloc.2
-		IL_005c: ldc.r8 1
-		IL_0065: box [System.Runtime]System.Double
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_006f: pop
-		IL_0070: ldc.r8 0.0
-		IL_0079: stloc.3
-		// loop start (head: IL_007a)
-			IL_007a: ldloc.3
-			IL_007b: stloc.s 4
-			IL_007d: ldloc.1
-			IL_007e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-			IL_0083: stloc.s 5
-			IL_0085: ldloc.s 4
-			IL_0087: ldloc.s 5
-			IL_0089: clt
-			IL_008b: brfalse IL_00cb
+		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0056: stloc.s 4
+		IL_0058: ldloc.s 4
+		IL_005a: ldstr "set"
+		IL_005f: ldloc.2
+		IL_0060: ldc.r8 1
+		IL_0069: box [System.Runtime]System.Double
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0073: pop
+		IL_0074: ldc.r8 0.0
+		IL_007d: stloc.3
+		// loop start (head: IL_007e)
+			IL_007e: ldloc.3
+			IL_007f: stloc.s 5
+			IL_0081: ldloc.1
+			IL_0082: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+			IL_0087: stloc.s 6
+			IL_0089: ldloc.s 5
+			IL_008b: ldloc.s 6
+			IL_008d: clt
+			IL_008f: brfalse IL_00cf
 
-			IL_0090: ldstr "console"
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009f: ldloc.1
-			IL_00a0: ldloc.3
-			IL_00a1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_00a6: box [System.Runtime]System.Double
-			IL_00ab: stloc.s 6
-			IL_00ad: ldstr "log"
-			IL_00b2: ldloc.s 6
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00b9: pop
-			IL_00ba: ldloc.3
-			IL_00bb: ldc.r8 1
-			IL_00c4: add
-			IL_00c5: stloc.3
-			IL_00c6: br IL_007a
+			IL_0094: ldstr "console"
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a3: ldloc.1
+			IL_00a4: ldloc.3
+			IL_00a5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_00aa: box [System.Runtime]System.Double
+			IL_00af: stloc.s 7
+			IL_00b1: ldstr "log"
+			IL_00b6: ldloc.s 7
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00bd: pop
+			IL_00be: ldloc.3
+			IL_00bf: ldc.r8 1
+			IL_00c8: add
+			IL_00c9: stloc.3
+			IL_00ca: br IL_007e
 		// end loop
 
-		IL_00cb: ret
+		IL_00cf: ret
 	} // end of method Int32Array_Set_FromArray_WithOffset::__js_module_init__
 
 } // end of class Modules.Int32Array_Set_FromArray_WithOffset
@@ -144,7 +147,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x213a
+		// Method begins at RVA 0x213e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_Basic.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2235
+			// Method begins at RVA 0x223d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2247
+				// Method begins at RVA 0x224f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x223e
+			// Method begins at RVA 0x2246
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 473 (0x1d9)
+		// Code size: 481 (0x1e1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Slice_Basic/Scope,
@@ -91,11 +91,12 @@
 			[3] float64,
 			[4] object,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[6] object,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[7] object,
-			[8] float64,
+			[8] object,
 			[9] float64,
-			[10] object
+			[10] float64,
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Slice_Basic/Scope::.ctor()
@@ -123,110 +124,114 @@
 		IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
 		IL_0061: stloc.1
 		IL_0062: ldloc.1
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0068: ldstr "slice"
-		IL_006d: ldc.r8 1
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: ldc.r8 4
-		IL_0084: box [System.Runtime]System.Double
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_008e: stloc.2
-		IL_008f: ldstr "console"
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009e: stloc.s 6
-		IL_00a0: ldloc.2
-		IL_00a1: ldstr "length"
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ab: stloc.s 7
-		IL_00ad: ldloc.s 6
-		IL_00af: ldstr "log"
-		IL_00b4: ldloc.s 7
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bb: pop
-		IL_00bc: ldc.r8 0.0
-		IL_00c5: stloc.3
-		// loop start (head: IL_00c6)
-			IL_00c6: ldloc.3
-			IL_00c7: stloc.s 8
-			IL_00c9: ldloc.2
-			IL_00ca: ldstr "length"
-			IL_00cf: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_00d4: stloc.s 9
-			IL_00d6: ldloc.s 8
-			IL_00d8: ldloc.s 9
-			IL_00da: clt
-			IL_00dc: brfalse IL_011b
+		IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0068: stloc.s 6
+		IL_006a: ldloc.s 6
+		IL_006c: ldstr "slice"
+		IL_0071: ldc.r8 1
+		IL_007a: box [System.Runtime]System.Double
+		IL_007f: ldc.r8 4
+		IL_0088: box [System.Runtime]System.Double
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0092: stloc.2
+		IL_0093: ldstr "console"
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a2: stloc.s 7
+		IL_00a4: ldloc.2
+		IL_00a5: ldstr "length"
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00af: stloc.s 8
+		IL_00b1: ldloc.s 7
+		IL_00b3: ldstr "log"
+		IL_00b8: ldloc.s 8
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bf: pop
+		IL_00c0: ldc.r8 0.0
+		IL_00c9: stloc.3
+		// loop start (head: IL_00ca)
+			IL_00ca: ldloc.3
+			IL_00cb: stloc.s 9
+			IL_00cd: ldloc.2
+			IL_00ce: ldstr "length"
+			IL_00d3: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_00d8: stloc.s 10
+			IL_00da: ldloc.s 9
+			IL_00dc: ldloc.s 10
+			IL_00de: clt
+			IL_00e0: brfalse IL_011f
 
-			IL_00e1: ldstr "console"
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f0: stloc.s 7
-			IL_00f2: ldloc.2
-			IL_00f3: ldloc.3
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00f9: stloc.s 6
-			IL_00fb: ldloc.s 7
-			IL_00fd: ldstr "log"
-			IL_0102: ldloc.s 6
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0109: pop
-			IL_010a: ldloc.3
-			IL_010b: ldc.r8 1
-			IL_0114: add
-			IL_0115: stloc.3
-			IL_0116: br IL_00c6
+			IL_00e5: ldstr "console"
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f4: stloc.s 8
+			IL_00f6: ldloc.2
+			IL_00f7: ldloc.3
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00fd: stloc.s 7
+			IL_00ff: ldloc.s 8
+			IL_0101: ldstr "log"
+			IL_0106: ldloc.s 7
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_010d: pop
+			IL_010e: ldloc.3
+			IL_010f: ldc.r8 1
+			IL_0118: add
+			IL_0119: stloc.3
+			IL_011a: br IL_00ca
 		// end loop
 
-		IL_011b: ldloc.2
-		IL_011c: ldc.r8 0.0
-		IL_0125: ldc.r8 99
-		IL_012e: ldc.i4.1
-		IL_012f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_0134: ldstr "console"
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0143: ldloc.1
-		IL_0144: ldc.r8 1
-		IL_014d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_0152: box [System.Runtime]System.Double
-		IL_0157: stloc.s 10
-		IL_0159: ldstr "log"
-		IL_015e: ldloc.s 10
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0165: pop
-		IL_0166: ldloc.1
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016c: ldstr "slice"
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0176: stloc.s 4
-		IL_0178: ldstr "console"
-		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0187: stloc.s 6
-		IL_0189: ldloc.s 4
-		IL_018b: ldstr "length"
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0195: stloc.s 7
-		IL_0197: ldloc.s 6
-		IL_0199: ldstr "log"
-		IL_019e: ldloc.s 7
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a5: pop
-		IL_01a6: ldstr "console"
-		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b5: stloc.s 7
-		IL_01b7: ldloc.s 4
-		IL_01b9: ldc.r8 4
-		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01c7: stloc.s 6
-		IL_01c9: ldloc.s 7
-		IL_01cb: ldstr "log"
-		IL_01d0: ldloc.s 6
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d7: pop
-		IL_01d8: ret
+		IL_011f: ldloc.2
+		IL_0120: ldc.r8 0.0
+		IL_0129: ldc.r8 99
+		IL_0132: ldc.i4.1
+		IL_0133: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0138: ldstr "console"
+		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0147: ldloc.1
+		IL_0148: ldc.r8 1
+		IL_0151: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_0156: box [System.Runtime]System.Double
+		IL_015b: stloc.s 11
+		IL_015d: ldstr "log"
+		IL_0162: ldloc.s 11
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0169: pop
+		IL_016a: ldloc.1
+		IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0170: stloc.s 6
+		IL_0172: ldloc.s 6
+		IL_0174: ldstr "slice"
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_017e: stloc.s 4
+		IL_0180: ldstr "console"
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018f: stloc.s 7
+		IL_0191: ldloc.s 4
+		IL_0193: ldstr "length"
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_019d: stloc.s 8
+		IL_019f: ldloc.s 7
+		IL_01a1: ldstr "log"
+		IL_01a6: ldloc.s 8
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ad: pop
+		IL_01ae: ldstr "console"
+		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01bd: stloc.s 8
+		IL_01bf: ldloc.s 4
+		IL_01c1: ldc.r8 4
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01cf: stloc.s 7
+		IL_01d1: ldloc.s 8
+		IL_01d3: ldstr "log"
+		IL_01d8: ldloc.s 7
+		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01df: pop
+		IL_01e0: ret
 	} // end of method Int32Array_Slice_Basic::__js_module_init__
 
 } // end of class Modules.Int32Array_Slice_Basic
@@ -238,7 +243,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2250
+		// Method begins at RVA 0x2258
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_RelativeIndices.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_RelativeIndices.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22ff
+			// Method begins at RVA 0x230f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2311
+				// Method begins at RVA 0x2321
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2308
+			// Method begins at RVA 0x2318
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2323
+				// Method begins at RVA 0x2333
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x231a
+			// Method begins at RVA 0x232a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -124,7 +124,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 675 (0x2a3)
+		// Code size: 691 (0x2b3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Slice_RelativeIndices/Scope,
@@ -134,12 +134,13 @@
 			[4] object,
 			[5] float64,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[7] float64,
-			[8] object,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[8] float64,
 			[9] object,
 			[10] object,
 			[11] object,
-			[12] float64
+			[12] object,
+			[13] float64
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Slice_RelativeIndices/Scope::.ctor()
@@ -167,175 +168,183 @@
 		IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
 		IL_0061: stloc.1
 		IL_0062: ldloc.1
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0068: ldc.r8 3
-		IL_0071: neg
-		IL_0072: stloc.s 7
-		IL_0074: ldloc.s 7
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: stloc.s 8
-		IL_007d: ldc.r8 1
-		IL_0086: neg
-		IL_0087: stloc.s 7
-		IL_0089: ldloc.s 7
-		IL_008b: box [System.Runtime]System.Double
-		IL_0090: stloc.s 9
-		IL_0092: ldstr "slice"
-		IL_0097: ldloc.s 8
-		IL_0099: ldloc.s 9
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00a0: stloc.2
-		IL_00a1: ldstr "console"
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b0: stloc.s 10
-		IL_00b2: ldloc.2
-		IL_00b3: ldstr "length"
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00bd: stloc.s 11
-		IL_00bf: ldloc.s 10
-		IL_00c1: ldstr "log"
-		IL_00c6: ldloc.s 11
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cd: pop
-		IL_00ce: ldc.r8 0.0
-		IL_00d7: stloc.3
-		// loop start (head: IL_00d8)
-			IL_00d8: ldloc.3
-			IL_00d9: stloc.s 7
-			IL_00db: ldloc.2
-			IL_00dc: ldstr "length"
-			IL_00e1: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_00e6: stloc.s 12
-			IL_00e8: ldloc.s 7
-			IL_00ea: ldloc.s 12
-			IL_00ec: clt
-			IL_00ee: brfalse IL_012d
+		IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0068: stloc.s 7
+		IL_006a: ldc.r8 3
+		IL_0073: neg
+		IL_0074: stloc.s 8
+		IL_0076: ldloc.s 8
+		IL_0078: box [System.Runtime]System.Double
+		IL_007d: stloc.s 9
+		IL_007f: ldc.r8 1
+		IL_0088: neg
+		IL_0089: stloc.s 8
+		IL_008b: ldloc.s 8
+		IL_008d: box [System.Runtime]System.Double
+		IL_0092: stloc.s 10
+		IL_0094: ldloc.s 7
+		IL_0096: ldstr "slice"
+		IL_009b: ldloc.s 9
+		IL_009d: ldloc.s 10
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00a4: stloc.2
+		IL_00a5: ldstr "console"
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b4: stloc.s 11
+		IL_00b6: ldloc.2
+		IL_00b7: ldstr "length"
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c1: stloc.s 12
+		IL_00c3: ldloc.s 11
+		IL_00c5: ldstr "log"
+		IL_00ca: ldloc.s 12
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d1: pop
+		IL_00d2: ldc.r8 0.0
+		IL_00db: stloc.3
+		// loop start (head: IL_00dc)
+			IL_00dc: ldloc.3
+			IL_00dd: stloc.s 8
+			IL_00df: ldloc.2
+			IL_00e0: ldstr "length"
+			IL_00e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_00ea: stloc.s 13
+			IL_00ec: ldloc.s 8
+			IL_00ee: ldloc.s 13
+			IL_00f0: clt
+			IL_00f2: brfalse IL_0131
 
-			IL_00f3: ldstr "console"
-			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0102: stloc.s 11
-			IL_0104: ldloc.2
-			IL_0105: ldloc.3
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_010b: stloc.s 10
-			IL_010d: ldloc.s 11
-			IL_010f: ldstr "log"
-			IL_0114: ldloc.s 10
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_011b: pop
-			IL_011c: ldloc.3
-			IL_011d: ldc.r8 1
-			IL_0126: add
-			IL_0127: stloc.3
-			IL_0128: br IL_00d8
+			IL_00f7: ldstr "console"
+			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0106: stloc.s 12
+			IL_0108: ldloc.2
+			IL_0109: ldloc.3
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_010f: stloc.s 11
+			IL_0111: ldloc.s 12
+			IL_0113: ldstr "log"
+			IL_0118: ldloc.s 11
+			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_011f: pop
+			IL_0120: ldloc.3
+			IL_0121: ldc.r8 1
+			IL_012a: add
+			IL_012b: stloc.3
+			IL_012c: br IL_00dc
 		// end loop
 
-		IL_012d: ldloc.1
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0133: ldc.r8 20
-		IL_013c: neg
-		IL_013d: stloc.s 12
-		IL_013f: ldloc.s 12
-		IL_0141: box [System.Runtime]System.Double
-		IL_0146: stloc.s 9
-		IL_0148: ldstr "slice"
-		IL_014d: ldloc.s 9
-		IL_014f: ldc.r8 2
-		IL_0158: box [System.Runtime]System.Double
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0162: stloc.s 4
-		IL_0164: ldstr "console"
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0173: stloc.s 10
-		IL_0175: ldloc.s 4
-		IL_0177: ldstr "length"
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0181: stloc.s 11
-		IL_0183: ldloc.s 10
-		IL_0185: ldstr "log"
-		IL_018a: ldloc.s 11
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0191: pop
-		IL_0192: ldc.r8 0.0
-		IL_019b: stloc.s 5
-		// loop start (head: IL_019d)
-			IL_019d: ldloc.s 5
-			IL_019f: stloc.s 12
-			IL_01a1: ldloc.s 4
-			IL_01a3: ldstr "length"
-			IL_01a8: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_01ad: stloc.s 7
-			IL_01af: ldloc.s 12
-			IL_01b1: ldloc.s 7
-			IL_01b3: clt
-			IL_01b5: brfalse IL_01f8
+		IL_0131: ldloc.1
+		IL_0132: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0137: stloc.s 7
+		IL_0139: ldc.r8 20
+		IL_0142: neg
+		IL_0143: stloc.s 13
+		IL_0145: ldloc.s 13
+		IL_0147: box [System.Runtime]System.Double
+		IL_014c: stloc.s 10
+		IL_014e: ldloc.s 7
+		IL_0150: ldstr "slice"
+		IL_0155: ldloc.s 10
+		IL_0157: ldc.r8 2
+		IL_0160: box [System.Runtime]System.Double
+		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_016a: stloc.s 4
+		IL_016c: ldstr "console"
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017b: stloc.s 11
+		IL_017d: ldloc.s 4
+		IL_017f: ldstr "length"
+		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0189: stloc.s 12
+		IL_018b: ldloc.s 11
+		IL_018d: ldstr "log"
+		IL_0192: ldloc.s 12
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0199: pop
+		IL_019a: ldc.r8 0.0
+		IL_01a3: stloc.s 5
+		// loop start (head: IL_01a5)
+			IL_01a5: ldloc.s 5
+			IL_01a7: stloc.s 13
+			IL_01a9: ldloc.s 4
+			IL_01ab: ldstr "length"
+			IL_01b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_01b5: stloc.s 8
+			IL_01b7: ldloc.s 13
+			IL_01b9: ldloc.s 8
+			IL_01bb: clt
+			IL_01bd: brfalse IL_0200
 
-			IL_01ba: ldstr "console"
-			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c9: stloc.s 11
-			IL_01cb: ldloc.s 4
-			IL_01cd: ldloc.s 5
-			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01d4: stloc.s 10
-			IL_01d6: ldloc.s 11
-			IL_01d8: ldstr "log"
-			IL_01dd: ldloc.s 10
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01e4: pop
-			IL_01e5: ldloc.s 5
-			IL_01e7: ldc.r8 1
-			IL_01f0: add
-			IL_01f1: stloc.s 5
-			IL_01f3: br IL_019d
+			IL_01c2: ldstr "console"
+			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01d1: stloc.s 12
+			IL_01d3: ldloc.s 4
+			IL_01d5: ldloc.s 5
+			IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01dc: stloc.s 11
+			IL_01de: ldloc.s 12
+			IL_01e0: ldstr "log"
+			IL_01e5: ldloc.s 11
+			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01ec: pop
+			IL_01ed: ldloc.s 5
+			IL_01ef: ldc.r8 1
+			IL_01f8: add
+			IL_01f9: stloc.s 5
+			IL_01fb: br IL_01a5
 		// end loop
 
-		IL_01f8: ldstr "console"
-		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0207: stloc.s 10
-		IL_0209: ldloc.1
+		IL_0200: ldstr "console"
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020f: ldstr "slice"
-		IL_0214: ldc.r8 3
-		IL_021d: box [System.Runtime]System.Double
-		IL_0222: ldc.r8 1
-		IL_022b: box [System.Runtime]System.Double
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0235: stloc.s 11
-		IL_0237: ldloc.s 11
-		IL_0239: ldstr "length"
-		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0243: stloc.s 11
-		IL_0245: ldloc.s 10
-		IL_0247: ldstr "log"
-		IL_024c: ldloc.s 11
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0253: pop
-		IL_0254: ldstr "console"
-		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0263: stloc.s 11
-		IL_0265: ldloc.1
-		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026b: ldstr "slice"
-		IL_0270: ldc.r8 10
-		IL_0279: box [System.Runtime]System.Double
-		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0283: stloc.s 10
-		IL_0285: ldloc.s 10
-		IL_0287: ldstr "length"
-		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0291: stloc.s 10
-		IL_0293: ldloc.s 11
-		IL_0295: ldstr "log"
-		IL_029a: ldloc.s 10
-		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a1: pop
-		IL_02a2: ret
+		IL_020f: stloc.s 11
+		IL_0211: ldloc.1
+		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0217: stloc.s 7
+		IL_0219: ldloc.s 7
+		IL_021b: ldstr "slice"
+		IL_0220: ldc.r8 3
+		IL_0229: box [System.Runtime]System.Double
+		IL_022e: ldc.r8 1
+		IL_0237: box [System.Runtime]System.Double
+		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0241: stloc.s 12
+		IL_0243: ldloc.s 12
+		IL_0245: ldstr "length"
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_024f: stloc.s 12
+		IL_0251: ldloc.s 11
+		IL_0253: ldstr "log"
+		IL_0258: ldloc.s 12
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025f: pop
+		IL_0260: ldstr "console"
+		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_026f: stloc.s 12
+		IL_0271: ldloc.1
+		IL_0272: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0277: stloc.s 7
+		IL_0279: ldloc.s 7
+		IL_027b: ldstr "slice"
+		IL_0280: ldc.r8 10
+		IL_0289: box [System.Runtime]System.Double
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0293: stloc.s 11
+		IL_0295: ldloc.s 11
+		IL_0297: ldstr "length"
+		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a1: stloc.s 11
+		IL_02a3: ldloc.s 12
+		IL_02a5: ldstr "log"
+		IL_02aa: ldloc.s 11
+		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b1: pop
+		IL_02b2: ret
 	} // end of method Int32Array_Slice_RelativeIndices::__js_module_init__
 
 } // end of class Modules.Int32Array_Slice_RelativeIndices
@@ -347,7 +356,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x232c
+		// Method begins at RVA 0x233c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Subarray_ViewSemantics.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Subarray_ViewSemantics.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22dc
+			// Method begins at RVA 0x22e0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 640 (0x280)
+		// Code size: 644 (0x284)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Subarray_ViewSemantics/Scope,
@@ -48,13 +48,14 @@
 			[2] object,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] object,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[6] object,
 			[7] object,
-			[8] bool,
-			[9] object,
+			[8] object,
+			[9] bool,
 			[10] object,
-			[11] float64
+			[11] object,
+			[12] float64
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Subarray_ViewSemantics/Scope::.ctor()
@@ -79,158 +80,160 @@
 		IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
 		IL_0052: stloc.1
 		IL_0053: ldloc.1
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0059: ldstr "subarray"
-		IL_005e: ldc.r8 1
-		IL_0067: box [System.Runtime]System.Double
-		IL_006c: ldc.r8 3
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_007f: stloc.2
-		IL_0080: ldstr "console"
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008f: stloc.s 5
-		IL_0091: ldloc.2
-		IL_0092: ldstr "length"
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009c: stloc.s 6
-		IL_009e: ldloc.s 5
-		IL_00a0: ldstr "log"
-		IL_00a5: ldloc.s 6
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ac: pop
-		IL_00ad: ldstr "console"
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bc: stloc.s 6
-		IL_00be: ldloc.2
-		IL_00bf: ldstr "byteOffset"
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c9: stloc.s 5
-		IL_00cb: ldloc.s 6
-		IL_00cd: ldstr "log"
-		IL_00d2: ldloc.s 5
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d9: pop
-		IL_00da: ldstr "console"
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e9: stloc.s 5
-		IL_00eb: ldloc.2
-		IL_00ec: ldstr "byteLength"
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f6: stloc.s 6
-		IL_00f8: ldloc.s 5
-		IL_00fa: ldstr "log"
-		IL_00ff: ldloc.s 6
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0106: pop
-		IL_0107: ldstr "console"
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0116: stloc.s 6
-		IL_0118: ldloc.2
-		IL_0119: ldstr "buffer"
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0123: stloc.s 5
-		IL_0125: ldloc.1
-		IL_0126: ldstr "buffer"
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0130: stloc.s 7
-		IL_0132: ldloc.s 5
-		IL_0134: ldloc.s 7
-		IL_0136: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_013b: stloc.s 8
-		IL_013d: ldloc.s 8
-		IL_013f: box [System.Runtime]System.Boolean
-		IL_0144: stloc.s 9
-		IL_0146: ldloc.s 6
-		IL_0148: ldstr "log"
-		IL_014d: ldloc.s 9
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0154: pop
-		IL_0155: ldloc.2
-		IL_0156: ldc.r8 0.0
-		IL_015f: ldc.r8 99
-		IL_0168: ldc.i4.1
-		IL_0169: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_016e: ldstr "console"
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017d: ldloc.1
-		IL_017e: ldc.r8 1
-		IL_0187: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_018c: box [System.Runtime]System.Double
-		IL_0191: stloc.s 10
-		IL_0193: ldstr "log"
-		IL_0198: ldloc.s 10
-		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019f: pop
-		IL_01a0: ldloc.2
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a6: ldstr "slice"
-		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01b0: stloc.3
-		IL_01b1: ldstr "console"
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c0: stloc.s 6
-		IL_01c2: ldloc.3
-		IL_01c3: ldstr "buffer"
-		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01cd: stloc.s 7
-		IL_01cf: ldloc.1
-		IL_01d0: ldstr "buffer"
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01da: stloc.s 5
-		IL_01dc: ldloc.s 7
-		IL_01de: ldloc.s 5
-		IL_01e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01e5: stloc.s 8
-		IL_01e7: ldloc.s 8
-		IL_01e9: box [System.Runtime]System.Boolean
-		IL_01ee: stloc.s 9
-		IL_01f0: ldloc.s 6
-		IL_01f2: ldstr "log"
-		IL_01f7: ldloc.s 9
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fe: pop
-		IL_01ff: ldc.r8 7
-		IL_0208: neg
-		IL_0209: stloc.s 11
-		IL_020b: ldloc.3
-		IL_020c: ldc.r8 0.0
-		IL_0215: ldloc.s 11
-		IL_0217: ldc.i4.1
-		IL_0218: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_021d: ldstr "console"
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022c: stloc.s 6
-		IL_022e: ldloc.2
-		IL_022f: ldc.r8 0.0
-		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_023d: stloc.s 5
-		IL_023f: ldloc.s 6
-		IL_0241: ldstr "log"
-		IL_0246: ldloc.s 5
-		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024d: pop
-		IL_024e: ldstr "console"
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025d: stloc.s 5
-		IL_025f: ldloc.3
-		IL_0260: ldc.r8 0.0
-		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_026e: stloc.s 6
-		IL_0270: ldloc.s 5
-		IL_0272: ldstr "log"
-		IL_0277: ldloc.s 6
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027e: pop
-		IL_027f: ret
+		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0059: stloc.s 5
+		IL_005b: ldloc.s 5
+		IL_005d: ldstr "subarray"
+		IL_0062: ldc.r8 1
+		IL_006b: box [System.Runtime]System.Double
+		IL_0070: ldc.r8 3
+		IL_0079: box [System.Runtime]System.Double
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0083: stloc.2
+		IL_0084: ldstr "console"
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0093: stloc.s 6
+		IL_0095: ldloc.2
+		IL_0096: ldstr "length"
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a0: stloc.s 7
+		IL_00a2: ldloc.s 6
+		IL_00a4: ldstr "log"
+		IL_00a9: ldloc.s 7
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b0: pop
+		IL_00b1: ldstr "console"
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c0: stloc.s 7
+		IL_00c2: ldloc.2
+		IL_00c3: ldstr "byteOffset"
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00cd: stloc.s 6
+		IL_00cf: ldloc.s 7
+		IL_00d1: ldstr "log"
+		IL_00d6: ldloc.s 6
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00dd: pop
+		IL_00de: ldstr "console"
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ed: stloc.s 6
+		IL_00ef: ldloc.2
+		IL_00f0: ldstr "byteLength"
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00fa: stloc.s 7
+		IL_00fc: ldloc.s 6
+		IL_00fe: ldstr "log"
+		IL_0103: ldloc.s 7
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010a: pop
+		IL_010b: ldstr "console"
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011a: stloc.s 7
+		IL_011c: ldloc.2
+		IL_011d: ldstr "buffer"
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0127: stloc.s 6
+		IL_0129: ldloc.1
+		IL_012a: ldstr "buffer"
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0134: stloc.s 8
+		IL_0136: ldloc.s 6
+		IL_0138: ldloc.s 8
+		IL_013a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_013f: stloc.s 9
+		IL_0141: ldloc.s 9
+		IL_0143: box [System.Runtime]System.Boolean
+		IL_0148: stloc.s 10
+		IL_014a: ldloc.s 7
+		IL_014c: ldstr "log"
+		IL_0151: ldloc.s 10
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0158: pop
+		IL_0159: ldloc.2
+		IL_015a: ldc.r8 0.0
+		IL_0163: ldc.r8 99
+		IL_016c: ldc.i4.1
+		IL_016d: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0172: ldstr "console"
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0181: ldloc.1
+		IL_0182: ldc.r8 1
+		IL_018b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_0190: box [System.Runtime]System.Double
+		IL_0195: stloc.s 11
+		IL_0197: ldstr "log"
+		IL_019c: ldloc.s 11
+		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a3: pop
+		IL_01a4: ldloc.2
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01aa: ldstr "slice"
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01b4: stloc.3
+		IL_01b5: ldstr "console"
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c4: stloc.s 7
+		IL_01c6: ldloc.3
+		IL_01c7: ldstr "buffer"
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d1: stloc.s 8
+		IL_01d3: ldloc.1
+		IL_01d4: ldstr "buffer"
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01de: stloc.s 6
+		IL_01e0: ldloc.s 8
+		IL_01e2: ldloc.s 6
+		IL_01e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01e9: stloc.s 9
+		IL_01eb: ldloc.s 9
+		IL_01ed: box [System.Runtime]System.Boolean
+		IL_01f2: stloc.s 10
+		IL_01f4: ldloc.s 7
+		IL_01f6: ldstr "log"
+		IL_01fb: ldloc.s 10
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0202: pop
+		IL_0203: ldc.r8 7
+		IL_020c: neg
+		IL_020d: stloc.s 12
+		IL_020f: ldloc.3
+		IL_0210: ldc.r8 0.0
+		IL_0219: ldloc.s 12
+		IL_021b: ldc.i4.1
+		IL_021c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0221: ldstr "console"
+		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0230: stloc.s 7
+		IL_0232: ldloc.2
+		IL_0233: ldc.r8 0.0
+		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0241: stloc.s 6
+		IL_0243: ldloc.s 7
+		IL_0245: ldstr "log"
+		IL_024a: ldloc.s 6
+		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0251: pop
+		IL_0252: ldstr "console"
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0261: stloc.s 6
+		IL_0263: ldloc.3
+		IL_0264: ldc.r8 0.0
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0272: stloc.s 7
+		IL_0274: ldloc.s 6
+		IL_0276: ldstr "log"
+		IL_027b: ldloc.s 7
+		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0282: pop
+		IL_0283: ret
 	} // end of method Int32Array_Subarray_ViewSemantics::__js_module_init__
 
 } // end of class Modules.Int32Array_Subarray_ViewSemantics
@@ -242,7 +245,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e5
+		// Method begins at RVA 0x22e9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ConstructorAndSet_Errors.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ConstructorAndSet_Errors.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ed
+				// Method begins at RVA 0x23f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f6
+				// Method begins at RVA 0x23fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ff
+				// Method begins at RVA 0x2407
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2408
+				// Method begins at RVA 0x2410
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2411
+				// Method begins at RVA 0x2419
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x241a
+				// Method begins at RVA 0x2422
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2423
+				// Method begins at RVA 0x242b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +158,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x242c
+				// Method begins at RVA 0x2434
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -176,7 +176,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23e4
+			// Method begins at RVA 0x23ec
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -202,7 +202,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 851 (0x353)
+		// Code size: 859 (0x35b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_ConstructorAndSet_Errors/Scope,
@@ -224,7 +224,8 @@
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
 			[17] float64,
 			[18] object,
-			[19] object
+			[19] object,
+			[20] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array
 		)
 
 		IL_0000: newobj instance void Modules.TypedArray_ConstructorAndSet_Errors/Scope::.ctor()
@@ -405,134 +406,138 @@
 		{
 			IL_01f3: nop
 			IL_01f4: ldloc.s 7
-			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01fb: ldstr "set"
-			IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0205: pop
-			IL_0206: leave IL_029e
+			IL_01f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+			IL_01fb: stloc.s 20
+			IL_01fd: ldloc.s 20
+			IL_01ff: ldstr "set"
+			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0209: pop
+			IL_020a: leave IL_02a2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_020b: stloc.s 8
-			IL_020d: ldloc.s 8
-			IL_020f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0214: dup
-			IL_0215: brtrue IL_022b
+			IL_020f: stloc.s 8
+			IL_0211: ldloc.s 8
+			IL_0213: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0218: dup
+			IL_0219: brtrue IL_022f
 
-			IL_021a: pop
-			IL_021b: ldloc.s 8
-			IL_021d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0222: dup
-			IL_0223: brtrue IL_0237
+			IL_021e: pop
+			IL_021f: ldloc.s 8
+			IL_0221: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0226: dup
+			IL_0227: brtrue IL_023b
 
-			IL_0228: pop
-			IL_0229: rethrow
+			IL_022c: pop
+			IL_022d: rethrow
 
-			IL_022b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0230: stloc.s 9
-			IL_0232: br IL_0239
+			IL_022f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0234: stloc.s 9
+			IL_0236: br IL_023d
 
-			IL_0237: stloc.s 9
+			IL_023b: stloc.s 9
 
-			IL_0239: ldloc.s 9
-			IL_023b: stloc.s 10
-			IL_023d: ldstr "console"
-			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_024c: stloc.s 15
-			IL_024e: ldloc.s 10
-			IL_0250: ldstr "name"
-			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_025a: stloc.s 19
-			IL_025c: ldloc.s 15
-			IL_025e: ldstr "log"
-			IL_0263: ldloc.s 19
-			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_026a: pop
-			IL_026b: ldstr "console"
-			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027a: stloc.s 19
-			IL_027c: ldloc.s 10
-			IL_027e: ldstr "message"
-			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0288: stloc.s 15
-			IL_028a: ldloc.s 19
-			IL_028c: ldstr "log"
-			IL_0291: ldloc.s 15
-			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0298: pop
-			IL_0299: leave IL_029e
+			IL_023d: ldloc.s 9
+			IL_023f: stloc.s 10
+			IL_0241: ldstr "console"
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0250: stloc.s 15
+			IL_0252: ldloc.s 10
+			IL_0254: ldstr "name"
+			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_025e: stloc.s 19
+			IL_0260: ldloc.s 15
+			IL_0262: ldstr "log"
+			IL_0267: ldloc.s 19
+			IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_026e: pop
+			IL_026f: ldstr "console"
+			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_027e: stloc.s 19
+			IL_0280: ldloc.s 10
+			IL_0282: ldstr "message"
+			IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_028c: stloc.s 15
+			IL_028e: ldloc.s 19
+			IL_0290: ldstr "log"
+			IL_0295: ldloc.s 15
+			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_029c: pop
+			IL_029d: leave IL_02a2
 		} // end handler
 		.try
 		{
-			IL_029e: nop
-			IL_029f: ldloc.s 7
-			IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a6: ldstr "set"
-			IL_02ab: ldc.i4.0
-			IL_02ac: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02b6: pop
-			IL_02b7: leave IL_034f
+			IL_02a2: nop
+			IL_02a3: ldloc.s 7
+			IL_02a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+			IL_02aa: stloc.s 20
+			IL_02ac: ldloc.s 20
+			IL_02ae: ldstr "set"
+			IL_02b3: ldc.i4.0
+			IL_02b4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02be: pop
+			IL_02bf: leave IL_0357
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02bc: stloc.s 11
-			IL_02be: ldloc.s 11
-			IL_02c0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02c5: dup
-			IL_02c6: brtrue IL_02dc
+			IL_02c4: stloc.s 11
+			IL_02c6: ldloc.s 11
+			IL_02c8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02cd: dup
+			IL_02ce: brtrue IL_02e4
 
-			IL_02cb: pop
-			IL_02cc: ldloc.s 11
-			IL_02ce: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02d3: dup
-			IL_02d4: brtrue IL_02e8
+			IL_02d3: pop
+			IL_02d4: ldloc.s 11
+			IL_02d6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02db: dup
+			IL_02dc: brtrue IL_02f0
 
-			IL_02d9: pop
-			IL_02da: rethrow
+			IL_02e1: pop
+			IL_02e2: rethrow
 
-			IL_02dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02e1: stloc.s 12
-			IL_02e3: br IL_02ea
+			IL_02e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02e9: stloc.s 12
+			IL_02eb: br IL_02f2
 
-			IL_02e8: stloc.s 12
+			IL_02f0: stloc.s 12
 
-			IL_02ea: ldloc.s 12
-			IL_02ec: stloc.s 13
-			IL_02ee: ldstr "console"
-			IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02fd: stloc.s 15
-			IL_02ff: ldloc.s 13
-			IL_0301: ldstr "name"
-			IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_030b: stloc.s 19
-			IL_030d: ldloc.s 15
-			IL_030f: ldstr "log"
-			IL_0314: ldloc.s 19
-			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_031b: pop
-			IL_031c: ldstr "console"
-			IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_032b: stloc.s 19
-			IL_032d: ldloc.s 13
-			IL_032f: ldstr "message"
-			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0339: stloc.s 15
-			IL_033b: ldloc.s 19
-			IL_033d: ldstr "log"
-			IL_0342: ldloc.s 15
-			IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0349: pop
-			IL_034a: leave IL_034f
+			IL_02f2: ldloc.s 12
+			IL_02f4: stloc.s 13
+			IL_02f6: ldstr "console"
+			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0305: stloc.s 15
+			IL_0307: ldloc.s 13
+			IL_0309: ldstr "name"
+			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0313: stloc.s 19
+			IL_0315: ldloc.s 15
+			IL_0317: ldstr "log"
+			IL_031c: ldloc.s 19
+			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0323: pop
+			IL_0324: ldstr "console"
+			IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0333: stloc.s 19
+			IL_0335: ldloc.s 13
+			IL_0337: ldstr "message"
+			IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0341: stloc.s 15
+			IL_0343: ldloc.s 19
+			IL_0345: ldstr "log"
+			IL_034a: ldloc.s 15
+			IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0351: pop
+			IL_0352: leave IL_0357
 		} // end handler
 
-		IL_034f: ldnull
-		IL_0350: stloc.s 14
-		IL_0352: ret
+		IL_0357: ldnull
+		IL_0358: stloc.s 14
+		IL_035a: ret
 	} // end of method TypedArray_ConstructorAndSet_Errors::__js_module_init__
 
 } // end of class Modules.TypedArray_ConstructorAndSet_Errors
@@ -544,7 +549,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2435
+		// Method begins at RVA 0x243d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2518
+				// Method begins at RVA 0x2528
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x24d0
+			// Method begins at RVA 0x24e0
 			// Header size: 12
 			// Code size: 51 (0x33)
 			.maxstack 8
@@ -87,7 +87,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2521
+				// Method begins at RVA 0x2531
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -107,7 +107,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x252a
+				// Method begins at RVA 0x253a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -128,7 +128,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x250f
+			// Method begins at RVA 0x251f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -154,7 +154,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1124 (0x464)
+		// Code size: 1140 (0x474)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope,
@@ -170,8 +170,12 @@
 			[10] object,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[12] object,
-			[13] object,
-			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.Int8Array,
+			[14] object,
+			[15] class [JavaScriptRuntime]JavaScriptRuntime.Int16Array,
+			[16] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
+			[17] class [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray,
+			[18] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
 		)
 
 		IL_0000: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::.ctor()
@@ -215,268 +219,276 @@
 		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00a1: stloc.s 12
 		IL_00a3: ldloc.1
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a9: ldstr "join"
-		IL_00ae: ldstr "|"
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b8: stloc.s 13
-		IL_00ba: ldloc.s 12
-		IL_00bc: ldstr "log"
-		IL_00c1: ldloc.s 13
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c8: pop
-		IL_00c9: ldc.i4.8
-		IL_00ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00cf: dup
-		IL_00d0: ldc.r8 32769
-		IL_00d9: neg
-		IL_00da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00df: dup
-		IL_00e0: ldc.r8 32768
-		IL_00e9: neg
-		IL_00ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00ef: dup
-		IL_00f0: ldc.r8 32767
-		IL_00f9: neg
-		IL_00fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00ff: dup
-		IL_0100: ldc.r8 32767
-		IL_0109: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_010e: dup
-		IL_010f: ldc.r8 32768
-		IL_0118: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_011d: dup
-		IL_011e: ldc.r8 32769
-		IL_0127: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_012c: dup
-		IL_012d: ldc.r8 65535
-		IL_0136: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_013b: dup
-		IL_013c: ldc.r8 65536
-		IL_0145: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_014a: stloc.s 11
-		IL_014c: ldloc.s 11
-		IL_014e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int16Array::.ctor(object)
-		IL_0153: stloc.2
-		IL_0154: ldstr "console"
-		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0163: stloc.s 13
-		IL_0165: ldloc.2
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016b: ldstr "join"
-		IL_0170: ldstr "|"
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017a: stloc.s 12
-		IL_017c: ldloc.s 13
-		IL_017e: ldstr "log"
-		IL_0183: ldloc.s 12
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018a: pop
-		IL_018b: ldc.i4.8
-		IL_018c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0191: dup
-		IL_0192: ldc.r8 1
-		IL_019b: neg
-		IL_019c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01a1: dup
-		IL_01a2: ldc.r8 0.0
-		IL_01ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01b0: dup
-		IL_01b1: ldc.r8 1
-		IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01bf: dup
-		IL_01c0: ldc.r8 255
-		IL_01c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01ce: dup
-		IL_01cf: ldc.r8 256
-		IL_01d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01dd: dup
-		IL_01de: ldc.r8 257
-		IL_01e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01ec: dup
-		IL_01ed: ldc.r8 511
-		IL_01f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01fb: dup
-		IL_01fc: ldc.r8 1.9
-		IL_0205: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_020a: stloc.s 11
-		IL_020c: ldloc.s 11
-		IL_020e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_0213: stloc.3
-		IL_0214: ldstr "console"
-		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0223: stloc.s 12
-		IL_0225: ldloc.3
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int8Array>(!!0)
+		IL_00a9: stloc.s 13
+		IL_00ab: ldloc.s 13
+		IL_00ad: ldstr "join"
+		IL_00b2: ldstr "|"
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bc: stloc.s 14
+		IL_00be: ldloc.s 12
+		IL_00c0: ldstr "log"
+		IL_00c5: ldloc.s 14
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cc: pop
+		IL_00cd: ldc.i4.8
+		IL_00ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00d3: dup
+		IL_00d4: ldc.r8 32769
+		IL_00dd: neg
+		IL_00de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00e3: dup
+		IL_00e4: ldc.r8 32768
+		IL_00ed: neg
+		IL_00ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00f3: dup
+		IL_00f4: ldc.r8 32767
+		IL_00fd: neg
+		IL_00fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0103: dup
+		IL_0104: ldc.r8 32767
+		IL_010d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0112: dup
+		IL_0113: ldc.r8 32768
+		IL_011c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0121: dup
+		IL_0122: ldc.r8 32769
+		IL_012b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0130: dup
+		IL_0131: ldc.r8 65535
+		IL_013a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_013f: dup
+		IL_0140: ldc.r8 65536
+		IL_0149: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_014e: stloc.s 11
+		IL_0150: ldloc.s 11
+		IL_0152: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int16Array::.ctor(object)
+		IL_0157: stloc.2
+		IL_0158: ldstr "console"
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0167: stloc.s 14
+		IL_0169: ldloc.2
+		IL_016a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int16Array>(!!0)
+		IL_016f: stloc.s 15
+		IL_0171: ldloc.s 15
+		IL_0173: ldstr "join"
+		IL_0178: ldstr "|"
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0182: stloc.s 12
+		IL_0184: ldloc.s 14
+		IL_0186: ldstr "log"
+		IL_018b: ldloc.s 12
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0192: pop
+		IL_0193: ldc.i4.8
+		IL_0194: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0199: dup
+		IL_019a: ldc.r8 1
+		IL_01a3: neg
+		IL_01a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01a9: dup
+		IL_01aa: ldc.r8 0.0
+		IL_01b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01b8: dup
+		IL_01b9: ldc.r8 1
+		IL_01c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01c7: dup
+		IL_01c8: ldc.r8 255
+		IL_01d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01d6: dup
+		IL_01d7: ldc.r8 256
+		IL_01e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01e5: dup
+		IL_01e6: ldc.r8 257
+		IL_01ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01f4: dup
+		IL_01f5: ldc.r8 511
+		IL_01fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0203: dup
+		IL_0204: ldc.r8 1.9
+		IL_020d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0212: stloc.s 11
+		IL_0214: ldloc.s 11
+		IL_0216: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_021b: stloc.3
+		IL_021c: ldstr "console"
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022b: ldstr "join"
-		IL_0230: ldstr "|"
-		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023a: stloc.s 13
-		IL_023c: ldloc.s 12
-		IL_023e: ldstr "log"
-		IL_0243: ldloc.s 13
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024a: pop
-		IL_024b: ldc.i4.s 10
-		IL_024d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0252: dup
-		IL_0253: ldc.r8 20
-		IL_025c: neg
-		IL_025d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0262: dup
-		IL_0263: ldc.r8 0.5
-		IL_026c: neg
-		IL_026d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0272: dup
-		IL_0273: ldc.r8 0.49
-		IL_027c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0281: dup
-		IL_0282: ldc.r8 0.5
-		IL_028b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0290: dup
-		IL_0291: ldc.r8 1.5
-		IL_029a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_029f: dup
-		IL_02a0: ldc.r8 2.5
-		IL_02a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02ae: dup
-		IL_02af: ldc.r8 254.6
-		IL_02b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02bd: dup
-		IL_02be: ldc.r8 255.4
-		IL_02c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02cc: dup
-		IL_02cd: ldc.r8 300
-		IL_02d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02db: dup
-		IL_02dc: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_02e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02ea: stloc.s 11
-		IL_02ec: ldloc.s 11
-		IL_02ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::.ctor(object)
-		IL_02f3: stloc.s 4
-		IL_02f5: ldstr "console"
-		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0304: stloc.s 13
-		IL_0306: ldloc.s 4
-		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_030d: ldstr "join"
-		IL_0312: ldstr "|"
-		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_031c: stloc.s 12
-		IL_031e: ldloc.s 13
-		IL_0320: ldstr "log"
-		IL_0325: ldloc.s 12
+		IL_022b: stloc.s 12
+		IL_022d: ldloc.3
+		IL_022e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
+		IL_0233: stloc.s 16
+		IL_0235: ldloc.s 16
+		IL_0237: ldstr "join"
+		IL_023c: ldstr "|"
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0246: stloc.s 14
+		IL_0248: ldloc.s 12
+		IL_024a: ldstr "log"
+		IL_024f: ldloc.s 14
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0256: pop
+		IL_0257: ldc.i4.s 10
+		IL_0259: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_025e: dup
+		IL_025f: ldc.r8 20
+		IL_0268: neg
+		IL_0269: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_026e: dup
+		IL_026f: ldc.r8 0.5
+		IL_0278: neg
+		IL_0279: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_027e: dup
+		IL_027f: ldc.r8 0.49
+		IL_0288: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_028d: dup
+		IL_028e: ldc.r8 0.5
+		IL_0297: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_029c: dup
+		IL_029d: ldc.r8 1.5
+		IL_02a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02ab: dup
+		IL_02ac: ldc.r8 2.5
+		IL_02b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02ba: dup
+		IL_02bb: ldc.r8 254.6
+		IL_02c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02c9: dup
+		IL_02ca: ldc.r8 255.4
+		IL_02d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02d8: dup
+		IL_02d9: ldc.r8 300
+		IL_02e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02e7: dup
+		IL_02e8: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_02f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02f6: stloc.s 11
+		IL_02f8: ldloc.s 11
+		IL_02fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::.ctor(object)
+		IL_02ff: stloc.s 4
+		IL_0301: ldstr "console"
+		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0310: stloc.s 14
+		IL_0312: ldloc.s 4
+		IL_0314: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray>(!!0)
+		IL_0319: stloc.s 17
+		IL_031b: ldloc.s 17
+		IL_031d: ldstr "join"
+		IL_0322: ldstr "|"
 		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_032c: pop
-		IL_032d: ldloc.0
-		IL_032e: ldc.r8 0.0
-		IL_0337: box [System.Runtime]System.Double
-		IL_033c: stfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
-		IL_0341: ldloc.0
-		IL_0342: castclass Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope
-		IL_0347: ldftn object Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue::__js_call__(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope, object)
-		IL_034d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0352: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0357: ldc.i4.0
-		IL_0358: conv.r8
-		IL_0359: ldstr ""
-		IL_035e: ldc.i4.0
-		IL_035f: ldc.i4.1
-		IL_0360: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0365: stloc.s 14
-		IL_0367: ldloc.s 14
-		IL_0369: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_036e: stloc.s 14
-		IL_0370: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0375: dup
-		IL_0376: ldstr "valueOf"
-		IL_037b: ldloc.s 14
-		IL_037d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0382: stloc.s 5
-		IL_0384: ldc.r8 0.0
-		IL_038d: box [System.Runtime]System.Double
-		IL_0392: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_0397: stloc.s 6
-		IL_0399: ldloc.s 6
-		IL_039b: ldc.r8 0.0
-		IL_03a4: ldloc.s 5
-		IL_03a6: ldc.i4.1
-		IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_03ac: pop
-		IL_03ad: ldstr "console"
-		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03bc: stloc.s 12
-		IL_03be: ldloc.0
-		IL_03bf: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
-		IL_03c4: stloc.s 13
-		IL_03c6: ldloc.s 12
-		IL_03c8: ldstr "log"
-		IL_03cd: ldloc.s 13
-		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03d4: pop
+		IL_032c: stloc.s 12
+		IL_032e: ldloc.s 14
+		IL_0330: ldstr "log"
+		IL_0335: ldloc.s 12
+		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_033c: pop
+		IL_033d: ldloc.0
+		IL_033e: ldc.r8 0.0
+		IL_0347: box [System.Runtime]System.Double
+		IL_034c: stfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
+		IL_0351: ldloc.0
+		IL_0352: castclass Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope
+		IL_0357: ldftn object Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue::__js_call__(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope, object)
+		IL_035d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0362: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0367: ldc.i4.0
+		IL_0368: conv.r8
+		IL_0369: ldstr ""
+		IL_036e: ldc.i4.0
+		IL_036f: ldc.i4.1
+		IL_0370: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0375: stloc.s 18
+		IL_0377: ldloc.s 18
+		IL_0379: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_037e: stloc.s 18
+		IL_0380: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0385: dup
+		IL_0386: ldstr "valueOf"
+		IL_038b: ldloc.s 18
+		IL_038d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0392: stloc.s 5
+		IL_0394: ldc.r8 0.0
+		IL_039d: box [System.Runtime]System.Double
+		IL_03a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_03a7: stloc.s 6
+		IL_03a9: ldloc.s 6
+		IL_03ab: ldc.r8 0.0
+		IL_03b4: ldloc.s 5
+		IL_03b6: ldc.i4.1
+		IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_03bc: pop
+		IL_03bd: ldstr "console"
+		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03cc: stloc.s 12
+		IL_03ce: ldloc.0
+		IL_03cf: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
+		IL_03d4: stloc.s 14
+		IL_03d6: ldloc.s 12
+		IL_03d8: ldstr "log"
+		IL_03dd: ldloc.s 14
+		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03e4: pop
 		.try
 		{
-			IL_03d5: nop
-			IL_03d6: ldstr "value"
-			IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
-			IL_03e0: stloc.s 13
-			IL_03e2: ldloc.s 6
-			IL_03e4: ldc.r8 0.0
-			IL_03ed: ldloc.s 13
-			IL_03ef: ldc.i4.1
-			IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_03f5: pop
-			IL_03f6: leave IL_0460
+			IL_03e5: nop
+			IL_03e6: ldstr "value"
+			IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
+			IL_03f0: stloc.s 14
+			IL_03f2: ldloc.s 6
+			IL_03f4: ldc.r8 0.0
+			IL_03fd: ldloc.s 14
+			IL_03ff: ldc.i4.1
+			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_0405: pop
+			IL_0406: leave IL_0470
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03fb: stloc.s 7
-			IL_03fd: ldloc.s 7
-			IL_03ff: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0404: dup
-			IL_0405: brtrue IL_041b
+			IL_040b: stloc.s 7
+			IL_040d: ldloc.s 7
+			IL_040f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0414: dup
+			IL_0415: brtrue IL_042b
 
-			IL_040a: pop
-			IL_040b: ldloc.s 7
-			IL_040d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0412: dup
-			IL_0413: brtrue IL_0427
+			IL_041a: pop
+			IL_041b: ldloc.s 7
+			IL_041d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0422: dup
+			IL_0423: brtrue IL_0437
 
-			IL_0418: pop
-			IL_0419: rethrow
+			IL_0428: pop
+			IL_0429: rethrow
 
-			IL_041b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0420: stloc.s 8
-			IL_0422: br IL_0429
+			IL_042b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0430: stloc.s 8
+			IL_0432: br IL_0439
 
-			IL_0427: stloc.s 8
+			IL_0437: stloc.s 8
 
-			IL_0429: ldloc.s 8
-			IL_042b: stloc.s 9
-			IL_042d: ldstr "console"
-			IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_043c: stloc.s 13
-			IL_043e: ldloc.s 9
-			IL_0440: ldstr "name"
-			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_044a: stloc.s 12
-			IL_044c: ldloc.s 13
-			IL_044e: ldstr "log"
-			IL_0453: ldloc.s 12
-			IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_045a: pop
-			IL_045b: leave IL_0460
+			IL_0439: ldloc.s 8
+			IL_043b: stloc.s 9
+			IL_043d: ldstr "console"
+			IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_044c: stloc.s 14
+			IL_044e: ldloc.s 9
+			IL_0450: ldstr "name"
+			IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_045a: stloc.s 12
+			IL_045c: ldloc.s 14
+			IL_045e: ldstr "log"
+			IL_0463: ldloc.s 12
+			IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_046a: pop
+			IL_046b: leave IL_0470
 		} // end handler
 
-		IL_0460: ldnull
-		IL_0461: stloc.s 10
-		IL_0463: ret
+		IL_0470: ldnull
+		IL_0471: stloc.s 10
+		IL_0473: ret
 	} // end of method TypedArray_SignedAndClamped_ConversionSemantics::__js_module_init__
 
 } // end of class Modules.TypedArray_SignedAndClamped_ConversionSemantics
@@ -488,7 +500,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2533
+		// Method begins at RVA 0x2543
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_Static_From_Of.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_Static_From_Of.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f2
+				// Method begins at RVA 0x2302
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a4
+			// Method begins at RVA 0x22b4
 			// Header size: 12
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -81,7 +81,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22fb
+				// Method begins at RVA 0x230b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,7 +105,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22d2
+			// Method begins at RVA 0x22e2
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -127,7 +127,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e9
+			// Method begins at RVA 0x22f9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -153,7 +153,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 581 (0x245)
+		// Code size: 597 (0x255)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_Static_From_Of/Scope,
@@ -165,9 +165,11 @@
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[8] object,
-			[9] object,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[10] object,
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
+			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.Float64Array
 		)
 
 		IL_0000: newobj instance void Modules.TypedArray_Static_From_Of/Scope::.ctor()
@@ -213,126 +215,134 @@
 		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0094: stloc.s 8
 		IL_0096: ldloc.1
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009c: ldstr "join"
-		IL_00a1: ldstr "|"
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ab: stloc.s 9
-		IL_00ad: ldloc.s 8
-		IL_00af: ldstr "log"
-		IL_00b4: ldloc.s 9
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bb: pop
-		IL_00bc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00c1: dup
-		IL_00c2: ldstr "0"
-		IL_00c7: ldc.r8 7
-		IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00d5: dup
-		IL_00d6: ldstr "1"
-		IL_00db: ldc.r8 8
-		IL_00e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00e9: dup
-		IL_00ea: ldstr "length"
-		IL_00ef: ldc.r8 2
-		IL_00f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00fd: call class [JavaScriptRuntime]JavaScriptRuntime.Int32Array [JavaScriptRuntime]JavaScriptRuntime.Int32Array::from(object)
-		IL_0102: stloc.2
-		IL_0103: ldstr "console"
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0112: stloc.s 9
-		IL_0114: ldloc.2
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011a: ldstr "join"
-		IL_011f: ldstr "|"
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0129: stloc.s 8
-		IL_012b: ldloc.s 9
-		IL_012d: ldstr "log"
-		IL_0132: ldloc.s 8
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0139: pop
-		IL_013a: ldc.i4.3
-		IL_013b: newarr [System.Runtime]System.Object
-		IL_0140: dup
-		IL_0141: ldc.i4.0
-		IL_0142: ldc.r8 257
-		IL_014b: box [System.Runtime]System.Double
-		IL_0150: stelem.ref
-		IL_0151: dup
-		IL_0152: ldc.i4.1
-		IL_0153: ldc.r8 1
-		IL_015c: neg
-		IL_015d: box [System.Runtime]System.Double
-		IL_0162: stelem.ref
-		IL_0163: dup
-		IL_0164: ldc.i4.2
-		IL_0165: ldc.r8 3
-		IL_016e: box [System.Runtime]System.Double
-		IL_0173: stelem.ref
-		IL_0174: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
-		IL_0179: stloc.3
-		IL_017a: ldstr "console"
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0189: stloc.s 8
-		IL_018b: ldloc.3
+		IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_009c: stloc.s 9
+		IL_009e: ldloc.s 9
+		IL_00a0: ldstr "join"
+		IL_00a5: ldstr "|"
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00af: stloc.s 10
+		IL_00b1: ldloc.s 8
+		IL_00b3: ldstr "log"
+		IL_00b8: ldloc.s 10
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bf: pop
+		IL_00c0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00c5: dup
+		IL_00c6: ldstr "0"
+		IL_00cb: ldc.r8 7
+		IL_00d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_00d9: dup
+		IL_00da: ldstr "1"
+		IL_00df: ldc.r8 8
+		IL_00e8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_00ed: dup
+		IL_00ee: ldstr "length"
+		IL_00f3: ldc.r8 2
+		IL_00fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0101: call class [JavaScriptRuntime]JavaScriptRuntime.Int32Array [JavaScriptRuntime]JavaScriptRuntime.Int32Array::from(object)
+		IL_0106: stloc.2
+		IL_0107: ldstr "console"
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0116: stloc.s 10
+		IL_0118: ldloc.2
+		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_011e: stloc.s 9
+		IL_0120: ldloc.s 9
+		IL_0122: ldstr "join"
+		IL_0127: ldstr "|"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0131: stloc.s 8
+		IL_0133: ldloc.s 10
+		IL_0135: ldstr "log"
+		IL_013a: ldloc.s 8
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0141: pop
+		IL_0142: ldc.i4.3
+		IL_0143: newarr [System.Runtime]System.Object
+		IL_0148: dup
+		IL_0149: ldc.i4.0
+		IL_014a: ldc.r8 257
+		IL_0153: box [System.Runtime]System.Double
+		IL_0158: stelem.ref
+		IL_0159: dup
+		IL_015a: ldc.i4.1
+		IL_015b: ldc.r8 1
+		IL_0164: neg
+		IL_0165: box [System.Runtime]System.Double
+		IL_016a: stelem.ref
+		IL_016b: dup
+		IL_016c: ldc.i4.2
+		IL_016d: ldc.r8 3
+		IL_0176: box [System.Runtime]System.Double
+		IL_017b: stelem.ref
+		IL_017c: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
+		IL_0181: stloc.3
+		IL_0182: ldstr "console"
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0191: ldstr "join"
-		IL_0196: ldstr "|"
-		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a0: stloc.s 9
-		IL_01a2: ldloc.s 8
-		IL_01a4: ldstr "log"
-		IL_01a9: ldloc.s 9
-		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b0: pop
-		IL_01b1: ldc.i4.2
-		IL_01b2: newarr [System.Runtime]System.Object
-		IL_01b7: dup
-		IL_01b8: ldc.i4.0
-		IL_01b9: ldc.r8 4
-		IL_01c2: box [System.Runtime]System.Double
-		IL_01c7: stelem.ref
-		IL_01c8: dup
-		IL_01c9: ldc.i4.1
-		IL_01ca: ldc.r8 5
-		IL_01d3: box [System.Runtime]System.Double
-		IL_01d8: stelem.ref
-		IL_01d9: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
-		IL_01de: stloc.s 10
-		IL_01e0: ldnull
-		IL_01e1: ldftn object Modules.TypedArray_Static_From_Of/FunctionExpression_floats::__js_call__(object, object)
-		IL_01e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01ec: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_01f1: ldc.i4.1
-		IL_01f2: conv.r8
-		IL_01f3: ldstr ""
-		IL_01f8: ldc.i4.0
-		IL_01f9: ldc.i4.1
-		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_01ff: stloc.s 11
-		IL_0201: ldloc.s 10
-		IL_0203: ldloc.s 11
-		IL_0205: call class [JavaScriptRuntime]JavaScriptRuntime.Float64Array [JavaScriptRuntime]JavaScriptRuntime.Float64Array::from(object, object)
-		IL_020a: stloc.s 4
-		IL_020c: ldstr "console"
-		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021b: stloc.s 9
-		IL_021d: ldloc.s 4
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0224: ldstr "join"
-		IL_0229: ldstr "|"
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0233: stloc.s 8
-		IL_0235: ldloc.s 9
-		IL_0237: ldstr "log"
-		IL_023c: ldloc.s 8
+		IL_0191: stloc.s 8
+		IL_0193: ldloc.3
+		IL_0194: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
+		IL_0199: stloc.s 11
+		IL_019b: ldloc.s 11
+		IL_019d: ldstr "join"
+		IL_01a2: ldstr "|"
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ac: stloc.s 10
+		IL_01ae: ldloc.s 8
+		IL_01b0: ldstr "log"
+		IL_01b5: ldloc.s 10
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bc: pop
+		IL_01bd: ldc.i4.2
+		IL_01be: newarr [System.Runtime]System.Object
+		IL_01c3: dup
+		IL_01c4: ldc.i4.0
+		IL_01c5: ldc.r8 4
+		IL_01ce: box [System.Runtime]System.Double
+		IL_01d3: stelem.ref
+		IL_01d4: dup
+		IL_01d5: ldc.i4.1
+		IL_01d6: ldc.r8 5
+		IL_01df: box [System.Runtime]System.Double
+		IL_01e4: stelem.ref
+		IL_01e5: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
+		IL_01ea: stloc.s 11
+		IL_01ec: ldnull
+		IL_01ed: ldftn object Modules.TypedArray_Static_From_Of/FunctionExpression_floats::__js_call__(object, object)
+		IL_01f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01f8: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_01fd: ldc.i4.1
+		IL_01fe: conv.r8
+		IL_01ff: ldstr ""
+		IL_0204: ldc.i4.0
+		IL_0205: ldc.i4.1
+		IL_0206: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_020b: stloc.s 12
+		IL_020d: ldloc.s 11
+		IL_020f: ldloc.s 12
+		IL_0211: call class [JavaScriptRuntime]JavaScriptRuntime.Float64Array [JavaScriptRuntime]JavaScriptRuntime.Float64Array::from(object, object)
+		IL_0216: stloc.s 4
+		IL_0218: ldstr "console"
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0227: stloc.s 10
+		IL_0229: ldloc.s 4
+		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_0230: stloc.s 13
+		IL_0232: ldloc.s 13
+		IL_0234: ldstr "join"
+		IL_0239: ldstr "|"
 		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0243: pop
-		IL_0244: ret
+		IL_0243: stloc.s 8
+		IL_0245: ldloc.s 10
+		IL_0247: ldstr "log"
+		IL_024c: ldloc.s 8
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0253: pop
+		IL_0254: ret
 	} // end of method TypedArray_Static_From_Of::__js_module_init__
 
 } // end of class Modules.TypedArray_Static_From_Of
@@ -344,7 +354,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2304
+		// Method begins at RVA 0x2314
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Construct_ArrayLike_Buffer_Search.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Construct_ArrayLike_Buffer_Search.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x237d
+			// Method begins at RVA 0x2389
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x238f
+				// Method begins at RVA 0x239b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2386
+			// Method begins at RVA 0x2392
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 801 (0x321)
+		// Code size: 813 (0x32d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search/Scope,
@@ -98,7 +98,8 @@
 			[10] float64,
 			[11] object,
 			[12] bool,
-			[13] object
+			[13] object,
+			[14] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array
 		)
 
 		IL_0000: newobj instance void Modules.Uint8Array_Construct_ArrayLike_Buffer_Search/Scope::.ctor()
@@ -272,55 +273,61 @@
 		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0263: stloc.s 11
 		IL_0265: ldloc.s 4
-		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026c: ldstr "includes"
-		IL_0271: ldc.r8 43
-		IL_027a: box [System.Runtime]System.Double
-		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0284: stloc.s 7
-		IL_0286: ldloc.s 11
-		IL_0288: ldstr "log"
-		IL_028d: ldloc.s 7
-		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0294: pop
-		IL_0295: ldstr "console"
-		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a4: stloc.s 7
-		IL_02a6: ldloc.s 4
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ad: ldstr "indexOf"
-		IL_02b2: ldc.r8 42
-		IL_02bb: box [System.Runtime]System.Double
-		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c5: stloc.s 11
-		IL_02c7: ldloc.s 7
-		IL_02c9: ldstr "log"
-		IL_02ce: ldloc.s 11
-		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d5: pop
-		IL_02d6: ldstr "console"
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e5: stloc.s 11
-		IL_02e7: ldloc.s 4
-		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ee: ldc.r8 1
-		IL_02f7: neg
-		IL_02f8: stloc.s 10
-		IL_02fa: ldloc.s 10
-		IL_02fc: box [System.Runtime]System.Double
-		IL_0301: stloc.s 9
-		IL_0303: ldstr "at"
-		IL_0308: ldloc.s 9
-		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_030f: stloc.s 7
-		IL_0311: ldloc.s 11
-		IL_0313: ldstr "log"
-		IL_0318: ldloc.s 7
-		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_031f: pop
-		IL_0320: ret
+		IL_0267: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
+		IL_026c: stloc.s 14
+		IL_026e: ldloc.s 14
+		IL_0270: ldstr "includes"
+		IL_0275: ldc.r8 43
+		IL_027e: box [System.Runtime]System.Double
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0288: stloc.s 7
+		IL_028a: ldloc.s 11
+		IL_028c: ldstr "log"
+		IL_0291: ldloc.s 7
+		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0298: pop
+		IL_0299: ldstr "console"
+		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a8: stloc.s 7
+		IL_02aa: ldloc.s 4
+		IL_02ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
+		IL_02b1: stloc.s 14
+		IL_02b3: ldloc.s 14
+		IL_02b5: ldstr "indexOf"
+		IL_02ba: ldc.r8 42
+		IL_02c3: box [System.Runtime]System.Double
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02cd: stloc.s 11
+		IL_02cf: ldloc.s 7
+		IL_02d1: ldstr "log"
+		IL_02d6: ldloc.s 11
+		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02dd: pop
+		IL_02de: ldstr "console"
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ed: stloc.s 11
+		IL_02ef: ldloc.s 4
+		IL_02f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
+		IL_02f6: stloc.s 14
+		IL_02f8: ldc.r8 1
+		IL_0301: neg
+		IL_0302: stloc.s 10
+		IL_0304: ldloc.s 10
+		IL_0306: box [System.Runtime]System.Double
+		IL_030b: stloc.s 9
+		IL_030d: ldloc.s 14
+		IL_030f: ldstr "at"
+		IL_0314: ldloc.s 9
+		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_031b: stloc.s 7
+		IL_031d: ldloc.s 11
+		IL_031f: ldstr "log"
+		IL_0324: ldloc.s 7
+		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_032b: pop
+		IL_032c: ret
 	} // end of method Uint8Array_Construct_ArrayLike_Buffer_Search::__js_module_init__
 
 } // end of class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search
@@ -332,7 +339,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2398
+		// Method begins at RVA 0x23a4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Iterator_Metadata.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Iterator_Metadata.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22d6
+			// Method begins at RVA 0x22ee
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 634 (0x27a)
+		// Code size: 658 (0x292)
 		.maxstack 11
 		.locals init (
 			[0] class Modules.Uint8Array_Iterator_Metadata/Scope,
@@ -48,8 +48,10 @@
 			[2] object,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] object,
-			[6] object
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
+			[6] object,
+			[7] object,
+			[8] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Uint8Array_Iterator_Metadata/Scope::.ctor()
@@ -68,166 +70,178 @@
 		IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
 		IL_0034: stloc.1
 		IL_0035: ldloc.1
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003b: ldstr "keys"
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0045: stloc.2
-		IL_0046: ldstr "console"
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0055: stloc.s 5
-		IL_0057: ldloc.2
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005d: ldstr "next"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0067: stloc.s 6
-		IL_0069: ldloc.s 6
-		IL_006b: ldstr "value"
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0075: stloc.s 6
-		IL_0077: ldloc.s 5
-		IL_0079: ldstr "log"
-		IL_007e: ldloc.s 6
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0085: pop
-		IL_0086: ldstr "console"
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0095: stloc.s 6
-		IL_0097: ldloc.2
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009d: ldstr "next"
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00a7: stloc.s 5
-		IL_00a9: ldloc.s 5
-		IL_00ab: ldstr "value"
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b5: stloc.s 5
-		IL_00b7: ldloc.s 6
-		IL_00b9: ldstr "log"
-		IL_00be: ldloc.s 5
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c5: pop
-		IL_00c6: ldstr "console"
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d5: stloc.s 5
-		IL_00d7: ldloc.2
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00dd: ldstr "next"
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00e7: stloc.s 6
-		IL_00e9: ldloc.s 6
-		IL_00eb: ldstr "done"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f5: stloc.s 6
-		IL_00f7: ldloc.s 5
-		IL_00f9: ldstr "log"
-		IL_00fe: ldloc.s 6
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0105: pop
-		IL_0106: ldloc.1
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010c: ldstr "entries"
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0116: stloc.s 6
-		IL_0118: ldloc.s 6
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011f: ldstr "next"
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0129: stloc.s 6
-		IL_012b: ldloc.s 6
-		IL_012d: ldstr "value"
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0137: stloc.3
-		IL_0138: ldstr "console"
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0147: stloc.s 6
-		IL_0149: ldloc.3
-		IL_014a: ldc.r8 0.0
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0158: stloc.s 5
-		IL_015a: ldloc.s 6
-		IL_015c: ldstr "log"
-		IL_0161: ldloc.s 5
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0168: pop
-		IL_0169: ldstr "console"
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0178: stloc.s 5
-		IL_017a: ldloc.3
-		IL_017b: ldc.r8 1
-		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0189: stloc.s 6
-		IL_018b: ldloc.s 5
-		IL_018d: ldstr "log"
-		IL_0192: ldloc.s 6
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0199: pop
-		IL_019a: ldstr "console"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a9: stloc.s 6
-		IL_01ab: ldloc.1
+		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
+		IL_003b: stloc.s 5
+		IL_003d: ldloc.s 5
+		IL_003f: ldstr "keys"
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0049: stloc.2
+		IL_004a: ldstr "console"
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0059: stloc.s 6
+		IL_005b: ldloc.2
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0061: ldstr "next"
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_006b: stloc.s 7
+		IL_006d: ldloc.s 7
+		IL_006f: ldstr "value"
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0079: stloc.s 7
+		IL_007b: ldloc.s 6
+		IL_007d: ldstr "log"
+		IL_0082: ldloc.s 7
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0089: pop
+		IL_008a: ldstr "console"
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0099: stloc.s 7
+		IL_009b: ldloc.2
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a1: ldstr "next"
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00ab: stloc.s 6
+		IL_00ad: ldloc.s 6
+		IL_00af: ldstr "value"
+		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b9: stloc.s 6
+		IL_00bb: ldloc.s 7
+		IL_00bd: ldstr "log"
+		IL_00c2: ldloc.s 6
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c9: pop
+		IL_00ca: ldstr "console"
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d9: stloc.s 6
+		IL_00db: ldloc.2
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e1: ldstr "next"
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00eb: stloc.s 7
+		IL_00ed: ldloc.s 7
+		IL_00ef: ldstr "done"
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f9: stloc.s 7
+		IL_00fb: ldloc.s 6
+		IL_00fd: ldstr "log"
+		IL_0102: ldloc.s 7
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0109: pop
+		IL_010a: ldloc.1
+		IL_010b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
+		IL_0110: stloc.s 5
+		IL_0112: ldloc.s 5
+		IL_0114: ldstr "entries"
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_011e: stloc.s 7
+		IL_0120: ldloc.s 7
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0127: ldstr "next"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0131: stloc.s 7
+		IL_0133: ldloc.s 7
+		IL_0135: ldstr "value"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013f: stloc.3
+		IL_0140: ldstr "console"
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014f: stloc.s 7
+		IL_0151: ldloc.3
+		IL_0152: ldc.r8 0.0
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0160: stloc.s 6
+		IL_0162: ldloc.s 7
+		IL_0164: ldstr "log"
+		IL_0169: ldloc.s 6
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0170: pop
+		IL_0171: ldstr "console"
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0180: stloc.s 6
+		IL_0182: ldloc.3
+		IL_0183: ldc.r8 1
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0191: stloc.s 7
+		IL_0193: ldloc.s 6
+		IL_0195: ldstr "log"
+		IL_019a: ldloc.s 7
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a1: pop
+		IL_01a2: ldstr "console"
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b1: ldstr "iterator"
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_01bb: ldc.i4.0
-		IL_01bc: newarr [System.Runtime]System.Object
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01cb: ldstr "next"
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01d5: stloc.s 5
-		IL_01d7: ldloc.s 5
-		IL_01d9: ldstr "value"
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e3: stloc.s 5
-		IL_01e5: ldloc.s 6
-		IL_01e7: ldstr "log"
-		IL_01ec: ldloc.s 5
-		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f3: pop
-		IL_01f4: ldstr "console"
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0203: stloc.s 5
-		IL_0205: ldstr "Object"
-		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020f: ldstr "prototype"
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0219: stloc.s 6
-		IL_021b: ldloc.s 6
-		IL_021d: ldstr "toString"
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0227: stloc.s 6
-		IL_0229: ldloc.s 6
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0230: ldstr "call"
-		IL_0235: ldloc.1
-		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023b: stloc.s 6
-		IL_023d: ldloc.s 5
-		IL_023f: ldstr "log"
-		IL_0244: ldloc.s 6
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024b: pop
-		IL_024c: ldstr "console"
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025b: stloc.s 6
-		IL_025d: ldloc.1
-		IL_025e: ldstr "BYTES_PER_ELEMENT"
-		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0268: stloc.s 5
-		IL_026a: ldloc.s 6
-		IL_026c: ldstr "log"
-		IL_0271: ldloc.s 5
-		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0278: pop
-		IL_0279: ret
+		IL_01b1: stloc.s 7
+		IL_01b3: ldloc.1
+		IL_01b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
+		IL_01b9: stloc.s 5
+		IL_01bb: ldstr "iterator"
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_01c5: stloc.s 6
+		IL_01c7: ldc.i4.0
+		IL_01c8: newarr [System.Runtime]System.Object
+		IL_01cd: stloc.s 8
+		IL_01cf: ldloc.s 5
+		IL_01d1: ldloc.s 6
+		IL_01d3: ldloc.s 8
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_01da: stloc.s 6
+		IL_01dc: ldloc.s 6
+		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e3: ldstr "next"
+		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01ed: stloc.s 6
+		IL_01ef: ldloc.s 6
+		IL_01f1: ldstr "value"
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01fb: stloc.s 6
+		IL_01fd: ldloc.s 7
+		IL_01ff: ldstr "log"
+		IL_0204: ldloc.s 6
+		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_020b: pop
+		IL_020c: ldstr "console"
+		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021b: stloc.s 6
+		IL_021d: ldstr "Object"
+		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0227: ldstr "prototype"
+		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0231: stloc.s 7
+		IL_0233: ldloc.s 7
+		IL_0235: ldstr "toString"
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023f: stloc.s 7
+		IL_0241: ldloc.s 7
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0248: ldstr "call"
+		IL_024d: ldloc.1
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0253: stloc.s 7
+		IL_0255: ldloc.s 6
+		IL_0257: ldstr "log"
+		IL_025c: ldloc.s 7
+		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0263: pop
+		IL_0264: ldstr "console"
+		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0273: stloc.s 7
+		IL_0275: ldloc.1
+		IL_0276: ldstr "BYTES_PER_ELEMENT"
+		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0280: stloc.s 6
+		IL_0282: ldloc.s 7
+		IL_0284: ldstr "log"
+		IL_0289: ldloc.s 6
+		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0290: pop
+		IL_0291: ret
 	} // end of method Uint8Array_Iterator_Metadata::__js_module_init__
 
 } // end of class Modules.Uint8Array_Iterator_Metadata
@@ -239,7 +253,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22df
+		// Method begins at RVA 0x22f7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Values_Iterator.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Values_Iterator.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2240
+			// Method begins at RVA 0x2244
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2252
+				// Method begins at RVA 0x2256
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2249
+			// Method begins at RVA 0x224d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 468 (0x1d4)
+		// Code size: 472 (0x1d8)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Uint8Array_Values_Iterator/Scope,
@@ -93,9 +93,10 @@
 			[5] bool,
 			[6] object,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[8] object,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
 			[9] object,
-			[10] bool
+			[10] object,
+			[11] bool
 		)
 
 		IL_0000: newobj instance void Modules.Uint8Array_Values_Iterator/Scope::.ctor()
@@ -117,140 +118,142 @@
 		IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
 		IL_0043: stloc.1
 		IL_0044: ldloc.1
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004a: ldstr "values"
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0054: stloc.2
-		IL_0055: ldstr "console"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0064: stloc.s 8
-		IL_0066: ldloc.2
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006c: ldstr "next"
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0076: stloc.s 9
-		IL_0078: ldloc.s 9
-		IL_007a: ldstr "value"
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0084: stloc.s 9
-		IL_0086: ldloc.s 8
-		IL_0088: ldstr "log"
-		IL_008d: ldloc.s 9
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0094: pop
-		IL_0095: ldstr "console"
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a4: stloc.s 9
-		IL_00a6: ldloc.2
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ac: ldstr "next"
-		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00b6: stloc.s 8
-		IL_00b8: ldloc.s 8
-		IL_00ba: ldstr "value"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c4: stloc.s 8
-		IL_00c6: ldloc.s 9
-		IL_00c8: ldstr "log"
-		IL_00cd: ldloc.s 8
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d4: pop
-		IL_00d5: ldstr "console"
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e4: stloc.s 8
-		IL_00e6: ldloc.2
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ec: ldstr "next"
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00f6: stloc.s 9
-		IL_00f8: ldloc.s 9
-		IL_00fa: ldstr "value"
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0104: stloc.s 9
-		IL_0106: ldloc.s 8
-		IL_0108: ldstr "log"
-		IL_010d: ldloc.s 9
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0114: pop
-		IL_0115: ldstr "console"
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0124: stloc.s 9
-		IL_0126: ldloc.2
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012c: ldstr "next"
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0136: stloc.s 8
-		IL_0138: ldloc.s 8
-		IL_013a: ldstr "done"
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0144: stloc.s 8
-		IL_0146: ldloc.s 9
-		IL_0148: ldstr "log"
-		IL_014d: ldloc.s 8
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0154: pop
-		IL_0155: ldloc.1
-		IL_0156: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-		IL_015b: stloc.3
-		IL_015c: ldc.i4.0
-		IL_015d: stloc.s 4
-		IL_015f: ldc.i4.0
-		IL_0160: stloc.s 5
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
+		IL_004a: stloc.s 8
+		IL_004c: ldloc.s 8
+		IL_004e: ldstr "values"
+		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0058: stloc.2
+		IL_0059: ldstr "console"
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0068: stloc.s 9
+		IL_006a: ldloc.2
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0070: ldstr "next"
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_007a: stloc.s 10
+		IL_007c: ldloc.s 10
+		IL_007e: ldstr "value"
+		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0088: stloc.s 10
+		IL_008a: ldloc.s 9
+		IL_008c: ldstr "log"
+		IL_0091: ldloc.s 10
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0098: pop
+		IL_0099: ldstr "console"
+		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a8: stloc.s 10
+		IL_00aa: ldloc.2
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b0: ldstr "next"
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00ba: stloc.s 9
+		IL_00bc: ldloc.s 9
+		IL_00be: ldstr "value"
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c8: stloc.s 9
+		IL_00ca: ldloc.s 10
+		IL_00cc: ldstr "log"
+		IL_00d1: ldloc.s 9
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d8: pop
+		IL_00d9: ldstr "console"
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e8: stloc.s 9
+		IL_00ea: ldloc.2
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f0: ldstr "next"
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00fa: stloc.s 10
+		IL_00fc: ldloc.s 10
+		IL_00fe: ldstr "value"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0108: stloc.s 10
+		IL_010a: ldloc.s 9
+		IL_010c: ldstr "log"
+		IL_0111: ldloc.s 10
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0118: pop
+		IL_0119: ldstr "console"
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0128: stloc.s 10
+		IL_012a: ldloc.2
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0130: ldstr "next"
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_013a: stloc.s 9
+		IL_013c: ldloc.s 9
+		IL_013e: ldstr "done"
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0148: stloc.s 9
+		IL_014a: ldloc.s 10
+		IL_014c: ldstr "log"
+		IL_0151: ldloc.s 9
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0158: pop
+		IL_0159: ldloc.1
+		IL_015a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+		IL_015f: stloc.3
+		IL_0160: ldc.i4.0
+		IL_0161: stloc.s 4
+		IL_0163: ldc.i4.0
+		IL_0164: stloc.s 5
 		.try
 		{
-			// loop start (head: IL_0162)
-				IL_0162: ldloc.3
-				IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-				IL_0168: stloc.s 8
-				IL_016a: ldloc.s 8
-				IL_016c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-				IL_0171: stloc.s 10
-				IL_0173: ldloc.s 10
-				IL_0175: brtrue IL_01b6
+			// loop start (head: IL_0166)
+				IL_0166: ldloc.3
+				IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+				IL_016c: stloc.s 9
+				IL_016e: ldloc.s 9
+				IL_0170: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+				IL_0175: stloc.s 11
+				IL_0177: ldloc.s 11
+				IL_0179: brtrue IL_01ba
 
-				IL_017a: ldloc.s 8
-				IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-				IL_0181: stloc.s 8
-				IL_0183: ldloc.s 8
-				IL_0185: stloc.s 6
-				IL_0187: ldstr "console"
-				IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0196: ldstr "log"
-				IL_019b: ldloc.s 6
-				IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_01a2: pop
-				IL_01a3: br IL_0162
+				IL_017e: ldloc.s 9
+				IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+				IL_0185: stloc.s 9
+				IL_0187: ldloc.s 9
+				IL_0189: stloc.s 6
+				IL_018b: ldstr "console"
+				IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_019a: ldstr "log"
+				IL_019f: ldloc.s 6
+				IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01a6: pop
+				IL_01a7: br IL_0166
 			// end loop
-			IL_01a8: ldloc.3
-			IL_01a9: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-			IL_01ae: ldc.i4.1
-			IL_01af: stloc.s 5
-			IL_01b1: leave IL_01d3
+			IL_01ac: ldloc.3
+			IL_01ad: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+			IL_01b2: ldc.i4.1
+			IL_01b3: stloc.s 5
+			IL_01b5: leave IL_01d7
 
-			IL_01b6: ldc.i4.1
-			IL_01b7: stloc.s 4
-			IL_01b9: leave IL_01d3
+			IL_01ba: ldc.i4.1
+			IL_01bb: stloc.s 4
+			IL_01bd: leave IL_01d7
 		} // end .try
 		finally
 		{
-			IL_01be: ldloc.s 4
-			IL_01c0: brtrue IL_01d2
+			IL_01c2: ldloc.s 4
+			IL_01c4: brtrue IL_01d6
 
-			IL_01c5: ldloc.s 5
-			IL_01c7: brtrue IL_01d2
+			IL_01c9: ldloc.s 5
+			IL_01cb: brtrue IL_01d6
 
-			IL_01cc: ldloc.3
-			IL_01cd: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+			IL_01d0: ldloc.3
+			IL_01d1: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-			IL_01d2: endfinally
+			IL_01d6: endfinally
 		} // end handler
 
-		IL_01d3: ret
+		IL_01d7: ret
 	} // end of method Uint8Array_Values_Iterator::__js_module_init__
 
 } // end of class Modules.Uint8Array_Values_Iterator
@@ -262,7 +265,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x225b
+		// Method begins at RVA 0x225f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Delete_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Delete_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2126
+			// Method begins at RVA 0x2136
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 202 (0xca)
+		// Code size: 218 (0xda)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Delete_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] object,
-			[5] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakMap_Delete_Basic/Scope::.ctor()
@@ -59,60 +60,68 @@
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0012: stloc.2
 		IL_0013: ldloc.1
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0019: ldstr "set"
-		IL_001e: ldloc.2
-		IL_001f: ldstr "value1"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0029: pop
-		IL_002a: ldstr "console"
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0039: stloc.s 4
-		IL_003b: ldloc.1
-		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0041: ldstr "delete"
-		IL_0046: ldloc.2
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004c: stloc.s 5
-		IL_004e: ldloc.s 4
-		IL_0050: ldstr "log"
-		IL_0055: ldloc.s 5
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005c: pop
-		IL_005d: ldstr "console"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006c: stloc.s 5
-		IL_006e: ldloc.1
+		IL_0014: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_0019: stloc.s 4
+		IL_001b: ldloc.s 4
+		IL_001d: ldstr "set"
+		IL_0022: ldloc.2
+		IL_0023: ldstr "value1"
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_002d: pop
+		IL_002e: ldstr "console"
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003d: stloc.s 5
+		IL_003f: ldloc.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_0045: stloc.s 4
+		IL_0047: ldloc.s 4
+		IL_0049: ldstr "delete"
+		IL_004e: ldloc.2
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0054: stloc.s 6
+		IL_0056: ldloc.s 5
+		IL_0058: ldstr "log"
+		IL_005d: ldloc.s 6
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0064: pop
+		IL_0065: ldstr "console"
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0074: ldstr "has"
-		IL_0079: ldloc.2
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007f: stloc.s 4
-		IL_0081: ldloc.s 5
-		IL_0083: ldstr "log"
-		IL_0088: ldloc.s 4
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008f: pop
-		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0095: stloc.3
-		IL_0096: ldstr "console"
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a5: stloc.s 4
-		IL_00a7: ldloc.1
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ad: ldstr "delete"
-		IL_00b2: ldloc.3
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b8: stloc.s 5
-		IL_00ba: ldloc.s 4
-		IL_00bc: ldstr "log"
-		IL_00c1: ldloc.s 5
+		IL_0074: stloc.s 6
+		IL_0076: ldloc.1
+		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_007c: stloc.s 4
+		IL_007e: ldloc.s 4
+		IL_0080: ldstr "has"
+		IL_0085: ldloc.2
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008b: stloc.s 5
+		IL_008d: ldloc.s 6
+		IL_008f: ldstr "log"
+		IL_0094: ldloc.s 5
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009b: pop
+		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00a1: stloc.3
+		IL_00a2: ldstr "console"
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b1: stloc.s 5
+		IL_00b3: ldloc.1
+		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_00b9: stloc.s 4
+		IL_00bb: ldloc.s 4
+		IL_00bd: ldstr "delete"
+		IL_00c2: ldloc.3
 		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c8: pop
-		IL_00c9: ret
+		IL_00c8: stloc.s 6
+		IL_00ca: ldloc.s 5
+		IL_00cc: ldstr "log"
+		IL_00d1: ldloc.s 6
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d8: pop
+		IL_00d9: ret
 	} // end of method WeakMap_Delete_Basic::__js_module_init__
 
 } // end of class Modules.WeakMap_Delete_Basic
@@ -124,7 +133,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212f
+		// Method begins at RVA 0x213f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Has_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Has_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f3
+			// Method begins at RVA 0x20ff
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 151 (0x97)
+		// Code size: 163 (0xa3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Has_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] object,
-			[5] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakMap_Has_Basic/Scope::.ctor()
@@ -61,43 +62,49 @@
 		IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0018: stloc.3
 		IL_0019: ldloc.1
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_001f: ldstr "set"
-		IL_0024: ldloc.2
-		IL_0025: ldstr "value1"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_002f: pop
-		IL_0030: ldstr "console"
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003f: stloc.s 4
-		IL_0041: ldloc.1
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0047: ldstr "has"
-		IL_004c: ldloc.2
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0052: stloc.s 5
-		IL_0054: ldloc.s 4
-		IL_0056: ldstr "log"
-		IL_005b: ldloc.s 5
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0062: pop
-		IL_0063: ldstr "console"
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0072: stloc.s 5
-		IL_0074: ldloc.1
+		IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_001f: stloc.s 4
+		IL_0021: ldloc.s 4
+		IL_0023: ldstr "set"
+		IL_0028: ldloc.2
+		IL_0029: ldstr "value1"
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0033: pop
+		IL_0034: ldstr "console"
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0043: stloc.s 5
+		IL_0045: ldloc.1
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_004b: stloc.s 4
+		IL_004d: ldloc.s 4
+		IL_004f: ldstr "has"
+		IL_0054: ldloc.2
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005a: stloc.s 6
+		IL_005c: ldloc.s 5
+		IL_005e: ldstr "log"
+		IL_0063: ldloc.s 6
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006a: pop
+		IL_006b: ldstr "console"
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007a: ldstr "has"
-		IL_007f: ldloc.3
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0085: stloc.s 4
-		IL_0087: ldloc.s 5
-		IL_0089: ldstr "log"
-		IL_008e: ldloc.s 4
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0095: pop
-		IL_0096: ret
+		IL_007a: stloc.s 6
+		IL_007c: ldloc.1
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_0082: stloc.s 4
+		IL_0084: ldloc.s 4
+		IL_0086: ldstr "has"
+		IL_008b: ldloc.3
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0091: stloc.s 5
+		IL_0093: ldloc.s 6
+		IL_0095: ldstr "log"
+		IL_009a: ldloc.s 5
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a1: pop
+		IL_00a2: ret
 	} // end of method WeakMap_Has_Basic::__js_module_init__
 
 } // end of class Modules.WeakMap_Has_Basic
@@ -109,7 +116,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20fc
+		// Method begins at RVA 0x2108
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Object_Keys.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Object_Keys.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x212a
+			// Method begins at RVA 0x213a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 206 (0xce)
+		// Code size: 222 (0xde)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Object_Keys/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] object,
-			[5] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakMap_Object_Keys/Scope::.ctor()
@@ -69,50 +70,58 @@
 		IL_0033: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_0038: stloc.3
 		IL_0039: ldloc.1
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003f: ldstr "set"
-		IL_0044: ldloc.2
-		IL_0045: ldstr "value1"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_004f: pop
-		IL_0050: ldloc.1
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0056: ldstr "set"
-		IL_005b: ldloc.3
-		IL_005c: ldstr "value2"
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0066: pop
-		IL_0067: ldstr "console"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0076: stloc.s 4
-		IL_0078: ldloc.1
+		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_003f: stloc.s 4
+		IL_0041: ldloc.s 4
+		IL_0043: ldstr "set"
+		IL_0048: ldloc.2
+		IL_0049: ldstr "value1"
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0053: pop
+		IL_0054: ldloc.1
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_005a: stloc.s 4
+		IL_005c: ldloc.s 4
+		IL_005e: ldstr "set"
+		IL_0063: ldloc.3
+		IL_0064: ldstr "value2"
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_006e: pop
+		IL_006f: ldstr "console"
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007e: ldstr "get"
-		IL_0083: ldloc.2
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0089: stloc.s 5
-		IL_008b: ldloc.s 4
-		IL_008d: ldstr "log"
-		IL_0092: ldloc.s 5
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0099: pop
-		IL_009a: ldstr "console"
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a9: stloc.s 5
-		IL_00ab: ldloc.1
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b1: ldstr "get"
-		IL_00b6: ldloc.3
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bc: stloc.s 4
-		IL_00be: ldloc.s 5
-		IL_00c0: ldstr "log"
-		IL_00c5: ldloc.s 4
+		IL_007e: stloc.s 5
+		IL_0080: ldloc.1
+		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_0086: stloc.s 4
+		IL_0088: ldloc.s 4
+		IL_008a: ldstr "get"
+		IL_008f: ldloc.2
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0095: stloc.s 6
+		IL_0097: ldloc.s 5
+		IL_0099: ldstr "log"
+		IL_009e: ldloc.s 6
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a5: pop
+		IL_00a6: ldstr "console"
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b5: stloc.s 6
+		IL_00b7: ldloc.1
+		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_00bd: stloc.s 4
+		IL_00bf: ldloc.s 4
+		IL_00c1: ldstr "get"
+		IL_00c6: ldloc.3
 		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cc: pop
-		IL_00cd: ret
+		IL_00cc: stloc.s 5
+		IL_00ce: ldloc.s 6
+		IL_00d0: ldstr "log"
+		IL_00d5: ldloc.s 5
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00dc: pop
+		IL_00dd: ret
 	} // end of method WeakMap_Object_Keys::__js_module_init__
 
 } // end of class Modules.WeakMap_Object_Keys
@@ -124,7 +133,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2133
+		// Method begins at RVA 0x2143
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Set_Get_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Set_Get_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20b8
+			// Method begins at RVA 0x20be
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 92 (0x5c)
+		// Code size: 98 (0x62)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Set_Get_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[3] object,
-			[4] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakMap_Set_Get_Basic/Scope::.ctor()
@@ -58,28 +59,32 @@
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0012: stloc.2
 		IL_0013: ldloc.1
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0019: ldstr "set"
-		IL_001e: ldloc.2
-		IL_001f: ldstr "value1"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0029: pop
-		IL_002a: ldstr "console"
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0039: stloc.3
-		IL_003a: ldloc.1
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0040: ldstr "get"
-		IL_0045: ldloc.2
-		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004b: stloc.s 4
-		IL_004d: ldloc.3
-		IL_004e: ldstr "log"
-		IL_0053: ldloc.s 4
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005a: pop
-		IL_005b: ret
+		IL_0014: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_0019: stloc.3
+		IL_001a: ldloc.3
+		IL_001b: ldstr "set"
+		IL_0020: ldloc.2
+		IL_0021: ldstr "value1"
+		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_002b: pop
+		IL_002c: ldstr "console"
+		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003b: stloc.s 4
+		IL_003d: ldloc.1
+		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
+		IL_0043: stloc.3
+		IL_0044: ldloc.3
+		IL_0045: ldstr "get"
+		IL_004a: ldloc.2
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0050: stloc.s 5
+		IL_0052: ldloc.s 4
+		IL_0054: ldstr "log"
+		IL_0059: ldloc.s 5
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0060: pop
+		IL_0061: ret
 	} // end of method WeakMap_Set_Get_Basic::__js_module_init__
 
 } // end of class Modules.WeakMap_Set_Get_Basic
@@ -91,7 +96,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20c1
+		// Method begins at RVA 0x20c7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
+++ b/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2338
+				// Method begins at RVA 0x2340
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,13 +46,14 @@
 			)
 			// Method begins at RVA 0x222c
 			// Header size: 12
-			// Code size: 153 (0x99)
+			// Code size: 163 (0xa3)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakRef,
 				[2] object,
-				[3] object
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.WeakRef,
+				[4] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -69,41 +70,45 @@
 			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002c: stloc.2
 			IL_002d: ldloc.1
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0033: ldstr "deref"
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_003d: stloc.3
-			IL_003e: ldloc.3
-			IL_003f: ldstr "name"
-			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0049: stloc.3
-			IL_004a: ldloc.2
-			IL_004b: ldstr "log"
-			IL_0050: ldloc.3
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0056: pop
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
+			IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakRef>(!!0)
+			IL_0033: stloc.3
+			IL_0034: ldloc.3
+			IL_0035: ldstr "deref"
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_003f: stloc.s 4
+			IL_0041: ldloc.s 4
+			IL_0043: ldstr "name"
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_004d: stloc.s 4
+			IL_004f: ldloc.2
+			IL_0050: ldstr "log"
+			IL_0055: ldloc.s 4
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_005c: pop
-			IL_005d: ldstr "console"
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006c: stloc.3
-			IL_006d: ldloc.1
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0073: ldstr "deref"
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_007d: stloc.2
-			IL_007e: ldloc.2
-			IL_007f: ldstr "name"
-			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0089: stloc.2
-			IL_008a: ldloc.3
-			IL_008b: ldstr "log"
-			IL_0090: ldloc.2
-			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0096: pop
-			IL_0097: ldloc.1
-			IL_0098: ret
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
+			IL_0062: pop
+			IL_0063: ldstr "console"
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0072: stloc.s 4
+			IL_0074: ldloc.1
+			IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakRef>(!!0)
+			IL_007a: stloc.3
+			IL_007b: ldloc.3
+			IL_007c: ldstr "deref"
+			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0086: stloc.2
+			IL_0087: ldloc.2
+			IL_0088: ldstr "name"
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0092: stloc.2
+			IL_0093: ldloc.s 4
+			IL_0095: ldstr "log"
+			IL_009a: ldloc.2
+			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00a0: pop
+			IL_00a1: ldloc.1
+			IL_00a2: ret
 		} // end of method createWeakRef::__js_call__
 
 	} // end of class createWeakRef
@@ -119,7 +124,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2353
+				// Method begins at RVA 0x235b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +150,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x22d4
+			// Method begins at RVA 0x22dc
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -204,7 +209,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2341
+				// Method begins at RVA 0x2349
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -224,7 +229,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x234a
+				// Method begins at RVA 0x2352
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -246,7 +251,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x232f
+			// Method begins at RVA 0x2337
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -448,7 +453,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x235c
+		// Method begins at RVA 0x2364
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Add_Has_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Add_Has_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20ee
+			// Method begins at RVA 0x20fa
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 146 (0x92)
+		// Code size: 158 (0x9e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakSet_Add_Has_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] object,
-			[5] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakSet_Add_Has_Basic/Scope::.ctor()
@@ -59,44 +60,50 @@
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0012: stloc.2
 		IL_0013: ldloc.1
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0019: ldstr "add"
-		IL_001e: ldloc.2
-		IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0024: pop
-		IL_0025: ldstr "console"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0034: stloc.s 4
-		IL_0036: ldloc.1
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003c: ldstr "has"
-		IL_0041: ldloc.2
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0047: stloc.s 5
-		IL_0049: ldloc.s 4
-		IL_004b: ldstr "log"
-		IL_0050: ldloc.s 5
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0057: pop
-		IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_005d: stloc.3
-		IL_005e: ldstr "console"
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006d: stloc.s 5
-		IL_006f: ldloc.1
+		IL_0014: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
+		IL_0019: stloc.s 4
+		IL_001b: ldloc.s 4
+		IL_001d: ldstr "add"
+		IL_0022: ldloc.2
+		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0028: pop
+		IL_0029: ldstr "console"
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0038: stloc.s 5
+		IL_003a: ldloc.1
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
+		IL_0040: stloc.s 4
+		IL_0042: ldloc.s 4
+		IL_0044: ldstr "has"
+		IL_0049: ldloc.2
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004f: stloc.s 6
+		IL_0051: ldloc.s 5
+		IL_0053: ldstr "log"
+		IL_0058: ldloc.s 6
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005f: pop
+		IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0065: stloc.3
+		IL_0066: ldstr "console"
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0075: ldstr "has"
-		IL_007a: ldloc.3
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0080: stloc.s 4
-		IL_0082: ldloc.s 5
-		IL_0084: ldstr "log"
-		IL_0089: ldloc.s 4
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0090: pop
-		IL_0091: ret
+		IL_0075: stloc.s 6
+		IL_0077: ldloc.1
+		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
+		IL_007d: stloc.s 4
+		IL_007f: ldloc.s 4
+		IL_0081: ldstr "has"
+		IL_0086: ldloc.3
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008c: stloc.s 5
+		IL_008e: ldloc.s 6
+		IL_0090: ldstr "log"
+		IL_0095: ldloc.s 5
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009c: pop
+		IL_009d: ret
 	} // end of method WeakSet_Add_Has_Basic::__js_module_init__
 
 } // end of class Modules.WeakSet_Add_Has_Basic
@@ -108,7 +115,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f7
+		// Method begins at RVA 0x2103
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Delete_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Delete_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2121
+			// Method begins at RVA 0x2131
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 197 (0xc5)
+		// Code size: 213 (0xd5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakSet_Delete_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] object,
-			[5] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakSet_Delete_Basic/Scope::.ctor()
@@ -59,59 +60,67 @@
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0012: stloc.2
 		IL_0013: ldloc.1
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0019: ldstr "add"
-		IL_001e: ldloc.2
-		IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0024: pop
-		IL_0025: ldstr "console"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0034: stloc.s 4
-		IL_0036: ldloc.1
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003c: ldstr "delete"
-		IL_0041: ldloc.2
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0047: stloc.s 5
-		IL_0049: ldloc.s 4
-		IL_004b: ldstr "log"
-		IL_0050: ldloc.s 5
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0057: pop
-		IL_0058: ldstr "console"
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0067: stloc.s 5
-		IL_0069: ldloc.1
+		IL_0014: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
+		IL_0019: stloc.s 4
+		IL_001b: ldloc.s 4
+		IL_001d: ldstr "add"
+		IL_0022: ldloc.2
+		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0028: pop
+		IL_0029: ldstr "console"
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0038: stloc.s 5
+		IL_003a: ldloc.1
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
+		IL_0040: stloc.s 4
+		IL_0042: ldloc.s 4
+		IL_0044: ldstr "delete"
+		IL_0049: ldloc.2
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004f: stloc.s 6
+		IL_0051: ldloc.s 5
+		IL_0053: ldstr "log"
+		IL_0058: ldloc.s 6
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005f: pop
+		IL_0060: ldstr "console"
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: ldstr "has"
-		IL_0074: ldloc.2
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007a: stloc.s 4
-		IL_007c: ldloc.s 5
-		IL_007e: ldstr "log"
-		IL_0083: ldloc.s 4
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008a: pop
-		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0090: stloc.3
-		IL_0091: ldstr "console"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a0: stloc.s 4
-		IL_00a2: ldloc.1
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a8: ldstr "delete"
-		IL_00ad: ldloc.3
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b3: stloc.s 5
-		IL_00b5: ldloc.s 4
-		IL_00b7: ldstr "log"
-		IL_00bc: ldloc.s 5
+		IL_006f: stloc.s 6
+		IL_0071: ldloc.1
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.s 4
+		IL_007b: ldstr "has"
+		IL_0080: ldloc.2
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0086: stloc.s 5
+		IL_0088: ldloc.s 6
+		IL_008a: ldstr "log"
+		IL_008f: ldloc.s 5
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0096: pop
+		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_009c: stloc.3
+		IL_009d: ldstr "console"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ac: stloc.s 5
+		IL_00ae: ldloc.1
+		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
+		IL_00b4: stloc.s 4
+		IL_00b6: ldloc.s 4
+		IL_00b8: ldstr "delete"
+		IL_00bd: ldloc.3
 		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c3: pop
-		IL_00c4: ret
+		IL_00c3: stloc.s 6
+		IL_00c5: ldloc.s 5
+		IL_00c7: ldstr "log"
+		IL_00cc: ldloc.s 6
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d3: pop
+		IL_00d4: ret
 	} // end of method WeakSet_Delete_Basic::__js_module_init__
 
 } // end of class Modules.WeakSet_Delete_Basic
@@ -123,7 +132,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212a
+		// Method begins at RVA 0x213a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Object_Values.verified.txt
+++ b/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Object_Values.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2120
+			// Method begins at RVA 0x2130
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 196 (0xc4)
+		// Code size: 212 (0xd4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakSet_Object_Values/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] object,
-			[5] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakSet_Object_Values/Scope::.ctor()
@@ -69,48 +70,56 @@
 		IL_0033: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_0038: stloc.3
 		IL_0039: ldloc.1
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003f: ldstr "add"
-		IL_0044: ldloc.2
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004a: pop
-		IL_004b: ldloc.1
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0051: ldstr "add"
-		IL_0056: ldloc.3
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005c: pop
-		IL_005d: ldstr "console"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006c: stloc.s 4
-		IL_006e: ldloc.1
+		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
+		IL_003f: stloc.s 4
+		IL_0041: ldloc.s 4
+		IL_0043: ldstr "add"
+		IL_0048: ldloc.2
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004e: pop
+		IL_004f: ldloc.1
+		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
+		IL_0055: stloc.s 4
+		IL_0057: ldloc.s 4
+		IL_0059: ldstr "add"
+		IL_005e: ldloc.3
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0064: pop
+		IL_0065: ldstr "console"
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0074: ldstr "has"
-		IL_0079: ldloc.2
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007f: stloc.s 5
-		IL_0081: ldloc.s 4
-		IL_0083: ldstr "log"
-		IL_0088: ldloc.s 5
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008f: pop
-		IL_0090: ldstr "console"
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009f: stloc.s 5
-		IL_00a1: ldloc.1
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a7: ldstr "has"
-		IL_00ac: ldloc.3
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b2: stloc.s 4
-		IL_00b4: ldloc.s 5
-		IL_00b6: ldstr "log"
-		IL_00bb: ldloc.s 4
+		IL_0074: stloc.s 5
+		IL_0076: ldloc.1
+		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
+		IL_007c: stloc.s 4
+		IL_007e: ldloc.s 4
+		IL_0080: ldstr "has"
+		IL_0085: ldloc.2
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008b: stloc.s 6
+		IL_008d: ldloc.s 5
+		IL_008f: ldstr "log"
+		IL_0094: ldloc.s 6
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009b: pop
+		IL_009c: ldstr "console"
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ab: stloc.s 6
+		IL_00ad: ldloc.1
+		IL_00ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
+		IL_00b3: stloc.s 4
+		IL_00b5: ldloc.s 4
+		IL_00b7: ldstr "has"
+		IL_00bc: ldloc.3
 		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c2: pop
-		IL_00c3: ret
+		IL_00c2: stloc.s 5
+		IL_00c4: ldloc.s 6
+		IL_00c6: ldstr "log"
+		IL_00cb: ldloc.s 5
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d2: pop
+		IL_00d3: ret
 	} // end of method WeakSet_Object_Values::__js_module_init__
 
 } // end of class Modules.WeakSet_Object_Values
@@ -122,7 +131,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2129
+		// Method begins at RVA 0x2139
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary
- retain known reference CLR storage through `RequireObjectCoercible` using its generic runtime helper
- remove the redundant `string` cast before `String.Trim` in the canonical integration callable
- update the generated IL regression snapshot and `CHANGELOG.md`

Fixes #1679

## Validation
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --nologo --filter FullyQualifiedName~Compile_Scripts_DecompileGeneratorTest`
- `dotnet build jroc.sln --no-restore --nologo`