### PR TITLE
perf(il): strongly type rest argument collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - compiler: preserve known reference types through
   `RequireObjectCoercible`, eliminating redundant casts before typed member
   calls such as `String.Trim`.
+- compiler/runtime: emit rest-parameter collection with an unboxed `double`
+  start index and a typed JavaScript `Array` result.
 
 ## v0.12.1 - 2026-08-02
 

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
@@ -1352,44 +1352,28 @@ internal sealed partial class LIRToILCompiler
                     // Emit call to JavaScriptRuntime.RuntimeServices static method
                     var runtimeServicesType = typeof(JavaScriptRuntime.RuntimeServices);
                     
-                    // Load arguments and box if necessary
-                    foreach (var arg in callRuntimeServices.Arguments)
+                    if (callRuntimeServices.ParameterTypes is { Count: var parameterTypeCount }
+                        && parameterTypeCount != callRuntimeServices.Arguments.Count)
                     {
-                        EmitLoadTemp(arg, ilEncoder, allocation, methodDescriptor);
-                        
-                        // Check if we need to box the value
-                        if (GetTempStorage(arg) is { } storage && 
-                            storage.Kind == ValueStorageKind.UnboxedValue &&
-                            storage.ClrType != null)
-                        {
-                            // Box the unboxed value to object
-                            ilEncoder.OpCode(ILOpCode.Box);
-                            if (storage.ClrType == typeof(double))
-                            {
-                                ilEncoder.Token(_bclReferences.DoubleType);
-                            }
-                            else if (storage.ClrType == typeof(bool))
-                            {
-                                ilEncoder.Token(_bclReferences.BooleanType);
-                            }
-                            else if (storage.ClrType == typeof(int))
-                            {
-                                ilEncoder.Token(_bclReferences.Int32Type);
-                            }
-                            else
-                            {
-                                throw new NotSupportedException($"Unsupported unboxed type for RuntimeServices call: {storage.ClrType}");
-                            }
-                        }
+                        throw new InvalidOperationException(
+                            $"RuntimeServices call '{callRuntimeServices.MethodName}' has {parameterTypeCount} parameter types for {callRuntimeServices.Arguments.Count} arguments.");
                     }
 
-                    // Emit call - use explicit parameter types to ensure correct method resolution
-                    ilEncoder.OpCode(ILOpCode.Call);
                     var paramTypes = new Type[callRuntimeServices.Arguments.Count];
-                    for (int i = 0; i < paramTypes.Length; i++)
+                    for (int i = 0; i < callRuntimeServices.Arguments.Count; i++)
                     {
-                        paramTypes[i] = typeof(object); // RuntimeServices methods take object parameters
+                        var parameterType = callRuntimeServices.ParameterTypes?[i] ?? typeof(object);
+                        paramTypes[i] = parameterType;
+                        EmitLoadTempForParameter(
+                            callRuntimeServices.Arguments[i],
+                            parameterType,
+                            ilEncoder,
+                            allocation,
+                            methodDescriptor);
                     }
+
+                    // Emit call - use explicit parameter types to ensure correct method resolution.
+                    ilEncoder.OpCode(ILOpCode.Call);
                     var methodRef = _memberRefRegistry.GetOrAddMethod(
                         runtimeServicesType, 
                         callRuntimeServices.MethodName,

--- a/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
+++ b/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
@@ -1967,40 +1967,27 @@ internal sealed partial class LIRToILCompiler
                     return true;
                 }
 
-                foreach (var arg in callRuntimeServices.Arguments)
+                if (callRuntimeServices.ParameterTypes is { Count: var parameterTypeCount }
+                    && parameterTypeCount != callRuntimeServices.Arguments.Count)
                 {
-                    EmitLoadTemp(arg, ilEncoder, allocation, methodDescriptor);
+                    throw new InvalidOperationException(
+                        $"RuntimeServices call '{callRuntimeServices.MethodName}' has {parameterTypeCount} parameter types for {callRuntimeServices.Arguments.Count} arguments.");
+                }
 
-                    if (GetTempStorage(arg) is { } storage
-                        && storage.Kind == ValueStorageKind.UnboxedValue
-                        && storage.ClrType != null)
-                    {
-                        ilEncoder.OpCode(ILOpCode.Box);
-                        if (storage.ClrType == typeof(double))
-                        {
-                            ilEncoder.Token(_bclReferences.DoubleType);
-                        }
-                        else if (storage.ClrType == typeof(bool))
-                        {
-                            ilEncoder.Token(_bclReferences.BooleanType);
-                        }
-                        else if (storage.ClrType == typeof(int))
-                        {
-                            ilEncoder.Token(_bclReferences.Int32Type);
-                        }
-                        else
-                        {
-                            throw new NotSupportedException($"Unsupported unboxed type for RuntimeServices call: {storage.ClrType}");
-                        }
-                    }
+                var paramTypes = new Type[callRuntimeServices.Arguments.Count];
+                for (int i = 0; i < callRuntimeServices.Arguments.Count; i++)
+                {
+                    var parameterType = callRuntimeServices.ParameterTypes?[i] ?? typeof(object);
+                    paramTypes[i] = parameterType;
+                    EmitLoadTempForParameter(
+                        callRuntimeServices.Arguments[i],
+                        parameterType,
+                        ilEncoder,
+                        allocation,
+                        methodDescriptor);
                 }
 
                 ilEncoder.OpCode(ILOpCode.Call);
-                var paramTypes = new Type[callRuntimeServices.Arguments.Count];
-                for (int i = 0; i < paramTypes.Length; i++)
-                {
-                    paramTypes[i] = typeof(object);
-                }
                 var methodRef = _memberRefRegistry.GetOrAddMethod(
                     typeof(JavaScriptRuntime.RuntimeServices),
                     callRuntimeServices.MethodName,

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Parameters.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Parameters.cs
@@ -355,8 +355,9 @@ public sealed partial class HIRToLIRLowerer
         _methodBodyIR.Instructions.Add(new LIRCallRuntimeServicesStatic(
             MethodName: nameof(JavaScriptRuntime.RuntimeServices.CollectRestArguments),
             Arguments: new[] { startIndexTemp },
-            Result: restArrayTemp));
-        DefineTempStorage(restArrayTemp, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+            Result: restArrayTemp,
+            ParameterTypes: new[] { typeof(double) }));
+        DefineTempStorage(restArrayTemp, new ValueStorage(ValueStorageKind.Reference, typeof(JavaScriptRuntime.Array)));
 
         // Now assign the rest array to the binding
         return TryLowerDestructuringPattern(restParameter.Target, restArrayTemp, DestructuringWriteMode.Declaration, "rest");

--- a/src/Compiler/IR/LIR/LIRInstructions.cs
+++ b/src/Compiler/IR/LIR/LIRInstructions.cs
@@ -598,6 +598,11 @@ public record LIRCreateLeafScopeInstance(ScopeId Scope) : LIRInstruction;
 
 /// <summary>
 /// Calls a static method on JavaScriptRuntime.RuntimeServices (runtime helper methods, not ECMA-262 intrinsics).
-/// Used for runtime services like CollectRestArguments that support JavaScript features.
+/// Optional parameter types allow callers with compile-time-known runtime helper signatures
+/// to preserve unboxed arguments and typed results.
 /// </summary>
-public record LIRCallRuntimeServicesStatic(string MethodName, IReadOnlyList<TempVariable> Arguments, TempVariable Result) : LIRInstruction;
+public record LIRCallRuntimeServicesStatic(
+    string MethodName,
+    IReadOnlyList<TempVariable> Arguments,
+    TempVariable Result,
+    IReadOnlyList<Type>? ParameterTypes = null) : LIRInstruction;

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -1096,26 +1096,19 @@ public class RuntimeServices
     /// Collects rest arguments starting from the specified index into an array.
     /// Used for rest parameter (...args) initialization.
     /// </summary>
-    public static object CollectRestArguments(object startIndexObj)
+    public static Array CollectRestArguments(double startIndex)
     {
-        // Convert to int using JavaScript number conversion
-        int startIndex = startIndexObj switch
-        {
-            int i => i,
-            double d => (int)d,
-            _ => 0
-        };
-        
+        var startIndexAsInt = (int)startIndex;
         var args = _currentArguments.Value;
-        
-        if (args == null || startIndex >= args.Length)
+
+        if (args == null || startIndexAsInt >= args.Length)
         {
             return new Array();
         }
 
         // Collect arguments from startIndex to end
-        var restArgs = new object?[args.Length - startIndex];
-        System.Array.Copy(args, startIndex, restArgs, 0, restArgs.Length);
+        var restArgs = new object?[args.Length - startIndexAsInt];
+        System.Array.Copy(args, startIndexAsInt, restArgs, 0, restArgs.Length);
         return new Array(restArgs);
     }
 

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_RestParameters_Basic.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_RestParameters_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2240
+				// Method begins at RVA 0x2236
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2252
+					// Method begins at RVA 0x2248
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2249
+				// Method begins at RVA 0x223f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,10 +88,10 @@
 			)
 			// Method begins at RVA 0x21b8
 			// Header size: 12
-			// Code size: 115 (0x73)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] object,
 				[2] float64,
 				[3] float64,
@@ -102,47 +102,45 @@
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldc.r8 0.0
-			IL_001d: box [System.Runtime]System.Double
-			IL_0022: stloc.1
-			IL_0023: ldc.r8 0.0
-			IL_002c: stloc.2
-			// loop start (head: IL_002d)
-				IL_002d: ldloc.2
-				IL_002e: stloc.3
-				IL_002f: ldloc.0
-				IL_0030: ldstr "length"
-				IL_0035: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_003a: stloc.s 4
-				IL_003c: ldloc.3
-				IL_003d: ldloc.s 4
-				IL_003f: clt
-				IL_0041: brfalse IL_0071
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldc.r8 0.0
+			IL_0018: box [System.Runtime]System.Double
+			IL_001d: stloc.1
+			IL_001e: ldc.r8 0.0
+			IL_0027: stloc.2
+			// loop start (head: IL_0028)
+				IL_0028: ldloc.2
+				IL_0029: stloc.3
+				IL_002a: ldloc.0
+				IL_002b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_0030: stloc.s 4
+				IL_0032: ldloc.3
+				IL_0033: ldloc.s 4
+				IL_0035: clt
+				IL_0037: brfalse IL_0067
 
-				IL_0046: ldloc.1
-				IL_0047: stloc.s 5
-				IL_0049: ldloc.0
-				IL_004a: ldloc.2
-				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0050: stloc.s 6
-				IL_0052: ldloc.s 5
-				IL_0054: ldloc.s 6
-				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_005b: stloc.s 7
-				IL_005d: ldloc.s 7
-				IL_005f: stloc.1
-				IL_0060: ldloc.2
-				IL_0061: ldc.r8 1
-				IL_006a: add
-				IL_006b: stloc.2
-				IL_006c: br IL_002d
+				IL_003c: ldloc.1
+				IL_003d: stloc.s 5
+				IL_003f: ldloc.0
+				IL_0040: ldloc.2
+				IL_0041: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0046: stloc.s 6
+				IL_0048: ldloc.s 5
+				IL_004a: ldloc.s 6
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0051: stloc.s 7
+				IL_0053: ldloc.s 7
+				IL_0055: stloc.1
+				IL_0056: ldloc.2
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.2
+				IL_0062: br IL_0028
 			// end loop
 
-			IL_0071: ldloc.1
-			IL_0072: ret
+			IL_0067: ldloc.1
+			IL_0068: ret
 		} // end of method ArrowFunction_L3C13::__js_call__
 
 	} // end of class ArrowFunction_L3C13
@@ -154,7 +152,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2237
+			// Method begins at RVA 0x222d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -306,7 +304,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x225b
+		// Method begins at RVA 0x2251
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_RestParameters_WithNamedParams.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_RestParameters_WithNamedParams.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2248
+				// Method begins at RVA 0x223e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -53,7 +53,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2263
+						// Method begins at RVA 0x2259
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -71,7 +71,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x225a
+					// Method begins at RVA 0x2250
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -89,7 +89,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2251
+				// Method begins at RVA 0x2247
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,10 +118,10 @@
 			)
 			// Method begins at RVA 0x21a4
 			// Header size: 12
-			// Code size: 143 (0x8f)
+			// Code size: 133 (0x85)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] string,
 				[2] float64,
 				[3] float64,
@@ -132,62 +132,60 @@
 			)
 
 			IL_0000: ldc.r8 1
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldstr ""
-			IL_0019: stloc.1
-			IL_001a: ldc.r8 0.0
-			IL_0023: stloc.2
-			// loop start (head: IL_0024)
-				IL_0024: ldloc.2
-				IL_0025: stloc.3
-				IL_0026: ldloc.0
-				IL_0027: ldstr "length"
-				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0031: stloc.s 4
-				IL_0033: ldloc.3
-				IL_0034: ldloc.s 4
-				IL_0036: clt
-				IL_0038: brfalse IL_008d
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldstr ""
+			IL_0014: stloc.1
+			IL_0015: ldc.r8 0.0
+			IL_001e: stloc.2
+			// loop start (head: IL_001f)
+				IL_001f: ldloc.2
+				IL_0020: stloc.3
+				IL_0021: ldloc.0
+				IL_0022: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_0027: stloc.s 4
+				IL_0029: ldloc.3
+				IL_002a: ldloc.s 4
+				IL_002c: clt
+				IL_002e: brfalse IL_0083
 
-				IL_003d: ldloc.2
-				IL_003e: stloc.s 4
-				IL_0040: ldloc.s 4
-				IL_0042: ldc.r8 0.0
-				IL_004b: cgt
-				IL_004d: brfalse IL_0062
+				IL_0033: ldloc.2
+				IL_0034: stloc.s 4
+				IL_0036: ldloc.s 4
+				IL_0038: ldc.r8 0.0
+				IL_0041: cgt
+				IL_0043: brfalse IL_0058
 
-				IL_0052: ldloc.1
-				IL_0053: stloc.s 5
-				IL_0055: ldloc.s 5
-				IL_0057: ldarg.2
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_005d: stloc.s 6
-				IL_005f: ldloc.s 6
-				IL_0061: stloc.1
+				IL_0048: ldloc.1
+				IL_0049: stloc.s 5
+				IL_004b: ldloc.s 5
+				IL_004d: ldarg.2
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0053: stloc.s 6
+				IL_0055: ldloc.s 6
+				IL_0057: stloc.1
 
-				IL_0062: ldloc.1
-				IL_0063: stloc.s 6
-				IL_0065: ldloc.0
-				IL_0066: ldloc.2
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_006c: stloc.s 7
-				IL_006e: ldloc.s 6
-				IL_0070: ldloc.s 7
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0077: stloc.s 6
-				IL_0079: ldloc.s 6
-				IL_007b: stloc.1
-				IL_007c: ldloc.2
-				IL_007d: ldc.r8 1
-				IL_0086: add
-				IL_0087: stloc.2
-				IL_0088: br IL_0024
+				IL_0058: ldloc.1
+				IL_0059: stloc.s 6
+				IL_005b: ldloc.0
+				IL_005c: ldloc.2
+				IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0062: stloc.s 7
+				IL_0064: ldloc.s 6
+				IL_0066: ldloc.s 7
+				IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_006d: stloc.s 6
+				IL_006f: ldloc.s 6
+				IL_0071: stloc.1
+				IL_0072: ldloc.2
+				IL_0073: ldc.r8 1
+				IL_007c: add
+				IL_007d: stloc.2
+				IL_007e: br IL_001f
 			// end loop
 
-			IL_008d: ldloc.1
-			IL_008e: ret
+			IL_0083: ldloc.1
+			IL_0084: ret
 		} // end of method ArrowFunction_L3C17::__js_call__
 
 	} // end of class ArrowFunction_L3C17
@@ -199,7 +197,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x223f
+			// Method begins at RVA 0x2235
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -358,7 +356,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x226c
+		// Method begins at RVA 0x2262
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/FunctionRuntimeTests.cs
+++ b/tests/Jroc.Tests/Function/FunctionRuntimeTests.cs
@@ -5,6 +5,24 @@ namespace Jroc.Tests.Function;
 public sealed class FunctionRuntimeTests
 {
     [Fact]
+    public void CollectRestArguments_UsesTypedStartIndexAndReturnsArray()
+    {
+        var previousArguments = RuntimeServices.SetCurrentArguments(new object?[] { "first", 2d, true });
+        try
+        {
+            var rest = RuntimeServices.CollectRestArguments(1d);
+
+            Assert.Equal(2, rest.Count);
+            Assert.Equal(2d, rest[0]);
+            Assert.True(Assert.IsType<bool>(rest[1]));
+        }
+        finally
+        {
+            RuntimeServices.SetCurrentArguments(previousArguments);
+        }
+    }
+
+    [Fact]
     public void Construct_UsesDescriptorFreeJsObjectStorage()
     {
         var runtime = RuntimeServices.BuildServiceProvider();

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e0
+				// Method begins at RVA 0x21d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21f2
+					// Method begins at RVA 0x21e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e9
+				// Method begins at RVA 0x21df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,10 +88,10 @@
 			)
 			// Method begins at RVA 0x2158
 			// Header size: 12
-			// Code size: 115 (0x73)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] object,
 				[2] float64,
 				[3] float64,
@@ -102,47 +102,45 @@
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldc.r8 0.0
-			IL_001d: box [System.Runtime]System.Double
-			IL_0022: stloc.1
-			IL_0023: ldc.r8 0.0
-			IL_002c: stloc.2
-			// loop start (head: IL_002d)
-				IL_002d: ldloc.2
-				IL_002e: stloc.3
-				IL_002f: ldloc.0
-				IL_0030: ldstr "length"
-				IL_0035: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_003a: stloc.s 4
-				IL_003c: ldloc.3
-				IL_003d: ldloc.s 4
-				IL_003f: clt
-				IL_0041: brfalse IL_0071
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldc.r8 0.0
+			IL_0018: box [System.Runtime]System.Double
+			IL_001d: stloc.1
+			IL_001e: ldc.r8 0.0
+			IL_0027: stloc.2
+			// loop start (head: IL_0028)
+				IL_0028: ldloc.2
+				IL_0029: stloc.3
+				IL_002a: ldloc.0
+				IL_002b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_0030: stloc.s 4
+				IL_0032: ldloc.3
+				IL_0033: ldloc.s 4
+				IL_0035: clt
+				IL_0037: brfalse IL_0067
 
-				IL_0046: ldloc.1
-				IL_0047: stloc.s 5
-				IL_0049: ldloc.0
-				IL_004a: ldloc.2
-				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0050: stloc.s 6
-				IL_0052: ldloc.s 5
-				IL_0054: ldloc.s 6
-				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_005b: stloc.s 7
-				IL_005d: ldloc.s 7
-				IL_005f: stloc.1
-				IL_0060: ldloc.2
-				IL_0061: ldc.r8 1
-				IL_006a: add
-				IL_006b: stloc.2
-				IL_006c: br IL_002d
+				IL_003c: ldloc.1
+				IL_003d: stloc.s 5
+				IL_003f: ldloc.0
+				IL_0040: ldloc.2
+				IL_0041: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0046: stloc.s 6
+				IL_0048: ldloc.s 5
+				IL_004a: ldloc.s 6
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0051: stloc.s 7
+				IL_0053: ldloc.s 7
+				IL_0055: stloc.1
+				IL_0056: ldloc.2
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.2
+				IL_0062: br IL_0028
 			// end loop
 
-			IL_0071: ldloc.1
-			IL_0072: ret
+			IL_0067: ldloc.1
+			IL_0068: ret
 		} // end of method sum::__js_call__
 
 	} // end of class sum
@@ -161,7 +159,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d7
+			// Method begins at RVA 0x21cd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -278,7 +276,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21fb
+		// Method begins at RVA 0x21f1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Empty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Empty.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x217a
+					// Method begins at RVA 0x2165
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2171
+				// Method begins at RVA 0x215c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,59 +65,50 @@
 			)
 			// Method begins at RVA 0x20c4
 			// Header size: 12
-			// Code size: 152 (0x98)
+			// Code size: 131 (0x83)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] object,
 				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldstr "console"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0023: stloc.1
-			IL_0024: ldloc.0
-			IL_0025: ldstr "length"
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_002f: stloc.2
-			IL_0030: ldloc.1
-			IL_0031: ldstr "log"
-			IL_0036: ldstr "length:"
-			IL_003b: ldloc.2
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0041: pop
-			IL_0042: ldloc.0
-			IL_0043: ldstr "length"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.2
-			IL_004e: ldloc.2
-			IL_004f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0054: ldc.r8 0.0
-			IL_005d: cgt
-			IL_005f: brfalse IL_0096
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldstr "console"
+			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001e: ldloc.0
+			IL_001f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0024: box [System.Runtime]System.Double
+			IL_0029: stloc.1
+			IL_002a: ldstr "log"
+			IL_002f: ldstr "length:"
+			IL_0034: ldloc.1
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_003a: pop
+			IL_003b: ldloc.0
+			IL_003c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0041: ldc.r8 0.0
+			IL_004a: cgt
+			IL_004c: brfalse IL_0081
 
-			IL_0064: ldstr "console"
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0073: stloc.2
-			IL_0074: ldloc.0
-			IL_0075: ldc.r8 0.0
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0083: stloc.1
-			IL_0084: ldloc.2
-			IL_0085: ldstr "log"
-			IL_008a: ldstr "first:"
-			IL_008f: ldloc.1
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0095: pop
+			IL_0051: ldstr "console"
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0060: ldloc.0
+			IL_0061: ldc.r8 0.0
+			IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_006f: stloc.2
+			IL_0070: ldstr "log"
+			IL_0075: ldstr "first:"
+			IL_007a: ldloc.2
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0080: pop
 
-			IL_0096: ldnull
-			IL_0097: ret
+			IL_0081: ldnull
+			IL_0082: ret
 		} // end of method logArgs::__js_call__
 
 	} // end of class logArgs
@@ -136,7 +127,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2168
+			// Method begins at RVA 0x2153
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -217,7 +208,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2183
+		// Method begins at RVA 0x216e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_MultipleNamed.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_MultipleNamed.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e3
+				// Method begins at RVA 0x21d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21f5
+					// Method begins at RVA 0x21eb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ec
+				// Method begins at RVA 0x21e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -90,10 +90,10 @@
 			)
 			// Method begins at RVA 0x2158
 			// Header size: 12
-			// Code size: 118 (0x76)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] object,
 				[2] float64,
 				[3] float64,
@@ -104,54 +104,52 @@
 			)
 
 			IL_0000: ldc.r8 2
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldarg.2
-			IL_0015: stloc.1
-			IL_0016: ldc.r8 0.0
-			IL_001f: stloc.2
-			// loop start (head: IL_0020)
-				IL_0020: ldloc.2
-				IL_0021: stloc.3
-				IL_0022: ldloc.0
-				IL_0023: ldstr "length"
-				IL_0028: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_002d: stloc.s 4
-				IL_002f: ldloc.3
-				IL_0030: ldloc.s 4
-				IL_0032: clt
-				IL_0034: brfalse IL_0064
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldarg.2
+			IL_0010: stloc.1
+			IL_0011: ldc.r8 0.0
+			IL_001a: stloc.2
+			// loop start (head: IL_001b)
+				IL_001b: ldloc.2
+				IL_001c: stloc.3
+				IL_001d: ldloc.0
+				IL_001e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_0023: stloc.s 4
+				IL_0025: ldloc.3
+				IL_0026: ldloc.s 4
+				IL_0028: clt
+				IL_002a: brfalse IL_005a
 
-				IL_0039: ldloc.1
-				IL_003a: stloc.s 5
-				IL_003c: ldloc.0
-				IL_003d: ldloc.2
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0043: stloc.s 6
-				IL_0045: ldloc.s 5
-				IL_0047: ldloc.s 6
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_004e: stloc.s 7
-				IL_0050: ldloc.s 7
-				IL_0052: stloc.1
-				IL_0053: ldloc.2
-				IL_0054: ldc.r8 1
-				IL_005d: add
-				IL_005e: stloc.2
-				IL_005f: br IL_0020
+				IL_002f: ldloc.1
+				IL_0030: stloc.s 5
+				IL_0032: ldloc.0
+				IL_0033: ldloc.2
+				IL_0034: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0039: stloc.s 6
+				IL_003b: ldloc.s 5
+				IL_003d: ldloc.s 6
+				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0044: stloc.s 7
+				IL_0046: ldloc.s 7
+				IL_0048: stloc.1
+				IL_0049: ldloc.2
+				IL_004a: ldc.r8 1
+				IL_0053: add
+				IL_0054: stloc.2
+				IL_0055: br IL_001b
 			// end loop
 
-			IL_0064: ldloc.1
+			IL_005a: ldloc.1
+			IL_005b: stloc.s 7
+			IL_005d: ldloc.s 7
+			IL_005f: ldarg.3
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0065: stloc.s 7
 			IL_0067: ldloc.s 7
-			IL_0069: ldarg.3
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006f: stloc.s 7
-			IL_0071: ldloc.s 7
-			IL_0073: stloc.1
-			IL_0074: ldloc.1
-			IL_0075: ret
+			IL_0069: stloc.1
+			IL_006a: ldloc.1
+			IL_006b: ret
 		} // end of method format::__js_call__
 
 	} // end of class format
@@ -170,7 +168,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21da
+			// Method begins at RVA 0x21d0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -306,7 +304,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21fe
+		// Method begins at RVA 0x21f4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_WithNamedParams.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_WithNamedParams.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f0
+				// Method begins at RVA 0x21e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x220b
+						// Method begins at RVA 0x2201
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2202
+					// Method begins at RVA 0x21f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f9
+				// Method begins at RVA 0x21ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,10 +111,10 @@
 			)
 			// Method begins at RVA 0x214c
 			// Header size: 12
-			// Code size: 143 (0x8f)
+			// Code size: 133 (0x85)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] string,
 				[2] float64,
 				[3] float64,
@@ -125,62 +125,60 @@
 			)
 
 			IL_0000: ldc.r8 1
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldstr ""
-			IL_0019: stloc.1
-			IL_001a: ldc.r8 0.0
-			IL_0023: stloc.2
-			// loop start (head: IL_0024)
-				IL_0024: ldloc.2
-				IL_0025: stloc.3
-				IL_0026: ldloc.0
-				IL_0027: ldstr "length"
-				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0031: stloc.s 4
-				IL_0033: ldloc.3
-				IL_0034: ldloc.s 4
-				IL_0036: clt
-				IL_0038: brfalse IL_008d
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldstr ""
+			IL_0014: stloc.1
+			IL_0015: ldc.r8 0.0
+			IL_001e: stloc.2
+			// loop start (head: IL_001f)
+				IL_001f: ldloc.2
+				IL_0020: stloc.3
+				IL_0021: ldloc.0
+				IL_0022: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_0027: stloc.s 4
+				IL_0029: ldloc.3
+				IL_002a: ldloc.s 4
+				IL_002c: clt
+				IL_002e: brfalse IL_0083
 
-				IL_003d: ldloc.2
-				IL_003e: stloc.s 4
-				IL_0040: ldloc.s 4
-				IL_0042: ldc.r8 0.0
-				IL_004b: cgt
-				IL_004d: brfalse IL_0062
+				IL_0033: ldloc.2
+				IL_0034: stloc.s 4
+				IL_0036: ldloc.s 4
+				IL_0038: ldc.r8 0.0
+				IL_0041: cgt
+				IL_0043: brfalse IL_0058
 
-				IL_0052: ldloc.1
-				IL_0053: stloc.s 5
-				IL_0055: ldloc.s 5
-				IL_0057: ldarg.2
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_005d: stloc.s 6
-				IL_005f: ldloc.s 6
-				IL_0061: stloc.1
+				IL_0048: ldloc.1
+				IL_0049: stloc.s 5
+				IL_004b: ldloc.s 5
+				IL_004d: ldarg.2
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0053: stloc.s 6
+				IL_0055: ldloc.s 6
+				IL_0057: stloc.1
 
-				IL_0062: ldloc.1
-				IL_0063: stloc.s 6
-				IL_0065: ldloc.0
-				IL_0066: ldloc.2
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_006c: stloc.s 7
-				IL_006e: ldloc.s 6
-				IL_0070: ldloc.s 7
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0077: stloc.s 6
-				IL_0079: ldloc.s 6
-				IL_007b: stloc.1
-				IL_007c: ldloc.2
-				IL_007d: ldc.r8 1
-				IL_0086: add
-				IL_0087: stloc.2
-				IL_0088: br IL_0024
+				IL_0058: ldloc.1
+				IL_0059: stloc.s 6
+				IL_005b: ldloc.0
+				IL_005c: ldloc.2
+				IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0062: stloc.s 7
+				IL_0064: ldloc.s 6
+				IL_0066: ldloc.s 7
+				IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_006d: stloc.s 6
+				IL_006f: ldloc.s 6
+				IL_0071: stloc.1
+				IL_0072: ldloc.2
+				IL_0073: ldc.r8 1
+				IL_007c: add
+				IL_007d: stloc.2
+				IL_007e: br IL_001f
 			// end loop
 
-			IL_008d: ldloc.1
-			IL_008e: ret
+			IL_0083: ldloc.1
+			IL_0084: ret
 		} // end of method combine::__js_call__
 
 	} // end of class combine
@@ -199,7 +197,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e7
+			// Method begins at RVA 0x21dd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -330,7 +328,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2214
+		// Method begins at RVA 0x220a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_AliasOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_AliasOverride.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2182
+				// Method begins at RVA 0x217c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,31 +43,32 @@
 			)
 			// Method begins at RVA 0x2130
 			// Header size: 12
-			// Code size: 61 (0x3d)
+			// Code size: 55 (0x37)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] string
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[1] string
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001a: ldstr "join"
-			IL_001f: ldstr "|"
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0029: stloc.1
-			IL_002a: ldloc.1
-			IL_002b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0030: stloc.2
-			IL_0031: ldstr "aliased:"
-			IL_0036: ldloc.2
-			IL_0037: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003c: ret
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldloc.0
+			IL_0010: ldc.i4.1
+			IL_0011: newarr [System.Runtime]System.Object
+			IL_0016: dup
+			IL_0017: ldc.i4.0
+			IL_0018: ldstr "|"
+			IL_001d: stelem.ref
+			IL_001e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0023: stloc.1
+			IL_0024: ldloc.1
+			IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_002a: stloc.1
+			IL_002b: ldstr "aliased:"
+			IL_0030: ldloc.1
+			IL_0031: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0036: ret
 		} // end of method ArrowFunction_L6C14::__js_call__
 
 	} // end of class ArrowFunction_L6C14
@@ -79,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2179
+			// Method begins at RVA 0x2173
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -207,7 +208,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218b
+		// Method begins at RVA 0x2185
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DefaultParameterOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DefaultParameterOverride.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21eb
+					// Method begins at RVA 0x21e5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,31 +47,32 @@
 				)
 				// Method begins at RVA 0x2190
 				// Header size: 12
-				// Code size: 61 (0x3d)
+				// Code size: 55 (0x37)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object,
-					[2] string
+					[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+					[1] string
 				)
 
 				IL_0000: ldc.r8 0.0
-				IL_0009: box [System.Runtime]System.Double
-				IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-				IL_0013: stloc.0
-				IL_0014: ldloc.0
-				IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_001a: ldstr "join"
-				IL_001f: ldstr "|"
-				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0029: stloc.1
-				IL_002a: ldloc.1
-				IL_002b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0030: stloc.2
-				IL_0031: ldstr "default:"
-				IL_0036: ldloc.2
-				IL_0037: call string [System.Runtime]System.String::Concat(string, string)
-				IL_003c: ret
+				IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+				IL_000e: stloc.0
+				IL_000f: ldloc.0
+				IL_0010: ldc.i4.1
+				IL_0011: newarr [System.Runtime]System.Object
+				IL_0016: dup
+				IL_0017: ldc.i4.0
+				IL_0018: ldstr "|"
+				IL_001d: stelem.ref
+				IL_001e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+				IL_0023: stloc.1
+				IL_0024: ldloc.1
+				IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_002a: stloc.1
+				IL_002b: ldstr "default:"
+				IL_0030: ldloc.1
+				IL_0031: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0036: ret
 			} // end of method ArrowFunction_L6C28::__js_call__
 
 		} // end of class ArrowFunction_L6C28
@@ -87,7 +88,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21f4
+					// Method begins at RVA 0x21ee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -105,7 +106,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e2
+				// Method begins at RVA 0x21dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -199,7 +200,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d9
+			// Method begins at RVA 0x21d3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -321,7 +322,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21fd
+		// Method begins at RVA 0x21f7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DynamicImportOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DynamicImportOverride.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x221b
+					// Method begins at RVA 0x2215
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,31 +47,32 @@
 				)
 				// Method begins at RVA 0x21c0
 				// Header size: 12
-				// Code size: 61 (0x3d)
+				// Code size: 55 (0x37)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object,
-					[2] string
+					[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+					[1] string
 				)
 
 				IL_0000: ldc.r8 0.0
-				IL_0009: box [System.Runtime]System.Double
-				IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-				IL_0013: stloc.0
-				IL_0014: ldloc.0
-				IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_001a: ldstr "join"
-				IL_001f: ldstr "|"
-				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0029: stloc.1
-				IL_002a: ldloc.1
-				IL_002b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0030: stloc.2
-				IL_0031: ldstr "dynamic:"
-				IL_0036: ldloc.2
-				IL_0037: call string [System.Runtime]System.String::Concat(string, string)
-				IL_003c: ret
+				IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+				IL_000e: stloc.0
+				IL_000f: ldloc.0
+				IL_0010: ldc.i4.1
+				IL_0011: newarr [System.Runtime]System.Object
+				IL_0016: dup
+				IL_0017: ldc.i4.0
+				IL_0018: ldstr "|"
+				IL_001d: stelem.ref
+				IL_001e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+				IL_0023: stloc.1
+				IL_0024: ldloc.1
+				IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_002a: stloc.1
+				IL_002b: ldstr "dynamic:"
+				IL_0030: ldloc.1
+				IL_0031: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0036: ret
 			} // end of method ArrowFunction_L6C30::__js_call__
 
 		} // end of class ArrowFunction_L6C30
@@ -90,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2212
+				// Method begins at RVA 0x220c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -228,7 +229,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2209
+			// Method begins at RVA 0x2203
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -318,7 +319,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2224
+		// Method begins at RVA 0x221e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_MemberOverrides.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_MemberOverrides.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2556
+				// Method begins at RVA 0x2550
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -77,7 +77,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x255f
+				// Method begins at RVA 0x2559
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,31 +102,32 @@
 			)
 			// Method begins at RVA 0x2504
 			// Header size: 12
-			// Code size: 61 (0x3d)
+			// Code size: 55 (0x37)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] string
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[1] string
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001a: ldstr "join"
-			IL_001f: ldstr "|"
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0029: stloc.1
-			IL_002a: ldloc.1
-			IL_002b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0030: stloc.2
-			IL_0031: ldstr "patched:"
-			IL_0036: ldloc.2
-			IL_0037: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003c: ret
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldloc.0
+			IL_0010: ldc.i4.1
+			IL_0011: newarr [System.Runtime]System.Object
+			IL_0016: dup
+			IL_0017: ldc.i4.0
+			IL_0018: ldstr "|"
+			IL_001d: stelem.ref
+			IL_001e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0023: stloc.1
+			IL_0024: ldloc.1
+			IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_002a: stloc.1
+			IL_002b: ldstr "patched:"
+			IL_0030: ldloc.1
+			IL_0031: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0036: ret
 		} // end of method ArrowFunction_L13C13::__js_call__
 
 	} // end of class ArrowFunction_L13C13
@@ -147,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2568
+				// Method begins at RVA 0x2562
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -167,7 +168,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2571
+				// Method begins at RVA 0x256b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -187,7 +188,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x257a
+				// Method begins at RVA 0x2574
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -207,7 +208,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2583
+				// Method begins at RVA 0x257d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -229,7 +230,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x254d
+			// Method begins at RVA 0x2547
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -694,7 +695,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x258c
+		// Method begins at RVA 0x2586
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_ModuleRequireOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_ModuleRequireOverride.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2196
+				// Method begins at RVA 0x2190
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,31 +43,32 @@
 			)
 			// Method begins at RVA 0x2144
 			// Header size: 12
-			// Code size: 61 (0x3d)
+			// Code size: 55 (0x37)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] string
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[1] string
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001a: ldstr "join"
-			IL_001f: ldstr "|"
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0029: stloc.1
-			IL_002a: ldloc.1
-			IL_002b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0030: stloc.2
-			IL_0031: ldstr "module-require:"
-			IL_0036: ldloc.2
-			IL_0037: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003c: ret
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldloc.0
+			IL_0010: ldc.i4.1
+			IL_0011: newarr [System.Runtime]System.Object
+			IL_0016: dup
+			IL_0017: ldc.i4.0
+			IL_0018: ldstr "|"
+			IL_001d: stelem.ref
+			IL_001e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0023: stloc.1
+			IL_0024: ldloc.1
+			IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_002a: stloc.1
+			IL_002b: ldstr "module-require:"
+			IL_0030: ldloc.1
+			IL_0031: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0036: ret
 		} // end of method ArrowFunction_L5C31::__js_call__
 
 	} // end of class ArrowFunction_L5C31
@@ -79,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x218d
+			// Method begins at RVA 0x2187
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -210,7 +211,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x219f
+		// Method begins at RVA 0x2199
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_RequireAliasOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_RequireAliasOverride.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x218e
+				// Method begins at RVA 0x2188
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,31 +43,32 @@
 			)
 			// Method begins at RVA 0x213c
 			// Header size: 12
-			// Code size: 61 (0x3d)
+			// Code size: 55 (0x37)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] string
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[1] string
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001a: ldstr "join"
-			IL_001f: ldstr "|"
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0029: stloc.1
-			IL_002a: ldloc.1
-			IL_002b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0030: stloc.2
-			IL_0031: ldstr "require-alias:"
-			IL_0036: ldloc.2
-			IL_0037: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003c: ret
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldloc.0
+			IL_0010: ldc.i4.1
+			IL_0011: newarr [System.Runtime]System.Object
+			IL_0016: dup
+			IL_0017: ldc.i4.0
+			IL_0018: ldstr "|"
+			IL_001d: stelem.ref
+			IL_001e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0023: stloc.1
+			IL_0024: ldloc.1
+			IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_002a: stloc.1
+			IL_002b: ldstr "require-alias:"
+			IL_0030: ldloc.1
+			IL_0031: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0036: ret
 		} // end of method ArrowFunction_L6C29::__js_call__
 
 	} // end of class ArrowFunction_L6C29
@@ -79,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2185
+			// Method begins at RVA 0x217f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -211,7 +212,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2197
+		// Method begins at RVA 0x2191
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b7
+				// Method begins at RVA 0x21b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,34 +44,33 @@
 			)
 			// Method begins at RVA 0x2148
 			// Header size: 12
-			// Code size: 90 (0x5a)
+			// Code size: 85 (0x55)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldc.r8 1
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldstr "console"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0023: ldstr "log"
-			IL_0028: ldstr "strings:"
-			IL_002d: ldarg.1
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0033: pop
-			IL_0034: ldstr "console"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0043: ldstr "log"
-			IL_0048: ldstr "values:"
-			IL_004d: ldloc.0
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0053: pop
-			IL_0054: ldstr "result"
-			IL_0059: ret
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldstr "console"
+			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001e: ldstr "log"
+			IL_0023: ldstr "strings:"
+			IL_0028: ldarg.1
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_002e: pop
+			IL_002f: ldstr "console"
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003e: ldstr "log"
+			IL_0043: ldstr "values:"
+			IL_0048: ldloc.0
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_004e: pop
+			IL_004f: ldstr "result"
+			IL_0054: ret
 		} // end of method tag::__js_call__
 
 	} // end of class tag
@@ -90,7 +89,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ae
+			// Method begins at RVA 0x21a9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -234,7 +233,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c0
+		// Method begins at RVA 0x21bb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2233
+				// Method begins at RVA 0x222b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,25 +44,24 @@
 			)
 			// Method begins at RVA 0x217c
 			// Header size: 12
-			// Code size: 57 (0x39)
+			// Code size: 52 (0x34)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldc.r8 1
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldstr "console"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0023: ldstr "log"
-			IL_0028: ldstr "tag called"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0032: pop
-			IL_0033: ldstr "result"
-			IL_0038: ret
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldstr "console"
+			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001e: ldstr "log"
+			IL_0023: ldstr "tag called"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002d: pop
+			IL_002e: ldstr "result"
+			IL_0033: ret
 		} // end of method tag::__js_call__
 
 	} // end of class tag
@@ -78,7 +77,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x223c
+				// Method begins at RVA 0x2234
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -104,7 +103,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21bc
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -171,7 +170,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x222a
+			// Method begins at RVA 0x2222
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -334,7 +333,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2245
+		// Method begins at RVA 0x223d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_RawStrings.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_RawStrings.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fb
+				// Method begins at RVA 0x21f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,84 +44,83 @@
 			)
 			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 246 (0xf6)
+			// Code size: 241 (0xf1)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] object,
 				[2] object
 			)
 
 			IL_0000: ldc.r8 1
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(object)
-			IL_0013: stloc.0
-			IL_0014: ldstr "console"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0023: stloc.1
-			IL_0024: ldarg.1
-			IL_0025: ldc.r8 0.0
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0033: stloc.2
-			IL_0034: ldloc.1
-			IL_0035: ldstr "log"
-			IL_003a: ldstr "cooked[0]:"
-			IL_003f: ldloc.2
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0045: pop
-			IL_0046: ldstr "console"
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0055: stloc.2
-			IL_0056: ldarg.1
-			IL_0057: ldstr "raw"
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0061: stloc.1
-			IL_0062: ldloc.1
-			IL_0063: ldc.r8 0.0
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0071: stloc.1
-			IL_0072: ldloc.2
-			IL_0073: ldstr "log"
-			IL_0078: ldstr "raw[0]:"
-			IL_007d: ldloc.1
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0083: pop
-			IL_0084: ldstr "console"
-			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0093: stloc.1
-			IL_0094: ldarg.1
-			IL_0095: ldc.r8 1
-			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00a3: stloc.2
-			IL_00a4: ldloc.1
-			IL_00a5: ldstr "log"
-			IL_00aa: ldstr "cooked[1]:"
-			IL_00af: ldloc.2
-			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00b5: pop
-			IL_00b6: ldstr "console"
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c5: stloc.2
-			IL_00c6: ldarg.1
-			IL_00c7: ldstr "raw"
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d1: stloc.1
-			IL_00d2: ldloc.1
-			IL_00d3: ldc.r8 1
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00e1: stloc.1
-			IL_00e2: ldloc.2
-			IL_00e3: ldstr "log"
-			IL_00e8: ldstr "raw[1]:"
-			IL_00ed: ldloc.1
-			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00f3: pop
-			IL_00f4: ldnull
-			IL_00f5: ret
+			IL_0009: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CollectRestArguments(float64)
+			IL_000e: stloc.0
+			IL_000f: ldstr "console"
+			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001e: stloc.1
+			IL_001f: ldarg.1
+			IL_0020: ldc.r8 0.0
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_002e: stloc.2
+			IL_002f: ldloc.1
+			IL_0030: ldstr "log"
+			IL_0035: ldstr "cooked[0]:"
+			IL_003a: ldloc.2
+			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0040: pop
+			IL_0041: ldstr "console"
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0050: stloc.2
+			IL_0051: ldarg.1
+			IL_0052: ldstr "raw"
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_005c: stloc.1
+			IL_005d: ldloc.1
+			IL_005e: ldc.r8 0.0
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_006c: stloc.1
+			IL_006d: ldloc.2
+			IL_006e: ldstr "log"
+			IL_0073: ldstr "raw[0]:"
+			IL_0078: ldloc.1
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_007e: pop
+			IL_007f: ldstr "console"
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008e: stloc.1
+			IL_008f: ldarg.1
+			IL_0090: ldc.r8 1
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_009e: stloc.2
+			IL_009f: ldloc.1
+			IL_00a0: ldstr "log"
+			IL_00a5: ldstr "cooked[1]:"
+			IL_00aa: ldloc.2
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00b0: pop
+			IL_00b1: ldstr "console"
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c0: stloc.2
+			IL_00c1: ldarg.1
+			IL_00c2: ldstr "raw"
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00cc: stloc.1
+			IL_00cd: ldloc.1
+			IL_00ce: ldc.r8 1
+			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00dc: stloc.1
+			IL_00dd: ldloc.2
+			IL_00de: ldstr "log"
+			IL_00e3: ldstr "raw[1]:"
+			IL_00e8: ldloc.1
+			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00ee: pop
+			IL_00ef: ldnull
+			IL_00f0: ret
 		} // end of method tag::__js_call__
 
 	} // end of class tag
@@ -140,7 +139,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21f2
+			// Method begins at RVA 0x21ed
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -250,7 +249,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2204
+		// Method begins at RVA 0x21ff
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary

- type `RuntimeServices.CollectRestArguments` as `double -> JavaScriptRuntime.Array`
- preserve the known helper signature through LIR and both IL emission paths
- retain the rest array type for direct `Array` member calls
- add runtime coverage and refresh focused rest-parameter IL snapshots

## Validation

- `dotnet build jroc.sln --no-restore --nologo`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --nologo --filter 'FullyQualifiedName~CollectRestArguments_UsesTypedStartIndexAndReturnsArray|FullyQualifiedName~Require_Path_DefaultParameterOverride|FullyQualifiedName~Function_RestParameters_|FullyQualifiedName~ArrowFunction_RestParameters_'`

Fixes #1682
