### PR TITLE
perf(il): omit redundant Error string conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   calls such as `String.Trim`.
 - compiler/runtime: emit rest-parameter collection with an unboxed `double`
   start index and a typed JavaScript `Array` result.
+- compiler: omit JavaScript-to-.NET string conversion when a built-in Error
+  constructor receives a value already known to be a CLR `string`.
 
 ## v0.12.1 - 2026-08-02
 

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.TempsAndExceptions.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.TempsAndExceptions.cs
@@ -164,15 +164,7 @@ internal sealed partial class LIRToILCompiler
 
                     if (newError.Message.HasValue)
                     {
-                        // JS: Error(message) stringifies message.
-                        EmitLoadTempAsObject(newError.Message.Value, ilEncoder, allocation, methodDescriptor);
-                        var toString = _memberRefRegistry.GetOrAddMethod(
-                            typeof(JavaScriptRuntime.DotNet2JSConversions),
-                            nameof(JavaScriptRuntime.DotNet2JSConversions.ToString),
-                            parameterTypes: new[] { typeof(object) });
-                        ilEncoder.OpCode(ILOpCode.Call);
-                        ilEncoder.Token(toString);
-
+                        EmitLoadBuiltInErrorMessage(newError.Message.Value, ilEncoder, allocation, methodDescriptor);
                         var ctor = _memberRefRegistry.GetOrAddConstructor(errorClrType, parameterTypes: new[] { typeof(string) });
                         ilEncoder.OpCode(ILOpCode.Newobj);
                         ilEncoder.Token(ctor);
@@ -207,5 +199,28 @@ internal sealed partial class LIRToILCompiler
             default:
                 return null;
         }
+    }
+
+    private void EmitLoadBuiltInErrorMessage(
+        TempVariable message,
+        InstructionEncoder ilEncoder,
+        TempLocalAllocation allocation,
+        MethodDescriptor methodDescriptor)
+    {
+        var storage = GetTempStorage(message);
+        if (storage.Kind == ValueStorageKind.Reference && storage.ClrType == typeof(string))
+        {
+            EmitLoadTempAsString(message, ilEncoder, allocation, methodDescriptor);
+            return;
+        }
+
+        // JavaScript Error constructors stringify non-string messages.
+        EmitLoadTempAsObject(message, ilEncoder, allocation, methodDescriptor);
+        var toString = _memberRefRegistry.GetOrAddMethod(
+            typeof(JavaScriptRuntime.DotNet2JSConversions),
+            nameof(JavaScriptRuntime.DotNet2JSConversions.ToString),
+            parameterTypes: new[] { typeof(object) });
+        ilEncoder.OpCode(ILOpCode.Call);
+        ilEncoder.Token(toString);
     }
 }

--- a/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
+++ b/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
@@ -254,13 +254,7 @@ internal sealed partial class LIRToILCompiler
 
                     if (newError.Message.HasValue)
                     {
-                        EmitLoadTempAsObject(newError.Message.Value, ilEncoder, allocation, methodDescriptor);
-                        var toString = _memberRefRegistry.GetOrAddMethod(
-                            typeof(JavaScriptRuntime.DotNet2JSConversions),
-                            nameof(JavaScriptRuntime.DotNet2JSConversions.ToString),
-                            parameterTypes: new[] { typeof(object) });
-                        ilEncoder.OpCode(ILOpCode.Call);
-                        ilEncoder.Token(toString);
+                        EmitLoadBuiltInErrorMessage(newError.Message.Value, ilEncoder, allocation, methodDescriptor);
                         var ctor = _memberRefRegistry.GetOrAddConstructor(errorClrType, parameterTypes: new[] { typeof(string) });
                         ilEncoder.OpCode(ILOpCode.Newobj);
                         ilEncoder.Token(ctor);

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x527d
+				// Method begins at RVA 0x5245
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5298
+						// Method begins at RVA 0x5260
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52a1
+						// Method begins at RVA 0x5269
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52aa
+						// Method begins at RVA 0x5272
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52b3
+						// Method begins at RVA 0x527b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52bc
+						// Method begins at RVA 0x5284
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -146,7 +146,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52c5
+						// Method begins at RVA 0x528d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -164,7 +164,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x528f
+					// Method begins at RVA 0x5257
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5286
+				// Method begins at RVA 0x524e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -500,7 +500,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52ce
+				// Method begins at RVA 0x5296
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -610,7 +610,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52d7
+				// Method begins at RVA 0x529f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -739,7 +739,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52e9
+					// Method begins at RVA 0x52b1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -757,7 +757,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52e0
+				// Method begins at RVA 0x52a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -881,7 +881,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52f2
+				// Method begins at RVA 0x52ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -944,7 +944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52fb
+				// Method begins at RVA 0x52c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1041,7 +1041,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x530d
+					// Method begins at RVA 0x52d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1059,7 +1059,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5304
+				// Method begins at RVA 0x52cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1086,7 +1086,7 @@
 			)
 			// Method begins at RVA 0x2c88
 			// Header size: 12
-			// Code size: 168 (0xa8)
+			// Code size: 163 (0xa3)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1138,7 +1138,7 @@
 			IL_005c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0061: stloc.2
 			IL_0062: ldloc.2
-			IL_0063: brfalse IL_00a6
+			IL_0063: brfalse IL_00a1
 
 			IL_0068: ldarg.2
 			IL_0069: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
@@ -1150,23 +1150,22 @@
 			IL_007f: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0084: stloc.1
 			IL_0085: ldloc.1
-			IL_0086: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_008b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0090: stloc.0
-			IL_0091: ldloc.0
-			IL_0092: isinst [System.Runtime]System.Exception
-			IL_0097: dup
-			IL_0098: brtrue IL_00a5
+			IL_0086: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_008b: stloc.0
+			IL_008c: ldloc.0
+			IL_008d: isinst [System.Runtime]System.Exception
+			IL_0092: dup
+			IL_0093: brtrue IL_00a0
 
-			IL_009d: pop
-			IL_009e: ldloc.0
-			IL_009f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00a4: throw
+			IL_0098: pop
+			IL_0099: ldloc.0
+			IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_009f: throw
 
-			IL_00a5: throw
+			IL_00a0: throw
 
-			IL_00a6: ldnull
-			IL_00a7: ret
+			IL_00a1: ldnull
+			IL_00a2: ret
 		} // end of method ensureString::__js_call__
 
 	} // end of class ensureString
@@ -1186,7 +1185,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x531f
+					// Method begins at RVA 0x52e7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1204,7 +1203,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5316
+				// Method begins at RVA 0x52de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1232,7 +1231,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x533a
+						// Method begins at RVA 0x5302
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1250,7 +1249,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5331
+					// Method begins at RVA 0x52f9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1268,7 +1267,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5328
+				// Method begins at RVA 0x52f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1293,9 +1292,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d3c
+			// Method begins at RVA 0x2d38
 			// Header size: 12
-			// Code size: 462 (0x1ce)
+			// Code size: 452 (0x1c4)
 			.maxstack 10
 			.locals init (
 				[0] object,
@@ -1353,7 +1352,7 @@
 			IL_0064: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0069: stloc.s 6
 			IL_006b: ldloc.s 6
-			IL_006d: brfalse IL_00b4
+			IL_006d: brfalse IL_00af
 
 			IL_0072: ldarg.2
 			IL_0073: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
@@ -1365,139 +1364,137 @@
 			IL_008b: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0090: stloc.s 12
 			IL_0092: ldloc.s 12
-			IL_0094: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0099: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_009e: stloc.0
-			IL_009f: ldloc.0
-			IL_00a0: isinst [System.Runtime]System.Exception
-			IL_00a5: dup
-			IL_00a6: brtrue IL_00b3
+			IL_0094: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0099: stloc.0
+			IL_009a: ldloc.0
+			IL_009b: isinst [System.Runtime]System.Exception
+			IL_00a0: dup
+			IL_00a1: brtrue IL_00ae
 
-			IL_00ab: pop
-			IL_00ac: ldloc.0
-			IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00b2: throw
+			IL_00a6: pop
+			IL_00a7: ldloc.0
+			IL_00a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00ad: throw
 
-			IL_00b3: throw
+			IL_00ae: throw
 
-			IL_00b4: ldarg.1
-			IL_00b5: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_00ba: stloc.1
-			IL_00bb: ldc.i4.0
-			IL_00bc: stloc.2
-			IL_00bd: ldc.i4.0
-			IL_00be: stloc.3
+			IL_00af: ldarg.1
+			IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_00b5: stloc.1
+			IL_00b6: ldc.i4.0
+			IL_00b7: stloc.2
+			IL_00b8: ldc.i4.0
+			IL_00b9: stloc.3
 			.try
 			{
-				// loop start (head: IL_00bf)
-					IL_00bf: ldloc.1
-					IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_00c5: stloc.s 8
-					IL_00c7: ldloc.s 8
-					IL_00c9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_00ce: stloc.s 6
-					IL_00d0: ldloc.s 6
-					IL_00d2: brtrue IL_01b2
+				// loop start (head: IL_00ba)
+					IL_00ba: ldloc.1
+					IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_00c0: stloc.s 8
+					IL_00c2: ldloc.s 8
+					IL_00c4: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_00c9: stloc.s 6
+					IL_00cb: ldloc.s 6
+					IL_00cd: brtrue IL_01a8
 
-					IL_00d7: ldloc.s 8
-					IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_00de: stloc.s 8
-					IL_00e0: ldloc.s 8
-					IL_00e2: stloc.s 4
-					IL_00e4: ldloc.s 4
-					IL_00e6: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-					IL_00eb: stloc.s 12
-					IL_00ed: ldloc.s 12
-					IL_00ef: ldstr "string"
-					IL_00f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-					IL_00f9: stloc.s 6
-					IL_00fb: ldloc.s 6
-					IL_00fd: box [System.Runtime]System.Boolean
-					IL_0102: stloc.s 7
-					IL_0104: ldloc.s 7
-					IL_0106: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_010b: stloc.s 6
-					IL_010d: ldloc.s 6
-					IL_010f: brtrue IL_0147
+					IL_00d2: ldloc.s 8
+					IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_00d9: stloc.s 8
+					IL_00db: ldloc.s 8
+					IL_00dd: stloc.s 4
+					IL_00df: ldloc.s 4
+					IL_00e1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+					IL_00e6: stloc.s 12
+					IL_00e8: ldloc.s 12
+					IL_00ea: ldstr "string"
+					IL_00ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+					IL_00f4: stloc.s 6
+					IL_00f6: ldloc.s 6
+					IL_00f8: box [System.Runtime]System.Boolean
+					IL_00fd: stloc.s 7
+					IL_00ff: ldloc.s 7
+					IL_0101: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0106: stloc.s 6
+					IL_0108: ldloc.s 6
+					IL_010a: brtrue IL_0142
 
-					IL_0114: ldloc.s 4
-					IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_011b: ldstr "trim"
-					IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_0125: stloc.s 8
-					IL_0127: ldloc.s 8
-					IL_0129: ldstr ""
-					IL_012e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-					IL_0133: stloc.s 6
-					IL_0135: ldloc.s 6
-					IL_0137: box [System.Runtime]System.Boolean
-					IL_013c: stloc.s 9
-					IL_013e: ldloc.s 9
-					IL_0140: stloc.s 13
-					IL_0142: br IL_014b
+					IL_010f: ldloc.s 4
+					IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0116: ldstr "trim"
+					IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_0120: stloc.s 8
+					IL_0122: ldloc.s 8
+					IL_0124: ldstr ""
+					IL_0129: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+					IL_012e: stloc.s 6
+					IL_0130: ldloc.s 6
+					IL_0132: box [System.Runtime]System.Boolean
+					IL_0137: stloc.s 9
+					IL_0139: ldloc.s 9
+					IL_013b: stloc.s 13
+					IL_013d: br IL_0146
 
-					IL_0147: ldloc.s 7
-					IL_0149: stloc.s 13
+					IL_0142: ldloc.s 7
+					IL_0144: stloc.s 13
 
-					IL_014b: ldloc.s 13
-					IL_014d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0152: stloc.s 6
-					IL_0154: ldloc.s 6
-					IL_0156: brfalse IL_01a0
+					IL_0146: ldloc.s 13
+					IL_0148: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_014d: stloc.s 6
+					IL_014f: ldloc.s 6
+					IL_0151: brfalse IL_0196
 
-					IL_015b: ldarg.2
-					IL_015c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0161: stloc.s 12
-					IL_0163: ldstr "Invalid pin file: '"
-					IL_0168: ldloc.s 12
-					IL_016a: call string [System.Runtime]System.String::Concat(string, string)
-					IL_016f: ldstr "' entries must be non-empty strings."
-					IL_0174: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0179: stloc.s 12
-					IL_017b: ldloc.s 12
-					IL_017d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0182: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0187: stloc.s 5
-					IL_0189: ldloc.s 5
-					IL_018b: isinst [System.Runtime]System.Exception
-					IL_0190: dup
-					IL_0191: brtrue IL_019f
+					IL_0156: ldarg.2
+					IL_0157: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_015c: stloc.s 12
+					IL_015e: ldstr "Invalid pin file: '"
+					IL_0163: ldloc.s 12
+					IL_0165: call string [System.Runtime]System.String::Concat(string, string)
+					IL_016a: ldstr "' entries must be non-empty strings."
+					IL_016f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0174: stloc.s 12
+					IL_0176: ldloc.s 12
+					IL_0178: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_017d: stloc.s 5
+					IL_017f: ldloc.s 5
+					IL_0181: isinst [System.Runtime]System.Exception
+					IL_0186: dup
+					IL_0187: brtrue IL_0195
 
-					IL_0196: pop
-					IL_0197: ldloc.s 5
-					IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-					IL_019e: throw
+					IL_018c: pop
+					IL_018d: ldloc.s 5
+					IL_018f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_0194: throw
 
-					IL_019f: throw
+					IL_0195: throw
 
-					IL_01a0: br IL_00bf
+					IL_0196: br IL_00ba
 				// end loop
-				IL_01a5: ldloc.1
-				IL_01a6: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_01ab: ldc.i4.1
-				IL_01ac: stloc.3
-				IL_01ad: leave IL_01cc
+				IL_019b: ldloc.1
+				IL_019c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_01a1: ldc.i4.1
+				IL_01a2: stloc.3
+				IL_01a3: leave IL_01c2
 
-				IL_01b2: ldc.i4.1
-				IL_01b3: stloc.2
-				IL_01b4: leave IL_01cc
+				IL_01a8: ldc.i4.1
+				IL_01a9: stloc.2
+				IL_01aa: leave IL_01c2
 			} // end .try
 			finally
 			{
-				IL_01b9: ldloc.2
-				IL_01ba: brtrue IL_01cb
+				IL_01af: ldloc.2
+				IL_01b0: brtrue IL_01c1
 
-				IL_01bf: ldloc.3
-				IL_01c0: brtrue IL_01cb
+				IL_01b5: ldloc.3
+				IL_01b6: brtrue IL_01c1
 
-				IL_01c5: ldloc.1
-				IL_01c6: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_01bb: ldloc.1
+				IL_01bc: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_01cb: endfinally
+				IL_01c1: endfinally
 			} // end handler
 
-			IL_01cc: ldnull
-			IL_01cd: ret
+			IL_01c2: ldnull
+			IL_01c3: ret
 		} // end of method ensureStringArray::__js_call__
 
 	} // end of class ensureStringArray
@@ -1513,7 +1510,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5343
+				// Method begins at RVA 0x530b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1541,7 +1538,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x535e
+						// Method begins at RVA 0x5326
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1559,7 +1556,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5355
+					// Method begins at RVA 0x531d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1577,7 +1574,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x534c
+				// Method begins at RVA 0x5314
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1604,9 +1601,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2f28
+			// Method begins at RVA 0x2f18
 			// Header size: 12
-			// Code size: 208 (0xd0)
+			// Code size: 203 (0xcb)
 			.maxstack 10
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
@@ -1652,7 +1649,7 @@
 					IL_0039: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_003e: stloc.s 7
 					IL_0040: ldloc.s 7
-					IL_0042: brtrue IL_00b4
+					IL_0042: brtrue IL_00af
 
 					IL_0047: ldloc.s 5
 					IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -1669,52 +1666,51 @@
 					IL_006c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_0071: stloc.s 7
 					IL_0073: ldloc.s 7
-					IL_0075: brfalse IL_00a2
+					IL_0075: brfalse IL_009d
 
 					IL_007a: ldstr "Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification."
-					IL_007f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0084: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0089: stloc.s 4
-					IL_008b: ldloc.s 4
-					IL_008d: isinst [System.Runtime]System.Exception
-					IL_0092: dup
-					IL_0093: brtrue IL_00a1
+					IL_007f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0084: stloc.s 4
+					IL_0086: ldloc.s 4
+					IL_0088: isinst [System.Runtime]System.Exception
+					IL_008d: dup
+					IL_008e: brtrue IL_009c
 
-					IL_0098: pop
-					IL_0099: ldloc.s 4
-					IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-					IL_00a0: throw
+					IL_0093: pop
+					IL_0094: ldloc.s 4
+					IL_0096: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_009b: throw
 
-					IL_00a1: throw
+					IL_009c: throw
 
-					IL_00a2: br IL_002f
+					IL_009d: br IL_002f
 				// end loop
-				IL_00a7: ldloc.0
-				IL_00a8: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_00ad: ldc.i4.1
-				IL_00ae: stloc.2
-				IL_00af: leave IL_00ce
+				IL_00a2: ldloc.0
+				IL_00a3: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_00a8: ldc.i4.1
+				IL_00a9: stloc.2
+				IL_00aa: leave IL_00c9
 
-				IL_00b4: ldc.i4.1
-				IL_00b5: stloc.1
-				IL_00b6: leave IL_00ce
+				IL_00af: ldc.i4.1
+				IL_00b0: stloc.1
+				IL_00b1: leave IL_00c9
 			} // end .try
 			finally
 			{
-				IL_00bb: ldloc.1
-				IL_00bc: brtrue IL_00cd
+				IL_00b6: ldloc.1
+				IL_00b7: brtrue IL_00c8
 
-				IL_00c1: ldloc.2
-				IL_00c2: brtrue IL_00cd
+				IL_00bc: ldloc.2
+				IL_00bd: brtrue IL_00c8
 
-				IL_00c7: ldloc.0
-				IL_00c8: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_00c2: ldloc.0
+				IL_00c3: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_00cd: endfinally
+				IL_00c8: endfinally
 			} // end handler
 
-			IL_00ce: ldnull
-			IL_00cf: ret
+			IL_00c9: ldnull
+			IL_00ca: ret
 		} // end of method validateExcludedFromMvp::__js_call__
 
 	} // end of class validateExcludedFromMvp
@@ -1734,7 +1730,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5370
+					// Method begins at RVA 0x5338
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1754,7 +1750,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5379
+					// Method begins at RVA 0x5341
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1774,7 +1770,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5382
+					// Method begins at RVA 0x534a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1792,7 +1788,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5367
+				// Method begins at RVA 0x532f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1819,9 +1815,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3014
+			// Method begins at RVA 0x3000
 			// Header size: 12
-			// Code size: 1263 (0x4ef)
+			// Code size: 1248 (0x4e0)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1875,469 +1871,466 @@
 			IL_004c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0051: stloc.3
 			IL_0052: ldloc.3
-			IL_0053: brfalse IL_007d
+			IL_0053: brfalse IL_0078
 
 			IL_0058: ldstr "Invalid pin file: expected a JSON object."
-			IL_005d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0062: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0067: stloc.0
-			IL_0068: ldloc.0
-			IL_0069: isinst [System.Runtime]System.Exception
-			IL_006e: dup
-			IL_006f: brtrue IL_007c
+			IL_005d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0062: stloc.0
+			IL_0063: ldloc.0
+			IL_0064: isinst [System.Runtime]System.Exception
+			IL_0069: dup
+			IL_006a: brtrue IL_0077
 
-			IL_0074: pop
-			IL_0075: ldloc.0
-			IL_0076: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_007b: throw
+			IL_006f: pop
+			IL_0070: ldloc.0
+			IL_0071: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0076: throw
 
-			IL_007c: throw
+			IL_0077: throw
 
-			IL_007d: ldarg.2
-			IL_007e: ldstr "upstream"
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0088: stloc.s 9
-			IL_008a: ldloc.s 9
-			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0091: ldc.i4.0
-			IL_0092: ceq
-			IL_0094: stloc.3
-			IL_0095: ldloc.3
-			IL_0096: box [System.Runtime]System.Boolean
-			IL_009b: stloc.s 4
-			IL_009d: ldloc.s 4
-			IL_009f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00a4: stloc.3
-			IL_00a5: ldloc.3
-			IL_00a6: brtrue IL_00df
+			IL_0078: ldarg.2
+			IL_0079: ldstr "upstream"
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0083: stloc.s 9
+			IL_0085: ldloc.s 9
+			IL_0087: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_008c: ldc.i4.0
+			IL_008d: ceq
+			IL_008f: stloc.3
+			IL_0090: ldloc.3
+			IL_0091: box [System.Runtime]System.Boolean
+			IL_0096: stloc.s 4
+			IL_0098: ldloc.s 4
+			IL_009a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_009f: stloc.3
+			IL_00a0: ldloc.3
+			IL_00a1: brtrue IL_00da
 
-			IL_00ab: ldarg.2
-			IL_00ac: ldstr "upstream"
-			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b6: stloc.s 9
-			IL_00b8: ldloc.s 9
-			IL_00ba: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_00bf: stloc.s 5
-			IL_00c1: ldloc.s 5
-			IL_00c3: ldstr "object"
-			IL_00c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00cd: stloc.3
-			IL_00ce: ldloc.3
-			IL_00cf: box [System.Runtime]System.Boolean
-			IL_00d4: stloc.s 6
-			IL_00d6: ldloc.s 6
-			IL_00d8: stloc.s 10
-			IL_00da: br IL_00e3
+			IL_00a6: ldarg.2
+			IL_00a7: ldstr "upstream"
+			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b1: stloc.s 9
+			IL_00b3: ldloc.s 9
+			IL_00b5: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_00ba: stloc.s 5
+			IL_00bc: ldloc.s 5
+			IL_00be: ldstr "object"
+			IL_00c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_00c8: stloc.3
+			IL_00c9: ldloc.3
+			IL_00ca: box [System.Runtime]System.Boolean
+			IL_00cf: stloc.s 6
+			IL_00d1: ldloc.s 6
+			IL_00d3: stloc.s 10
+			IL_00d5: br IL_00de
 
-			IL_00df: ldloc.s 4
-			IL_00e1: stloc.s 10
+			IL_00da: ldloc.s 4
+			IL_00dc: stloc.s 10
 
-			IL_00e3: ldloc.s 10
-			IL_00e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00ea: stloc.3
-			IL_00eb: ldloc.3
-			IL_00ec: brfalse IL_0116
+			IL_00de: ldloc.s 10
+			IL_00e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00e5: stloc.3
+			IL_00e6: ldloc.3
+			IL_00e7: brfalse IL_010c
 
-			IL_00f1: ldstr "Invalid pin file: expected object for 'upstream'."
-			IL_00f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0100: stloc.1
-			IL_0101: ldloc.1
-			IL_0102: isinst [System.Runtime]System.Exception
-			IL_0107: dup
-			IL_0108: brtrue IL_0115
+			IL_00ec: ldstr "Invalid pin file: expected object for 'upstream'."
+			IL_00f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00f6: stloc.1
+			IL_00f7: ldloc.1
+			IL_00f8: isinst [System.Runtime]System.Exception
+			IL_00fd: dup
+			IL_00fe: brtrue IL_010b
 
-			IL_010d: pop
-			IL_010e: ldloc.1
-			IL_010f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0114: throw
+			IL_0103: pop
+			IL_0104: ldloc.1
+			IL_0105: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_010a: throw
 
-			IL_0115: throw
+			IL_010b: throw
 
-			IL_0116: ldarg.0
-			IL_0117: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_011c: stloc.s 9
-			IL_011e: ldc.i4.1
-			IL_011f: newarr [System.Runtime]System.Object
-			IL_0124: dup
-			IL_0125: ldc.i4.0
-			IL_0126: ldarg.0
-			IL_0127: stelem.ref
-			IL_0128: stloc.s 11
-			IL_012a: ldarg.2
-			IL_012b: ldstr "upstream"
-			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0135: stloc.s 12
-			IL_0137: ldloc.s 12
-			IL_0139: ldstr "owner"
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0143: stloc.s 12
-			IL_0145: ldloc.s 9
-			IL_0147: ldloc.s 11
-			IL_0149: ldloc.s 12
-			IL_014b: ldstr "upstream.owner"
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0155: pop
-			IL_0156: ldarg.0
-			IL_0157: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_015c: stloc.s 12
-			IL_015e: ldc.i4.1
-			IL_015f: newarr [System.Runtime]System.Object
-			IL_0164: dup
-			IL_0165: ldc.i4.0
-			IL_0166: ldarg.0
-			IL_0167: stelem.ref
-			IL_0168: stloc.s 11
-			IL_016a: ldarg.2
-			IL_016b: ldstr "upstream"
-			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 9
-			IL_0177: ldloc.s 9
-			IL_0179: ldstr "repo"
-			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 9
-			IL_0185: ldloc.s 12
-			IL_0187: ldloc.s 11
-			IL_0189: ldloc.s 9
-			IL_018b: ldstr "upstream.repo"
-			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0195: pop
-			IL_0196: ldarg.0
-			IL_0197: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_019c: stloc.s 9
-			IL_019e: ldc.i4.1
-			IL_019f: newarr [System.Runtime]System.Object
-			IL_01a4: dup
-			IL_01a5: ldc.i4.0
-			IL_01a6: ldarg.0
-			IL_01a7: stelem.ref
-			IL_01a8: stloc.s 11
-			IL_01aa: ldarg.2
-			IL_01ab: ldstr "upstream"
-			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01b5: stloc.s 12
-			IL_01b7: ldloc.s 12
-			IL_01b9: ldstr "cloneUrl"
-			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c3: stloc.s 12
-			IL_01c5: ldloc.s 9
-			IL_01c7: ldloc.s 11
-			IL_01c9: ldloc.s 12
-			IL_01cb: ldstr "upstream.cloneUrl"
-			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01d5: pop
-			IL_01d6: ldarg.0
-			IL_01d7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_01dc: stloc.s 12
-			IL_01de: ldc.i4.1
-			IL_01df: newarr [System.Runtime]System.Object
-			IL_01e4: dup
-			IL_01e5: ldc.i4.0
-			IL_01e6: ldarg.0
-			IL_01e7: stelem.ref
-			IL_01e8: stloc.s 11
-			IL_01ea: ldarg.2
-			IL_01eb: ldstr "upstream"
-			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f5: stloc.s 9
-			IL_01f7: ldloc.s 9
-			IL_01f9: ldstr "commit"
-			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0203: stloc.s 9
-			IL_0205: ldloc.s 12
-			IL_0207: ldloc.s 11
-			IL_0209: ldloc.s 9
-			IL_020b: ldstr "upstream.commit"
-			IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0215: pop
-			IL_0216: ldarg.0
-			IL_0217: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_021c: stloc.s 9
-			IL_021e: ldc.i4.1
-			IL_021f: newarr [System.Runtime]System.Object
-			IL_0224: dup
-			IL_0225: ldc.i4.0
-			IL_0226: ldarg.0
-			IL_0227: stelem.ref
-			IL_0228: stloc.s 11
-			IL_022a: ldarg.2
-			IL_022b: ldstr "upstream"
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0235: stloc.s 12
-			IL_0237: ldloc.s 12
-			IL_0239: ldstr "packageVersion"
-			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0243: stloc.s 12
-			IL_0245: ldloc.s 9
-			IL_0247: ldloc.s 11
-			IL_0249: ldloc.s 12
-			IL_024b: ldstr "upstream.packageVersion"
-			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0255: pop
-			IL_0256: ldarg.0
-			IL_0257: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_025c: stloc.s 12
-			IL_025e: ldc.i4.1
-			IL_025f: newarr [System.Runtime]System.Object
-			IL_0264: dup
-			IL_0265: ldc.i4.0
-			IL_0266: ldarg.0
-			IL_0267: stelem.ref
-			IL_0268: stloc.s 11
-			IL_026a: ldarg.2
-			IL_026b: ldstr "localOverrideEnvVar"
-			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0275: stloc.s 9
-			IL_0277: ldloc.s 12
-			IL_0279: ldloc.s 11
-			IL_027b: ldloc.s 9
-			IL_027d: ldstr "localOverrideEnvVar"
-			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0287: pop
-			IL_0288: ldarg.0
-			IL_0289: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_028e: stloc.s 9
-			IL_0290: ldc.i4.1
-			IL_0291: newarr [System.Runtime]System.Object
-			IL_0296: dup
-			IL_0297: ldc.i4.0
-			IL_0298: ldarg.0
-			IL_0299: stelem.ref
-			IL_029a: stloc.s 11
-			IL_029c: ldarg.2
-			IL_029d: ldstr "managedRoot"
-			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a7: stloc.s 12
-			IL_02a9: ldloc.s 9
-			IL_02ab: ldloc.s 11
-			IL_02ad: ldloc.s 12
-			IL_02af: ldstr "managedRoot"
-			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02b9: pop
-			IL_02ba: ldarg.0
-			IL_02bb: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_02c0: stloc.s 12
-			IL_02c2: ldc.i4.1
-			IL_02c3: newarr [System.Runtime]System.Object
-			IL_02c8: dup
-			IL_02c9: ldc.i4.0
-			IL_02ca: ldarg.0
-			IL_02cb: stelem.ref
-			IL_02cc: stloc.s 11
-			IL_02ce: ldarg.2
-			IL_02cf: ldstr "lineEndings"
-			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02d9: stloc.s 9
-			IL_02db: ldloc.s 12
-			IL_02dd: ldloc.s 11
-			IL_02df: ldloc.s 9
-			IL_02e1: ldstr "lineEndings"
-			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02eb: pop
-			IL_02ec: ldarg.0
-			IL_02ed: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_02f2: stloc.s 9
-			IL_02f4: ldc.i4.1
-			IL_02f5: newarr [System.Runtime]System.Object
-			IL_02fa: dup
-			IL_02fb: ldc.i4.0
-			IL_02fc: ldarg.0
-			IL_02fd: stelem.ref
-			IL_02fe: stloc.s 11
-			IL_0300: ldarg.2
-			IL_0301: ldstr "updateStrategy"
-			IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_030b: stloc.s 12
-			IL_030d: ldloc.s 9
-			IL_030f: ldloc.s 11
-			IL_0311: ldloc.s 12
-			IL_0313: ldstr "updateStrategy"
-			IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_031d: pop
-			IL_031e: ldarg.0
-			IL_031f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_0324: stloc.s 12
-			IL_0326: ldc.i4.1
-			IL_0327: newarr [System.Runtime]System.Object
-			IL_032c: dup
-			IL_032d: ldc.i4.0
-			IL_032e: ldarg.0
-			IL_032f: stelem.ref
-			IL_0330: stloc.s 11
-			IL_0332: ldarg.2
-			IL_0333: ldstr "includeFiles"
-			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_033d: stloc.s 9
-			IL_033f: ldloc.s 12
-			IL_0341: ldloc.s 11
-			IL_0343: ldloc.s 9
-			IL_0345: ldstr "includeFiles"
-			IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_034f: pop
-			IL_0350: ldarg.0
-			IL_0351: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_0356: stloc.s 9
-			IL_0358: ldc.i4.1
-			IL_0359: newarr [System.Runtime]System.Object
-			IL_035e: dup
-			IL_035f: ldc.i4.0
-			IL_0360: ldarg.0
-			IL_0361: stelem.ref
-			IL_0362: stloc.s 11
-			IL_0364: ldarg.2
-			IL_0365: ldstr "includeDirectories"
-			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_036f: stloc.s 12
-			IL_0371: ldloc.s 9
-			IL_0373: ldloc.s 11
-			IL_0375: ldloc.s 12
-			IL_0377: ldstr "includeDirectories"
-			IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0381: pop
-			IL_0382: ldarg.0
-			IL_0383: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_0388: stloc.s 12
-			IL_038a: ldc.i4.1
-			IL_038b: newarr [System.Runtime]System.Object
-			IL_0390: dup
-			IL_0391: ldc.i4.0
-			IL_0392: ldarg.0
-			IL_0393: stelem.ref
-			IL_0394: stloc.s 11
-			IL_0396: ldarg.2
-			IL_0397: ldstr "requiredFiles"
-			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03a1: stloc.s 9
-			IL_03a3: ldloc.s 12
-			IL_03a5: ldloc.s 11
-			IL_03a7: ldloc.s 9
-			IL_03a9: ldstr "requiredFiles"
-			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03b3: pop
-			IL_03b4: ldarg.0
-			IL_03b5: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_03ba: stloc.s 9
-			IL_03bc: ldc.i4.1
-			IL_03bd: newarr [System.Runtime]System.Object
-			IL_03c2: dup
-			IL_03c3: ldc.i4.0
-			IL_03c4: ldarg.0
-			IL_03c5: stelem.ref
-			IL_03c6: stloc.s 11
-			IL_03c8: ldarg.2
-			IL_03c9: ldstr "requiredDirectories"
-			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03d3: stloc.s 12
-			IL_03d5: ldloc.s 9
-			IL_03d7: ldloc.s 11
-			IL_03d9: ldloc.s 12
-			IL_03db: ldstr "requiredDirectories"
-			IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03e5: pop
-			IL_03e6: ldarg.0
-			IL_03e7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_03ec: stloc.s 12
-			IL_03ee: ldc.i4.1
-			IL_03ef: newarr [System.Runtime]System.Object
-			IL_03f4: dup
-			IL_03f5: ldc.i4.0
-			IL_03f6: ldarg.0
-			IL_03f7: stelem.ref
-			IL_03f8: stloc.s 11
-			IL_03fa: ldarg.2
-			IL_03fb: ldstr "defaultHarnessFiles"
-			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0405: stloc.s 9
-			IL_0407: ldloc.s 12
-			IL_0409: ldloc.s 11
-			IL_040b: ldloc.s 9
-			IL_040d: ldstr "defaultHarnessFiles"
-			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0417: pop
-			IL_0418: ldarg.0
-			IL_0419: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateExcludedFromMvp
-			IL_041e: stloc.s 9
-			IL_0420: ldc.i4.1
-			IL_0421: newarr [System.Runtime]System.Object
-			IL_0426: dup
-			IL_0427: ldc.i4.0
-			IL_0428: ldarg.0
-			IL_0429: stelem.ref
-			IL_042a: stloc.s 11
-			IL_042c: ldarg.2
-			IL_042d: ldstr "excludedFromMvp"
-			IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0437: stloc.s 12
-			IL_0439: ldloc.s 9
-			IL_043b: ldloc.s 11
-			IL_043d: ldloc.s 12
-			IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0444: pop
-			IL_0445: ldarg.0
-			IL_0446: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_044b: stloc.s 12
-			IL_044d: ldc.i4.1
-			IL_044e: newarr [System.Runtime]System.Object
-			IL_0453: dup
-			IL_0454: ldc.i4.0
-			IL_0455: ldarg.0
-			IL_0456: stelem.ref
-			IL_0457: stloc.s 11
-			IL_0459: ldarg.2
-			IL_045a: ldstr "attributionFiles"
-			IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0464: stloc.s 9
-			IL_0466: ldloc.s 12
-			IL_0468: ldloc.s 11
-			IL_046a: ldloc.s 9
-			IL_046c: ldstr "attributionFiles"
-			IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0476: pop
-			IL_0477: ldstr "^[0-9a-f]{40}$"
-			IL_047c: ldstr "i"
-			IL_0481: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0486: stloc.s 13
-			IL_0488: ldloc.s 13
-			IL_048a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_048f: stloc.s 13
-			IL_0491: ldarg.2
-			IL_0492: ldstr "upstream"
-			IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_049c: stloc.s 9
-			IL_049e: ldloc.s 9
-			IL_04a0: ldstr "commit"
-			IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04aa: stloc.s 9
-			IL_04ac: ldloc.s 13
-			IL_04ae: ldloc.s 9
-			IL_04b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_04b5: stloc.s 9
-			IL_04b7: ldloc.s 9
-			IL_04b9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_04be: ldc.i4.0
-			IL_04bf: ceq
-			IL_04c1: stloc.3
-			IL_04c2: ldloc.3
-			IL_04c3: brfalse IL_04ed
+			IL_010c: ldarg.0
+			IL_010d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_0112: stloc.s 9
+			IL_0114: ldc.i4.1
+			IL_0115: newarr [System.Runtime]System.Object
+			IL_011a: dup
+			IL_011b: ldc.i4.0
+			IL_011c: ldarg.0
+			IL_011d: stelem.ref
+			IL_011e: stloc.s 11
+			IL_0120: ldarg.2
+			IL_0121: ldstr "upstream"
+			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_012b: stloc.s 12
+			IL_012d: ldloc.s 12
+			IL_012f: ldstr "owner"
+			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0139: stloc.s 12
+			IL_013b: ldloc.s 9
+			IL_013d: ldloc.s 11
+			IL_013f: ldloc.s 12
+			IL_0141: ldstr "upstream.owner"
+			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_014b: pop
+			IL_014c: ldarg.0
+			IL_014d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_0152: stloc.s 12
+			IL_0154: ldc.i4.1
+			IL_0155: newarr [System.Runtime]System.Object
+			IL_015a: dup
+			IL_015b: ldc.i4.0
+			IL_015c: ldarg.0
+			IL_015d: stelem.ref
+			IL_015e: stloc.s 11
+			IL_0160: ldarg.2
+			IL_0161: ldstr "upstream"
+			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_016b: stloc.s 9
+			IL_016d: ldloc.s 9
+			IL_016f: ldstr "repo"
+			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0179: stloc.s 9
+			IL_017b: ldloc.s 12
+			IL_017d: ldloc.s 11
+			IL_017f: ldloc.s 9
+			IL_0181: ldstr "upstream.repo"
+			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_018b: pop
+			IL_018c: ldarg.0
+			IL_018d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_0192: stloc.s 9
+			IL_0194: ldc.i4.1
+			IL_0195: newarr [System.Runtime]System.Object
+			IL_019a: dup
+			IL_019b: ldc.i4.0
+			IL_019c: ldarg.0
+			IL_019d: stelem.ref
+			IL_019e: stloc.s 11
+			IL_01a0: ldarg.2
+			IL_01a1: ldstr "upstream"
+			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ab: stloc.s 12
+			IL_01ad: ldloc.s 12
+			IL_01af: ldstr "cloneUrl"
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01b9: stloc.s 12
+			IL_01bb: ldloc.s 9
+			IL_01bd: ldloc.s 11
+			IL_01bf: ldloc.s 12
+			IL_01c1: ldstr "upstream.cloneUrl"
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01cb: pop
+			IL_01cc: ldarg.0
+			IL_01cd: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_01d2: stloc.s 12
+			IL_01d4: ldc.i4.1
+			IL_01d5: newarr [System.Runtime]System.Object
+			IL_01da: dup
+			IL_01db: ldc.i4.0
+			IL_01dc: ldarg.0
+			IL_01dd: stelem.ref
+			IL_01de: stloc.s 11
+			IL_01e0: ldarg.2
+			IL_01e1: ldstr "upstream"
+			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01eb: stloc.s 9
+			IL_01ed: ldloc.s 9
+			IL_01ef: ldstr "commit"
+			IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f9: stloc.s 9
+			IL_01fb: ldloc.s 12
+			IL_01fd: ldloc.s 11
+			IL_01ff: ldloc.s 9
+			IL_0201: ldstr "upstream.commit"
+			IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_020b: pop
+			IL_020c: ldarg.0
+			IL_020d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_0212: stloc.s 9
+			IL_0214: ldc.i4.1
+			IL_0215: newarr [System.Runtime]System.Object
+			IL_021a: dup
+			IL_021b: ldc.i4.0
+			IL_021c: ldarg.0
+			IL_021d: stelem.ref
+			IL_021e: stloc.s 11
+			IL_0220: ldarg.2
+			IL_0221: ldstr "upstream"
+			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_022b: stloc.s 12
+			IL_022d: ldloc.s 12
+			IL_022f: ldstr "packageVersion"
+			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0239: stloc.s 12
+			IL_023b: ldloc.s 9
+			IL_023d: ldloc.s 11
+			IL_023f: ldloc.s 12
+			IL_0241: ldstr "upstream.packageVersion"
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_024b: pop
+			IL_024c: ldarg.0
+			IL_024d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_0252: stloc.s 12
+			IL_0254: ldc.i4.1
+			IL_0255: newarr [System.Runtime]System.Object
+			IL_025a: dup
+			IL_025b: ldc.i4.0
+			IL_025c: ldarg.0
+			IL_025d: stelem.ref
+			IL_025e: stloc.s 11
+			IL_0260: ldarg.2
+			IL_0261: ldstr "localOverrideEnvVar"
+			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_026b: stloc.s 9
+			IL_026d: ldloc.s 12
+			IL_026f: ldloc.s 11
+			IL_0271: ldloc.s 9
+			IL_0273: ldstr "localOverrideEnvVar"
+			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_027d: pop
+			IL_027e: ldarg.0
+			IL_027f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_0284: stloc.s 9
+			IL_0286: ldc.i4.1
+			IL_0287: newarr [System.Runtime]System.Object
+			IL_028c: dup
+			IL_028d: ldc.i4.0
+			IL_028e: ldarg.0
+			IL_028f: stelem.ref
+			IL_0290: stloc.s 11
+			IL_0292: ldarg.2
+			IL_0293: ldstr "managedRoot"
+			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_029d: stloc.s 12
+			IL_029f: ldloc.s 9
+			IL_02a1: ldloc.s 11
+			IL_02a3: ldloc.s 12
+			IL_02a5: ldstr "managedRoot"
+			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02af: pop
+			IL_02b0: ldarg.0
+			IL_02b1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_02b6: stloc.s 12
+			IL_02b8: ldc.i4.1
+			IL_02b9: newarr [System.Runtime]System.Object
+			IL_02be: dup
+			IL_02bf: ldc.i4.0
+			IL_02c0: ldarg.0
+			IL_02c1: stelem.ref
+			IL_02c2: stloc.s 11
+			IL_02c4: ldarg.2
+			IL_02c5: ldstr "lineEndings"
+			IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02cf: stloc.s 9
+			IL_02d1: ldloc.s 12
+			IL_02d3: ldloc.s 11
+			IL_02d5: ldloc.s 9
+			IL_02d7: ldstr "lineEndings"
+			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02e1: pop
+			IL_02e2: ldarg.0
+			IL_02e3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_02e8: stloc.s 9
+			IL_02ea: ldc.i4.1
+			IL_02eb: newarr [System.Runtime]System.Object
+			IL_02f0: dup
+			IL_02f1: ldc.i4.0
+			IL_02f2: ldarg.0
+			IL_02f3: stelem.ref
+			IL_02f4: stloc.s 11
+			IL_02f6: ldarg.2
+			IL_02f7: ldstr "updateStrategy"
+			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0301: stloc.s 12
+			IL_0303: ldloc.s 9
+			IL_0305: ldloc.s 11
+			IL_0307: ldloc.s 12
+			IL_0309: ldstr "updateStrategy"
+			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0313: pop
+			IL_0314: ldarg.0
+			IL_0315: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_031a: stloc.s 12
+			IL_031c: ldc.i4.1
+			IL_031d: newarr [System.Runtime]System.Object
+			IL_0322: dup
+			IL_0323: ldc.i4.0
+			IL_0324: ldarg.0
+			IL_0325: stelem.ref
+			IL_0326: stloc.s 11
+			IL_0328: ldarg.2
+			IL_0329: ldstr "includeFiles"
+			IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0333: stloc.s 9
+			IL_0335: ldloc.s 12
+			IL_0337: ldloc.s 11
+			IL_0339: ldloc.s 9
+			IL_033b: ldstr "includeFiles"
+			IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0345: pop
+			IL_0346: ldarg.0
+			IL_0347: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_034c: stloc.s 9
+			IL_034e: ldc.i4.1
+			IL_034f: newarr [System.Runtime]System.Object
+			IL_0354: dup
+			IL_0355: ldc.i4.0
+			IL_0356: ldarg.0
+			IL_0357: stelem.ref
+			IL_0358: stloc.s 11
+			IL_035a: ldarg.2
+			IL_035b: ldstr "includeDirectories"
+			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0365: stloc.s 12
+			IL_0367: ldloc.s 9
+			IL_0369: ldloc.s 11
+			IL_036b: ldloc.s 12
+			IL_036d: ldstr "includeDirectories"
+			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0377: pop
+			IL_0378: ldarg.0
+			IL_0379: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_037e: stloc.s 12
+			IL_0380: ldc.i4.1
+			IL_0381: newarr [System.Runtime]System.Object
+			IL_0386: dup
+			IL_0387: ldc.i4.0
+			IL_0388: ldarg.0
+			IL_0389: stelem.ref
+			IL_038a: stloc.s 11
+			IL_038c: ldarg.2
+			IL_038d: ldstr "requiredFiles"
+			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0397: stloc.s 9
+			IL_0399: ldloc.s 12
+			IL_039b: ldloc.s 11
+			IL_039d: ldloc.s 9
+			IL_039f: ldstr "requiredFiles"
+			IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03a9: pop
+			IL_03aa: ldarg.0
+			IL_03ab: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_03b0: stloc.s 9
+			IL_03b2: ldc.i4.1
+			IL_03b3: newarr [System.Runtime]System.Object
+			IL_03b8: dup
+			IL_03b9: ldc.i4.0
+			IL_03ba: ldarg.0
+			IL_03bb: stelem.ref
+			IL_03bc: stloc.s 11
+			IL_03be: ldarg.2
+			IL_03bf: ldstr "requiredDirectories"
+			IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c9: stloc.s 12
+			IL_03cb: ldloc.s 9
+			IL_03cd: ldloc.s 11
+			IL_03cf: ldloc.s 12
+			IL_03d1: ldstr "requiredDirectories"
+			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03db: pop
+			IL_03dc: ldarg.0
+			IL_03dd: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_03e2: stloc.s 12
+			IL_03e4: ldc.i4.1
+			IL_03e5: newarr [System.Runtime]System.Object
+			IL_03ea: dup
+			IL_03eb: ldc.i4.0
+			IL_03ec: ldarg.0
+			IL_03ed: stelem.ref
+			IL_03ee: stloc.s 11
+			IL_03f0: ldarg.2
+			IL_03f1: ldstr "defaultHarnessFiles"
+			IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03fb: stloc.s 9
+			IL_03fd: ldloc.s 12
+			IL_03ff: ldloc.s 11
+			IL_0401: ldloc.s 9
+			IL_0403: ldstr "defaultHarnessFiles"
+			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_040d: pop
+			IL_040e: ldarg.0
+			IL_040f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateExcludedFromMvp
+			IL_0414: stloc.s 9
+			IL_0416: ldc.i4.1
+			IL_0417: newarr [System.Runtime]System.Object
+			IL_041c: dup
+			IL_041d: ldc.i4.0
+			IL_041e: ldarg.0
+			IL_041f: stelem.ref
+			IL_0420: stloc.s 11
+			IL_0422: ldarg.2
+			IL_0423: ldstr "excludedFromMvp"
+			IL_0428: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_042d: stloc.s 12
+			IL_042f: ldloc.s 9
+			IL_0431: ldloc.s 11
+			IL_0433: ldloc.s 12
+			IL_0435: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_043a: pop
+			IL_043b: ldarg.0
+			IL_043c: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_0441: stloc.s 12
+			IL_0443: ldc.i4.1
+			IL_0444: newarr [System.Runtime]System.Object
+			IL_0449: dup
+			IL_044a: ldc.i4.0
+			IL_044b: ldarg.0
+			IL_044c: stelem.ref
+			IL_044d: stloc.s 11
+			IL_044f: ldarg.2
+			IL_0450: ldstr "attributionFiles"
+			IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_045a: stloc.s 9
+			IL_045c: ldloc.s 12
+			IL_045e: ldloc.s 11
+			IL_0460: ldloc.s 9
+			IL_0462: ldstr "attributionFiles"
+			IL_0467: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_046c: pop
+			IL_046d: ldstr "^[0-9a-f]{40}$"
+			IL_0472: ldstr "i"
+			IL_0477: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_047c: stloc.s 13
+			IL_047e: ldloc.s 13
+			IL_0480: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_0485: stloc.s 13
+			IL_0487: ldarg.2
+			IL_0488: ldstr "upstream"
+			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0492: stloc.s 9
+			IL_0494: ldloc.s 9
+			IL_0496: ldstr "commit"
+			IL_049b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04a0: stloc.s 9
+			IL_04a2: ldloc.s 13
+			IL_04a4: ldloc.s 9
+			IL_04a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_04ab: stloc.s 9
+			IL_04ad: ldloc.s 9
+			IL_04af: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04b4: ldc.i4.0
+			IL_04b5: ceq
+			IL_04b7: stloc.3
+			IL_04b8: ldloc.3
+			IL_04b9: brfalse IL_04de
 
-			IL_04c8: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
-			IL_04cd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_04d7: stloc.2
-			IL_04d8: ldloc.2
-			IL_04d9: isinst [System.Runtime]System.Exception
-			IL_04de: dup
-			IL_04df: brtrue IL_04ec
+			IL_04be: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
+			IL_04c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_04c8: stloc.2
+			IL_04c9: ldloc.2
+			IL_04ca: isinst [System.Runtime]System.Exception
+			IL_04cf: dup
+			IL_04d0: brtrue IL_04dd
 
-			IL_04e4: pop
-			IL_04e5: ldloc.2
-			IL_04e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_04eb: throw
+			IL_04d5: pop
+			IL_04d6: ldloc.2
+			IL_04d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_04dc: throw
 
-			IL_04ec: throw
+			IL_04dd: throw
 
-			IL_04ed: ldnull
-			IL_04ee: ret
+			IL_04de: ldnull
+			IL_04df: ret
 		} // end of method validatePin::__js_call__
 
 	} // end of class validatePin
@@ -2353,7 +2346,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x538b
+				// Method begins at RVA 0x5353
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2380,7 +2373,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3510
+			// Method begins at RVA 0x34ec
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -2454,7 +2447,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5394
+				// Method begins at RVA 0x535c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2482,7 +2475,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3588
+			// Method begins at RVA 0x3564
 			// Header size: 12
 			// Code size: 139 (0x8b)
 			.maxstack 8
@@ -2574,7 +2567,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x539d
+				// Method begins at RVA 0x5365
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2601,7 +2594,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3620
+			// Method begins at RVA 0x35fc
 			// Header size: 12
 			// Code size: 158 (0x9e)
 			.maxstack 8
@@ -2699,7 +2692,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53af
+					// Method begins at RVA 0x5377
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2717,7 +2710,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53a6
+				// Method begins at RVA 0x536e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2745,7 +2738,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x36cc
+			// Method begins at RVA 0x36a8
 			// Header size: 12
 			// Code size: 242 (0xf2)
 			.maxstack 8
@@ -2879,7 +2872,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53c1
+					// Method begins at RVA 0x5389
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2897,7 +2890,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53b8
+				// Method begins at RVA 0x5380
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2925,7 +2918,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x37cc
+			// Method begins at RVA 0x37a8
 			// Header size: 12
 			// Code size: 1135 (0x46f)
 			.maxstack 8
@@ -3341,7 +3334,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53ca
+				// Method begins at RVA 0x5392
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3368,7 +3361,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3c48
+			// Method begins at RVA 0x3c24
 			// Header size: 12
 			// Code size: 83 (0x53)
 			.maxstack 8
@@ -3434,7 +3427,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53dc
+					// Method begins at RVA 0x53a4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3452,7 +3445,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53d3
+				// Method begins at RVA 0x539b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3479,7 +3472,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3ca8
+			// Method begins at RVA 0x3c84
 			// Header size: 12
 			// Code size: 175 (0xaf)
 			.maxstack 8
@@ -3587,7 +3580,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53ee
+					// Method begins at RVA 0x53b6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3607,7 +3600,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53f7
+					// Method begins at RVA 0x53bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3625,7 +3618,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53e5
+				// Method begins at RVA 0x53ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3653,9 +3646,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3d64
+			// Method begins at RVA 0x3d40
 			// Header size: 12
-			// Code size: 691 (0x2b3)
+			// Code size: 686 (0x2ae)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3770,7 +3763,7 @@
 			IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
 			IL_0109: stloc.s 10
 			IL_010b: ldloc.s 10
-			IL_010d: brfalse IL_028d
+			IL_010d: brfalse IL_0288
 
 			IL_0112: ldloc.0
 			IL_0113: ldstr "stderr"
@@ -3893,36 +3886,35 @@
 			IL_0261: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0266: stloc.s 16
 			IL_0268: ldloc.s 16
-			IL_026a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_026f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0274: stloc.s 6
-			IL_0276: ldloc.s 6
-			IL_0278: isinst [System.Runtime]System.Exception
-			IL_027d: dup
-			IL_027e: brtrue IL_028c
+			IL_026a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_026f: stloc.s 6
+			IL_0271: ldloc.s 6
+			IL_0273: isinst [System.Runtime]System.Exception
+			IL_0278: dup
+			IL_0279: brtrue IL_0287
 
-			IL_0283: pop
-			IL_0284: ldloc.s 6
-			IL_0286: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_028b: throw
+			IL_027e: pop
+			IL_027f: ldloc.s 6
+			IL_0281: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0286: throw
 
-			IL_028c: throw
+			IL_0287: throw
 
-			IL_028d: ldloc.0
-			IL_028e: ldstr "stdout"
-			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0298: stloc.s 9
-			IL_029a: ldloc.s 9
-			IL_029c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02a1: stloc.s 10
-			IL_02a3: ldloc.s 10
-			IL_02a5: brtrue IL_02b0
+			IL_0288: ldloc.0
+			IL_0289: ldstr "stdout"
+			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0293: stloc.s 9
+			IL_0295: ldloc.s 9
+			IL_0297: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_029c: stloc.s 10
+			IL_029e: ldloc.s 10
+			IL_02a0: brtrue IL_02ab
 
-			IL_02aa: ldstr ""
-			IL_02af: ret
+			IL_02a5: ldstr ""
+			IL_02aa: ret
 
-			IL_02b0: ldloc.s 9
-			IL_02b2: ret
+			IL_02ab: ldloc.s 9
+			IL_02ad: ret
 		} // end of method runGit::__js_call__
 
 	} // end of class runGit
@@ -3938,7 +3930,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5400
+				// Method begins at RVA 0x53c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3962,7 +3954,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5412
+					// Method begins at RVA 0x53da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3980,7 +3972,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5409
+				// Method begins at RVA 0x53d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4004,7 +3996,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5424
+					// Method begins at RVA 0x53ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4022,7 +4014,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x541b
+				// Method begins at RVA 0x53e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4049,7 +4041,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4024
+			// Method begins at RVA 0x3ffc
 			// Header size: 12
 			// Code size: 397 (0x18d)
 			.maxstack 11
@@ -4264,7 +4256,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5475
+						// Method begins at RVA 0x543d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4284,7 +4276,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x547e
+						// Method begins at RVA 0x5446
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4302,7 +4294,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x546c
+					// Method begins at RVA 0x5434
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4322,7 +4314,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5487
+					// Method begins at RVA 0x544f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4340,7 +4332,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x542d
+				// Method begins at RVA 0x53f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4368,7 +4360,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5448
+						// Method begins at RVA 0x5410
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4386,7 +4378,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x543f
+					// Method begins at RVA 0x5407
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4404,7 +4396,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5436
+				// Method begins at RVA 0x53fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4432,7 +4424,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5463
+						// Method begins at RVA 0x542b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4450,7 +4442,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x545a
+					// Method begins at RVA 0x5422
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4468,7 +4460,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5451
+				// Method begins at RVA 0x5419
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4496,7 +4488,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x41dc
+			// Method begins at RVA 0x41b4
 			// Header size: 12
 			// Code size: 1836 (0x72c)
 			.maxstack 11
@@ -5258,7 +5250,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x54a2
+						// Method begins at RVA 0x546a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5276,7 +5268,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5499
+					// Method begins at RVA 0x5461
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5296,7 +5288,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54ab
+					// Method begins at RVA 0x5473
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5314,7 +5306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5490
+				// Method begins at RVA 0x5458
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5343,9 +5335,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4948
+			// Method begins at RVA 0x4920
 			// Header size: 12
-			// Code size: 1053 (0x41d)
+			// Code size: 1048 (0x418)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5726,7 +5718,7 @@
 			IL_03a0: ceq
 			IL_03a2: stloc.3
 			IL_03a3: ldloc.3
-			IL_03a4: brfalse IL_03ef
+			IL_03a4: brfalse IL_03ea
 
 			IL_03a9: ldloc.1
 			IL_03aa: ldstr "message"
@@ -5740,35 +5732,34 @@
 			IL_03c6: call string [System.Runtime]System.String::Concat(string, string)
 			IL_03cb: stloc.s 9
 			IL_03cd: ldloc.s 9
-			IL_03cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_03d9: stloc.2
-			IL_03da: ldloc.2
-			IL_03db: isinst [System.Runtime]System.Exception
-			IL_03e0: dup
-			IL_03e1: brtrue IL_03ee
+			IL_03cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03d4: stloc.2
+			IL_03d5: ldloc.2
+			IL_03d6: isinst [System.Runtime]System.Exception
+			IL_03db: dup
+			IL_03dc: brtrue IL_03e9
 
-			IL_03e6: pop
-			IL_03e7: ldloc.2
-			IL_03e8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03ed: throw
+			IL_03e1: pop
+			IL_03e2: ldloc.2
+			IL_03e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03e8: throw
 
-			IL_03ee: throw
+			IL_03e9: throw
 
-			IL_03ef: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03f4: dup
-			IL_03f5: ldstr "source"
-			IL_03fa: ldstr "managed-cache"
-			IL_03ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0404: dup
-			IL_0405: ldstr "rootPath"
-			IL_040a: ldarg.2
-			IL_040b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0410: dup
-			IL_0411: ldstr "reused"
-			IL_0416: ldc.i4.0
-			IL_0417: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_041c: ret
+			IL_03ea: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03ef: dup
+			IL_03f0: ldstr "source"
+			IL_03f5: ldstr "managed-cache"
+			IL_03fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03ff: dup
+			IL_0400: ldstr "rootPath"
+			IL_0405: ldarg.2
+			IL_0406: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_040b: dup
+			IL_040c: ldstr "reused"
+			IL_0411: ldc.i4.0
+			IL_0412: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0417: ret
 		} // end of method ensureManagedCheckout::__js_call__
 
 	} // end of class ensureManagedCheckout
@@ -5792,7 +5783,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x54c6
+						// Method begins at RVA 0x548e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5810,7 +5801,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54bd
+					// Method begins at RVA 0x5485
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5828,7 +5819,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54b4
+				// Method begins at RVA 0x547c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5857,9 +5848,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4d74
+			// Method begins at RVA 0x4d44
 			// Header size: 12
-			// Code size: 373 (0x175)
+			// Code size: 368 (0x170)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5891,7 +5882,7 @@
 			IL_001c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0021: stloc.s 4
 			IL_0023: ldloc.s 4
-			IL_0025: brfalse IL_0129
+			IL_0025: brfalse IL_0124
 
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
@@ -5921,7 +5912,7 @@
 			IL_0067: ceq
 			IL_0069: stloc.s 4
 			IL_006b: ldloc.s 4
-			IL_006d: brfalse IL_00df
+			IL_006d: brfalse IL_00da
 
 			IL_0072: ldloc.0
 			IL_0073: ldstr "rootPath"
@@ -5946,85 +5937,84 @@
 			IL_00b6: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00bb: stloc.s 6
 			IL_00bd: ldloc.s 6
-			IL_00bf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00c9: stloc.2
-			IL_00ca: ldloc.2
-			IL_00cb: isinst [System.Runtime]System.Exception
-			IL_00d0: dup
-			IL_00d1: brtrue IL_00de
+			IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00c4: stloc.2
+			IL_00c5: ldloc.2
+			IL_00c6: isinst [System.Runtime]System.Exception
+			IL_00cb: dup
+			IL_00cc: brtrue IL_00d9
 
-			IL_00d6: pop
-			IL_00d7: ldloc.2
-			IL_00d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00dd: throw
+			IL_00d1: pop
+			IL_00d2: ldloc.2
+			IL_00d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00d8: throw
 
-			IL_00de: throw
+			IL_00d9: throw
 
-			IL_00df: ldloc.0
-			IL_00e0: ldstr "source"
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ea: stloc.s 5
-			IL_00ec: ldloc.0
-			IL_00ed: ldstr "rootPath"
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f7: stloc.s 7
-			IL_00f9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00fe: dup
-			IL_00ff: ldstr "source"
-			IL_0104: ldloc.s 5
-			IL_0106: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_010b: dup
-			IL_010c: ldstr "rootPath"
-			IL_0111: ldloc.s 7
-			IL_0113: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0118: dup
-			IL_0119: ldstr "reused"
-			IL_011e: ldc.i4.1
-			IL_011f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0124: stloc.s 8
-			IL_0126: ldloc.s 8
-			IL_0128: ret
+			IL_00da: ldloc.0
+			IL_00db: ldstr "source"
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e5: stloc.s 5
+			IL_00e7: ldloc.0
+			IL_00e8: ldstr "rootPath"
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f2: stloc.s 7
+			IL_00f4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00f9: dup
+			IL_00fa: ldstr "source"
+			IL_00ff: ldloc.s 5
+			IL_0101: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0106: dup
+			IL_0107: ldstr "rootPath"
+			IL_010c: ldloc.s 7
+			IL_010e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0113: dup
+			IL_0114: ldstr "reused"
+			IL_0119: ldc.i4.1
+			IL_011a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_011f: stloc.s 8
+			IL_0121: ldloc.s 8
+			IL_0123: ret
 
-			IL_0129: ldarg.0
-			IL_012a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
-			IL_012f: ldc.i4.1
-			IL_0130: newarr [System.Runtime]System.Object
-			IL_0135: dup
-			IL_0136: ldc.i4.0
-			IL_0137: ldarg.0
-			IL_0138: stelem.ref
-			IL_0139: stloc.3
-			IL_013a: ldloc.3
-			IL_013b: ldarg.2
-			IL_013c: ldarg.3
-			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0142: stloc.s 7
-			IL_0144: ldarg.s args
-			IL_0146: ldstr "force"
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0150: stloc.s 5
-			IL_0152: ldc.i4.1
-			IL_0153: newarr [System.Runtime]System.Object
-			IL_0158: dup
+			IL_0124: ldarg.0
+			IL_0125: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
+			IL_012a: ldc.i4.1
+			IL_012b: newarr [System.Runtime]System.Object
+			IL_0130: dup
+			IL_0131: ldc.i4.0
+			IL_0132: ldarg.0
+			IL_0133: stelem.ref
+			IL_0134: stloc.3
+			IL_0135: ldloc.3
+			IL_0136: ldarg.2
+			IL_0137: ldarg.3
+			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_013d: stloc.s 7
+			IL_013f: ldarg.s args
+			IL_0141: ldstr "force"
+			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014b: stloc.s 5
+			IL_014d: ldc.i4.1
+			IL_014e: newarr [System.Runtime]System.Object
+			IL_0153: dup
+			IL_0154: ldc.i4.0
+			IL_0155: ldarg.0
+			IL_0156: stelem.ref
+			IL_0157: stloc.3
+			IL_0158: ldloc.3
 			IL_0159: ldc.i4.0
-			IL_015a: ldarg.0
-			IL_015b: stelem.ref
-			IL_015c: stloc.3
-			IL_015d: ldloc.3
-			IL_015e: ldc.i4.0
-			IL_015f: ldelem.ref
-			IL_0160: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0165: ldnull
-			IL_0166: ldloc.s 7
-			IL_0168: ldarg.3
-			IL_0169: ldloc.s 5
-			IL_016b: tail.
-			IL_016d: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-			IL_0172: ret
+			IL_015a: ldelem.ref
+			IL_015b: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0160: ldnull
+			IL_0161: ldloc.s 7
+			IL_0163: ldarg.3
+			IL_0164: ldloc.s 5
+			IL_0166: tail.
+			IL_0168: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_016d: ret
 
-			IL_0173: ldnull
-			IL_0174: ret
+			IL_016e: ldnull
+			IL_016f: ret
 		} // end of method resolveBootstrapRoot::__js_call__
 
 	} // end of class resolveBootstrapRoot
@@ -6044,7 +6034,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54d8
+					// Method begins at RVA 0x54a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6062,7 +6052,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54cf
+				// Method begins at RVA 0x5497
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6091,7 +6081,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4ef8
+			// Method begins at RVA 0x4ec0
 			// Header size: 12
 			// Code size: 419 (0x1a3)
 			.maxstack 8
@@ -6280,7 +6270,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54ea
+					// Method begins at RVA 0x54b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6300,7 +6290,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54f3
+					// Method begins at RVA 0x54bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6318,7 +6308,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54e1
+				// Method begins at RVA 0x54a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6344,7 +6334,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x50a8
+			// Method begins at RVA 0x5070
 			// Header size: 12
 			// Code size: 448 (0x1c0)
 			.maxstack 9
@@ -6583,7 +6573,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5505
+					// Method begins at RVA 0x54cd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6603,7 +6593,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x550e
+					// Method begins at RVA 0x54d6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6621,7 +6611,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54fc
+				// Method begins at RVA 0x54c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6669,7 +6659,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5274
+			// Method begins at RVA 0x523c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -7327,7 +7317,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x5517
+		// Method begins at RVA 0x54df
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65c3
+				// Method begins at RVA 0x65b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65d5
+					// Method begins at RVA 0x65c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -153,7 +153,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65de
+					// Method begins at RVA 0x65d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -173,7 +173,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65e7
+					// Method begins at RVA 0x65db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65cc
+				// Method begins at RVA 0x65c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -296,7 +296,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65f9
+					// Method begins at RVA 0x65ed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -314,7 +314,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65f0
+				// Method begins at RVA 0x65e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -434,7 +434,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x660b
+					// Method begins at RVA 0x65ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -452,7 +452,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6602
+				// Method begins at RVA 0x65f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -593,7 +593,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6614
+				// Method begins at RVA 0x6608
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2459,7 +2459,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x65ba
+			// Method begins at RVA 0x65ae
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2759,7 +2759,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6626
+				// Method begins at RVA 0x661a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2847,7 +2847,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6641
+						// Method begins at RVA 0x6635
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2865,7 +2865,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6638
+					// Method begins at RVA 0x662c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2883,7 +2883,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x662f
+				// Method begins at RVA 0x6623
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3012,7 +3012,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x665c
+						// Method begins at RVA 0x6650
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3030,7 +3030,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6653
+					// Method begins at RVA 0x6647
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3048,7 +3048,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x664a
+				// Method begins at RVA 0x663e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3240,7 +3240,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x666e
+					// Method begins at RVA 0x6662
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3258,7 +3258,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6665
+				// Method begins at RVA 0x6659
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3286,7 +3286,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6689
+						// Method begins at RVA 0x667d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3304,7 +3304,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6680
+					// Method begins at RVA 0x6674
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3322,7 +3322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6677
+				// Method begins at RVA 0x666b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3491,7 +3491,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x669b
+					// Method begins at RVA 0x668f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3509,7 +3509,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6692
+				// Method begins at RVA 0x6686
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3637,7 +3637,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66a4
+				// Method begins at RVA 0x6698
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3665,7 +3665,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66bf
+						// Method begins at RVA 0x66b3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3685,7 +3685,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66c8
+						// Method begins at RVA 0x66bc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3705,7 +3705,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66d1
+						// Method begins at RVA 0x66c5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3725,7 +3725,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66da
+						// Method begins at RVA 0x66ce
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3743,7 +3743,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66b6
+					// Method begins at RVA 0x66aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3761,7 +3761,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66ad
+				// Method begins at RVA 0x66a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3940,7 +3940,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66f5
+						// Method begins at RVA 0x66e9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3960,7 +3960,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66fe
+						// Method begins at RVA 0x66f2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3980,7 +3980,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6707
+						// Method begins at RVA 0x66fb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3998,7 +3998,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66ec
+					// Method begins at RVA 0x66e0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4016,7 +4016,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66e3
+				// Method begins at RVA 0x66d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4248,7 +4248,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6719
+					// Method begins at RVA 0x670d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4268,7 +4268,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6722
+					// Method begins at RVA 0x6716
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4288,7 +4288,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x672b
+					// Method begins at RVA 0x671f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4306,7 +4306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6710
+				// Method begins at RVA 0x6704
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4535,7 +4535,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6746
+						// Method begins at RVA 0x673a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4555,7 +4555,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x674f
+						// Method begins at RVA 0x6743
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4575,7 +4575,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6758
+						// Method begins at RVA 0x674c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4595,7 +4595,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6761
+						// Method begins at RVA 0x6755
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4615,7 +4615,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x676a
+						// Method begins at RVA 0x675e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4635,7 +4635,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6773
+						// Method begins at RVA 0x6767
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4655,7 +4655,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x677c
+						// Method begins at RVA 0x6770
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4673,7 +4673,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x673d
+					// Method begins at RVA 0x6731
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4691,7 +4691,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6734
+				// Method begins at RVA 0x6728
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4722,7 +4722,7 @@
 			)
 			// Method begins at RVA 0x4770
 			// Header size: 12
-			// Code size: 892 (0x37c)
+			// Code size: 882 (0x372)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -4765,7 +4765,7 @@
 				IL_0027: ldloc.s 11
 				IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_002e: clt
-				IL_0030: brfalse IL_037a
+				IL_0030: brfalse IL_0370
 
 				IL_0035: ldarg.3
 				IL_0036: ldstr "index"
@@ -4822,12 +4822,12 @@
 				IL_00c4: clt
 				IL_00c6: brfalse IL_00d0
 
-				IL_00cb: br IL_037a
+				IL_00cb: br IL_0370
 
 				IL_00d0: ldloc.2
 				IL_00d1: ldarg.s baseIndent
 				IL_00d3: cgt
-				IL_00d5: brfalse IL_013c
+				IL_00d5: brfalse IL_0137
 
 				IL_00da: ldarg.3
 				IL_00db: ldstr "index"
@@ -4847,237 +4847,235 @@
 				IL_0113: call string [System.Runtime]System.String::Concat(string, string)
 				IL_0118: stloc.s 15
 				IL_011a: ldloc.s 15
-				IL_011c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0121: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0126: stloc.3
-				IL_0127: ldloc.3
-				IL_0128: isinst [System.Runtime]System.Exception
-				IL_012d: dup
-				IL_012e: brtrue IL_013b
+				IL_011c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0121: stloc.3
+				IL_0122: ldloc.3
+				IL_0123: isinst [System.Runtime]System.Exception
+				IL_0128: dup
+				IL_0129: brtrue IL_0136
 
-				IL_0133: pop
-				IL_0134: ldloc.3
-				IL_0135: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_013a: throw
+				IL_012e: pop
+				IL_012f: ldloc.3
+				IL_0130: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0135: throw
 
-				IL_013b: throw
+				IL_0136: throw
 
-				IL_013c: ldloc.1
-				IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0142: ldloc.2
-				IL_0143: box [System.Runtime]System.Double
-				IL_0148: stloc.s 16
-				IL_014a: ldstr "substring"
-				IL_014f: ldloc.s 16
-				IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0156: stloc.s 4
-				IL_0158: ldstr "^([A-Za-z0-9_-]+):(.*)$"
-				IL_015d: ldstr ""
-				IL_0162: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0167: stloc.s 17
-				IL_0169: ldloc.s 17
-				IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-				IL_0170: stloc.s 17
-				IL_0172: ldloc.s 17
-				IL_0174: ldstr "exec"
-				IL_0179: ldloc.s 4
-				IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0180: stloc.s 5
-				IL_0182: ldloc.s 5
-				IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0189: ldc.i4.0
-				IL_018a: ceq
-				IL_018c: stloc.s 12
-				IL_018e: ldloc.s 12
-				IL_0190: brfalse IL_020a
+				IL_0137: ldloc.1
+				IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_013d: ldloc.2
+				IL_013e: box [System.Runtime]System.Double
+				IL_0143: stloc.s 16
+				IL_0145: ldstr "substring"
+				IL_014a: ldloc.s 16
+				IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0151: stloc.s 4
+				IL_0153: ldstr "^([A-Za-z0-9_-]+):(.*)$"
+				IL_0158: ldstr ""
+				IL_015d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_0162: stloc.s 17
+				IL_0164: ldloc.s 17
+				IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+				IL_016b: stloc.s 17
+				IL_016d: ldloc.s 17
+				IL_016f: ldstr "exec"
+				IL_0174: ldloc.s 4
+				IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_017b: stloc.s 5
+				IL_017d: ldloc.s 5
+				IL_017f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0184: ldc.i4.0
+				IL_0185: ceq
+				IL_0187: stloc.s 12
+				IL_0189: ldloc.s 12
+				IL_018b: brfalse IL_0200
 
-				IL_0195: ldarg.3
-				IL_0196: ldstr "index"
-				IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01a0: stloc.s 11
-				IL_01a2: ldloc.s 11
-				IL_01a4: ldc.r8 1
-				IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_01b2: stloc.s 14
-				IL_01b4: ldloc.s 14
-				IL_01b6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01bb: stloc.s 15
-				IL_01bd: ldstr "Invalid frontmatter line "
-				IL_01c2: ldloc.s 15
-				IL_01c4: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01c9: ldstr ": "
-				IL_01ce: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01d3: ldloc.s 4
-				IL_01d5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01da: stloc.s 15
-				IL_01dc: ldloc.s 15
-				IL_01de: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01e3: stloc.s 15
-				IL_01e5: ldloc.s 15
-				IL_01e7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_01f1: stloc.s 6
-				IL_01f3: ldloc.s 6
-				IL_01f5: isinst [System.Runtime]System.Exception
-				IL_01fa: dup
-				IL_01fb: brtrue IL_0209
+				IL_0190: ldarg.3
+				IL_0191: ldstr "index"
+				IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_019b: stloc.s 11
+				IL_019d: ldloc.s 11
+				IL_019f: ldc.r8 1
+				IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_01ad: stloc.s 14
+				IL_01af: ldloc.s 14
+				IL_01b1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01b6: stloc.s 15
+				IL_01b8: ldstr "Invalid frontmatter line "
+				IL_01bd: ldloc.s 15
+				IL_01bf: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01c4: ldstr ": "
+				IL_01c9: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01ce: ldloc.s 4
+				IL_01d0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01d5: stloc.s 15
+				IL_01d7: ldloc.s 15
+				IL_01d9: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01de: stloc.s 15
+				IL_01e0: ldloc.s 15
+				IL_01e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_01e7: stloc.s 6
+				IL_01e9: ldloc.s 6
+				IL_01eb: isinst [System.Runtime]System.Exception
+				IL_01f0: dup
+				IL_01f1: brtrue IL_01ff
 
-				IL_0200: pop
-				IL_0201: ldloc.s 6
-				IL_0203: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0208: throw
+				IL_01f6: pop
+				IL_01f7: ldloc.s 6
+				IL_01f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_01fe: throw
 
-				IL_0209: throw
+				IL_01ff: throw
 
-				IL_020a: ldloc.s 5
-				IL_020c: ldc.r8 1
-				IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_021a: stloc.s 7
-				IL_021c: ldloc.s 5
-				IL_021e: ldc.r8 2
-				IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_022c: stloc.s 11
-				IL_022e: ldloc.s 11
-				IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0235: ldstr "trim"
-				IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_023f: stloc.s 8
-				IL_0241: ldarg.3
-				IL_0242: ldstr "index"
-				IL_0247: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_024c: stloc.s 13
-				IL_024e: ldloc.s 13
-				IL_0250: ldc.r8 1
-				IL_0259: add
-				IL_025a: stloc.s 13
-				IL_025c: ldarg.3
-				IL_025d: ldstr "index"
-				IL_0262: ldloc.s 13
-				IL_0264: ldc.i4.1
-				IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_026a: pop
-				IL_026b: ldnull
-				IL_026c: stloc.s 9
-				IL_026e: ldloc.s 8
-				IL_0270: ldstr "|"
-				IL_0275: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_027a: stloc.s 12
-				IL_027c: ldloc.s 12
-				IL_027e: box [System.Runtime]System.Boolean
-				IL_0283: stloc.s 18
-				IL_0285: ldloc.s 18
-				IL_0287: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_028c: stloc.s 12
-				IL_028e: ldloc.s 12
-				IL_0290: brtrue IL_02b5
+				IL_0200: ldloc.s 5
+				IL_0202: ldc.r8 1
+				IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0210: stloc.s 7
+				IL_0212: ldloc.s 5
+				IL_0214: ldc.r8 2
+				IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0222: stloc.s 11
+				IL_0224: ldloc.s 11
+				IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_022b: ldstr "trim"
+				IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0235: stloc.s 8
+				IL_0237: ldarg.3
+				IL_0238: ldstr "index"
+				IL_023d: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0242: stloc.s 13
+				IL_0244: ldloc.s 13
+				IL_0246: ldc.r8 1
+				IL_024f: add
+				IL_0250: stloc.s 13
+				IL_0252: ldarg.3
+				IL_0253: ldstr "index"
+				IL_0258: ldloc.s 13
+				IL_025a: ldc.i4.1
+				IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_0260: pop
+				IL_0261: ldnull
+				IL_0262: stloc.s 9
+				IL_0264: ldloc.s 8
+				IL_0266: ldstr "|"
+				IL_026b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0270: stloc.s 12
+				IL_0272: ldloc.s 12
+				IL_0274: box [System.Runtime]System.Boolean
+				IL_0279: stloc.s 18
+				IL_027b: ldloc.s 18
+				IL_027d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0282: stloc.s 12
+				IL_0284: ldloc.s 12
+				IL_0286: brtrue IL_02ab
 
-				IL_0295: ldloc.s 8
-				IL_0297: ldstr ">"
-				IL_029c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02a1: stloc.s 12
-				IL_02a3: ldloc.s 12
-				IL_02a5: box [System.Runtime]System.Boolean
-				IL_02aa: stloc.s 19
-				IL_02ac: ldloc.s 19
-				IL_02ae: stloc.s 20
-				IL_02b0: br IL_02b9
+				IL_028b: ldloc.s 8
+				IL_028d: ldstr ">"
+				IL_0292: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0297: stloc.s 12
+				IL_0299: ldloc.s 12
+				IL_029b: box [System.Runtime]System.Boolean
+				IL_02a0: stloc.s 19
+				IL_02a2: ldloc.s 19
+				IL_02a4: stloc.s 20
+				IL_02a6: br IL_02af
 
-				IL_02b5: ldloc.s 18
-				IL_02b7: stloc.s 20
+				IL_02ab: ldloc.s 18
+				IL_02ad: stloc.s 20
 
-				IL_02b9: ldloc.s 20
-				IL_02bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02c0: stloc.s 12
-				IL_02c2: ldloc.s 12
-				IL_02c4: brfalse IL_030a
+				IL_02af: ldloc.s 20
+				IL_02b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02b6: stloc.s 12
+				IL_02b8: ldloc.s 12
+				IL_02ba: brfalse IL_0300
 
-				IL_02c9: ldarg.0
-				IL_02ca: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
-				IL_02cf: ldc.i4.1
-				IL_02d0: newarr [System.Runtime]System.Object
-				IL_02d5: dup
-				IL_02d6: ldc.i4.0
-				IL_02d7: ldarg.0
-				IL_02d8: stelem.ref
-				IL_02d9: stloc.s 21
-				IL_02db: ldloc.s 21
-				IL_02dd: ldc.i4.4
-				IL_02de: newarr [System.Runtime]System.Object
-				IL_02e3: dup
-				IL_02e4: ldc.i4.0
-				IL_02e5: ldarg.2
-				IL_02e6: stelem.ref
-				IL_02e7: dup
-				IL_02e8: ldc.i4.1
-				IL_02e9: ldarg.3
+				IL_02bf: ldarg.0
+				IL_02c0: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
+				IL_02c5: ldc.i4.1
+				IL_02c6: newarr [System.Runtime]System.Object
+				IL_02cb: dup
+				IL_02cc: ldc.i4.0
+				IL_02cd: ldarg.0
+				IL_02ce: stelem.ref
+				IL_02cf: stloc.s 21
+				IL_02d1: ldloc.s 21
+				IL_02d3: ldc.i4.4
+				IL_02d4: newarr [System.Runtime]System.Object
+				IL_02d9: dup
+				IL_02da: ldc.i4.0
+				IL_02db: ldarg.2
+				IL_02dc: stelem.ref
+				IL_02dd: dup
+				IL_02de: ldc.i4.1
+				IL_02df: ldarg.3
+				IL_02e0: stelem.ref
+				IL_02e1: dup
+				IL_02e2: ldc.i4.2
+				IL_02e3: ldarg.s baseIndent
+				IL_02e5: box [System.Runtime]System.Double
 				IL_02ea: stelem.ref
 				IL_02eb: dup
-				IL_02ec: ldc.i4.2
-				IL_02ed: ldarg.s baseIndent
-				IL_02ef: box [System.Runtime]System.Double
-				IL_02f4: stelem.ref
-				IL_02f5: dup
-				IL_02f6: ldc.i4.3
-				IL_02f7: ldloc.s 8
-				IL_02f9: stelem.ref
-				IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_02ff: stloc.s 11
-				IL_0301: ldloc.s 11
-				IL_0303: stloc.s 9
-				IL_0305: br IL_0369
+				IL_02ec: ldc.i4.3
+				IL_02ed: ldloc.s 8
+				IL_02ef: stelem.ref
+				IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_02f5: stloc.s 11
+				IL_02f7: ldloc.s 11
+				IL_02f9: stloc.s 9
+				IL_02fb: br IL_035f
 
-				IL_030a: ldloc.s 8
-				IL_030c: ldstr ""
-				IL_0311: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0316: stloc.s 12
-				IL_0318: ldloc.s 12
-				IL_031a: brfalse IL_034c
+				IL_0300: ldloc.s 8
+				IL_0302: ldstr ""
+				IL_0307: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_030c: stloc.s 12
+				IL_030e: ldloc.s 12
+				IL_0310: brfalse IL_0342
 
-				IL_031f: ldarg.0
-				IL_0320: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
-				IL_0325: ldc.i4.1
-				IL_0326: newarr [System.Runtime]System.Object
-				IL_032b: dup
-				IL_032c: ldc.i4.0
-				IL_032d: ldarg.0
-				IL_032e: stelem.ref
-				IL_032f: stloc.s 21
-				IL_0331: ldloc.s 21
-				IL_0333: ldarg.2
-				IL_0334: ldarg.3
-				IL_0335: ldarg.s baseIndent
-				IL_0337: box [System.Runtime]System.Double
-				IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_0341: stloc.s 11
-				IL_0343: ldloc.s 11
-				IL_0345: stloc.s 9
-				IL_0347: br IL_0369
+				IL_0315: ldarg.0
+				IL_0316: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
+				IL_031b: ldc.i4.1
+				IL_031c: newarr [System.Runtime]System.Object
+				IL_0321: dup
+				IL_0322: ldc.i4.0
+				IL_0323: ldarg.0
+				IL_0324: stelem.ref
+				IL_0325: stloc.s 21
+				IL_0327: ldloc.s 21
+				IL_0329: ldarg.2
+				IL_032a: ldarg.3
+				IL_032b: ldarg.s baseIndent
+				IL_032d: box [System.Runtime]System.Double
+				IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_0337: stloc.s 11
+				IL_0339: ldloc.s 11
+				IL_033b: stloc.s 9
+				IL_033d: br IL_035f
 
-				IL_034c: ldarg.0
-				IL_034d: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
-				IL_0352: ldc.i4.1
-				IL_0353: newarr [System.Runtime]System.Object
-				IL_0358: dup
-				IL_0359: ldc.i4.0
-				IL_035a: ldarg.0
-				IL_035b: stelem.ref
-				IL_035c: ldloc.s 8
-				IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0363: stloc.s 11
-				IL_0365: ldloc.s 11
-				IL_0367: stloc.s 9
+				IL_0342: ldarg.0
+				IL_0343: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
+				IL_0348: ldc.i4.1
+				IL_0349: newarr [System.Runtime]System.Object
+				IL_034e: dup
+				IL_034f: ldc.i4.0
+				IL_0350: ldarg.0
+				IL_0351: stelem.ref
+				IL_0352: ldloc.s 8
+				IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0359: stloc.s 11
+				IL_035b: ldloc.s 11
+				IL_035d: stloc.s 9
 
-				IL_0369: ldloc.0
-				IL_036a: ldloc.s 7
-				IL_036c: ldloc.s 9
-				IL_036e: ldc.i4.1
-				IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_0374: pop
-				IL_0375: br IL_0006
+				IL_035f: ldloc.0
+				IL_0360: ldloc.s 7
+				IL_0362: ldloc.s 9
+				IL_0364: ldc.i4.1
+				IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_036a: pop
+				IL_036b: br IL_0006
 			// end loop
 
-			IL_037a: ldloc.0
-			IL_037b: ret
+			IL_0370: ldloc.0
+			IL_0371: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -5093,7 +5091,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6785
+				// Method begins at RVA 0x6779
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5120,7 +5118,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4af8
+			// Method begins at RVA 0x4af0
 			// Header size: 12
 			// Code size: 114 (0x72)
 			.maxstack 8
@@ -5196,7 +5194,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6797
+					// Method begins at RVA 0x678b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5216,7 +5214,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67a0
+					// Method begins at RVA 0x6794
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5236,7 +5234,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67a9
+					// Method begins at RVA 0x679d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5254,7 +5252,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x678e
+				// Method begins at RVA 0x6782
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5281,9 +5279,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4b78
+			// Method begins at RVA 0x4b70
 			// Header size: 12
-			// Code size: 304 (0x130)
+			// Code size: 299 (0x12b)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5343,61 +5341,60 @@
 			IL_007c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0081: ldc.r8 0.0
 			IL_008a: clt
-			IL_008c: brfalse IL_00b6
+			IL_008c: brfalse IL_00b1
 
 			IL_0091: ldstr "Unterminated test262 frontmatter block."
-			IL_0096: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00a0: stloc.3
-			IL_00a1: ldloc.3
-			IL_00a2: isinst [System.Runtime]System.Exception
-			IL_00a7: dup
-			IL_00a8: brtrue IL_00b5
+			IL_0096: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_009b: stloc.3
+			IL_009c: ldloc.3
+			IL_009d: isinst [System.Runtime]System.Exception
+			IL_00a2: dup
+			IL_00a3: brtrue IL_00b0
 
-			IL_00ad: pop
-			IL_00ae: ldloc.3
-			IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00b4: throw
+			IL_00a8: pop
+			IL_00a9: ldloc.3
+			IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00af: throw
 
-			IL_00b5: throw
+			IL_00b0: throw
 
-			IL_00b6: ldloc.0
-			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00bc: stloc.s 6
-			IL_00be: ldloc.1
-			IL_00bf: ldc.r8 5
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_00cd: stloc.s 7
-			IL_00cf: ldloc.s 6
-			IL_00d1: ldstr "substring"
-			IL_00d6: ldloc.s 7
-			IL_00d8: ldloc.2
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00de: stloc.s 4
-			IL_00e0: ldloc.s 4
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e7: ldstr "startsWith"
-			IL_00ec: ldstr "\n"
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00f6: stloc.s 6
-			IL_00f8: ldloc.s 6
-			IL_00fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00ff: stloc.s 8
-			IL_0101: ldloc.s 8
-			IL_0103: brfalse IL_012d
+			IL_00b1: ldloc.0
+			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b7: stloc.s 6
+			IL_00b9: ldloc.1
+			IL_00ba: ldc.r8 5
+			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_00c8: stloc.s 7
+			IL_00ca: ldloc.s 6
+			IL_00cc: ldstr "substring"
+			IL_00d1: ldloc.s 7
+			IL_00d3: ldloc.2
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00d9: stloc.s 4
+			IL_00db: ldloc.s 4
+			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e2: ldstr "startsWith"
+			IL_00e7: ldstr "\n"
+			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00f1: stloc.s 6
+			IL_00f3: ldloc.s 6
+			IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00fa: stloc.s 8
+			IL_00fc: ldloc.s 8
+			IL_00fe: brfalse IL_0128
 
-			IL_0108: ldloc.s 4
-			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010f: ldstr "substring"
-			IL_0114: ldc.r8 1
-			IL_011d: box [System.Runtime]System.Double
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0127: stloc.s 6
-			IL_0129: ldloc.s 6
-			IL_012b: stloc.s 4
+			IL_0103: ldloc.s 4
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010a: ldstr "substring"
+			IL_010f: ldc.r8 1
+			IL_0118: box [System.Runtime]System.Double
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0122: stloc.s 6
+			IL_0124: ldloc.s 6
+			IL_0126: stloc.s 4
 
-			IL_012d: ldloc.s 4
-			IL_012f: ret
+			IL_0128: ldloc.s 4
+			IL_012a: ret
 		} // end of method extractTest262Frontmatter::__js_call__
 
 	} // end of class extractTest262Frontmatter
@@ -5413,7 +5410,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67b2
+				// Method begins at RVA 0x67a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5437,7 +5434,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4cb4
+			// Method begins at RVA 0x4ca8
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -5496,7 +5493,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67c4
+					// Method begins at RVA 0x67b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5514,7 +5511,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67bb
+				// Method begins at RVA 0x67af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5538,7 +5535,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4d08
+			// Method begins at RVA 0x4cfc
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -5606,7 +5603,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67cd
+				// Method begins at RVA 0x67c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5631,7 +5628,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4d84
+			// Method begins at RVA 0x4d78
 			// Header size: 12
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -5668,7 +5665,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67d6
+				// Method begins at RVA 0x67ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5695,7 +5692,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4dbc
+			// Method begins at RVA 0x4db0
 			// Header size: 12
 			// Code size: 53 (0x35)
 			.maxstack 8
@@ -5742,7 +5739,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67e8
+					// Method begins at RVA 0x67dc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5762,7 +5759,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67f1
+					// Method begins at RVA 0x67e5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5780,7 +5777,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67df
+				// Method begins at RVA 0x67d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5808,7 +5805,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x680c
+						// Method begins at RVA 0x6800
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5826,7 +5823,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6803
+					// Method begins at RVA 0x67f7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5844,7 +5841,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67fa
+				// Method begins at RVA 0x67ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5873,7 +5870,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4e00
+			// Method begins at RVA 0x4df4
 			// Header size: 12
 			// Code size: 452 (0x1c4)
 			.maxstack 8
@@ -6116,7 +6113,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x681e
+					// Method begins at RVA 0x6812
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6136,7 +6133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6827
+					// Method begins at RVA 0x681b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6154,7 +6151,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6815
+				// Method begins at RVA 0x6809
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6183,7 +6180,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4fd0
+			// Method begins at RVA 0x4fc4
 			// Header size: 12
 			// Code size: 247 (0xf7)
 			.maxstack 8
@@ -6330,7 +6327,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6839
+					// Method begins at RVA 0x682d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6350,7 +6347,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6842
+					// Method begins at RVA 0x6836
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6370,7 +6367,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x684b
+					// Method begins at RVA 0x683f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6390,7 +6387,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x686f
+					// Method begins at RVA 0x6863
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6408,7 +6405,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6830
+				// Method begins at RVA 0x6824
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6436,7 +6433,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6866
+						// Method begins at RVA 0x685a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6454,7 +6451,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x685d
+					// Method begins at RVA 0x6851
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6472,7 +6469,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6854
+				// Method begins at RVA 0x6848
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6500,7 +6497,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x50d4
+			// Method begins at RVA 0x50c8
 			// Header size: 12
 			// Code size: 1063 (0x427)
 			.maxstack 8
@@ -6984,7 +6981,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68a5
+						// Method begins at RVA 0x6899
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7004,7 +7001,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68ae
+						// Method begins at RVA 0x68a2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7024,7 +7021,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68b7
+						// Method begins at RVA 0x68ab
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7042,7 +7039,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x689c
+					// Method begins at RVA 0x6890
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7062,7 +7059,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68c0
+					// Method begins at RVA 0x68b4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7082,7 +7079,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68c9
+					// Method begins at RVA 0x68bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7100,7 +7097,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6878
+				// Method begins at RVA 0x686c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7128,7 +7125,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6893
+						// Method begins at RVA 0x6887
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7146,7 +7143,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x688a
+					// Method begins at RVA 0x687e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7164,7 +7161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6881
+				// Method begins at RVA 0x6875
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7192,7 +7189,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68e4
+						// Method begins at RVA 0x68d8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7210,7 +7207,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68db
+					// Method begins at RVA 0x68cf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7228,7 +7225,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x68d2
+				// Method begins at RVA 0x68c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7257,7 +7254,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5508
+			// Method begins at RVA 0x54fc
 			// Header size: 12
 			// Code size: 1583 (0x62f)
 			.maxstack 8
@@ -7916,7 +7913,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68f6
+					// Method begins at RVA 0x68ea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7936,7 +7933,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68ff
+					// Method begins at RVA 0x68f3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7956,7 +7953,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6908
+					// Method begins at RVA 0x68fc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7976,7 +7973,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6911
+					// Method begins at RVA 0x6905
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7996,7 +7993,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x691a
+					// Method begins at RVA 0x690e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8016,7 +8013,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6923
+					// Method begins at RVA 0x6917
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8036,7 +8033,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x692c
+					// Method begins at RVA 0x6920
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8054,7 +8051,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x68ed
+				// Method begins at RVA 0x68e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8083,7 +8080,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5b44
+			// Method begins at RVA 0x5b38
 			// Header size: 12
 			// Code size: 769 (0x301)
 			.maxstack 8
@@ -8485,7 +8482,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6974
+					// Method begins at RVA 0x6968
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8503,7 +8500,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6935
+				// Method begins at RVA 0x6929
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8531,7 +8528,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6950
+						// Method begins at RVA 0x6944
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8549,7 +8546,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6947
+					// Method begins at RVA 0x693b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8567,7 +8564,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x693e
+				// Method begins at RVA 0x6932
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8595,7 +8592,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x696b
+						// Method begins at RVA 0x695f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8613,7 +8610,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6962
+					// Method begins at RVA 0x6956
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8631,7 +8628,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6959
+				// Method begins at RVA 0x694d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8659,7 +8656,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5e54
+			// Method begins at RVA 0x5e48
 			// Header size: 12
 			// Code size: 1799 (0x707)
 			.maxstack 8
@@ -9424,7 +9421,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x697d
+				// Method begins at RVA 0x6971
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -9451,7 +9448,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x6568
+			// Method begins at RVA 0x655c
 			// Header size: 12
 			// Code size: 70 (0x46)
 			.maxstack 8
@@ -9557,7 +9554,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x661d
+			// Method begins at RVA 0x6611
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -10096,7 +10093,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x6986
+		// Method begins at RVA 0x697a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedComparisonScheduler.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedComparisonScheduler.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26f6
+				// Method begins at RVA 0x26ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25c0
+			// Method begins at RVA 0x25b8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -66,7 +66,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26ff
+				// Method begins at RVA 0x26f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -90,7 +90,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25cc
+			// Method begins at RVA 0x25c4
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -119,7 +119,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2708
+				// Method begins at RVA 0x2700
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -144,7 +144,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25e6
+			// Method begins at RVA 0x25de
 			// Header size: 1
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -171,7 +171,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2711
+				// Method begins at RVA 0x2709
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -197,7 +197,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25fb
+			// Method begins at RVA 0x25f3
 			// Header size: 1
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -234,7 +234,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2723
+					// Method begins at RVA 0x271b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -252,7 +252,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x271a
+				// Method begins at RVA 0x2712
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -277,7 +277,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x261f
+			// Method begins at RVA 0x2617
 			// Header size: 1
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -313,7 +313,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x272c
+				// Method begins at RVA 0x2724
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -338,7 +338,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x264c
+			// Method begins at RVA 0x2644
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -385,7 +385,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2735
+				// Method begins at RVA 0x272d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -411,7 +411,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2680
+			// Method begins at RVA 0x2678
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -448,7 +448,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x273e
+				// Method begins at RVA 0x2736
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -474,7 +474,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x26b8
+			// Method begins at RVA 0x26b0
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -522,7 +522,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2747
+				// Method begins at RVA 0x273f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -542,7 +542,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2750
+				// Method begins at RVA 0x2748
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -571,7 +571,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26ed
+			// Method begins at RVA 0x26e5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -597,7 +597,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1361 (0x551)
+		// Code size: 1356 (0x54c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_TypedComparisonScheduler/Scope,
@@ -949,90 +949,89 @@
 			IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_046d: stloc.s 16
 			IL_046f: ldstr "Cannot access 'tdzValue' before initialization"
-			IL_0474: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0479: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_047e: stloc.s 20
-			IL_0480: ldloc.s 20
-			IL_0482: isinst [System.Runtime]System.Exception
-			IL_0487: dup
-			IL_0488: brtrue IL_0496
+			IL_0474: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_0479: stloc.s 20
+			IL_047b: ldloc.s 20
+			IL_047d: isinst [System.Runtime]System.Exception
+			IL_0482: dup
+			IL_0483: brtrue IL_0491
 
-			IL_048d: pop
-			IL_048e: ldloc.s 20
-			IL_0490: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0495: throw
+			IL_0488: pop
+			IL_0489: ldloc.s 20
+			IL_048b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0490: throw
 
-			IL_0496: throw
+			IL_0491: throw
 
-			IL_0497: ldnull
-			IL_0498: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_049d: ldc.r8 1
-			IL_04a6: clt
-			IL_04a8: stloc.s 22
-			IL_04aa: ldloc.s 22
-			IL_04ac: box [System.Runtime]System.Boolean
-			IL_04b1: stloc.s 19
-			IL_04b3: ldloc.s 16
-			IL_04b5: ldstr "log"
-			IL_04ba: ldloc.s 19
-			IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_04c1: pop
-			IL_04c2: leave IL_0542
+			IL_0492: ldnull
+			IL_0493: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0498: ldc.r8 1
+			IL_04a1: clt
+			IL_04a3: stloc.s 22
+			IL_04a5: ldloc.s 22
+			IL_04a7: box [System.Runtime]System.Boolean
+			IL_04ac: stloc.s 19
+			IL_04ae: ldloc.s 16
+			IL_04b0: ldstr "log"
+			IL_04b5: ldloc.s 19
+			IL_04b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04bc: pop
+			IL_04bd: leave IL_053d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_04c7: stloc.s 9
-			IL_04c9: ldloc.s 9
-			IL_04cb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_04d0: dup
-			IL_04d1: brtrue IL_04e7
+			IL_04c2: stloc.s 9
+			IL_04c4: ldloc.s 9
+			IL_04c6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_04cb: dup
+			IL_04cc: brtrue IL_04e2
 
-			IL_04d6: pop
-			IL_04d7: ldloc.s 9
-			IL_04d9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_04de: dup
-			IL_04df: brtrue IL_04f3
+			IL_04d1: pop
+			IL_04d2: ldloc.s 9
+			IL_04d4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04d9: dup
+			IL_04da: brtrue IL_04ee
 
-			IL_04e4: pop
-			IL_04e5: rethrow
+			IL_04df: pop
+			IL_04e0: rethrow
 
-			IL_04e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_04ec: stloc.s 10
-			IL_04ee: br IL_04f5
+			IL_04e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_04e7: stloc.s 10
+			IL_04e9: br IL_04f0
 
-			IL_04f3: stloc.s 10
+			IL_04ee: stloc.s 10
 
-			IL_04f5: ldloc.s 10
-			IL_04f7: stloc.s 11
-			IL_04f9: ldstr "console"
-			IL_04fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0503: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0508: stloc.s 16
-			IL_050a: ldloc.s 11
-			IL_050c: stloc.s 20
-			IL_050e: ldstr "ReferenceError"
-			IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0518: stloc.s 21
-			IL_051a: ldloc.s 20
-			IL_051c: ldloc.s 21
-			IL_051e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0523: stloc.s 22
-			IL_0525: ldloc.s 22
-			IL_0527: box [System.Runtime]System.Boolean
-			IL_052c: stloc.s 19
-			IL_052e: ldloc.s 16
-			IL_0530: ldstr "log"
-			IL_0535: ldloc.s 19
-			IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_053c: pop
-			IL_053d: leave IL_0542
+			IL_04f0: ldloc.s 10
+			IL_04f2: stloc.s 11
+			IL_04f4: ldstr "console"
+			IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0503: stloc.s 16
+			IL_0505: ldloc.s 11
+			IL_0507: stloc.s 20
+			IL_0509: ldstr "ReferenceError"
+			IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0513: stloc.s 21
+			IL_0515: ldloc.s 20
+			IL_0517: ldloc.s 21
+			IL_0519: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_051e: stloc.s 22
+			IL_0520: ldloc.s 22
+			IL_0522: box [System.Runtime]System.Boolean
+			IL_0527: stloc.s 19
+			IL_0529: ldloc.s 16
+			IL_052b: ldstr "log"
+			IL_0530: ldloc.s 19
+			IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0537: pop
+			IL_0538: leave IL_053d
 		} // end handler
 
-		IL_0542: ldc.r8 0.0
-		IL_054b: stloc.s 12
-		IL_054d: ldnull
-		IL_054e: stloc.s 13
-		IL_0550: ret
+		IL_053d: ldc.r8 0.0
+		IL_0546: stloc.s 12
+		IL_0548: ldnull
+		IL_0549: stloc.s 13
+		IL_054b: ret
 	} // end of method BinaryOperator_TypedComparisonScheduler::__js_module_init__
 
 } // end of class Modules.BinaryOperator_TypedComparisonScheduler
@@ -1044,7 +1043,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2759
+		// Method begins at RVA 0x2751
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_CustomIterable_IteratorProtocol.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_CustomIterable_IteratorProtocol.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2922
+					// Method begins at RVA 0x291a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26ac
+				// Method begins at RVA 0x26a8
 				// Header size: 12
 				// Code size: 230 (0xe6)
 				.maxstack 8
@@ -150,7 +150,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x292b
+					// Method begins at RVA 0x2923
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -174,7 +174,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x27a0
+				// Method begins at RVA 0x279c
 				// Header size: 12
 				// Code size: 84 (0x54)
 				.maxstack 8
@@ -228,7 +228,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2919
+				// Method begins at RVA 0x2911
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -254,7 +254,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x256c
+			// Method begins at RVA 0x2568
 			// Header size: 12
 			// Code size: 148 (0x94)
 			.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2985
+					// Method begins at RVA 0x297d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,9 +366,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2800
+				// Method begins at RVA 0x27fc
 				// Header size: 12
-				// Code size: 166 (0xa6)
+				// Code size: 161 (0xa1)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -422,23 +422,22 @@
 				IL_007e: ret
 
 				IL_007f: ldstr "nextboom"
-				IL_0084: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0089: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_008e: stloc.0
-				IL_008f: ldloc.0
-				IL_0090: isinst [System.Runtime]System.Exception
-				IL_0095: dup
-				IL_0096: brtrue IL_00a3
+				IL_0084: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0089: stloc.0
+				IL_008a: ldloc.0
+				IL_008b: isinst [System.Runtime]System.Exception
+				IL_0090: dup
+				IL_0091: brtrue IL_009e
 
-				IL_009b: pop
-				IL_009c: ldloc.0
-				IL_009d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_00a2: throw
+				IL_0096: pop
+				IL_0097: ldloc.0
+				IL_0098: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_009d: throw
 
-				IL_00a3: throw
+				IL_009e: throw
 
-				IL_00a4: ldnull
-				IL_00a5: ret
+				IL_009f: ldnull
+				IL_00a0: ret
 			} // end of method FunctionExpression_iterableThrow::__js_call__
 
 		} // end of class FunctionExpression_iterableThrow
@@ -454,7 +453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x298e
+					// Method begins at RVA 0x2986
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -478,7 +477,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x28b4
+				// Method begins at RVA 0x28ac
 				// Header size: 12
 				// Code size: 80 (0x50)
 				.maxstack 8
@@ -532,7 +531,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x297c
+				// Method begins at RVA 0x2974
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -558,7 +557,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x260c
+			// Method begins at RVA 0x2608
 			// Header size: 12
 			// Code size: 148 (0x94)
 			.maxstack 8
@@ -647,7 +646,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2958
+				// Method begins at RVA 0x2950
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -671,7 +670,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x296a
+					// Method begins at RVA 0x2962
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -689,7 +688,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2961
+				// Method begins at RVA 0x2959
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -709,7 +708,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2973
+				// Method begins at RVA 0x296b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -729,7 +728,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2997
+				// Method begins at RVA 0x298f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -753,7 +752,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29a9
+					// Method begins at RVA 0x29a1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -771,7 +770,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29a0
+				// Method begins at RVA 0x2998
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -791,7 +790,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29b2
+				// Method begins at RVA 0x29aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -813,7 +812,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2910
+			// Method begins at RVA 0x2908
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -837,7 +836,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x293d
+				// Method begins at RVA 0x2935
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -855,7 +854,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2934
+			// Method begins at RVA 0x292c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -879,7 +878,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x294f
+				// Method begins at RVA 0x2947
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -897,7 +896,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2946
+			// Method begins at RVA 0x293e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -923,7 +922,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1219 (0x4c3)
+		// Code size: 1214 (0x4be)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope,
@@ -1164,7 +1163,7 @@
 					IL_020b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_0210: stloc.s 30
 					IL_0212: ldloc.s 30
-					IL_0214: brtrue IL_0283
+					IL_0214: brtrue IL_027e
 
 					IL_0219: ldloc.s 27
 					IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -1180,253 +1179,252 @@
 					IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 					IL_0246: pop
 					IL_0247: ldstr "boom"
-					IL_024c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0251: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0256: stloc.s 14
-					IL_0258: ldloc.s 14
-					IL_025a: isinst [System.Runtime]System.Exception
-					IL_025f: dup
-					IL_0260: brtrue IL_026e
+					IL_024c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0251: stloc.s 14
+					IL_0253: ldloc.s 14
+					IL_0255: isinst [System.Runtime]System.Exception
+					IL_025a: dup
+					IL_025b: brtrue IL_0269
 
-					IL_0265: pop
-					IL_0266: ldloc.s 14
-					IL_0268: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-					IL_026d: throw
+					IL_0260: pop
+					IL_0261: ldloc.s 14
+					IL_0263: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_0268: throw
 
-					IL_026e: throw
+					IL_0269: throw
 
-					IL_026f: br IL_0200
+					IL_026a: br IL_0200
 				// end loop
-				IL_0274: ldloc.s 10
-				IL_0276: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_027b: ldc.i4.1
-				IL_027c: stloc.s 12
-				IL_027e: leave IL_02a1
+				IL_026f: ldloc.s 10
+				IL_0271: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_0276: ldc.i4.1
+				IL_0277: stloc.s 12
+				IL_0279: leave IL_029c
 
-				IL_0283: ldc.i4.1
-				IL_0284: stloc.s 11
-				IL_0286: leave IL_02a1
+				IL_027e: ldc.i4.1
+				IL_027f: stloc.s 11
+				IL_0281: leave IL_029c
 			} // end .try
 			finally
 			{
-				IL_028b: ldloc.s 11
-				IL_028d: brtrue IL_02a0
+				IL_0286: ldloc.s 11
+				IL_0288: brtrue IL_029b
 
-				IL_0292: ldloc.s 12
-				IL_0294: brtrue IL_02a0
+				IL_028d: ldloc.s 12
+				IL_028f: brtrue IL_029b
 
-				IL_0299: ldloc.s 10
-				IL_029b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_0294: ldloc.s 10
+				IL_0296: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_02a0: endfinally
+				IL_029b: endfinally
 			} // end handler
 
-			IL_02a1: leave IL_0310
+			IL_029c: leave IL_030b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02a6: stloc.s 15
-			IL_02a8: ldloc.s 15
-			IL_02aa: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02af: dup
-			IL_02b0: brtrue IL_02c6
+			IL_02a1: stloc.s 15
+			IL_02a3: ldloc.s 15
+			IL_02a5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02aa: dup
+			IL_02ab: brtrue IL_02c1
 
-			IL_02b5: pop
-			IL_02b6: ldloc.s 15
-			IL_02b8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02bd: dup
-			IL_02be: brtrue IL_02d2
+			IL_02b0: pop
+			IL_02b1: ldloc.s 15
+			IL_02b3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02b8: dup
+			IL_02b9: brtrue IL_02cd
 
-			IL_02c3: pop
-			IL_02c4: rethrow
+			IL_02be: pop
+			IL_02bf: rethrow
 
-			IL_02c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02cb: stloc.s 16
-			IL_02cd: br IL_02d4
+			IL_02c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02c6: stloc.s 16
+			IL_02c8: br IL_02cf
 
-			IL_02d2: stloc.s 16
+			IL_02cd: stloc.s 16
 
-			IL_02d4: ldloc.s 16
-			IL_02d6: stloc.s 17
-			IL_02d8: ldstr "console"
-			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e7: stloc.s 27
-			IL_02e9: ldloc.s 17
-			IL_02eb: ldstr "name"
-			IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02f5: stloc.s 31
-			IL_02f7: ldloc.s 27
-			IL_02f9: ldstr "log"
-			IL_02fe: ldstr "caught"
-			IL_0303: ldloc.s 31
-			IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_030a: pop
-			IL_030b: leave IL_0310
+			IL_02cf: ldloc.s 16
+			IL_02d1: stloc.s 17
+			IL_02d3: ldstr "console"
+			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02e2: stloc.s 27
+			IL_02e4: ldloc.s 17
+			IL_02e6: ldstr "name"
+			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02f0: stloc.s 31
+			IL_02f2: ldloc.s 27
+			IL_02f4: ldstr "log"
+			IL_02f9: ldstr "caught"
+			IL_02fe: ldloc.s 31
+			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0305: pop
+			IL_0306: leave IL_030b
 		} // end handler
 
-		IL_0310: ldstr "console"
-		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_031f: stloc.s 31
-		IL_0321: ldloc.0
-		IL_0322: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed
-		IL_0327: stloc.s 27
-		IL_0329: ldloc.s 31
-		IL_032b: ldstr "log"
-		IL_0330: ldstr "closed"
-		IL_0335: ldloc.s 27
-		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_033c: pop
-		IL_033d: ldloc.0
-		IL_033e: ldc.r8 0.0
-		IL_0347: box [System.Runtime]System.Double
-		IL_034c: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed2
-		IL_0351: ldstr "iterator"
-		IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_035b: stloc.s 27
-		IL_035d: ldloc.0
-		IL_035e: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
-		IL_0363: ldftn object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
-		IL_0369: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_036e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0373: ldc.i4.0
-		IL_0374: conv.r8
-		IL_0375: ldstr ""
-		IL_037a: ldc.i4.0
-		IL_037b: ldc.i4.1
-		IL_037c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0381: stloc.s 28
-		IL_0383: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0388: stloc.s 29
-		IL_038a: ldloc.s 29
-		IL_038c: ldloc.s 27
-		IL_038e: ldloc.s 28
-		IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_0395: pop
-		IL_0396: ldloc.s 29
-		IL_0398: stloc.s 18
+		IL_030b: ldstr "console"
+		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_031a: stloc.s 31
+		IL_031c: ldloc.0
+		IL_031d: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed
+		IL_0322: stloc.s 27
+		IL_0324: ldloc.s 31
+		IL_0326: ldstr "log"
+		IL_032b: ldstr "closed"
+		IL_0330: ldloc.s 27
+		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0337: pop
+		IL_0338: ldloc.0
+		IL_0339: ldc.r8 0.0
+		IL_0342: box [System.Runtime]System.Double
+		IL_0347: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed2
+		IL_034c: ldstr "iterator"
+		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0356: stloc.s 27
+		IL_0358: ldloc.0
+		IL_0359: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
+		IL_035e: ldftn object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
+		IL_0364: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0369: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_036e: ldc.i4.0
+		IL_036f: conv.r8
+		IL_0370: ldstr ""
+		IL_0375: ldc.i4.0
+		IL_0376: ldc.i4.1
+		IL_0377: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_037c: stloc.s 28
+		IL_037e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0383: stloc.s 29
+		IL_0385: ldloc.s 29
+		IL_0387: ldloc.s 27
+		IL_0389: ldloc.s 28
+		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0390: pop
+		IL_0391: ldloc.s 29
+		IL_0393: stloc.s 18
 		.try
 		{
-			IL_039a: nop
-			IL_039b: ldloc.s 18
-			IL_039d: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_03a2: stloc.s 19
-			IL_03a4: ldc.i4.0
-			IL_03a5: stloc.s 20
-			IL_03a7: ldc.i4.0
-			IL_03a8: stloc.s 21
+			IL_0395: nop
+			IL_0396: ldloc.s 18
+			IL_0398: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_039d: stloc.s 19
+			IL_039f: ldc.i4.0
+			IL_03a0: stloc.s 20
+			IL_03a2: ldc.i4.0
+			IL_03a3: stloc.s 21
 			.try
 			{
-				// loop start (head: IL_03aa)
-					IL_03aa: ldloc.s 19
-					IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_03b1: stloc.s 27
-					IL_03b3: ldloc.s 27
-					IL_03b5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_03ba: stloc.s 30
-					IL_03bc: ldloc.s 30
-					IL_03be: brtrue IL_0405
+				// loop start (head: IL_03a5)
+					IL_03a5: ldloc.s 19
+					IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_03ac: stloc.s 27
+					IL_03ae: ldloc.s 27
+					IL_03b0: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_03b5: stloc.s 30
+					IL_03b7: ldloc.s 30
+					IL_03b9: brtrue IL_0400
 
-					IL_03c3: ldloc.s 27
-					IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_03ca: stloc.s 27
-					IL_03cc: ldloc.s 27
-					IL_03ce: stloc.s 22
-					IL_03d0: ldstr "console"
-					IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_03df: ldstr "log"
-					IL_03e4: ldstr "iter"
-					IL_03e9: ldloc.s 22
-					IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_03f0: pop
-					IL_03f1: br IL_03aa
+					IL_03be: ldloc.s 27
+					IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_03c5: stloc.s 27
+					IL_03c7: ldloc.s 27
+					IL_03c9: stloc.s 22
+					IL_03cb: ldstr "console"
+					IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+					IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_03da: ldstr "log"
+					IL_03df: ldstr "iter"
+					IL_03e4: ldloc.s 22
+					IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_03eb: pop
+					IL_03ec: br IL_03a5
 				// end loop
-				IL_03f6: ldloc.s 19
-				IL_03f8: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_03fd: ldc.i4.1
-				IL_03fe: stloc.s 21
-				IL_0400: leave IL_0423
+				IL_03f1: ldloc.s 19
+				IL_03f3: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_03f8: ldc.i4.1
+				IL_03f9: stloc.s 21
+				IL_03fb: leave IL_041e
 
-				IL_0405: ldc.i4.1
-				IL_0406: stloc.s 20
-				IL_0408: leave IL_0423
+				IL_0400: ldc.i4.1
+				IL_0401: stloc.s 20
+				IL_0403: leave IL_041e
 			} // end .try
 			finally
 			{
-				IL_040d: ldloc.s 20
-				IL_040f: brtrue IL_0422
+				IL_0408: ldloc.s 20
+				IL_040a: brtrue IL_041d
 
-				IL_0414: ldloc.s 21
-				IL_0416: brtrue IL_0422
+				IL_040f: ldloc.s 21
+				IL_0411: brtrue IL_041d
 
-				IL_041b: ldloc.s 19
-				IL_041d: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_0416: ldloc.s 19
+				IL_0418: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_0422: endfinally
+				IL_041d: endfinally
 			} // end handler
 
-			IL_0423: leave IL_0492
+			IL_041e: leave IL_048d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0428: stloc.s 23
-			IL_042a: ldloc.s 23
-			IL_042c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0431: dup
-			IL_0432: brtrue IL_0448
+			IL_0423: stloc.s 23
+			IL_0425: ldloc.s 23
+			IL_0427: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_042c: dup
+			IL_042d: brtrue IL_0443
 
-			IL_0437: pop
-			IL_0438: ldloc.s 23
-			IL_043a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_043f: dup
-			IL_0440: brtrue IL_0454
+			IL_0432: pop
+			IL_0433: ldloc.s 23
+			IL_0435: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_043a: dup
+			IL_043b: brtrue IL_044f
 
-			IL_0445: pop
-			IL_0446: rethrow
+			IL_0440: pop
+			IL_0441: rethrow
 
-			IL_0448: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_044d: stloc.s 24
-			IL_044f: br IL_0456
+			IL_0443: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0448: stloc.s 24
+			IL_044a: br IL_0451
 
-			IL_0454: stloc.s 24
+			IL_044f: stloc.s 24
 
-			IL_0456: ldloc.s 24
-			IL_0458: stloc.s 25
-			IL_045a: ldstr "console"
-			IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0469: stloc.s 27
-			IL_046b: ldloc.s 25
-			IL_046d: ldstr "name"
-			IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0477: stloc.s 31
-			IL_0479: ldloc.s 27
-			IL_047b: ldstr "log"
-			IL_0480: ldstr "caught"
-			IL_0485: ldloc.s 31
-			IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_048c: pop
-			IL_048d: leave IL_0492
+			IL_0451: ldloc.s 24
+			IL_0453: stloc.s 25
+			IL_0455: ldstr "console"
+			IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0464: stloc.s 27
+			IL_0466: ldloc.s 25
+			IL_0468: ldstr "name"
+			IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0472: stloc.s 31
+			IL_0474: ldloc.s 27
+			IL_0476: ldstr "log"
+			IL_047b: ldstr "caught"
+			IL_0480: ldloc.s 31
+			IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0487: pop
+			IL_0488: leave IL_048d
 		} // end handler
 
-		IL_0492: ldstr "console"
-		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04a1: stloc.s 31
-		IL_04a3: ldloc.0
-		IL_04a4: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed2
-		IL_04a9: stloc.s 27
-		IL_04ab: ldloc.s 31
-		IL_04ad: ldstr "log"
-		IL_04b2: ldstr "closed2"
-		IL_04b7: ldloc.s 27
-		IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04be: pop
-		IL_04bf: ldnull
-		IL_04c0: stloc.s 26
-		IL_04c2: ret
+		IL_048d: ldstr "console"
+		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_049c: stloc.s 31
+		IL_049e: ldloc.0
+		IL_049f: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed2
+		IL_04a4: stloc.s 27
+		IL_04a6: ldloc.s 31
+		IL_04a8: ldstr "log"
+		IL_04ad: ldstr "closed2"
+		IL_04b2: ldloc.s 27
+		IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04b9: pop
+		IL_04ba: ldnull
+		IL_04bb: stloc.s 26
+		IL_04bd: ret
 	} // end of method ControlFlow_ForOf_CustomIterable_IteratorProtocol::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol
@@ -1438,7 +1436,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29bb
+		// Method begins at RVA 0x29b3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_SyntaxError.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_SyntaxError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x217d
+				// Method begins at RVA 0x2179
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2186
+				// Method begins at RVA 0x2182
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2174
+			// Method begins at RVA 0x2170
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 262 (0x106)
+		// Code size: 257 (0x101)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_SyntaxError/Scope,
@@ -104,97 +104,96 @@
 		{
 			IL_0007: nop
 			IL_0008: ldstr "Unexpected token '}' (dynamic-function:3:1)"
-			IL_000d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0012: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.SyntaxError::.ctor(string)
-			IL_0017: stloc.s 6
-			IL_0019: ldloc.s 6
-			IL_001b: isinst [System.Runtime]System.Exception
-			IL_0020: dup
-			IL_0021: brtrue IL_002f
+			IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.SyntaxError::.ctor(string)
+			IL_0012: stloc.s 6
+			IL_0014: ldloc.s 6
+			IL_0016: isinst [System.Runtime]System.Exception
+			IL_001b: dup
+			IL_001c: brtrue IL_002a
 
-			IL_0026: pop
-			IL_0027: ldloc.s 6
-			IL_0029: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_002e: throw
+			IL_0021: pop
+			IL_0022: ldloc.s 6
+			IL_0024: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0029: throw
 
-			IL_002f: throw
+			IL_002a: throw
 
-			IL_0030: ldstr "console"
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003f: ldstr "log"
-			IL_0044: ldstr "no-error"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_004e: pop
-			IL_004f: leave IL_0102
+			IL_002b: ldstr "console"
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003a: ldstr "log"
+			IL_003f: ldstr "no-error"
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0049: pop
+			IL_004a: leave IL_00fd
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0054: stloc.1
-			IL_0055: ldloc.1
-			IL_0056: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_005b: dup
-			IL_005c: brtrue IL_0071
+			IL_004f: stloc.1
+			IL_0050: ldloc.1
+			IL_0051: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0056: dup
+			IL_0057: brtrue IL_006c
 
-			IL_0061: pop
-			IL_0062: ldloc.1
-			IL_0063: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0068: dup
-			IL_0069: brtrue IL_007c
+			IL_005c: pop
+			IL_005d: ldloc.1
+			IL_005e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0063: dup
+			IL_0064: brtrue IL_0077
 
-			IL_006e: pop
-			IL_006f: rethrow
+			IL_0069: pop
+			IL_006a: rethrow
 
-			IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0076: stloc.2
-			IL_0077: br IL_007d
+			IL_006c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0071: stloc.2
+			IL_0072: br IL_0078
 
-			IL_007c: stloc.2
+			IL_0077: stloc.2
 
-			IL_007d: ldloc.2
-			IL_007e: stloc.3
-			IL_007f: ldloc.3
-			IL_0080: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0085: stloc.s 4
-			IL_0087: ldstr "console"
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0096: stloc.s 6
-			IL_0098: ldloc.s 4
-			IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_009f: stloc.s 7
-			IL_00a1: ldloc.s 7
-			IL_00a3: ldstr "SyntaxError"
-			IL_00a8: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_00ad: stloc.s 8
-			IL_00af: ldloc.s 6
-			IL_00b1: ldstr "log"
-			IL_00b6: ldloc.s 8
-			IL_00b8: box [System.Runtime]System.Boolean
-			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00c2: pop
-			IL_00c3: ldstr "console"
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d2: ldloc.s 4
-			IL_00d4: callvirt instance int32 [System.Runtime]System.String::get_Length()
-			IL_00d9: conv.r8
-			IL_00da: ldc.r8 0.0
-			IL_00e3: cgt
-			IL_00e5: stloc.s 8
-			IL_00e7: ldloc.s 8
-			IL_00e9: box [System.Runtime]System.Boolean
-			IL_00ee: stloc.s 9
-			IL_00f0: ldstr "log"
-			IL_00f5: ldloc.s 9
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00fc: pop
-			IL_00fd: leave IL_0102
+			IL_0078: ldloc.2
+			IL_0079: stloc.3
+			IL_007a: ldloc.3
+			IL_007b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0080: stloc.s 4
+			IL_0082: ldstr "console"
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0091: stloc.s 6
+			IL_0093: ldloc.s 4
+			IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_009a: stloc.s 7
+			IL_009c: ldloc.s 7
+			IL_009e: ldstr "SyntaxError"
+			IL_00a3: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_00a8: stloc.s 8
+			IL_00aa: ldloc.s 6
+			IL_00ac: ldstr "log"
+			IL_00b1: ldloc.s 8
+			IL_00b3: box [System.Runtime]System.Boolean
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00bd: pop
+			IL_00be: ldstr "console"
+			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00cd: ldloc.s 4
+			IL_00cf: callvirt instance int32 [System.Runtime]System.String::get_Length()
+			IL_00d4: conv.r8
+			IL_00d5: ldc.r8 0.0
+			IL_00de: cgt
+			IL_00e0: stloc.s 8
+			IL_00e2: ldloc.s 8
+			IL_00e4: box [System.Runtime]System.Boolean
+			IL_00e9: stloc.s 9
+			IL_00eb: ldstr "log"
+			IL_00f0: ldloc.s 9
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00f7: pop
+			IL_00f8: leave IL_00fd
 		} // end handler
 
-		IL_0102: ldnull
-		IL_0103: stloc.s 5
-		IL_0105: ret
+		IL_00fd: ldnull
+		IL_00fe: stloc.s 5
+		IL_0100: ret
 	} // end of method Function_Constructor_SyntaxError::__js_module_init__
 
 } // end of class Modules.Function_Constructor_SyntaxError
@@ -206,7 +205,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218f
+		// Method begins at RVA 0x218b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3224
+				// Method begins at RVA 0x321c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x322d
+				// Method begins at RVA 0x3225
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3236
+				// Method begins at RVA 0x322e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -173,7 +173,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x323f
+				// Method begins at RVA 0x3237
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -235,7 +235,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3248
+				// Method begins at RVA 0x3240
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -302,7 +302,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3251
+				// Method begins at RVA 0x3249
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -365,7 +365,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x325a
+				// Method begins at RVA 0x3252
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -428,7 +428,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3263
+				// Method begins at RVA 0x325b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -524,7 +524,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x327e
+					// Method begins at RVA 0x3276
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -550,7 +550,7 @@
 				)
 				// Method begins at RVA 0x2f34
 				// Header size: 12
-				// Code size: 79 (0x4f)
+				// Code size: 74 (0x4a)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -575,23 +575,22 @@
 				IL_0022: ldloc.2
 				IL_0023: stfld object Modules.Function_SchedulerCallResults/Scope::order
 				IL_0028: ldstr "x"
-				IL_002d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0032: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0037: stloc.0
-				IL_0038: ldloc.0
-				IL_0039: isinst [System.Runtime]System.Exception
-				IL_003e: dup
-				IL_003f: brtrue IL_004c
+				IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0032: stloc.0
+				IL_0033: ldloc.0
+				IL_0034: isinst [System.Runtime]System.Exception
+				IL_0039: dup
+				IL_003a: brtrue IL_0047
 
-				IL_0044: pop
-				IL_0045: ldloc.0
-				IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_004b: throw
+				IL_003f: pop
+				IL_0040: ldloc.0
+				IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0046: throw
 
-				IL_004c: throw
+				IL_0047: throw
 
-				IL_004d: ldnull
-				IL_004e: ret
+				IL_0048: ldnull
+				IL_0049: ret
 			} // end of method ArrowFunction_L44C23::__js_call__
 
 		} // end of class ArrowFunction_L44C23
@@ -607,7 +606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3275
+					// Method begins at RVA 0x326d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -627,7 +626,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3287
+					// Method begins at RVA 0x327f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -645,7 +644,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x326c
+				// Method begins at RVA 0x3264
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -805,7 +804,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3290
+				// Method begins at RVA 0x3288
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -890,7 +889,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32fc
+				// Method begins at RVA 0x32f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -978,7 +977,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3305
+				// Method begins at RVA 0x32fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1084,7 +1083,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x330e
+				// Method begins at RVA 0x3306
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1176,7 +1175,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3317
+				// Method begins at RVA 0x330f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1265,7 +1264,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3320
+				// Method begins at RVA 0x3318
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1354,7 +1353,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3299
+				// Method begins at RVA 0x3291
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1374,7 +1373,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32a2
+				// Method begins at RVA 0x329a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1394,7 +1393,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32ab
+				// Method begins at RVA 0x32a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1414,7 +1413,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32b4
+				// Method begins at RVA 0x32ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1434,7 +1433,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32bd
+				// Method begins at RVA 0x32b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1454,7 +1453,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32c6
+				// Method begins at RVA 0x32be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1474,7 +1473,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32cf
+				// Method begins at RVA 0x32c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1494,7 +1493,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32d8
+				// Method begins at RVA 0x32d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1514,7 +1513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32e1
+				// Method begins at RVA 0x32d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1534,7 +1533,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32ea
+				// Method begins at RVA 0x32e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1554,7 +1553,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32f3
+				// Method begins at RVA 0x32eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1580,7 +1579,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3207
+			// Method begins at RVA 0x31ff
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1602,7 +1601,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x303c
+			// Method begins at RVA 0x3034
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -1632,7 +1631,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3065
+			// Method begins at RVA 0x305d
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1648,7 +1647,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fa8
+			// Method begins at RVA 0x2fa0
 			// Header size: 12
 			// Code size: 135 (0x87)
 			.maxstack 8
@@ -1709,7 +1708,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f8f
+			// Method begins at RVA 0x2f8a
 			// Header size: 1
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -1727,7 +1726,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31b8
+			// Method begins at RVA 0x31b0
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1758,7 +1757,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x306d
+			// Method begins at RVA 0x3065
 			// Header size: 1
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -1795,7 +1794,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31ee
+			// Method begins at RVA 0x31e6
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -1826,7 +1825,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3094
+			// Method begins at RVA 0x308c
 			// Header size: 12
 			// Code size: 124 (0x7c)
 			.maxstack 13
@@ -1863,7 +1862,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x311c
+			// Method begins at RVA 0x3114
 			// Header size: 12
 			// Code size: 144 (0x90)
 			.maxstack 16
@@ -1940,7 +1939,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x321b
+			// Method begins at RVA 0x3213
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2875,7 +2874,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3329
+		// Method begins at RVA 0x3321
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2600
+				// Method begins at RVA 0x25fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24b8
+			// Method begins at RVA 0x24b4
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2609
+				// Method begins at RVA 0x2605
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -100,7 +100,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24de
+			// Method begins at RVA 0x24da
 			// Header size: 1
 			// Code size: 23 (0x17)
 			.maxstack 8
@@ -127,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2612
+				// Method begins at RVA 0x260e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -151,7 +151,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24f6
+			// Method begins at RVA 0x24f2
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -177,7 +177,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x261b
+				// Method begins at RVA 0x2617
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -201,7 +201,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2510
+			// Method begins at RVA 0x250c
 			// Header size: 12
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -235,7 +235,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2624
+				// Method begins at RVA 0x2620
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -259,7 +259,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2540
+			// Method begins at RVA 0x253c
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -298,7 +298,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x262d
+				// Method begins at RVA 0x2629
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -322,7 +322,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2574
+			// Method begins at RVA 0x2570
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -372,7 +372,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2636
+				// Method begins at RVA 0x2632
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -398,7 +398,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x25b8
+			// Method begins at RVA 0x25b4
 			// Header size: 12
 			// Code size: 51 (0x33)
 			.maxstack 8
@@ -451,7 +451,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x263f
+				// Method begins at RVA 0x263b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -471,7 +471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2648
+				// Method begins at RVA 0x2644
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -498,7 +498,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25f7
+			// Method begins at RVA 0x25f3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -524,7 +524,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1099 (0x44b)
+		// Code size: 1094 (0x446)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerConversionsStableLoads/Scope,
@@ -824,86 +824,85 @@
 			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0372: stloc.s 20
 			IL_0374: ldstr "Cannot access 'tdzValue' before initialization"
-			IL_0379: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_037e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_0383: stloc.s 15
-			IL_0385: ldloc.s 15
-			IL_0387: isinst [System.Runtime]System.Exception
-			IL_038c: dup
-			IL_038d: brtrue IL_039b
+			IL_0379: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_037e: stloc.s 15
+			IL_0380: ldloc.s 15
+			IL_0382: isinst [System.Runtime]System.Exception
+			IL_0387: dup
+			IL_0388: brtrue IL_0396
 
-			IL_0392: pop
-			IL_0393: ldloc.s 15
-			IL_0395: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_039a: throw
+			IL_038d: pop
+			IL_038e: ldloc.s 15
+			IL_0390: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0395: throw
 
-			IL_039b: throw
+			IL_0396: throw
 
-			IL_039c: ldnull
-			IL_039d: ldc.r8 1
-			IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_03ab: stloc.s 21
-			IL_03ad: ldloc.s 20
-			IL_03af: ldstr "log"
-			IL_03b4: ldloc.s 21
-			IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03bb: pop
-			IL_03bc: leave IL_043c
+			IL_0397: ldnull
+			IL_0398: ldc.r8 1
+			IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_03a6: stloc.s 21
+			IL_03a8: ldloc.s 20
+			IL_03aa: ldstr "log"
+			IL_03af: ldloc.s 21
+			IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03b6: pop
+			IL_03b7: leave IL_0437
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03c1: stloc.s 8
-			IL_03c3: ldloc.s 8
-			IL_03c5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03ca: dup
-			IL_03cb: brtrue IL_03e1
+			IL_03bc: stloc.s 8
+			IL_03be: ldloc.s 8
+			IL_03c0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03c5: dup
+			IL_03c6: brtrue IL_03dc
 
-			IL_03d0: pop
-			IL_03d1: ldloc.s 8
-			IL_03d3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03d8: dup
-			IL_03d9: brtrue IL_03ed
+			IL_03cb: pop
+			IL_03cc: ldloc.s 8
+			IL_03ce: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03d3: dup
+			IL_03d4: brtrue IL_03e8
 
-			IL_03de: pop
-			IL_03df: rethrow
+			IL_03d9: pop
+			IL_03da: rethrow
 
-			IL_03e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03e6: stloc.s 9
-			IL_03e8: br IL_03ef
+			IL_03dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03e1: stloc.s 9
+			IL_03e3: br IL_03ea
 
-			IL_03ed: stloc.s 9
+			IL_03e8: stloc.s 9
 
-			IL_03ef: ldloc.s 9
-			IL_03f1: stloc.s 10
-			IL_03f3: ldstr "console"
-			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0402: stloc.s 20
-			IL_0404: ldloc.s 10
-			IL_0406: stloc.s 15
-			IL_0408: ldstr "ReferenceError"
-			IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0412: stloc.s 17
-			IL_0414: ldloc.s 15
-			IL_0416: ldloc.s 17
-			IL_0418: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_041d: stloc.s 22
-			IL_041f: ldloc.s 22
-			IL_0421: box [System.Runtime]System.Boolean
-			IL_0426: stloc.s 23
-			IL_0428: ldloc.s 20
-			IL_042a: ldstr "log"
-			IL_042f: ldloc.s 23
-			IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0436: pop
-			IL_0437: leave IL_043c
+			IL_03ea: ldloc.s 9
+			IL_03ec: stloc.s 10
+			IL_03ee: ldstr "console"
+			IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03fd: stloc.s 20
+			IL_03ff: ldloc.s 10
+			IL_0401: stloc.s 15
+			IL_0403: ldstr "ReferenceError"
+			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_040d: stloc.s 17
+			IL_040f: ldloc.s 15
+			IL_0411: ldloc.s 17
+			IL_0413: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0418: stloc.s 22
+			IL_041a: ldloc.s 22
+			IL_041c: box [System.Runtime]System.Boolean
+			IL_0421: stloc.s 23
+			IL_0423: ldloc.s 20
+			IL_0425: ldstr "log"
+			IL_042a: ldloc.s 23
+			IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0431: pop
+			IL_0432: leave IL_0437
 		} // end handler
 
-		IL_043c: ldc.r8 2
-		IL_0445: stloc.s 11
-		IL_0447: ldnull
-		IL_0448: stloc.s 12
-		IL_044a: ret
+		IL_0437: ldc.r8 2
+		IL_0440: stloc.s 11
+		IL_0442: ldnull
+		IL_0443: stloc.s 12
+		IL_0445: ret
 	} // end of method Function_SchedulerConversionsStableLoads::__js_module_init__
 
 } // end of class Modules.Function_SchedulerConversionsStableLoads
@@ -915,7 +914,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2651
+		// Method begins at RVA 0x264d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b2e
+				// Method begins at RVA 0x2b29
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b37
+				// Method begins at RVA 0x2b32
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +140,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b40
+				// Method begins at RVA 0x2b3b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -202,7 +202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b49
+				// Method begins at RVA 0x2b44
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -271,7 +271,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b52
+				// Method begins at RVA 0x2b4d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -345,7 +345,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b5b
+				// Method begins at RVA 0x2b56
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -408,7 +408,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b64
+				// Method begins at RVA 0x2b5f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -551,7 +551,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b6d
+				// Method begins at RVA 0x2b68
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -680,7 +680,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b76
+				// Method begins at RVA 0x2b71
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -762,7 +762,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b7f
+				// Method begins at RVA 0x2b7a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -888,7 +888,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b91
+					// Method begins at RVA 0x2b8c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -908,7 +908,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b9a
+					// Method begins at RVA 0x2b95
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -926,7 +926,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b88
+				// Method begins at RVA 0x2b83
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1066,7 +1066,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ba3
+				// Method begins at RVA 0x2b9e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1095,7 +1095,7 @@
 			)
 			// Method begins at RVA 0x2ae0
 			// Header size: 12
-			// Code size: 57 (0x39)
+			// Code size: 52 (0x34)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1114,23 +1114,22 @@
 			IL_0010: ldloc.2
 			IL_0011: stfld object Modules.Function_SchedulerLiteralArguments/Scope::order
 			IL_0016: ldarg.2
-			IL_0017: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_001c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: isinst [System.Runtime]System.Exception
-			IL_0028: dup
-			IL_0029: brtrue IL_0036
+			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: isinst [System.Runtime]System.Exception
+			IL_0023: dup
+			IL_0024: brtrue IL_0031
 
-			IL_002e: pop
-			IL_002f: ldloc.0
-			IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0035: throw
+			IL_0029: pop
+			IL_002a: ldloc.0
+			IL_002b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0030: throw
 
-			IL_0036: throw
+			IL_0031: throw
 
-			IL_0037: ldnull
-			IL_0038: ret
+			IL_0032: ldnull
+			IL_0033: ret
 		} // end of method throwValue::__js_call__
 
 	} // end of class throwValue
@@ -1170,7 +1169,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b25
+			// Method begins at RVA 0x2b20
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1652,7 +1651,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2bac
+		// Method begins at RVA 0x2ba7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37fa
+				// Method begins at RVA 0x37e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3803
+				// Method begins at RVA 0x37eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +140,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x380c
+				// Method begins at RVA 0x37f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			)
 			// Method begins at RVA 0x2498
 			// Header size: 12
-			// Code size: 126 (0x7e)
+			// Code size: 121 (0x79)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -194,35 +194,34 @@
 			IL_002b: ceq
 			IL_002d: stloc.s 4
 			IL_002f: ldloc.s 4
-			IL_0031: brfalse IL_005b
+			IL_0031: brfalse IL_0056
 
 			IL_0036: ldstr "Could not find <Version> in Jroc.csproj"
-			IL_003b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0040: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0045: stloc.1
-			IL_0046: ldloc.1
-			IL_0047: isinst [System.Runtime]System.Exception
-			IL_004c: dup
-			IL_004d: brtrue IL_005a
+			IL_003b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0040: stloc.1
+			IL_0041: ldloc.1
+			IL_0042: isinst [System.Runtime]System.Exception
+			IL_0047: dup
+			IL_0048: brtrue IL_0055
 
-			IL_0052: pop
-			IL_0053: ldloc.1
-			IL_0054: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0059: throw
+			IL_004d: pop
+			IL_004e: ldloc.1
+			IL_004f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0054: throw
 
-			IL_005a: throw
+			IL_0055: throw
 
-			IL_005b: ldloc.0
-			IL_005c: ldc.r8 1
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_006a: stloc.2
-			IL_006b: ldloc.2
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0071: ldstr "trim"
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_007b: stloc.2
-			IL_007c: ldloc.2
-			IL_007d: ret
+			IL_0056: ldloc.0
+			IL_0057: ldc.r8 1
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0065: stloc.2
+			IL_0066: ldloc.2
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006c: ldstr "trim"
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0076: stloc.2
+			IL_0077: ldloc.2
+			IL_0078: ret
 		} // end of method parseCurrentVersion::__js_call__
 
 	} // end of class parseCurrentVersion
@@ -248,7 +247,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x381e
+					// Method begins at RVA 0x3806
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -272,7 +271,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36bc
+				// Method begins at RVA 0x36a4
 				// Header size: 12
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -309,7 +308,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3827
+					// Method begins at RVA 0x380f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -333,7 +332,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36e4
+				// Method begins at RVA 0x36cc
 				// Header size: 1
 				// Code size: 12 (0xc)
 				.maxstack 8
@@ -357,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3830
+					// Method begins at RVA 0x3818
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -375,7 +374,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3815
+				// Method begins at RVA 0x37fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -400,7 +399,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2524
+			// Method begins at RVA 0x2520
 			// Header size: 12
 			// Code size: 901 (0x385)
 			.maxstack 10
@@ -772,7 +771,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3839
+				// Method begins at RVA 0x3821
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -800,9 +799,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x28c8
+			// Method begins at RVA 0x28c4
 			// Header size: 12
-			// Code size: 210 (0xd2)
+			// Code size: 200 (0xc8)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -819,92 +818,90 @@
 			IL_0007: ceq
 			IL_0009: stloc.2
 			IL_000a: ldloc.2
-			IL_000b: brfalse IL_0035
+			IL_000b: brfalse IL_0030
 
 			IL_0010: ldstr "Provide a bump type (major|minor|patch) or explicit version"
-			IL_0015: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_001a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_001f: stloc.0
-			IL_0020: ldloc.0
-			IL_0021: isinst [System.Runtime]System.Exception
-			IL_0026: dup
-			IL_0027: brtrue IL_0034
+			IL_0015: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_001a: stloc.0
+			IL_001b: ldloc.0
+			IL_001c: isinst [System.Runtime]System.Exception
+			IL_0021: dup
+			IL_0022: brtrue IL_002f
 
-			IL_002c: pop
-			IL_002d: ldloc.0
-			IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0033: throw
+			IL_0027: pop
+			IL_0028: ldloc.0
+			IL_0029: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_002e: throw
 
-			IL_0034: throw
+			IL_002f: throw
 
-			IL_0035: ldstr "^major|minor|patch$"
-			IL_003a: ldstr ""
-			IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0044: stloc.3
-			IL_0045: ldloc.3
-			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_004b: stloc.3
-			IL_004c: ldloc.3
-			IL_004d: ldarg.2
-			IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0053: stloc.s 4
-			IL_0055: ldloc.s 4
-			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_005c: stloc.2
-			IL_005d: ldloc.2
-			IL_005e: brfalse IL_007a
+			IL_0030: ldstr "^major|minor|patch$"
+			IL_0035: ldstr ""
+			IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_003f: stloc.3
+			IL_0040: ldloc.3
+			IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_0046: stloc.3
+			IL_0047: ldloc.3
+			IL_0048: ldarg.2
+			IL_0049: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_004e: stloc.s 4
+			IL_0050: ldloc.s 4
+			IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0057: stloc.2
+			IL_0058: ldloc.2
+			IL_0059: brfalse IL_0075
 
-			IL_0063: ldc.i4.1
-			IL_0064: newarr [System.Runtime]System.Object
-			IL_0069: dup
-			IL_006a: ldc.i4.0
-			IL_006b: ldarg.0
-			IL_006c: stelem.ref
-			IL_006d: stloc.s 5
-			IL_006f: ldnull
-			IL_0070: ldarg.3
-			IL_0071: ldarg.2
-			IL_0072: tail.
-			IL_0074: call object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
-			IL_0079: ret
+			IL_005e: ldc.i4.1
+			IL_005f: newarr [System.Runtime]System.Object
+			IL_0064: dup
+			IL_0065: ldc.i4.0
+			IL_0066: ldarg.0
+			IL_0067: stelem.ref
+			IL_0068: stloc.s 5
+			IL_006a: ldnull
+			IL_006b: ldarg.3
+			IL_006c: ldarg.2
+			IL_006d: tail.
+			IL_006f: call object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
+			IL_0074: ret
 
-			IL_007a: ldstr "^\\d+\\.\\d+\\.\\d+$"
-			IL_007f: ldstr ""
-			IL_0084: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0089: stloc.3
-			IL_008a: ldloc.3
-			IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_0090: stloc.3
-			IL_0091: ldloc.3
-			IL_0092: ldarg.2
-			IL_0093: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0098: stloc.s 4
-			IL_009a: ldloc.s 4
-			IL_009c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00a1: ldc.i4.0
-			IL_00a2: ceq
-			IL_00a4: stloc.2
-			IL_00a5: ldloc.2
-			IL_00a6: brfalse IL_00d0
+			IL_0075: ldstr "^\\d+\\.\\d+\\.\\d+$"
+			IL_007a: ldstr ""
+			IL_007f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0084: stloc.3
+			IL_0085: ldloc.3
+			IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+			IL_008b: stloc.3
+			IL_008c: ldloc.3
+			IL_008d: ldarg.2
+			IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0093: stloc.s 4
+			IL_0095: ldloc.s 4
+			IL_0097: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_009c: ldc.i4.0
+			IL_009d: ceq
+			IL_009f: stloc.2
+			IL_00a0: ldloc.2
+			IL_00a1: brfalse IL_00c6
 
-			IL_00ab: ldstr "Explicit version must be major.minor.patch"
-			IL_00b0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00ba: stloc.1
-			IL_00bb: ldloc.1
-			IL_00bc: isinst [System.Runtime]System.Exception
-			IL_00c1: dup
-			IL_00c2: brtrue IL_00cf
+			IL_00a6: ldstr "Explicit version must be major.minor.patch"
+			IL_00ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00b0: stloc.1
+			IL_00b1: ldloc.1
+			IL_00b2: isinst [System.Runtime]System.Exception
+			IL_00b7: dup
+			IL_00b8: brtrue IL_00c5
 
-			IL_00c7: pop
-			IL_00c8: ldloc.1
-			IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00ce: throw
+			IL_00bd: pop
+			IL_00be: ldloc.1
+			IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00c4: throw
 
-			IL_00cf: throw
+			IL_00c5: throw
 
-			IL_00d0: ldarg.2
-			IL_00d1: ret
+			IL_00c6: ldarg.2
+			IL_00c7: ret
 		} // end of method resolveTargetVersion::__js_call__
 
 	} // end of class resolveTargetVersion
@@ -924,7 +921,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x384b
+					// Method begins at RVA 0x3833
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -942,7 +939,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3842
+				// Method begins at RVA 0x382a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -967,7 +964,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29a8
+			// Method begins at RVA 0x2998
 			// Header size: 12
 			// Code size: 171 (0xab)
 			.maxstack 8
@@ -1058,7 +1055,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x385d
+					// Method begins at RVA 0x3845
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1076,7 +1073,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3854
+				// Method begins at RVA 0x383c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1101,9 +1098,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a60
+			// Method begins at RVA 0x2a50
 			// Header size: 12
-			// Code size: 142 (0x8e)
+			// Code size: 137 (0x89)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -1131,44 +1128,43 @@
 			IL_0026: ceq
 			IL_0028: stloc.s 4
 			IL_002a: ldloc.s 4
-			IL_002c: brfalse IL_0056
+			IL_002c: brfalse IL_0051
 
 			IL_0031: ldstr "Could not find <JrocPackageVersion> in samples/Directory.Build.props"
-			IL_0036: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_003b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0040: stloc.1
-			IL_0041: ldloc.1
-			IL_0042: isinst [System.Runtime]System.Exception
-			IL_0047: dup
-			IL_0048: brtrue IL_0055
+			IL_0036: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_003b: stloc.1
+			IL_003c: ldloc.1
+			IL_003d: isinst [System.Runtime]System.Exception
+			IL_0042: dup
+			IL_0043: brtrue IL_0050
 
-			IL_004d: pop
-			IL_004e: ldloc.1
-			IL_004f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0054: throw
+			IL_0048: pop
+			IL_0049: ldloc.1
+			IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_004f: throw
 
-			IL_0055: throw
+			IL_0050: throw
 
-			IL_0056: ldarg.1
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005c: stloc.3
-			IL_005d: ldarg.2
-			IL_005e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0063: stloc.s 5
-			IL_0065: ldstr "<JrocPackageVersion$1>"
-			IL_006a: ldloc.s 5
-			IL_006c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0071: ldstr "</JrocPackageVersion>"
-			IL_0076: call string [System.Runtime]System.String::Concat(string, string)
-			IL_007b: stloc.s 5
-			IL_007d: ldloc.3
-			IL_007e: ldstr "replace"
-			IL_0083: ldloc.0
-			IL_0084: ldloc.s 5
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_008b: stloc.3
-			IL_008c: ldloc.3
-			IL_008d: ret
+			IL_0051: ldarg.1
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0057: stloc.3
+			IL_0058: ldarg.2
+			IL_0059: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_005e: stloc.s 5
+			IL_0060: ldstr "<JrocPackageVersion$1>"
+			IL_0065: ldloc.s 5
+			IL_0067: call string [System.Runtime]System.String::Concat(string, string)
+			IL_006c: ldstr "</JrocPackageVersion>"
+			IL_0071: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0076: stloc.s 5
+			IL_0078: ldloc.3
+			IL_0079: ldstr "replace"
+			IL_007e: ldloc.0
+			IL_007f: ldloc.s 5
+			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0086: stloc.3
+			IL_0087: ldloc.3
+			IL_0088: ret
 		} // end of method updateSamplesPropsVersion::__js_call__
 
 	} // end of class updateSamplesPropsVersion
@@ -1188,7 +1184,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x386f
+					// Method begins at RVA 0x3857
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1206,7 +1202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3866
+				// Method begins at RVA 0x384e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1233,9 +1229,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2afc
+			// Method begins at RVA 0x2ae8
 			// Header size: 12
-			// Code size: 534 (0x216)
+			// Code size: 529 (0x211)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1272,162 +1268,161 @@
 			IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0033: stloc.s 10
 			IL_0035: ldloc.s 10
-			IL_0037: brfalse IL_0061
+			IL_0037: brfalse IL_005c
 
 			IL_003c: ldstr "CHANGELOG.md missing \"## Unreleased\" section"
-			IL_0041: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_004b: stloc.1
-			IL_004c: ldloc.1
-			IL_004d: isinst [System.Runtime]System.Exception
-			IL_0052: dup
-			IL_0053: brtrue IL_0060
+			IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0046: stloc.1
+			IL_0047: ldloc.1
+			IL_0048: isinst [System.Runtime]System.Exception
+			IL_004d: dup
+			IL_004e: brtrue IL_005b
 
-			IL_0058: pop
-			IL_0059: ldloc.1
-			IL_005a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_005f: throw
+			IL_0053: pop
+			IL_0054: ldloc.1
+			IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_005a: throw
 
-			IL_0060: throw
+			IL_005b: throw
 
-			IL_0061: ldarg.2
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0067: ldstr "indexOf"
-			IL_006c: ldstr "\n"
-			IL_0071: ldloc.0
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0077: stloc.2
-			IL_0078: ldarg.2
-			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007e: stloc.s 11
-			IL_0080: ldloc.2
-			IL_0081: ldc.r8 1
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_008f: stloc.s 12
-			IL_0091: ldloc.s 11
-			IL_0093: ldstr "slice"
-			IL_0098: ldloc.s 12
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_009f: stloc.s 11
-			IL_00a1: ldloc.s 11
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a8: stloc.s 11
-			IL_00aa: ldstr "\\n## v?\\d+\\.\\d+\\.\\d+ "
-			IL_00af: ldstr ""
-			IL_00b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_00b9: stloc.s 13
-			IL_00bb: ldloc.s 11
-			IL_00bd: ldstr "match"
-			IL_00c2: ldloc.s 13
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00c9: stloc.3
-			IL_00ca: ldc.r8 1
-			IL_00d3: neg
-			IL_00d4: stloc.s 8
-			IL_00d6: ldloc.s 8
-			IL_00d8: box [System.Runtime]System.Double
-			IL_00dd: stloc.s 4
-			IL_00df: ldloc.3
-			IL_00e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e5: stloc.s 10
-			IL_00e7: ldloc.s 10
-			IL_00e9: brfalse IL_012d
+			IL_005c: ldarg.2
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0062: ldstr "indexOf"
+			IL_0067: ldstr "\n"
+			IL_006c: ldloc.0
+			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0072: stloc.2
+			IL_0073: ldarg.2
+			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0079: stloc.s 11
+			IL_007b: ldloc.2
+			IL_007c: ldc.r8 1
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_008a: stloc.s 12
+			IL_008c: ldloc.s 11
+			IL_008e: ldstr "slice"
+			IL_0093: ldloc.s 12
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_009a: stloc.s 11
+			IL_009c: ldloc.s 11
+			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a3: stloc.s 11
+			IL_00a5: ldstr "\\n## v?\\d+\\.\\d+\\.\\d+ "
+			IL_00aa: ldstr ""
+			IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00b4: stloc.s 13
+			IL_00b6: ldloc.s 11
+			IL_00b8: ldstr "match"
+			IL_00bd: ldloc.s 13
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00c4: stloc.3
+			IL_00c5: ldc.r8 1
+			IL_00ce: neg
+			IL_00cf: stloc.s 8
+			IL_00d1: ldloc.s 8
+			IL_00d3: box [System.Runtime]System.Double
+			IL_00d8: stloc.s 4
+			IL_00da: ldloc.3
+			IL_00db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00e0: stloc.s 10
+			IL_00e2: ldloc.s 10
+			IL_00e4: brfalse IL_0128
 
-			IL_00ee: ldloc.2
-			IL_00ef: ldc.r8 1
-			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_00fd: stloc.s 12
-			IL_00ff: ldloc.3
-			IL_0100: ldstr "index"
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_010a: stloc.s 11
-			IL_010c: ldloc.s 12
-			IL_010e: ldloc.s 11
-			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0115: stloc.s 12
-			IL_0117: ldloc.s 12
-			IL_0119: ldc.r8 1
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0127: stloc.s 12
-			IL_0129: ldloc.s 12
-			IL_012b: stloc.s 4
+			IL_00e9: ldloc.2
+			IL_00ea: ldc.r8 1
+			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_00f8: stloc.s 12
+			IL_00fa: ldloc.3
+			IL_00fb: ldstr "index"
+			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0105: stloc.s 11
+			IL_0107: ldloc.s 12
+			IL_0109: ldloc.s 11
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0110: stloc.s 12
+			IL_0112: ldloc.s 12
+			IL_0114: ldc.r8 1
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0122: stloc.s 12
+			IL_0124: ldloc.s 12
+			IL_0126: stloc.s 4
 
-			IL_012d: ldloc.s 4
-			IL_012f: stloc.s 12
-			IL_0131: ldc.r8 1
-			IL_013a: neg
-			IL_013b: stloc.s 8
-			IL_013d: ldloc.s 8
-			IL_013f: box [System.Runtime]System.Double
-			IL_0144: stloc.s 9
-			IL_0146: ldloc.s 12
-			IL_0148: ldloc.s 9
-			IL_014a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_014f: stloc.s 10
-			IL_0151: ldloc.s 10
-			IL_0153: brfalse IL_016e
+			IL_0128: ldloc.s 4
+			IL_012a: stloc.s 12
+			IL_012c: ldc.r8 1
+			IL_0135: neg
+			IL_0136: stloc.s 8
+			IL_0138: ldloc.s 8
+			IL_013a: box [System.Runtime]System.Double
+			IL_013f: stloc.s 9
+			IL_0141: ldloc.s 12
+			IL_0143: ldloc.s 9
+			IL_0145: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_014a: stloc.s 10
+			IL_014c: ldloc.s 10
+			IL_014e: brfalse IL_0169
 
-			IL_0158: ldarg.2
-			IL_0159: ldstr "length"
-			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0163: stloc.s 11
-			IL_0165: ldloc.s 11
-			IL_0167: stloc.s 5
-			IL_0169: br IL_0192
+			IL_0153: ldarg.2
+			IL_0154: ldstr "length"
+			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_015e: stloc.s 11
+			IL_0160: ldloc.s 11
+			IL_0162: stloc.s 5
+			IL_0164: br IL_018d
 
-			IL_016e: ldloc.s 4
-			IL_0170: stloc.s 12
-			IL_0172: ldloc.s 12
-			IL_0174: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0179: ldc.r8 1
-			IL_0182: sub
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
-			IL_0187: box [System.Runtime]System.Double
-			IL_018c: stloc.s 9
-			IL_018e: ldloc.s 9
-			IL_0190: stloc.s 5
+			IL_0169: ldloc.s 4
+			IL_016b: stloc.s 12
+			IL_016d: ldloc.s 12
+			IL_016f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0174: ldc.r8 1
+			IL_017d: sub
+			IL_017e: stloc.s 8
+			IL_0180: ldloc.s 8
+			IL_0182: box [System.Runtime]System.Double
+			IL_0187: stloc.s 9
+			IL_0189: ldloc.s 9
+			IL_018b: stloc.s 5
 
-			IL_0192: ldloc.s 5
-			IL_0194: stloc.s 6
-			IL_0196: ldarg.2
-			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_019c: stloc.s 11
-			IL_019e: ldloc.2
-			IL_019f: ldc.r8 1
-			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_01ad: stloc.s 12
-			IL_01af: ldloc.s 11
-			IL_01b1: ldstr "slice"
-			IL_01b6: ldloc.s 12
-			IL_01b8: ldloc.s 6
-			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01bf: stloc.s 11
-			IL_01c1: ldloc.s 11
-			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c8: ldstr "trim"
-			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_01d2: stloc.s 7
-			IL_01d4: ldloc.2
-			IL_01d5: ldc.r8 1
-			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_01e3: stloc.s 12
-			IL_01e5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01ea: dup
-			IL_01eb: ldstr "body"
-			IL_01f0: ldloc.s 7
-			IL_01f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01f7: dup
-			IL_01f8: ldstr "start"
-			IL_01fd: ldloc.s 12
-			IL_01ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0204: dup
-			IL_0205: ldstr "end"
-			IL_020a: ldloc.s 6
-			IL_020c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0211: stloc.s 14
-			IL_0213: ldloc.s 14
-			IL_0215: ret
+			IL_018d: ldloc.s 5
+			IL_018f: stloc.s 6
+			IL_0191: ldarg.2
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0197: stloc.s 11
+			IL_0199: ldloc.2
+			IL_019a: ldc.r8 1
+			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01a8: stloc.s 12
+			IL_01aa: ldloc.s 11
+			IL_01ac: ldstr "slice"
+			IL_01b1: ldloc.s 12
+			IL_01b3: ldloc.s 6
+			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01ba: stloc.s 11
+			IL_01bc: ldloc.s 11
+			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c3: ldstr "trim"
+			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_01cd: stloc.s 7
+			IL_01cf: ldloc.2
+			IL_01d0: ldc.r8 1
+			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01de: stloc.s 12
+			IL_01e0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01e5: dup
+			IL_01e6: ldstr "body"
+			IL_01eb: ldloc.s 7
+			IL_01ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01f2: dup
+			IL_01f3: ldstr "start"
+			IL_01f8: ldloc.s 12
+			IL_01fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01ff: dup
+			IL_0200: ldstr "end"
+			IL_0205: ldloc.s 6
+			IL_0207: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_020c: stloc.s 14
+			IL_020e: ldloc.s 14
+			IL_0210: ret
 		} // end of method extractUnreleased::__js_call__
 
 	} // end of class extractUnreleased
@@ -1443,7 +1438,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3878
+				// Method begins at RVA 0x3860
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1467,7 +1462,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d20
+			// Method begins at RVA 0x2d08
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -1519,7 +1514,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x388a
+					// Method begins at RVA 0x3872
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1544,7 +1539,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36f4
+				// Method begins at RVA 0x36dc
 				// Header size: 12
 				// Code size: 126 (0x7e)
 				.maxstack 8
@@ -1624,7 +1619,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3881
+				// Method begins at RVA 0x3869
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1652,7 +1647,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2d60
+			// Method begins at RVA 0x2d48
 			// Header size: 12
 			// Code size: 338 (0x152)
 			.maxstack 8
@@ -1799,7 +1794,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38a5
+					// Method begins at RVA 0x388d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1824,7 +1819,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3780
+				// Method begins at RVA 0x3768
 				// Header size: 12
 				// Code size: 101 (0x65)
 				.maxstack 8
@@ -1900,7 +1895,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x389c
+					// Method begins at RVA 0x3884
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1920,7 +1915,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38ae
+					// Method begins at RVA 0x3896
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1938,7 +1933,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3893
+				// Method begins at RVA 0x387b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1964,7 +1959,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2ec0
+			// Method begins at RVA 0x2ea8
 			// Header size: 12
 			// Code size: 2030 (0x7ee)
 			.maxstack 8
@@ -2801,7 +2796,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38b7
+				// Method begins at RVA 0x389f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2821,7 +2816,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38c0
+				// Method begins at RVA 0x38a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2859,7 +2854,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x37f1
+			// Method begins at RVA 0x37d9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3303,7 +3298,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x38c9
+		// Method begins at RVA 0x38b1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3169
+				// Method begins at RVA 0x3161
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3184
+						// Method begins at RVA 0x317c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x318d
+						// Method begins at RVA 0x3185
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3196
+						// Method begins at RVA 0x318e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x319f
+						// Method begins at RVA 0x3197
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -124,7 +124,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x317b
+					// Method begins at RVA 0x3173
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -142,7 +142,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3172
+				// Method begins at RVA 0x316a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -445,7 +445,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31b1
+					// Method begins at RVA 0x31a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -470,7 +470,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bbc
+				// Method begins at RVA 0x2bb4
 				// Header size: 12
 				// Code size: 409 (0x199)
 				.maxstack 8
@@ -639,7 +639,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31ba
+					// Method begins at RVA 0x31b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -663,7 +663,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d64
+				// Method begins at RVA 0x2d5c
 				// Header size: 12
 				// Code size: 140 (0x8c)
 				.maxstack 8
@@ -741,7 +741,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31c3
+					// Method begins at RVA 0x31bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -765,7 +765,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2dfc
+				// Method begins at RVA 0x2df4
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -811,7 +811,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31d5
+						// Method begins at RVA 0x31cd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -835,7 +835,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x301c
+					// Method begins at RVA 0x3014
 					// Header size: 12
 					// Code size: 225 (0xe1)
 					.maxstack 8
@@ -960,7 +960,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31de
+						// Method begins at RVA 0x31d6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -978,7 +978,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31cc
+					// Method begins at RVA 0x31c4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1004,7 +1004,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e28
+				// Method begins at RVA 0x2e20
 				// Header size: 12
 				// Code size: 488 (0x1e8)
 				.maxstack 8
@@ -1207,7 +1207,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31a8
+				// Method begins at RVA 0x31a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1472,7 +1472,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e7
+				// Method begins at RVA 0x31df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1500,7 +1500,7 @@
 			)
 			// Method begins at RVA 0x280c
 			// Header size: 12
-			// Code size: 932 (0x3a4)
+			// Code size: 922 (0x39a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1549,323 +1549,321 @@
 			IL_0047: ceq
 			IL_0049: stloc.s 9
 			IL_004b: ldloc.s 9
-			IL_004d: brfalse IL_0077
+			IL_004d: brfalse IL_0072
 
 			IL_0052: ldstr "Missing --in <input.html>"
-			IL_0057: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0061: stloc.1
-			IL_0062: ldloc.1
-			IL_0063: isinst [System.Runtime]System.Exception
-			IL_0068: dup
-			IL_0069: brtrue IL_0076
+			IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_005c: stloc.1
+			IL_005d: ldloc.1
+			IL_005e: isinst [System.Runtime]System.Exception
+			IL_0063: dup
+			IL_0064: brtrue IL_0071
 
-			IL_006e: pop
-			IL_006f: ldloc.1
-			IL_0070: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0075: throw
+			IL_0069: pop
+			IL_006a: ldloc.1
+			IL_006b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0070: throw
 
-			IL_0076: throw
+			IL_0071: throw
 
-			IL_0077: ldloc.0
-			IL_0078: ldstr "outFile"
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0082: stloc.s 8
-			IL_0084: ldloc.s 8
-			IL_0086: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_008b: ldc.i4.0
-			IL_008c: ceq
-			IL_008e: stloc.s 9
-			IL_0090: ldloc.s 9
-			IL_0092: brfalse IL_00bc
+			IL_0072: ldloc.0
+			IL_0073: ldstr "outFile"
+			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007d: stloc.s 8
+			IL_007f: ldloc.s 8
+			IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0086: ldc.i4.0
+			IL_0087: ceq
+			IL_0089: stloc.s 9
+			IL_008b: ldloc.s 9
+			IL_008d: brfalse IL_00b2
 
-			IL_0097: ldstr "Missing --out <output.md>"
-			IL_009c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00a6: stloc.2
-			IL_00a7: ldloc.2
-			IL_00a8: isinst [System.Runtime]System.Exception
-			IL_00ad: dup
-			IL_00ae: brtrue IL_00bb
+			IL_0092: ldstr "Missing --out <output.md>"
+			IL_0097: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_009c: stloc.2
+			IL_009d: ldloc.2
+			IL_009e: isinst [System.Runtime]System.Exception
+			IL_00a3: dup
+			IL_00a4: brtrue IL_00b1
 
-			IL_00b3: pop
-			IL_00b4: ldloc.2
-			IL_00b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00ba: throw
+			IL_00a9: pop
+			IL_00aa: ldloc.2
+			IL_00ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00b0: throw
 
-			IL_00bb: throw
+			IL_00b1: throw
 
-			IL_00bc: ldarg.0
-			IL_00bd: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_00c2: stloc.s 10
-			IL_00c4: ldstr "process"
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d3: ldstr "cwd"
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_00dd: stloc.s 8
-			IL_00df: ldloc.0
-			IL_00e0: ldstr "inFile"
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ea: stloc.s 11
-			IL_00ec: ldloc.s 10
-			IL_00ee: ldstr "resolve"
-			IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_00f8: brtrue IL_011a
+			IL_00b2: ldarg.0
+			IL_00b3: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_00b8: stloc.s 10
+			IL_00ba: ldstr "process"
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c9: ldstr "cwd"
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00d3: stloc.s 8
+			IL_00d5: ldloc.0
+			IL_00d6: ldstr "inFile"
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e0: stloc.s 11
+			IL_00e2: ldloc.s 10
+			IL_00e4: ldstr "resolve"
+			IL_00e9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_00ee: brtrue IL_0110
 
-			IL_00fd: ldloc.s 10
-			IL_00ff: ldc.i4.2
-			IL_0100: newarr [System.Runtime]System.Object
-			IL_0105: dup
-			IL_0106: ldc.i4.0
-			IL_0107: ldloc.s 8
-			IL_0109: stelem.ref
-			IL_010a: dup
-			IL_010b: ldc.i4.1
-			IL_010c: ldloc.s 11
-			IL_010e: stelem.ref
-			IL_010f: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
-			IL_0114: stloc.3
-			IL_0115: br IL_0137
+			IL_00f3: ldloc.s 10
+			IL_00f5: ldc.i4.2
+			IL_00f6: newarr [System.Runtime]System.Object
+			IL_00fb: dup
+			IL_00fc: ldc.i4.0
+			IL_00fd: ldloc.s 8
+			IL_00ff: stelem.ref
+			IL_0100: dup
+			IL_0101: ldc.i4.1
+			IL_0102: ldloc.s 11
+			IL_0104: stelem.ref
+			IL_0105: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
+			IL_010a: stloc.3
+			IL_010b: br IL_012d
 
-			IL_011a: ldloc.s 10
-			IL_011c: ldstr "resolve"
-			IL_0121: ldc.i4.2
-			IL_0122: newarr [System.Runtime]System.Object
-			IL_0127: dup
-			IL_0128: ldc.i4.0
-			IL_0129: ldloc.s 8
-			IL_012b: stelem.ref
-			IL_012c: dup
-			IL_012d: ldc.i4.1
-			IL_012e: ldloc.s 11
-			IL_0130: stelem.ref
-			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_0136: stloc.3
+			IL_0110: ldloc.s 10
+			IL_0112: ldstr "resolve"
+			IL_0117: ldc.i4.2
+			IL_0118: newarr [System.Runtime]System.Object
+			IL_011d: dup
+			IL_011e: ldc.i4.0
+			IL_011f: ldloc.s 8
+			IL_0121: stelem.ref
+			IL_0122: dup
+			IL_0123: ldc.i4.1
+			IL_0124: ldloc.s 11
+			IL_0126: stelem.ref
+			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_012c: stloc.3
 
-			IL_0137: ldarg.0
-			IL_0138: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_013d: stloc.s 10
-			IL_013f: ldstr "process"
-			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014e: ldstr "cwd"
-			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0158: stloc.s 11
-			IL_015a: ldloc.0
-			IL_015b: ldstr "outFile"
-			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0165: stloc.s 8
-			IL_0167: ldloc.s 10
-			IL_0169: ldstr "resolve"
-			IL_016e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0173: brtrue IL_0196
+			IL_012d: ldarg.0
+			IL_012e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_0133: stloc.s 10
+			IL_0135: ldstr "process"
+			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0144: ldstr "cwd"
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_014e: stloc.s 11
+			IL_0150: ldloc.0
+			IL_0151: ldstr "outFile"
+			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_015b: stloc.s 8
+			IL_015d: ldloc.s 10
+			IL_015f: ldstr "resolve"
+			IL_0164: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0169: brtrue IL_018c
 
-			IL_0178: ldloc.s 10
-			IL_017a: ldc.i4.2
-			IL_017b: newarr [System.Runtime]System.Object
-			IL_0180: dup
-			IL_0181: ldc.i4.0
-			IL_0182: ldloc.s 11
-			IL_0184: stelem.ref
-			IL_0185: dup
-			IL_0186: ldc.i4.1
-			IL_0187: ldloc.s 8
-			IL_0189: stelem.ref
-			IL_018a: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
-			IL_018f: stloc.s 4
-			IL_0191: br IL_01b4
+			IL_016e: ldloc.s 10
+			IL_0170: ldc.i4.2
+			IL_0171: newarr [System.Runtime]System.Object
+			IL_0176: dup
+			IL_0177: ldc.i4.0
+			IL_0178: ldloc.s 11
+			IL_017a: stelem.ref
+			IL_017b: dup
+			IL_017c: ldc.i4.1
+			IL_017d: ldloc.s 8
+			IL_017f: stelem.ref
+			IL_0180: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
+			IL_0185: stloc.s 4
+			IL_0187: br IL_01aa
 
-			IL_0196: ldloc.s 10
-			IL_0198: ldstr "resolve"
-			IL_019d: ldc.i4.2
-			IL_019e: newarr [System.Runtime]System.Object
-			IL_01a3: dup
-			IL_01a4: ldc.i4.0
-			IL_01a5: ldloc.s 11
-			IL_01a7: stelem.ref
-			IL_01a8: dup
-			IL_01a9: ldc.i4.1
-			IL_01aa: ldloc.s 8
-			IL_01ac: stelem.ref
-			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_01b2: stloc.s 4
+			IL_018c: ldloc.s 10
+			IL_018e: ldstr "resolve"
+			IL_0193: ldc.i4.2
+			IL_0194: newarr [System.Runtime]System.Object
+			IL_0199: dup
+			IL_019a: ldc.i4.0
+			IL_019b: ldloc.s 11
+			IL_019d: stelem.ref
+			IL_019e: dup
+			IL_019f: ldc.i4.1
+			IL_01a0: ldloc.s 8
+			IL_01a2: stelem.ref
+			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_01a8: stloc.s 4
 
-			IL_01b4: ldarg.0
-			IL_01b5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_01ba: stloc.s 12
-			IL_01bc: ldloc.s 12
-			IL_01be: ldstr "readFileSync"
-			IL_01c3: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_01c8: brtrue IL_01e1
+			IL_01aa: ldarg.0
+			IL_01ab: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_01b0: stloc.s 12
+			IL_01b2: ldloc.s 12
+			IL_01b4: ldstr "readFileSync"
+			IL_01b9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_01be: brtrue IL_01d7
 
-			IL_01cd: ldloc.s 12
-			IL_01cf: ldloc.3
-			IL_01d0: ldstr "utf8"
-			IL_01d5: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_01da: stloc.s 5
-			IL_01dc: br IL_0201
+			IL_01c3: ldloc.s 12
+			IL_01c5: ldloc.3
+			IL_01c6: ldstr "utf8"
+			IL_01cb: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_01d0: stloc.s 5
+			IL_01d2: br IL_01f7
 
-			IL_01e1: ldloc.s 12
-			IL_01e3: ldstr "readFileSync"
-			IL_01e8: ldc.i4.2
-			IL_01e9: newarr [System.Runtime]System.Object
-			IL_01ee: dup
-			IL_01ef: ldc.i4.0
-			IL_01f0: ldloc.3
-			IL_01f1: stelem.ref
-			IL_01f2: dup
-			IL_01f3: ldc.i4.1
-			IL_01f4: ldstr "utf8"
-			IL_01f9: stelem.ref
-			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_01ff: stloc.s 5
+			IL_01d7: ldloc.s 12
+			IL_01d9: ldstr "readFileSync"
+			IL_01de: ldc.i4.2
+			IL_01df: newarr [System.Runtime]System.Object
+			IL_01e4: dup
+			IL_01e5: ldc.i4.0
+			IL_01e6: ldloc.3
+			IL_01e7: stelem.ref
+			IL_01e8: dup
+			IL_01e9: ldc.i4.1
+			IL_01ea: ldstr "utf8"
+			IL_01ef: stelem.ref
+			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_01f5: stloc.s 5
 
-			IL_0201: ldarg.0
-			IL_0202: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::convertHtmlToMarkdown
-			IL_0207: ldc.i4.1
-			IL_0208: newarr [System.Runtime]System.Object
-			IL_020d: dup
-			IL_020e: ldc.i4.0
-			IL_020f: ldarg.0
-			IL_0210: stelem.ref
-			IL_0211: ldloc.s 5
-			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0218: stloc.s 6
-			IL_021a: ldarg.0
-			IL_021b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_0220: stloc.s 12
-			IL_0222: ldarg.0
-			IL_0223: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_0228: ldstr "dirname"
-			IL_022d: ldloc.s 4
-			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0234: stloc.s 8
-			IL_0236: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_023b: dup
-			IL_023c: ldstr "recursive"
-			IL_0241: ldc.i4.1
-			IL_0242: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0247: stloc.s 13
-			IL_0249: ldloc.s 12
-			IL_024b: ldstr "mkdirSync"
-			IL_0250: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0255: brtrue IL_026b
+			IL_01f7: ldarg.0
+			IL_01f8: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::convertHtmlToMarkdown
+			IL_01fd: ldc.i4.1
+			IL_01fe: newarr [System.Runtime]System.Object
+			IL_0203: dup
+			IL_0204: ldc.i4.0
+			IL_0205: ldarg.0
+			IL_0206: stelem.ref
+			IL_0207: ldloc.s 5
+			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_020e: stloc.s 6
+			IL_0210: ldarg.0
+			IL_0211: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_0216: stloc.s 12
+			IL_0218: ldarg.0
+			IL_0219: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_021e: ldstr "dirname"
+			IL_0223: ldloc.s 4
+			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_022a: stloc.s 8
+			IL_022c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0231: dup
+			IL_0232: ldstr "recursive"
+			IL_0237: ldc.i4.1
+			IL_0238: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_023d: stloc.s 13
+			IL_023f: ldloc.s 12
+			IL_0241: ldstr "mkdirSync"
+			IL_0246: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_024b: brtrue IL_0261
 
-			IL_025a: ldloc.s 12
-			IL_025c: ldloc.s 8
-			IL_025e: ldloc.s 13
-			IL_0260: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
-			IL_0265: pop
-			IL_0266: br IL_0288
+			IL_0250: ldloc.s 12
+			IL_0252: ldloc.s 8
+			IL_0254: ldloc.s 13
+			IL_0256: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
+			IL_025b: pop
+			IL_025c: br IL_027e
 
-			IL_026b: ldloc.s 12
-			IL_026d: ldstr "mkdirSync"
-			IL_0272: ldc.i4.2
-			IL_0273: newarr [System.Runtime]System.Object
-			IL_0278: dup
-			IL_0279: ldc.i4.0
-			IL_027a: ldloc.s 8
-			IL_027c: stelem.ref
-			IL_027d: dup
-			IL_027e: ldc.i4.1
-			IL_027f: ldloc.s 13
-			IL_0281: stelem.ref
-			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_0287: pop
+			IL_0261: ldloc.s 12
+			IL_0263: ldstr "mkdirSync"
+			IL_0268: ldc.i4.2
+			IL_0269: newarr [System.Runtime]System.Object
+			IL_026e: dup
+			IL_026f: ldc.i4.0
+			IL_0270: ldloc.s 8
+			IL_0272: stelem.ref
+			IL_0273: dup
+			IL_0274: ldc.i4.1
+			IL_0275: ldloc.s 13
+			IL_0277: stelem.ref
+			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_027d: pop
 
-			IL_0288: ldarg.0
-			IL_0289: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_028e: stloc.s 12
-			IL_0290: ldloc.s 12
-			IL_0292: ldstr "writeFileSync"
-			IL_0297: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_029c: brtrue IL_02b6
+			IL_027e: ldarg.0
+			IL_027f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_0284: stloc.s 12
+			IL_0286: ldloc.s 12
+			IL_0288: ldstr "writeFileSync"
+			IL_028d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0292: brtrue IL_02ac
 
-			IL_02a1: ldloc.s 12
-			IL_02a3: ldloc.s 4
-			IL_02a5: ldloc.s 6
-			IL_02a7: ldstr "utf8"
-			IL_02ac: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_02b1: br IL_02db
+			IL_0297: ldloc.s 12
+			IL_0299: ldloc.s 4
+			IL_029b: ldloc.s 6
+			IL_029d: ldstr "utf8"
+			IL_02a2: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_02a7: br IL_02d1
 
-			IL_02b6: ldloc.s 12
-			IL_02b8: ldstr "writeFileSync"
-			IL_02bd: ldc.i4.3
-			IL_02be: newarr [System.Runtime]System.Object
+			IL_02ac: ldloc.s 12
+			IL_02ae: ldstr "writeFileSync"
+			IL_02b3: ldc.i4.3
+			IL_02b4: newarr [System.Runtime]System.Object
+			IL_02b9: dup
+			IL_02ba: ldc.i4.0
+			IL_02bb: ldloc.s 4
+			IL_02bd: stelem.ref
+			IL_02be: dup
+			IL_02bf: ldc.i4.1
+			IL_02c0: ldloc.s 6
+			IL_02c2: stelem.ref
 			IL_02c3: dup
-			IL_02c4: ldc.i4.0
-			IL_02c5: ldloc.s 4
-			IL_02c7: stelem.ref
-			IL_02c8: dup
-			IL_02c9: ldc.i4.1
-			IL_02ca: ldloc.s 6
-			IL_02cc: stelem.ref
-			IL_02cd: dup
-			IL_02ce: ldc.i4.2
-			IL_02cf: ldstr "utf8"
-			IL_02d4: stelem.ref
-			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_02da: pop
+			IL_02c4: ldc.i4.2
+			IL_02c5: ldstr "utf8"
+			IL_02ca: stelem.ref
+			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_02d0: pop
 
-			IL_02db: ldstr "console"
-			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ea: stloc.s 8
-			IL_02ec: ldloc.0
-			IL_02ed: ldstr "inFile"
-			IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02f7: stloc.s 11
-			IL_02f9: ldloc.s 11
-			IL_02fb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0300: stloc.s 14
-			IL_0302: ldstr "Converted "
-			IL_0307: ldloc.s 14
+			IL_02d1: ldstr "console"
+			IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02e0: stloc.s 8
+			IL_02e2: ldloc.0
+			IL_02e3: ldstr "inFile"
+			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ed: stloc.s 11
+			IL_02ef: ldloc.s 11
+			IL_02f1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02f6: stloc.s 14
+			IL_02f8: ldstr "Converted "
+			IL_02fd: ldloc.s 14
+			IL_02ff: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0304: ldstr " -> "
 			IL_0309: call string [System.Runtime]System.String::Concat(string, string)
-			IL_030e: ldstr " -> "
-			IL_0313: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0318: ldloc.0
-			IL_0319: ldstr "outFile"
-			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0323: stloc.s 11
-			IL_0325: ldloc.s 11
-			IL_0327: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_032c: stloc.s 14
-			IL_032e: ldloc.s 14
+			IL_030e: ldloc.0
+			IL_030f: ldstr "outFile"
+			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0319: stloc.s 11
+			IL_031b: ldloc.s 11
+			IL_031d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0322: stloc.s 14
+			IL_0324: ldloc.s 14
+			IL_0326: call string [System.Runtime]System.String::Concat(string, string)
+			IL_032b: ldstr " ("
 			IL_0330: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0335: ldstr " ("
-			IL_033a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_033f: ldloc.s 6
-			IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0346: stloc.s 11
-			IL_0348: ldstr "\\n"
-			IL_034d: ldstr ""
-			IL_0352: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0357: stloc.s 15
-			IL_0359: ldloc.s 11
-			IL_035b: ldstr "split"
-			IL_0360: ldloc.s 15
-			IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0367: stloc.s 11
-			IL_0369: ldloc.s 11
-			IL_036b: ldstr "length"
-			IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0375: stloc.s 11
-			IL_0377: ldloc.s 11
-			IL_0379: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_037e: stloc.s 14
-			IL_0380: ldloc.s 14
+			IL_0335: ldloc.s 6
+			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_033c: stloc.s 11
+			IL_033e: ldstr "\\n"
+			IL_0343: ldstr ""
+			IL_0348: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_034d: stloc.s 15
+			IL_034f: ldloc.s 11
+			IL_0351: ldstr "split"
+			IL_0356: ldloc.s 15
+			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_035d: stloc.s 11
+			IL_035f: ldloc.s 11
+			IL_0361: ldstr "length"
+			IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_036b: stloc.s 11
+			IL_036d: ldloc.s 11
+			IL_036f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0374: stloc.s 14
+			IL_0376: ldloc.s 14
+			IL_0378: call string [System.Runtime]System.String::Concat(string, string)
+			IL_037d: ldstr " lines)"
 			IL_0382: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0387: ldstr " lines)"
-			IL_038c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0391: stloc.s 14
-			IL_0393: ldloc.s 8
-			IL_0395: ldstr "log"
-			IL_039a: ldloc.s 14
-			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03a1: pop
-			IL_03a2: ldnull
-			IL_03a3: ret
+			IL_0387: stloc.s 14
+			IL_0389: ldloc.s 8
+			IL_038b: ldstr "log"
+			IL_0390: ldloc.s 14
+			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0397: pop
+			IL_0398: ldnull
+			IL_0399: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1897,7 +1895,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31f9
+					// Method begins at RVA 0x31f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1917,7 +1915,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3202
+					// Method begins at RVA 0x31fa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1935,7 +1933,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31f0
+				// Method begins at RVA 0x31e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1961,7 +1959,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3160
+			// Method begins at RVA 0x3158
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2195,7 +2193,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3214
+				// Method begins at RVA 0x320c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2218,7 +2216,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3109
+			// Method begins at RVA 0x3101
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2247,7 +2245,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x321d
+				// Method begins at RVA 0x3215
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2272,7 +2270,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x310c
+			// Method begins at RVA 0x3104
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -2309,7 +2307,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3226
+				// Method begins at RVA 0x321e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2333,7 +2331,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3124
+			// Method begins at RVA 0x311c
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -2387,7 +2385,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x320b
+			// Method begins at RVA 0x3203
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2498,7 +2496,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x322f
+		// Method begins at RVA 0x3227
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3418
+				// Method begins at RVA 0x340c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -136,7 +136,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x342a
+					// Method begins at RVA 0x341e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3421
+				// Method begins at RVA 0x3415
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -183,7 +183,7 @@
 			)
 			// Method begins at RVA 0x2338
 			// Header size: 12
-			// Code size: 273 (0x111)
+			// Code size: 268 (0x10c)
 			.maxstack 10
 			.locals init (
 				[0] object,
@@ -243,48 +243,47 @@
 			IL_008e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0093: stloc.s 5
 			IL_0095: ldloc.s 5
-			IL_0097: brfalse IL_00c1
+			IL_0097: brfalse IL_00bc
 
 			IL_009c: ldstr "Category must contain at least one name segment."
-			IL_00a1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00ab: stloc.1
-			IL_00ac: ldloc.1
-			IL_00ad: isinst [System.Runtime]System.Exception
-			IL_00b2: dup
-			IL_00b3: brtrue IL_00c0
+			IL_00a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00a6: stloc.1
+			IL_00a7: ldloc.1
+			IL_00a8: isinst [System.Runtime]System.Exception
+			IL_00ad: dup
+			IL_00ae: brtrue IL_00bb
 
-			IL_00b8: pop
-			IL_00b9: ldloc.1
-			IL_00ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00bf: throw
+			IL_00b3: pop
+			IL_00b4: ldloc.1
+			IL_00b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00ba: throw
 
-			IL_00c0: throw
+			IL_00bb: throw
 
-			IL_00c1: ldloc.0
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c7: ldstr "join"
-			IL_00cc: ldstr "."
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00d6: stloc.3
-			IL_00d7: ldloc.0
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00dd: ldstr "join"
-			IL_00e2: ldstr "/"
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00ec: stloc.s 6
-			IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00f3: dup
-			IL_00f4: ldstr "namespace"
-			IL_00f9: ldloc.3
-			IL_00fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00ff: dup
-			IL_0100: ldstr "path"
-			IL_0105: ldloc.s 6
-			IL_0107: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_010c: stloc.s 7
-			IL_010e: ldloc.s 7
-			IL_0110: ret
+			IL_00bc: ldloc.0
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c2: ldstr "join"
+			IL_00c7: ldstr "."
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00d1: stloc.3
+			IL_00d2: ldloc.0
+			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d8: ldstr "join"
+			IL_00dd: ldstr "/"
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00e7: stloc.s 6
+			IL_00e9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00ee: dup
+			IL_00ef: ldstr "namespace"
+			IL_00f4: ldloc.3
+			IL_00f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00fa: dup
+			IL_00fb: ldstr "path"
+			IL_0100: ldloc.s 6
+			IL_0102: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0107: stloc.s 7
+			IL_0109: ldloc.s 7
+			IL_010b: ret
 		} // end of method normalizeCategory::__js_call__
 
 	} // end of class normalizeCategory
@@ -300,7 +299,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3433
+				// Method begins at RVA 0x3427
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -327,7 +326,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2458
+			// Method begins at RVA 0x2450
 			// Header size: 12
 			// Code size: 173 (0xad)
 			.maxstack 8
@@ -441,7 +440,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x344e
+					// Method begins at RVA 0x3442
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -465,7 +464,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33a4
+				// Method begins at RVA 0x3398
 				// Header size: 12
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -501,7 +500,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3457
+					// Method begins at RVA 0x344b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -526,7 +525,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33c4
+				// Method begins at RVA 0x33b8
 				// Header size: 12
 				// Code size: 63 (0x3f)
 				.maxstack 8
@@ -587,7 +586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3445
+					// Method begins at RVA 0x3439
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -608,7 +607,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x343c
+				// Method begins at RVA 0x3430
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -636,7 +635,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3472
+						// Method begins at RVA 0x3466
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -654,7 +653,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3469
+					// Method begins at RVA 0x345d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -672,7 +671,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3460
+				// Method begins at RVA 0x3454
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -700,7 +699,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2514
+			// Method begins at RVA 0x250c
 			// Header size: 12
 			// Code size: 575 (0x23f)
 			.maxstack 10
@@ -975,7 +974,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3484
+					// Method begins at RVA 0x3478
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -993,7 +992,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x347b
+				// Method begins at RVA 0x346f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1021,7 +1020,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2770
+			// Method begins at RVA 0x2768
 			// Header size: 12
 			// Code size: 315 (0x13b)
 			.maxstack 10
@@ -1216,7 +1215,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x349f
+						// Method begins at RVA 0x3493
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1234,7 +1233,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3496
+					// Method begins at RVA 0x348a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1252,7 +1251,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x348d
+				// Method begins at RVA 0x3481
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1279,9 +1278,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x28c8
+			// Method begins at RVA 0x28c0
 			// Header size: 12
-			// Code size: 351 (0x15f)
+			// Code size: 346 (0x15a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1437,23 +1436,22 @@
 			IL_0131: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0136: stloc.s 15
 			IL_0138: ldloc.s 15
-			IL_013a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0144: stloc.s 4
-			IL_0146: ldloc.s 4
-			IL_0148: isinst [System.Runtime]System.Exception
-			IL_014d: dup
-			IL_014e: brtrue IL_015c
+			IL_013a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_013f: stloc.s 4
+			IL_0141: ldloc.s 4
+			IL_0143: isinst [System.Runtime]System.Exception
+			IL_0148: dup
+			IL_0149: brtrue IL_0157
 
-			IL_0153: pop
-			IL_0154: ldloc.s 4
-			IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_015b: throw
+			IL_014e: pop
+			IL_014f: ldloc.s 4
+			IL_0151: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0156: throw
 
-			IL_015c: throw
+			IL_0157: throw
 
-			IL_015d: ldnull
-			IL_015e: ret
+			IL_0158: ldnull
+			IL_0159: ret
 		} // end of method findProjectRoot::__js_call__
 
 	} // end of class findProjectRoot
@@ -1469,7 +1467,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34a8
+				// Method begins at RVA 0x349c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1497,7 +1495,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2a34
+			// Method begins at RVA 0x2a28
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1568,7 +1566,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34b1
+				// Method begins at RVA 0x34a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1595,7 +1593,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2aa0
+			// Method begins at RVA 0x2a94
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1672,7 +1670,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34c3
+					// Method begins at RVA 0x34b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1692,7 +1690,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34cc
+					// Method begins at RVA 0x34c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1716,7 +1714,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34de
+						// Method begins at RVA 0x34d2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1734,7 +1732,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34d5
+					// Method begins at RVA 0x34c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1754,7 +1752,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34e7
+					// Method begins at RVA 0x34db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1778,7 +1776,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34f9
+						// Method begins at RVA 0x34ed
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1796,7 +1794,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34f0
+					// Method begins at RVA 0x34e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1816,7 +1814,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3502
+					// Method begins at RVA 0x34f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1836,7 +1834,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x350b
+					// Method begins at RVA 0x34ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1854,7 +1852,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34ba
+				// Method begins at RVA 0x34ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1880,7 +1878,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2b38
+			// Method begins at RVA 0x2b2c
 			// Header size: 12
 			// Code size: 2125 (0x84d)
 			.maxstack 8
@@ -2624,7 +2622,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x340f
+			// Method begins at RVA 0x3403
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2860,7 +2858,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3514
+		// Method begins at RVA 0x3508
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x455b
+				// Method begins at RVA 0x4523
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4564
+				// Method begins at RVA 0x452c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -355,7 +355,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4552
+			// Method begins at RVA 0x451a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -470,7 +470,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x457f
+					// Method begins at RVA 0x4547
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -488,7 +488,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4576
+				// Method begins at RVA 0x453e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -633,7 +633,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4588
+				// Method begins at RVA 0x4550
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -661,7 +661,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45a3
+						// Method begins at RVA 0x456b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -681,7 +681,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45ac
+						// Method begins at RVA 0x4574
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -701,7 +701,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45b5
+						// Method begins at RVA 0x457d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -721,7 +721,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45be
+						// Method begins at RVA 0x4586
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -741,7 +741,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45c7
+						// Method begins at RVA 0x458f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -761,7 +761,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45d0
+						// Method begins at RVA 0x4598
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -779,7 +779,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x459a
+					// Method begins at RVA 0x4562
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -797,7 +797,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4591
+				// Method begins at RVA 0x4559
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1156,7 +1156,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x462a
+							// Method begins at RVA 0x45f2
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1181,7 +1181,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44cc
+						// Method begins at RVA 0x4494
 						// Header size: 12
 						// Code size: 38 (0x26)
 						.maxstack 8
@@ -1223,7 +1223,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4633
+							// Method begins at RVA 0x45fb
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1247,7 +1247,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4500
+						// Method begins at RVA 0x44c8
 						// Header size: 12
 						// Code size: 70 (0x46)
 						.maxstack 8
@@ -1326,7 +1326,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x4618
+								// Method begins at RVA 0x45e0
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1344,7 +1344,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x460f
+							// Method begins at RVA 0x45d7
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1364,7 +1364,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4621
+							// Method begins at RVA 0x45e9
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1386,7 +1386,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4606
+						// Method begins at RVA 0x45ce
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1411,9 +1411,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x4068
+					// Method begins at RVA 0x4038
 					// Header size: 12
-					// Code size: 1111 (0x457)
+					// Code size: 1101 (0x44d)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -1514,7 +1514,7 @@
 					IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00d0: stloc.s 5
 					IL_00d2: ldloc.s 5
-					IL_00d4: brfalse IL_0267
+					IL_00d4: brfalse IL_0262
 
 					IL_00d9: ldarg.0
 					IL_00da: ldc.i4.1
@@ -1526,7 +1526,7 @@
 					IL_00f4: cgt
 					IL_00f6: ldc.i4.0
 					IL_00f7: ceq
-					IL_00f9: brfalse IL_017a
+					IL_00f9: brfalse IL_0175
 
 					IL_00fe: ldarg.2
 					IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
@@ -1574,325 +1574,323 @@
 					IL_0157: call string [System.Runtime]System.String::Concat(string, string)
 					IL_015c: stloc.s 14
 					IL_015e: ldloc.s 14
-					IL_0160: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0165: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_016a: stloc.s 13
-					IL_016c: ldloc.s 4
-					IL_016e: ldloc.s 12
-					IL_0170: ldloc.s 13
-					IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0177: pop
-					IL_0178: ldnull
-					IL_0179: ret
+					IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0165: stloc.s 13
+					IL_0167: ldloc.s 4
+					IL_0169: ldloc.s 12
+					IL_016b: ldloc.s 13
+					IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0172: pop
+					IL_0173: ldnull
+					IL_0174: ret
 
-					IL_017a: ldarg.0
-					IL_017b: ldc.i4.0
-					IL_017c: ldelem.ref
-					IL_017d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0182: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-					IL_0187: stloc.s 13
-					IL_0189: ldarg.0
-					IL_018a: ldc.i4.2
-					IL_018b: ldelem.ref
-					IL_018c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0191: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_0196: stloc.s 4
-					IL_0198: ldloc.s 13
-					IL_019a: ldc.i4.2
-					IL_019b: newarr [System.Runtime]System.Object
-					IL_01a0: dup
-					IL_01a1: ldc.i4.0
-					IL_01a2: ldloc.2
+					IL_0175: ldarg.0
+					IL_0176: ldc.i4.0
+					IL_0177: ldelem.ref
+					IL_0178: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_017d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+					IL_0182: stloc.s 13
+					IL_0184: ldarg.0
+					IL_0185: ldc.i4.2
+					IL_0186: ldelem.ref
+					IL_0187: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_018c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_0191: stloc.s 4
+					IL_0193: ldloc.s 13
+					IL_0195: ldc.i4.2
+					IL_0196: newarr [System.Runtime]System.Object
+					IL_019b: dup
+					IL_019c: ldc.i4.0
+					IL_019d: ldloc.2
+					IL_019e: stelem.ref
+					IL_019f: dup
+					IL_01a0: ldc.i4.1
+					IL_01a1: ldloc.s 4
 					IL_01a3: stelem.ref
-					IL_01a4: dup
-					IL_01a5: ldc.i4.1
-					IL_01a6: ldloc.s 4
-					IL_01a8: stelem.ref
-					IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-					IL_01ae: stloc.s 13
-					IL_01b0: ldloc.s 13
-					IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01b7: ldstr "toString"
-					IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_01c1: stloc.3
-					IL_01c2: ldarg.2
-					IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01c8: ldstr "resume"
-					IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_01d2: pop
-					IL_01d3: ldarg.0
-					IL_01d4: ldc.i4.0
-					IL_01d5: ldelem.ref
-					IL_01d6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_01db: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-					IL_01e0: ldc.i4.3
-					IL_01e1: newarr [System.Runtime]System.Object
-					IL_01e6: dup
-					IL_01e7: ldc.i4.0
-					IL_01e8: ldarg.0
-					IL_01e9: ldc.i4.0
-					IL_01ea: ldelem.ref
-					IL_01eb: stelem.ref
-					IL_01ec: dup
-					IL_01ed: ldc.i4.1
-					IL_01ee: ldarg.0
-					IL_01ef: ldc.i4.1
-					IL_01f0: ldelem.ref
-					IL_01f1: stelem.ref
-					IL_01f2: dup
-					IL_01f3: ldc.i4.2
-					IL_01f4: ldarg.0
-					IL_01f5: ldc.i4.2
-					IL_01f6: ldelem.ref
-					IL_01f7: stelem.ref
-					IL_01f8: stloc.s 12
-					IL_01fa: ldarg.0
-					IL_01fb: ldc.i4.1
-					IL_01fc: ldelem.ref
-					IL_01fd: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0202: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_0207: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_020c: ldc.r8 1
-					IL_0215: sub
-					IL_0216: stloc.s 15
-					IL_0218: ldloc.s 15
-					IL_021a: box [System.Runtime]System.Double
-					IL_021f: stloc.s 16
-					IL_0221: ldloc.s 12
-					IL_0223: ldloc.3
-					IL_0224: ldloc.s 16
-					IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-					IL_022b: stloc.s 13
-					IL_022d: ldloc.s 13
-					IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0234: stloc.s 13
-					IL_0236: ldarg.0
-					IL_0237: ldc.i4.2
-					IL_0238: ldelem.ref
-					IL_0239: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_023e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_0243: stloc.s 4
-					IL_0245: ldarg.0
-					IL_0246: ldc.i4.2
-					IL_0247: ldelem.ref
-					IL_0248: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_024d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0252: stloc.s 17
-					IL_0254: ldloc.s 13
-					IL_0256: ldstr "then"
-					IL_025b: ldloc.s 4
-					IL_025d: ldloc.s 17
-					IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_0264: pop
-					IL_0265: ldnull
-					IL_0266: ret
+					IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+					IL_01a9: stloc.s 13
+					IL_01ab: ldloc.s 13
+					IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01b2: ldstr "toString"
+					IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_01bc: stloc.3
+					IL_01bd: ldarg.2
+					IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01c3: ldstr "resume"
+					IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_01cd: pop
+					IL_01ce: ldarg.0
+					IL_01cf: ldc.i4.0
+					IL_01d0: ldelem.ref
+					IL_01d1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_01d6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+					IL_01db: ldc.i4.3
+					IL_01dc: newarr [System.Runtime]System.Object
+					IL_01e1: dup
+					IL_01e2: ldc.i4.0
+					IL_01e3: ldarg.0
+					IL_01e4: ldc.i4.0
+					IL_01e5: ldelem.ref
+					IL_01e6: stelem.ref
+					IL_01e7: dup
+					IL_01e8: ldc.i4.1
+					IL_01e9: ldarg.0
+					IL_01ea: ldc.i4.1
+					IL_01eb: ldelem.ref
+					IL_01ec: stelem.ref
+					IL_01ed: dup
+					IL_01ee: ldc.i4.2
+					IL_01ef: ldarg.0
+					IL_01f0: ldc.i4.2
+					IL_01f1: ldelem.ref
+					IL_01f2: stelem.ref
+					IL_01f3: stloc.s 12
+					IL_01f5: ldarg.0
+					IL_01f6: ldc.i4.1
+					IL_01f7: ldelem.ref
+					IL_01f8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_01fd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_0202: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0207: ldc.r8 1
+					IL_0210: sub
+					IL_0211: stloc.s 15
+					IL_0213: ldloc.s 15
+					IL_0215: box [System.Runtime]System.Double
+					IL_021a: stloc.s 16
+					IL_021c: ldloc.s 12
+					IL_021e: ldloc.3
+					IL_021f: ldloc.s 16
+					IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+					IL_0226: stloc.s 13
+					IL_0228: ldloc.s 13
+					IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_022f: stloc.s 13
+					IL_0231: ldarg.0
+					IL_0232: ldc.i4.2
+					IL_0233: ldelem.ref
+					IL_0234: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0239: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_023e: stloc.s 4
+					IL_0240: ldarg.0
+					IL_0241: ldc.i4.2
+					IL_0242: ldelem.ref
+					IL_0243: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0248: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_024d: stloc.s 17
+					IL_024f: ldloc.s 13
+					IL_0251: ldstr "then"
+					IL_0256: ldloc.s 4
+					IL_0258: ldloc.s 17
+					IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_025f: pop
+					IL_0260: ldnull
+					IL_0261: ret
 
-					IL_0267: ldloc.1
-					IL_0268: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_026d: ldc.r8 200
-					IL_0276: clt
-					IL_0278: stloc.s 5
-					IL_027a: ldloc.s 5
-					IL_027c: box [System.Runtime]System.Boolean
-					IL_0281: stloc.s 8
-					IL_0283: ldloc.s 8
-					IL_0285: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_028a: stloc.s 5
-					IL_028c: ldloc.s 5
-					IL_028e: brtrue IL_02bb
+					IL_0262: ldloc.1
+					IL_0263: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0268: ldc.r8 200
+					IL_0271: clt
+					IL_0273: stloc.s 5
+					IL_0275: ldloc.s 5
+					IL_0277: box [System.Runtime]System.Boolean
+					IL_027c: stloc.s 8
+					IL_027e: ldloc.s 8
+					IL_0280: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0285: stloc.s 5
+					IL_0287: ldloc.s 5
+					IL_0289: brtrue IL_02b6
 
-					IL_0293: ldloc.1
-					IL_0294: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0299: ldc.r8 300
-					IL_02a2: clt
-					IL_02a4: ldc.i4.0
-					IL_02a5: ceq
-					IL_02a7: stloc.s 5
-					IL_02a9: ldloc.s 5
-					IL_02ab: box [System.Runtime]System.Boolean
-					IL_02b0: stloc.s 9
-					IL_02b2: ldloc.s 9
-					IL_02b4: stloc.s 18
-					IL_02b6: br IL_02bf
+					IL_028e: ldloc.1
+					IL_028f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0294: ldc.r8 300
+					IL_029d: clt
+					IL_029f: ldc.i4.0
+					IL_02a0: ceq
+					IL_02a2: stloc.s 5
+					IL_02a4: ldloc.s 5
+					IL_02a6: box [System.Runtime]System.Boolean
+					IL_02ab: stloc.s 9
+					IL_02ad: ldloc.s 9
+					IL_02af: stloc.s 18
+					IL_02b1: br IL_02ba
 
-					IL_02bb: ldloc.s 8
-					IL_02bd: stloc.s 18
+					IL_02b6: ldloc.s 8
+					IL_02b8: stloc.s 18
 
-					IL_02bf: ldloc.s 18
-					IL_02c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02c6: stloc.s 5
-					IL_02c8: ldloc.s 5
-					IL_02ca: brfalse IL_0364
+					IL_02ba: ldloc.s 18
+					IL_02bc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02c1: stloc.s 5
+					IL_02c3: ldloc.s 5
+					IL_02c5: brfalse IL_035a
 
-					IL_02cf: ldarg.2
-					IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02d5: ldstr "resume"
-					IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_02df: pop
-					IL_02e0: ldarg.0
-					IL_02e1: ldc.i4.2
-					IL_02e2: ldelem.ref
-					IL_02e3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_02e8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_02ed: stloc.s 17
-					IL_02ef: ldc.i4.3
-					IL_02f0: newarr [System.Runtime]System.Object
-					IL_02f5: dup
-					IL_02f6: ldc.i4.0
-					IL_02f7: ldarg.0
-					IL_02f8: ldc.i4.0
-					IL_02f9: ldelem.ref
-					IL_02fa: stelem.ref
-					IL_02fb: dup
-					IL_02fc: ldc.i4.1
-					IL_02fd: ldarg.0
-					IL_02fe: ldc.i4.1
-					IL_02ff: ldelem.ref
-					IL_0300: stelem.ref
-					IL_0301: dup
-					IL_0302: ldc.i4.2
-					IL_0303: ldarg.0
-					IL_0304: ldc.i4.2
-					IL_0305: ldelem.ref
-					IL_0306: stelem.ref
-					IL_0307: stloc.s 12
-					IL_0309: ldloc.1
-					IL_030a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_030f: stloc.s 14
-					IL_0311: ldstr "HTTP "
-					IL_0316: ldloc.s 14
-					IL_0318: call string [System.Runtime]System.String::Concat(string, string)
-					IL_031d: ldstr " fetching "
-					IL_0322: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0327: ldarg.0
-					IL_0328: ldc.i4.1
-					IL_0329: ldelem.ref
-					IL_032a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_032f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0334: stloc.s 4
-					IL_0336: ldloc.s 4
-					IL_0338: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_033d: stloc.s 14
-					IL_033f: ldloc.s 14
-					IL_0341: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0346: stloc.s 14
-					IL_0348: ldloc.s 14
-					IL_034a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_034f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0354: stloc.s 4
-					IL_0356: ldloc.s 17
-					IL_0358: ldloc.s 12
-					IL_035a: ldloc.s 4
-					IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0361: pop
-					IL_0362: ldnull
-					IL_0363: ret
+					IL_02ca: ldarg.2
+					IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02d0: ldstr "resume"
+					IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_02da: pop
+					IL_02db: ldarg.0
+					IL_02dc: ldc.i4.2
+					IL_02dd: ldelem.ref
+					IL_02de: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_02e3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_02e8: stloc.s 17
+					IL_02ea: ldc.i4.3
+					IL_02eb: newarr [System.Runtime]System.Object
+					IL_02f0: dup
+					IL_02f1: ldc.i4.0
+					IL_02f2: ldarg.0
+					IL_02f3: ldc.i4.0
+					IL_02f4: ldelem.ref
+					IL_02f5: stelem.ref
+					IL_02f6: dup
+					IL_02f7: ldc.i4.1
+					IL_02f8: ldarg.0
+					IL_02f9: ldc.i4.1
+					IL_02fa: ldelem.ref
+					IL_02fb: stelem.ref
+					IL_02fc: dup
+					IL_02fd: ldc.i4.2
+					IL_02fe: ldarg.0
+					IL_02ff: ldc.i4.2
+					IL_0300: ldelem.ref
+					IL_0301: stelem.ref
+					IL_0302: stloc.s 12
+					IL_0304: ldloc.1
+					IL_0305: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_030a: stloc.s 14
+					IL_030c: ldstr "HTTP "
+					IL_0311: ldloc.s 14
+					IL_0313: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0318: ldstr " fetching "
+					IL_031d: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0322: ldarg.0
+					IL_0323: ldc.i4.1
+					IL_0324: ldelem.ref
+					IL_0325: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_032a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_032f: stloc.s 4
+					IL_0331: ldloc.s 4
+					IL_0333: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0338: stloc.s 14
+					IL_033a: ldloc.s 14
+					IL_033c: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0341: stloc.s 14
+					IL_0343: ldloc.s 14
+					IL_0345: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_034a: stloc.s 4
+					IL_034c: ldloc.s 17
+					IL_034e: ldloc.s 12
+					IL_0350: ldloc.s 4
+					IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0357: pop
+					IL_0358: ldnull
+					IL_0359: ret
 
-					IL_0364: ldarg.2
-					IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_036a: ldstr "setEncoding"
-					IL_036f: ldstr "utf8"
-					IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0379: pop
-					IL_037a: ldloc.0
-					IL_037b: ldstr ""
-					IL_0380: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_0385: ldarg.2
-					IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_038b: stloc.s 4
-					IL_038d: ldnull
-					IL_038e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
-					IL_0394: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_0399: ldc.i4.4
-					IL_039a: newarr [System.Runtime]System.Object
-					IL_039f: dup
-					IL_03a0: ldc.i4.0
-					IL_03a1: ldarg.0
-					IL_03a2: ldc.i4.0
-					IL_03a3: ldelem.ref
-					IL_03a4: stelem.ref
-					IL_03a5: dup
-					IL_03a6: ldc.i4.1
-					IL_03a7: ldarg.0
-					IL_03a8: ldc.i4.1
-					IL_03a9: ldelem.ref
+					IL_035a: ldarg.2
+					IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0360: ldstr "setEncoding"
+					IL_0365: ldstr "utf8"
+					IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_036f: pop
+					IL_0370: ldloc.0
+					IL_0371: ldstr ""
+					IL_0376: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_037b: ldarg.2
+					IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0381: stloc.s 4
+					IL_0383: ldnull
+					IL_0384: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_038a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_038f: ldc.i4.4
+					IL_0390: newarr [System.Runtime]System.Object
+					IL_0395: dup
+					IL_0396: ldc.i4.0
+					IL_0397: ldarg.0
+					IL_0398: ldc.i4.0
+					IL_0399: ldelem.ref
+					IL_039a: stelem.ref
+					IL_039b: dup
+					IL_039c: ldc.i4.1
+					IL_039d: ldarg.0
+					IL_039e: ldc.i4.1
+					IL_039f: ldelem.ref
+					IL_03a0: stelem.ref
+					IL_03a1: dup
+					IL_03a2: ldc.i4.2
+					IL_03a3: ldarg.0
+					IL_03a4: ldc.i4.2
+					IL_03a5: ldelem.ref
+					IL_03a6: stelem.ref
+					IL_03a7: dup
+					IL_03a8: ldc.i4.3
+					IL_03a9: ldloc.0
 					IL_03aa: stelem.ref
-					IL_03ab: dup
-					IL_03ac: ldc.i4.2
-					IL_03ad: ldarg.0
-					IL_03ae: ldc.i4.2
-					IL_03af: ldelem.ref
-					IL_03b0: stelem.ref
-					IL_03b1: dup
-					IL_03b2: ldc.i4.3
-					IL_03b3: ldloc.0
-					IL_03b4: stelem.ref
-					IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_03bf: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-					IL_03c4: ldc.i4.1
-					IL_03c5: conv.r8
-					IL_03c6: ldstr ""
-					IL_03cb: ldc.i4.0
-					IL_03cc: ldc.i4.0
-					IL_03cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-					IL_03d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-					IL_03d7: stloc.s 19
-					IL_03d9: ldloc.s 4
-					IL_03db: ldstr "on"
-					IL_03e0: ldstr "data"
-					IL_03e5: ldloc.s 19
-					IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_03ec: pop
-					IL_03ed: ldarg.2
-					IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_03f3: stloc.s 4
-					IL_03f5: ldnull
-					IL_03f6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
-					IL_03fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_0401: ldc.i4.4
-					IL_0402: newarr [System.Runtime]System.Object
-					IL_0407: dup
-					IL_0408: ldc.i4.0
-					IL_0409: ldarg.0
-					IL_040a: ldc.i4.0
-					IL_040b: ldelem.ref
-					IL_040c: stelem.ref
-					IL_040d: dup
-					IL_040e: ldc.i4.1
-					IL_040f: ldarg.0
-					IL_0410: ldc.i4.1
-					IL_0411: ldelem.ref
+					IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03b5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+					IL_03ba: ldc.i4.1
+					IL_03bb: conv.r8
+					IL_03bc: ldstr ""
+					IL_03c1: ldc.i4.0
+					IL_03c2: ldc.i4.0
+					IL_03c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+					IL_03c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+					IL_03cd: stloc.s 19
+					IL_03cf: ldloc.s 4
+					IL_03d1: ldstr "on"
+					IL_03d6: ldstr "data"
+					IL_03db: ldloc.s 19
+					IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_03e2: pop
+					IL_03e3: ldarg.2
+					IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_03e9: stloc.s 4
+					IL_03eb: ldnull
+					IL_03ec: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_03f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_03f7: ldc.i4.4
+					IL_03f8: newarr [System.Runtime]System.Object
+					IL_03fd: dup
+					IL_03fe: ldc.i4.0
+					IL_03ff: ldarg.0
+					IL_0400: ldc.i4.0
+					IL_0401: ldelem.ref
+					IL_0402: stelem.ref
+					IL_0403: dup
+					IL_0404: ldc.i4.1
+					IL_0405: ldarg.0
+					IL_0406: ldc.i4.1
+					IL_0407: ldelem.ref
+					IL_0408: stelem.ref
+					IL_0409: dup
+					IL_040a: ldc.i4.2
+					IL_040b: ldarg.0
+					IL_040c: ldc.i4.2
+					IL_040d: ldelem.ref
+					IL_040e: stelem.ref
+					IL_040f: dup
+					IL_0410: ldc.i4.3
+					IL_0411: ldloc.0
 					IL_0412: stelem.ref
-					IL_0413: dup
-					IL_0414: ldc.i4.2
-					IL_0415: ldarg.0
-					IL_0416: ldc.i4.2
-					IL_0417: ldelem.ref
-					IL_0418: stelem.ref
-					IL_0419: dup
-					IL_041a: ldc.i4.3
-					IL_041b: ldloc.0
-					IL_041c: stelem.ref
-					IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_0427: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-					IL_042c: ldc.i4.0
-					IL_042d: conv.r8
-					IL_042e: ldstr ""
-					IL_0433: ldc.i4.0
-					IL_0434: ldc.i4.0
-					IL_0435: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-					IL_043a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-					IL_043f: stloc.s 20
-					IL_0441: ldloc.s 4
-					IL_0443: ldstr "on"
-					IL_0448: ldstr "end"
-					IL_044d: ldloc.s 20
-					IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_0454: pop
-					IL_0455: ldnull
-					IL_0456: ret
+					IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_041d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+					IL_0422: ldc.i4.0
+					IL_0423: conv.r8
+					IL_0424: ldstr ""
+					IL_0429: ldc.i4.0
+					IL_042a: ldc.i4.0
+					IL_042b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+					IL_0430: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+					IL_0435: stloc.s 20
+					IL_0437: ldloc.s 4
+					IL_0439: ldstr "on"
+					IL_043e: ldstr "end"
+					IL_0443: ldloc.s 20
+					IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_044a: pop
+					IL_044b: ldnull
+					IL_044c: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -1914,7 +1912,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45f4
+						// Method begins at RVA 0x45bc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1934,7 +1932,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45fd
+						// Method begins at RVA 0x45c5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1957,7 +1955,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45eb
+					// Method begins at RVA 0x45b3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1983,9 +1981,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e48
+				// Method begins at RVA 0x3e1c
 				// Header size: 12
-				// Code size: 516 (0x204)
+				// Code size: 511 (0x1ff)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope,
@@ -2043,7 +2041,7 @@
 					IL_004e: ldloc.0
 					IL_004f: ldloc.s 6
 					IL_0051: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_0056: leave IL_00c6
+					IL_0056: leave IL_00c1
 				} // end .try
 				catch [System.Runtime]System.Exception
 				{
@@ -2080,139 +2078,138 @@
 					IL_0097: call string [System.Runtime]System.String::Concat(string, string)
 					IL_009c: stloc.s 9
 					IL_009e: ldloc.s 9
-					IL_00a0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_00a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_00aa: stloc.s 7
-					IL_00ac: ldloc.s 6
-					IL_00ae: ldloc.s 8
-					IL_00b0: ldloc.s 7
-					IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_00b7: pop
-					IL_00b8: ldnull
-					IL_00b9: stloc.2
-					IL_00ba: ldnull
-					IL_00bb: stloc.2
-					IL_00bc: leave IL_0202
+					IL_00a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_00a5: stloc.s 7
+					IL_00a7: ldloc.s 6
+					IL_00a9: ldloc.s 8
+					IL_00ab: ldloc.s 7
+					IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_00b2: pop
+					IL_00b3: ldnull
+					IL_00b4: stloc.2
+					IL_00b5: ldnull
+					IL_00b6: stloc.2
+					IL_00b7: leave IL_01fd
 
-					IL_00c1: leave IL_00c6
+					IL_00bc: leave IL_00c1
 				} // end handler
 
-				IL_00c6: ldloc.0
-				IL_00c7: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_00cc: ldstr "protocol"
-				IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00d6: stloc.s 7
-				IL_00d8: ldloc.s 7
-				IL_00da: ldstr "https:"
-				IL_00df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00e4: stloc.s 10
-				IL_00e6: ldloc.s 10
-				IL_00e8: brfalse IL_0104
+				IL_00c1: ldloc.0
+				IL_00c2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_00c7: ldstr "protocol"
+				IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00d1: stloc.s 7
+				IL_00d3: ldloc.s 7
+				IL_00d5: ldstr "https:"
+				IL_00da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00df: stloc.s 10
+				IL_00e1: ldloc.s 10
+				IL_00e3: brfalse IL_00ff
 
-				IL_00ed: ldarg.0
-				IL_00ee: ldc.i4.0
-				IL_00ef: ldelem.ref
-				IL_00f0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_00f5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
-				IL_00fa: stloc.s 11
-				IL_00fc: ldloc.s 11
-				IL_00fe: stloc.3
-				IL_00ff: br IL_0116
+				IL_00e8: ldarg.0
+				IL_00e9: ldc.i4.0
+				IL_00ea: ldelem.ref
+				IL_00eb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_00f0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+				IL_00f5: stloc.s 11
+				IL_00f7: ldloc.s 11
+				IL_00f9: stloc.3
+				IL_00fa: br IL_0111
 
-				IL_0104: ldarg.0
-				IL_0105: ldc.i4.0
-				IL_0106: ldelem.ref
-				IL_0107: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_010c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
-				IL_0111: stloc.s 12
-				IL_0113: ldloc.s 12
-				IL_0115: stloc.3
+				IL_00ff: ldarg.0
+				IL_0100: ldc.i4.0
+				IL_0101: ldelem.ref
+				IL_0102: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_0107: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+				IL_010c: stloc.s 12
+				IL_010e: ldloc.s 12
+				IL_0110: stloc.3
 
-				IL_0116: ldloc.3
-				IL_0117: stloc.s 4
-				IL_0119: ldloc.s 4
-				IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0120: stloc.s 7
-				IL_0122: ldloc.0
-				IL_0123: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_0128: stloc.s 6
-				IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_012f: dup
-				IL_0130: ldstr "method"
-				IL_0135: ldstr "GET"
-				IL_013a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_013f: dup
-				IL_0140: ldstr "headers"
-				IL_0145: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_014a: dup
-				IL_014b: ldstr "Accept-Encoding"
-				IL_0150: ldstr "identity"
-				IL_0155: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_015a: dup
-				IL_015b: ldstr "User-Agent"
-				IL_0160: ldstr "jroc-docs-script"
+				IL_0111: ldloc.3
+				IL_0112: stloc.s 4
+				IL_0114: ldloc.s 4
+				IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_011b: stloc.s 7
+				IL_011d: ldloc.0
+				IL_011e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_0123: stloc.s 6
+				IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_012a: dup
+				IL_012b: ldstr "method"
+				IL_0130: ldstr "GET"
+				IL_0135: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_013a: dup
+				IL_013b: ldstr "headers"
+				IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0145: dup
+				IL_0146: ldstr "Accept-Encoding"
+				IL_014b: ldstr "identity"
+				IL_0150: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0155: dup
+				IL_0156: ldstr "User-Agent"
+				IL_015b: ldstr "jroc-docs-script"
+				IL_0160: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 				IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_016a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_016f: stloc.s 13
-				IL_0171: ldnull
-				IL_0172: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
-				IL_0178: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_017d: ldc.i4.3
-				IL_017e: newarr [System.Runtime]System.Object
-				IL_0183: dup
-				IL_0184: ldc.i4.0
-				IL_0185: ldarg.0
-				IL_0186: ldc.i4.0
-				IL_0187: ldelem.ref
-				IL_0188: stelem.ref
-				IL_0189: dup
-				IL_018a: ldc.i4.1
-				IL_018b: ldarg.0
-				IL_018c: ldc.i4.1
-				IL_018d: ldelem.ref
-				IL_018e: stelem.ref
-				IL_018f: dup
-				IL_0190: ldc.i4.2
-				IL_0191: ldloc.0
-				IL_0192: stelem.ref
-				IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_019d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-				IL_01a2: ldc.i4.1
-				IL_01a3: conv.r8
-				IL_01a4: ldstr ""
-				IL_01a9: ldc.i4.0
-				IL_01aa: ldc.i4.0
-				IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-				IL_01b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-				IL_01b5: stloc.s 14
-				IL_01b7: ldloc.s 7
-				IL_01b9: ldstr "request"
-				IL_01be: ldloc.s 6
-				IL_01c0: ldloc.s 13
-				IL_01c2: ldloc.s 14
-				IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-				IL_01c9: stloc.s 5
-				IL_01cb: ldloc.s 5
-				IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01d2: stloc.s 6
-				IL_01d4: ldloc.0
-				IL_01d5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-				IL_01da: stloc.s 7
-				IL_01dc: ldloc.s 6
-				IL_01de: ldstr "on"
-				IL_01e3: ldstr "error"
-				IL_01e8: ldloc.s 7
-				IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_01ef: pop
-				IL_01f0: ldloc.s 5
-				IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01f7: ldstr "end"
-				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0201: pop
+				IL_016a: stloc.s 13
+				IL_016c: ldnull
+				IL_016d: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
+				IL_0173: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_0178: ldc.i4.3
+				IL_0179: newarr [System.Runtime]System.Object
+				IL_017e: dup
+				IL_017f: ldc.i4.0
+				IL_0180: ldarg.0
+				IL_0181: ldc.i4.0
+				IL_0182: ldelem.ref
+				IL_0183: stelem.ref
+				IL_0184: dup
+				IL_0185: ldc.i4.1
+				IL_0186: ldarg.0
+				IL_0187: ldc.i4.1
+				IL_0188: ldelem.ref
+				IL_0189: stelem.ref
+				IL_018a: dup
+				IL_018b: ldc.i4.2
+				IL_018c: ldloc.0
+				IL_018d: stelem.ref
+				IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_0198: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+				IL_019d: ldc.i4.1
+				IL_019e: conv.r8
+				IL_019f: ldstr ""
+				IL_01a4: ldc.i4.0
+				IL_01a5: ldc.i4.0
+				IL_01a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+				IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+				IL_01b0: stloc.s 14
+				IL_01b2: ldloc.s 7
+				IL_01b4: ldstr "request"
+				IL_01b9: ldloc.s 6
+				IL_01bb: ldloc.s 13
+				IL_01bd: ldloc.s 14
+				IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+				IL_01c4: stloc.s 5
+				IL_01c6: ldloc.s 5
+				IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01cd: stloc.s 6
+				IL_01cf: ldloc.0
+				IL_01d0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+				IL_01d5: stloc.s 7
+				IL_01d7: ldloc.s 6
+				IL_01d9: ldstr "on"
+				IL_01de: ldstr "error"
+				IL_01e3: ldloc.s 7
+				IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_01ea: pop
+				IL_01eb: ldloc.s 5
+				IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01f2: ldstr "end"
+				IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_01fc: pop
 
-				IL_0202: ldloc.2
-				IL_0203: ret
+				IL_01fd: ldloc.2
+				IL_01fe: ret
 			} // end of method ArrowFunction_L72C22::__js_call__
 
 		} // end of class ArrowFunction_L72C22
@@ -2234,7 +2231,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45e2
+					// Method begins at RVA 0x45aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2256,7 +2253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45d9
+				// Method begins at RVA 0x45a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2353,7 +2350,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x463c
+				// Method begins at RVA 0x4604
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2420,7 +2417,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x464e
+					// Method begins at RVA 0x4616
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2444,7 +2441,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4660
+						// Method begins at RVA 0x4628
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2462,7 +2459,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4657
+					// Method begins at RVA 0x461f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2480,7 +2477,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4645
+				// Method begins at RVA 0x460d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2745,7 +2742,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4672
+					// Method begins at RVA 0x463a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2765,7 +2762,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x467b
+					// Method begins at RVA 0x4643
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2785,7 +2782,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4684
+					// Method begins at RVA 0x464c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2805,7 +2802,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x468d
+					// Method begins at RVA 0x4655
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2829,7 +2826,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x469f
+						// Method begins at RVA 0x4667
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2849,7 +2846,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46a8
+						// Method begins at RVA 0x4670
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2873,7 +2870,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x46ba
+							// Method begins at RVA 0x4682
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2891,7 +2888,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46b1
+						// Method begins at RVA 0x4679
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2911,7 +2908,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46c3
+						// Method begins at RVA 0x468b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2929,7 +2926,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4696
+					// Method begins at RVA 0x465e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2947,7 +2944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4669
+				// Method begins at RVA 0x4631
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2977,7 +2974,7 @@
 			)
 			// Method begins at RVA 0x2c2c
 			// Header size: 12
-			// Code size: 964 (0x3c4)
+			// Code size: 944 (0x3b0)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -3052,7 +3049,7 @@
 			IL_0085: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_008a: ldc.r8 0.0
 			IL_0093: clt
-			IL_0095: brfalse IL_00dc
+			IL_0095: brfalse IL_00d7
 
 			IL_009a: ldarg.3
 			IL_009b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
@@ -3064,278 +3061,274 @@
 			IL_00b3: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00b8: stloc.s 14
 			IL_00ba: ldloc.s 14
-			IL_00bc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00c6: stloc.3
-			IL_00c7: ldloc.3
-			IL_00c8: isinst [System.Runtime]System.Exception
-			IL_00cd: dup
-			IL_00ce: brtrue IL_00db
+			IL_00bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00c1: stloc.3
+			IL_00c2: ldloc.3
+			IL_00c3: isinst [System.Runtime]System.Exception
+			IL_00c8: dup
+			IL_00c9: brtrue IL_00d6
 
-			IL_00d3: pop
-			IL_00d4: ldloc.3
-			IL_00d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00da: throw
+			IL_00ce: pop
+			IL_00cf: ldloc.3
+			IL_00d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00d5: throw
 
-			IL_00db: throw
+			IL_00d6: throw
 
-			IL_00dc: ldarg.2
-			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e2: ldstr "lastIndexOf"
-			IL_00e7: ldstr "<"
-			IL_00ec: ldloc.2
-			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00f2: stloc.s 4
-			IL_00f4: ldloc.s 4
-			IL_00f6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00fb: ldc.r8 0.0
-			IL_0104: clt
-			IL_0106: brfalse IL_0150
+			IL_00d7: ldarg.2
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00dd: ldstr "lastIndexOf"
+			IL_00e2: ldstr "<"
+			IL_00e7: ldloc.2
+			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00ed: stloc.s 4
+			IL_00ef: ldloc.s 4
+			IL_00f1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00f6: ldc.r8 0.0
+			IL_00ff: clt
+			IL_0101: brfalse IL_0146
 
-			IL_010b: ldarg.3
-			IL_010c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0111: stloc.s 14
-			IL_0113: ldstr "Could not locate tag start for id '"
-			IL_0118: ldloc.s 14
-			IL_011a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_011f: ldstr "'."
-			IL_0124: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0129: stloc.s 14
-			IL_012b: ldloc.s 14
-			IL_012d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0137: stloc.s 5
-			IL_0139: ldloc.s 5
-			IL_013b: isinst [System.Runtime]System.Exception
-			IL_0140: dup
-			IL_0141: brtrue IL_014f
+			IL_0106: ldarg.3
+			IL_0107: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_010c: stloc.s 14
+			IL_010e: ldstr "Could not locate tag start for id '"
+			IL_0113: ldloc.s 14
+			IL_0115: call string [System.Runtime]System.String::Concat(string, string)
+			IL_011a: ldstr "'."
+			IL_011f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0124: stloc.s 14
+			IL_0126: ldloc.s 14
+			IL_0128: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_012d: stloc.s 5
+			IL_012f: ldloc.s 5
+			IL_0131: isinst [System.Runtime]System.Exception
+			IL_0136: dup
+			IL_0137: brtrue IL_0145
 
-			IL_0146: pop
-			IL_0147: ldloc.s 5
-			IL_0149: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_014e: throw
+			IL_013c: pop
+			IL_013d: ldloc.s 5
+			IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0144: throw
 
-			IL_014f: throw
+			IL_0145: throw
 
-			IL_0150: ldarg.0
-			IL_0151: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
-			IL_0156: ldc.i4.1
-			IL_0157: newarr [System.Runtime]System.Object
-			IL_015c: dup
-			IL_015d: ldc.i4.0
-			IL_015e: ldarg.0
-			IL_015f: stelem.ref
-			IL_0160: stloc.s 16
-			IL_0162: ldloc.s 16
-			IL_0164: ldarg.2
-			IL_0165: ldloc.s 4
-			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_016c: stloc.s 6
-			IL_016e: ldloc.s 6
-			IL_0170: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0175: ldc.i4.0
-			IL_0176: ceq
-			IL_0178: stloc.s 17
-			IL_017a: ldloc.s 17
-			IL_017c: brfalse IL_01c6
+			IL_0146: ldarg.0
+			IL_0147: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
+			IL_014c: ldc.i4.1
+			IL_014d: newarr [System.Runtime]System.Object
+			IL_0152: dup
+			IL_0153: ldc.i4.0
+			IL_0154: ldarg.0
+			IL_0155: stelem.ref
+			IL_0156: stloc.s 16
+			IL_0158: ldloc.s 16
+			IL_015a: ldarg.2
+			IL_015b: ldloc.s 4
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0162: stloc.s 6
+			IL_0164: ldloc.s 6
+			IL_0166: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_016b: ldc.i4.0
+			IL_016c: ceq
+			IL_016e: stloc.s 17
+			IL_0170: ldloc.s 17
+			IL_0172: brfalse IL_01b7
 
-			IL_0181: ldarg.3
-			IL_0182: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0187: stloc.s 14
-			IL_0189: ldstr "Could not determine tag name for id '"
-			IL_018e: ldloc.s 14
+			IL_0177: ldarg.3
+			IL_0178: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_017d: stloc.s 14
+			IL_017f: ldstr "Could not determine tag name for id '"
+			IL_0184: ldloc.s 14
+			IL_0186: call string [System.Runtime]System.String::Concat(string, string)
+			IL_018b: ldstr "'."
 			IL_0190: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0195: ldstr "'."
-			IL_019a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_019f: stloc.s 14
-			IL_01a1: ldloc.s 14
-			IL_01a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01ad: stloc.s 7
-			IL_01af: ldloc.s 7
-			IL_01b1: isinst [System.Runtime]System.Exception
-			IL_01b6: dup
-			IL_01b7: brtrue IL_01c5
+			IL_0195: stloc.s 14
+			IL_0197: ldloc.s 14
+			IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_019e: stloc.s 7
+			IL_01a0: ldloc.s 7
+			IL_01a2: isinst [System.Runtime]System.Exception
+			IL_01a7: dup
+			IL_01a8: brtrue IL_01b6
 
-			IL_01bc: pop
-			IL_01bd: ldloc.s 7
-			IL_01bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_01c4: throw
+			IL_01ad: pop
+			IL_01ae: ldloc.s 7
+			IL_01b0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_01b5: throw
 
-			IL_01c5: throw
+			IL_01b6: throw
 
-			IL_01c6: ldarg.0
-			IL_01c7: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_01cc: ldc.i4.1
-			IL_01cd: newarr [System.Runtime]System.Object
-			IL_01d2: dup
-			IL_01d3: ldc.i4.0
-			IL_01d4: ldarg.0
-			IL_01d5: stelem.ref
-			IL_01d6: ldloc.s 6
-			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01dd: stloc.s 15
-			IL_01df: ldloc.s 15
-			IL_01e1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01e6: stloc.s 14
-			IL_01e8: ldstr "<\\/?"
-			IL_01ed: ldloc.s 14
-			IL_01ef: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01f4: ldstr "\\b[^>]*>"
-			IL_01f9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01fe: stloc.s 14
-			IL_0200: ldloc.s 14
-			IL_0202: ldstr "gi"
-			IL_0207: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_020c: stloc.s 8
-			IL_020e: ldloc.s 8
-			IL_0210: ldstr "lastIndex"
-			IL_0215: ldloc.s 4
-			IL_0217: ldc.i4.1
-			IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_021d: pop
-			IL_021e: ldc.r8 0.0
-			IL_0227: stloc.s 9
-			IL_0229: ldc.r8 1
-			IL_0232: neg
-			IL_0233: stloc.s 18
-			IL_0235: ldloc.s 18
-			IL_0237: box [System.Runtime]System.Double
-			IL_023c: stloc.s 10
-			// loop start (head: IL_023e)
-				IL_023e: ldc.i4.1
-				IL_023f: brfalse IL_0363
+			IL_01b7: ldarg.0
+			IL_01b8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_01bd: ldc.i4.1
+			IL_01be: newarr [System.Runtime]System.Object
+			IL_01c3: dup
+			IL_01c4: ldc.i4.0
+			IL_01c5: ldarg.0
+			IL_01c6: stelem.ref
+			IL_01c7: ldloc.s 6
+			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_01ce: stloc.s 15
+			IL_01d0: ldloc.s 15
+			IL_01d2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d7: stloc.s 14
+			IL_01d9: ldstr "<\\/?"
+			IL_01de: ldloc.s 14
+			IL_01e0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e5: ldstr "\\b[^>]*>"
+			IL_01ea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ef: stloc.s 14
+			IL_01f1: ldloc.s 14
+			IL_01f3: ldstr "gi"
+			IL_01f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_01fd: stloc.s 8
+			IL_01ff: ldloc.s 8
+			IL_0201: ldstr "lastIndex"
+			IL_0206: ldloc.s 4
+			IL_0208: ldc.i4.1
+			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_020e: pop
+			IL_020f: ldc.r8 0.0
+			IL_0218: stloc.s 9
+			IL_021a: ldc.r8 1
+			IL_0223: neg
+			IL_0224: stloc.s 18
+			IL_0226: ldloc.s 18
+			IL_0228: box [System.Runtime]System.Double
+			IL_022d: stloc.s 10
+			// loop start (head: IL_022f)
+				IL_022f: ldc.i4.1
+				IL_0230: brfalse IL_0354
 
-				IL_0244: ldloc.s 8
-				IL_0246: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-				IL_024b: stloc.s 19
-				IL_024d: ldloc.s 19
-				IL_024f: ldstr "exec"
-				IL_0254: ldarg.2
-				IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_025a: stloc.s 11
-				IL_025c: ldloc.s 11
-				IL_025e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0263: ldc.i4.0
-				IL_0264: ceq
-				IL_0266: stloc.s 17
-				IL_0268: ldloc.s 17
-				IL_026a: brfalse IL_0274
+				IL_0235: ldloc.s 8
+				IL_0237: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+				IL_023c: stloc.s 19
+				IL_023e: ldloc.s 19
+				IL_0240: ldstr "exec"
+				IL_0245: ldarg.2
+				IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_024b: stloc.s 11
+				IL_024d: ldloc.s 11
+				IL_024f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0254: ldc.i4.0
+				IL_0255: ceq
+				IL_0257: stloc.s 17
+				IL_0259: ldloc.s 17
+				IL_025b: brfalse IL_0265
 
-				IL_026f: br IL_0363
+				IL_0260: br IL_0354
 
-				IL_0274: ldloc.s 11
-				IL_0276: ldc.r8 0.0
-				IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0284: stloc.s 12
-				IL_0286: ldloc.s 10
-				IL_0288: stloc.s 20
-				IL_028a: ldloc.s 20
-				IL_028c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0291: ldc.r8 0.0
-				IL_029a: clt
-				IL_029c: brfalse IL_02b3
+				IL_0265: ldloc.s 11
+				IL_0267: ldc.r8 0.0
+				IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0275: stloc.s 12
+				IL_0277: ldloc.s 10
+				IL_0279: stloc.s 20
+				IL_027b: ldloc.s 20
+				IL_027d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0282: ldc.r8 0.0
+				IL_028b: clt
+				IL_028d: brfalse IL_02a4
 
-				IL_02a1: ldloc.s 11
-				IL_02a3: ldstr "index"
-				IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02ad: stloc.s 15
-				IL_02af: ldloc.s 15
-				IL_02b1: stloc.s 10
+				IL_0292: ldloc.s 11
+				IL_0294: ldstr "index"
+				IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_029e: stloc.s 15
+				IL_02a0: ldloc.s 15
+				IL_02a2: stloc.s 10
 
-				IL_02b3: ldloc.s 12
-				IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02ba: ldstr "startsWith"
-				IL_02bf: ldstr "</"
-				IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02c9: stloc.s 15
-				IL_02cb: ldloc.s 15
-				IL_02cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02d2: stloc.s 17
-				IL_02d4: ldloc.s 17
-				IL_02d6: brfalse IL_0350
+				IL_02a4: ldloc.s 12
+				IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02ab: ldstr "startsWith"
+				IL_02b0: ldstr "</"
+				IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02ba: stloc.s 15
+				IL_02bc: ldloc.s 15
+				IL_02be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02c3: stloc.s 17
+				IL_02c5: ldloc.s 17
+				IL_02c7: brfalse IL_0341
 
-				IL_02db: ldloc.s 9
-				IL_02dd: ldc.r8 1
-				IL_02e6: sub
-				IL_02e7: stloc.s 9
-				IL_02e9: ldloc.s 9
-				IL_02eb: stloc.s 18
-				IL_02ed: ldloc.s 18
-				IL_02ef: ldc.r8 0.0
-				IL_02f8: ceq
-				IL_02fa: brfalse IL_034b
+				IL_02cc: ldloc.s 9
+				IL_02ce: ldc.r8 1
+				IL_02d7: sub
+				IL_02d8: stloc.s 9
+				IL_02da: ldloc.s 9
+				IL_02dc: stloc.s 18
+				IL_02de: ldloc.s 18
+				IL_02e0: ldc.r8 0.0
+				IL_02e9: ceq
+				IL_02eb: brfalse IL_033c
 
-				IL_02ff: ldarg.2
-				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0305: stloc.s 15
-				IL_0307: ldloc.s 8
-				IL_0309: ldstr "lastIndex"
-				IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0313: stloc.s 21
-				IL_0315: ldloc.s 15
-				IL_0317: ldstr "substring"
-				IL_031c: ldloc.s 10
-				IL_031e: ldloc.s 21
-				IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0325: stloc.s 21
-				IL_0327: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_032c: dup
-				IL_032d: ldstr "tagName"
-				IL_0332: ldloc.s 6
-				IL_0334: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0339: dup
-				IL_033a: ldstr "html"
-				IL_033f: ldloc.s 21
-				IL_0341: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0346: stloc.s 22
-				IL_0348: ldloc.s 22
-				IL_034a: ret
+				IL_02f0: ldarg.2
+				IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02f6: stloc.s 15
+				IL_02f8: ldloc.s 8
+				IL_02fa: ldstr "lastIndex"
+				IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0304: stloc.s 21
+				IL_0306: ldloc.s 15
+				IL_0308: ldstr "substring"
+				IL_030d: ldloc.s 10
+				IL_030f: ldloc.s 21
+				IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0316: stloc.s 21
+				IL_0318: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_031d: dup
+				IL_031e: ldstr "tagName"
+				IL_0323: ldloc.s 6
+				IL_0325: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_032a: dup
+				IL_032b: ldstr "html"
+				IL_0330: ldloc.s 21
+				IL_0332: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0337: stloc.s 22
+				IL_0339: ldloc.s 22
+				IL_033b: ret
 
-				IL_034b: br IL_035e
+				IL_033c: br IL_034f
 
-				IL_0350: ldloc.s 9
-				IL_0352: ldc.r8 1
-				IL_035b: add
-				IL_035c: stloc.s 9
+				IL_0341: ldloc.s 9
+				IL_0343: ldc.r8 1
+				IL_034c: add
+				IL_034d: stloc.s 9
 
-				IL_035e: br IL_023e
+				IL_034f: br IL_022f
 			// end loop
 
-			IL_0363: ldloc.s 6
-			IL_0365: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_036a: stloc.s 14
-			IL_036c: ldstr "Could not find a matching closing </"
-			IL_0371: ldloc.s 14
-			IL_0373: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0378: ldstr "> for id '"
+			IL_0354: ldloc.s 6
+			IL_0356: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_035b: stloc.s 14
+			IL_035d: ldstr "Could not find a matching closing </"
+			IL_0362: ldloc.s 14
+			IL_0364: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0369: ldstr "> for id '"
+			IL_036e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0373: ldarg.3
+			IL_0374: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0379: stloc.s 14
+			IL_037b: ldloc.s 14
 			IL_037d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0382: ldarg.3
-			IL_0383: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0388: stloc.s 14
-			IL_038a: ldloc.s 14
-			IL_038c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0391: ldstr "'."
-			IL_0396: call string [System.Runtime]System.String::Concat(string, string)
-			IL_039b: stloc.s 14
-			IL_039d: ldloc.s 14
-			IL_039f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_03a9: stloc.s 13
-			IL_03ab: ldloc.s 13
-			IL_03ad: isinst [System.Runtime]System.Exception
-			IL_03b2: dup
-			IL_03b3: brtrue IL_03c1
+			IL_0382: ldstr "'."
+			IL_0387: call string [System.Runtime]System.String::Concat(string, string)
+			IL_038c: stloc.s 14
+			IL_038e: ldloc.s 14
+			IL_0390: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0395: stloc.s 13
+			IL_0397: ldloc.s 13
+			IL_0399: isinst [System.Runtime]System.Exception
+			IL_039e: dup
+			IL_039f: brtrue IL_03ad
 
-			IL_03b8: pop
-			IL_03b9: ldloc.s 13
-			IL_03bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03c0: throw
+			IL_03a4: pop
+			IL_03a5: ldloc.s 13
+			IL_03a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03ac: throw
 
-			IL_03c1: throw
+			IL_03ad: throw
 
-			IL_03c2: ldnull
-			IL_03c3: ret
+			IL_03ae: ldnull
+			IL_03af: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3355,7 +3348,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46d5
+					// Method begins at RVA 0x469d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3373,7 +3366,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46cc
+				// Method begins at RVA 0x4694
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3401,7 +3394,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2ffc
+			// Method begins at RVA 0x2fe8
 			// Header size: 12
 			// Code size: 476 (0x1dc)
 			.maxstack 8
@@ -3609,7 +3602,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46de
+				// Method begins at RVA 0x46a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3635,7 +3628,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31e4
+			// Method begins at RVA 0x31d0
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -3727,7 +3720,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46f0
+					// Method begins at RVA 0x46b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3747,7 +3740,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46f9
+					// Method begins at RVA 0x46c1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3767,7 +3760,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4702
+					// Method begins at RVA 0x46ca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3791,7 +3784,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4714
+						// Method begins at RVA 0x46dc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3811,7 +3804,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x471d
+						// Method begins at RVA 0x46e5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3829,7 +3822,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x470b
+					// Method begins at RVA 0x46d3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3849,7 +3842,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4726
+					// Method begins at RVA 0x46ee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3869,7 +3862,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x472f
+					// Method begins at RVA 0x46f7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3909,7 +3902,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46e7
+				// Method begins at RVA 0x46af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3933,9 +3926,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3274
+			// Method begins at RVA 0x3260
 			// Header size: 12
-			// Code size: 3014 (0xbc6)
+			// Code size: 2989 (0xbad)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -4152,7 +4145,7 @@
 
 			IL_0139: ldloc.0
 			IL_013a: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_013f: switch (IL_0154, IL_04df, IL_0747, IL_08d2)
+			IL_013f: switch (IL_0154, IL_04d0, IL_0733, IL_08be)
 
 			IL_0154: ldarg.0
 			IL_0155: ldc.i4.1
@@ -4189,1149 +4182,1144 @@
 			IL_01a8: ceq
 			IL_01aa: stloc.s 23
 			IL_01ac: ldloc.s 23
-			IL_01ae: brfalse IL_01f2
+			IL_01ae: brfalse IL_01ed
 
 			IL_01b3: ldstr "Missing required --section (e.g. 27.3)."
-			IL_01b8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01c2: stloc.2
-			IL_01c3: ldloc.0
-			IL_01c4: ldc.i4.m1
-			IL_01c5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01ca: ldloc.0
-			IL_01cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_01d5: ldarg.0
-			IL_01d6: ldc.i4.1
-			IL_01d7: newarr [System.Runtime]System.Object
-			IL_01dc: dup
-			IL_01dd: ldc.i4.0
-			IL_01de: ldloc.2
-			IL_01df: stelem.ref
-			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01e5: pop
-			IL_01e6: ldloc.0
-			IL_01e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ec: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01f1: ret
+			IL_01b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01bd: stloc.2
+			IL_01be: ldloc.0
+			IL_01bf: ldc.i4.m1
+			IL_01c0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01c5: ldloc.0
+			IL_01c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_01d0: ldarg.0
+			IL_01d1: ldc.i4.1
+			IL_01d2: newarr [System.Runtime]System.Object
+			IL_01d7: dup
+			IL_01d8: ldc.i4.0
+			IL_01d9: ldloc.2
+			IL_01da: stelem.ref
+			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01e0: pop
+			IL_01e1: ldloc.0
+			IL_01e2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01e7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01ec: ret
 
-			IL_01f2: ldloc.1
-			IL_01f3: ldstr "outFile"
-			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01fd: stloc.s 22
-			IL_01ff: ldloc.s 22
-			IL_0201: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0206: ldc.i4.0
-			IL_0207: ceq
-			IL_0209: stloc.s 23
-			IL_020b: ldloc.s 23
-			IL_020d: brfalse IL_0251
+			IL_01ed: ldloc.1
+			IL_01ee: ldstr "outFile"
+			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f8: stloc.s 22
+			IL_01fa: ldloc.s 22
+			IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0201: ldc.i4.0
+			IL_0202: ceq
+			IL_0204: stloc.s 23
+			IL_0206: ldloc.s 23
+			IL_0208: brfalse IL_0247
 
-			IL_0212: ldstr "Missing required --out <output.html>."
-			IL_0217: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_021c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0221: stloc.3
-			IL_0222: ldloc.0
-			IL_0223: ldc.i4.m1
-			IL_0224: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0229: ldloc.0
-			IL_022a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_022f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0234: ldarg.0
-			IL_0235: ldc.i4.1
-			IL_0236: newarr [System.Runtime]System.Object
-			IL_023b: dup
-			IL_023c: ldc.i4.0
-			IL_023d: ldloc.3
-			IL_023e: stelem.ref
-			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0244: pop
-			IL_0245: ldloc.0
-			IL_0246: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_024b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0250: ret
+			IL_020d: ldstr "Missing required --out <output.html>."
+			IL_0212: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0217: stloc.3
+			IL_0218: ldloc.0
+			IL_0219: ldc.i4.m1
+			IL_021a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_021f: ldloc.0
+			IL_0220: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0225: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_022a: ldarg.0
+			IL_022b: ldc.i4.1
+			IL_022c: newarr [System.Runtime]System.Object
+			IL_0231: dup
+			IL_0232: ldc.i4.0
+			IL_0233: ldloc.3
+			IL_0234: stelem.ref
+			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_023a: pop
+			IL_023b: ldloc.0
+			IL_023c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0241: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0246: ret
 
-			IL_0251: ldloc.1
-			IL_0252: ldstr "url"
-			IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_025c: stloc.s 22
-			IL_025e: ldloc.s 22
-			IL_0260: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0265: stloc.s 23
-			IL_0267: ldloc.s 23
-			IL_0269: brfalse IL_0283
+			IL_0247: ldloc.1
+			IL_0248: ldstr "url"
+			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0252: stloc.s 22
+			IL_0254: ldloc.s 22
+			IL_0256: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_025b: stloc.s 23
+			IL_025d: ldloc.s 23
+			IL_025f: brfalse IL_0279
 
-			IL_026e: ldc.r8 1
-			IL_0277: box [System.Runtime]System.Double
-			IL_027c: stloc.s 4
-			IL_027e: br IL_0293
+			IL_0264: ldc.r8 1
+			IL_026d: box [System.Runtime]System.Double
+			IL_0272: stloc.s 4
+			IL_0274: br IL_0289
 
-			IL_0283: ldc.r8 0.0
-			IL_028c: box [System.Runtime]System.Double
-			IL_0291: stloc.s 4
+			IL_0279: ldc.r8 0.0
+			IL_0282: box [System.Runtime]System.Double
+			IL_0287: stloc.s 4
 
-			IL_0293: ldloc.s 4
-			IL_0295: stloc.s 24
-			IL_0297: ldloc.1
-			IL_0298: ldstr "auto"
-			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a2: stloc.s 22
-			IL_02a4: ldloc.s 22
-			IL_02a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02ab: stloc.s 23
-			IL_02ad: ldloc.s 23
-			IL_02af: brfalse IL_02c9
+			IL_0289: ldloc.s 4
+			IL_028b: stloc.s 24
+			IL_028d: ldloc.1
+			IL_028e: ldstr "auto"
+			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0298: stloc.s 22
+			IL_029a: ldloc.s 22
+			IL_029c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02a1: stloc.s 23
+			IL_02a3: ldloc.s 23
+			IL_02a5: brfalse IL_02bf
 
-			IL_02b4: ldc.r8 1
-			IL_02bd: box [System.Runtime]System.Double
-			IL_02c2: stloc.s 5
-			IL_02c4: br IL_02d9
+			IL_02aa: ldc.r8 1
+			IL_02b3: box [System.Runtime]System.Double
+			IL_02b8: stloc.s 5
+			IL_02ba: br IL_02cf
 
-			IL_02c9: ldc.r8 0.0
-			IL_02d2: box [System.Runtime]System.Double
-			IL_02d7: stloc.s 5
+			IL_02bf: ldc.r8 0.0
+			IL_02c8: box [System.Runtime]System.Double
+			IL_02cd: stloc.s 5
 
-			IL_02d9: ldloc.s 24
-			IL_02db: ldloc.s 5
-			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02e2: stloc.s 6
-			IL_02e4: ldloc.s 6
-			IL_02e6: ldc.r8 1
-			IL_02ef: box [System.Runtime]System.Double
-			IL_02f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_02f9: stloc.s 23
-			IL_02fb: ldloc.s 23
-			IL_02fd: brfalse IL_0343
+			IL_02cf: ldloc.s 24
+			IL_02d1: ldloc.s 5
+			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02d8: stloc.s 6
+			IL_02da: ldloc.s 6
+			IL_02dc: ldc.r8 1
+			IL_02e5: box [System.Runtime]System.Double
+			IL_02ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_02ef: stloc.s 23
+			IL_02f1: ldloc.s 23
+			IL_02f3: brfalse IL_0334
 
-			IL_0302: ldstr "Provide exactly one input mode: --url or --auto."
-			IL_0307: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_030c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0311: stloc.s 7
-			IL_0313: ldloc.0
-			IL_0314: ldc.i4.m1
-			IL_0315: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_031a: ldloc.0
-			IL_031b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0320: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0325: ldarg.0
-			IL_0326: ldc.i4.1
-			IL_0327: newarr [System.Runtime]System.Object
-			IL_032c: dup
-			IL_032d: ldc.i4.0
-			IL_032e: ldloc.s 7
-			IL_0330: stelem.ref
-			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0336: pop
-			IL_0337: ldloc.0
-			IL_0338: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_033d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0342: ret
+			IL_02f8: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_02fd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0302: stloc.s 7
+			IL_0304: ldloc.0
+			IL_0305: ldc.i4.m1
+			IL_0306: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_030b: ldloc.0
+			IL_030c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0311: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0316: ldarg.0
+			IL_0317: ldc.i4.1
+			IL_0318: newarr [System.Runtime]System.Object
+			IL_031d: dup
+			IL_031e: ldc.i4.0
+			IL_031f: ldloc.s 7
+			IL_0321: stelem.ref
+			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0327: pop
+			IL_0328: ldloc.0
+			IL_0329: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_032e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0333: ret
 
-			IL_0343: ldnull
-			IL_0344: stloc.s 8
-			IL_0346: ldloc.1
-			IL_0347: ldstr "id"
-			IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0351: stloc.s 22
-			IL_0353: ldloc.s 22
-			IL_0355: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_035a: stloc.s 23
-			IL_035c: ldloc.s 23
-			IL_035e: brtrue IL_036f
+			IL_0334: ldnull
+			IL_0335: stloc.s 8
+			IL_0337: ldloc.1
+			IL_0338: ldstr "id"
+			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0342: stloc.s 22
+			IL_0344: ldloc.s 22
+			IL_0346: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_034b: stloc.s 23
+			IL_034d: ldloc.s 23
+			IL_034f: brtrue IL_0360
 
-			IL_0363: ldstr ""
-			IL_0368: stloc.s 25
-			IL_036a: br IL_0373
+			IL_0354: ldstr ""
+			IL_0359: stloc.s 25
+			IL_035b: br IL_0364
 
-			IL_036f: ldloc.s 22
-			IL_0371: stloc.s 25
+			IL_0360: ldloc.s 22
+			IL_0362: stloc.s 25
 
-			IL_0373: ldloc.s 25
-			IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_037a: stloc.s 22
-			IL_037c: ldloc.s 22
-			IL_037e: castclass [System.Runtime]System.String
-			IL_0383: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0388: stloc.s 26
-			IL_038a: ldloc.s 26
-			IL_038c: stloc.s 9
-			IL_038e: ldstr ""
-			IL_0393: stloc.s 10
-			IL_0395: ldloc.1
-			IL_0396: ldstr "auto"
-			IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03a0: stloc.s 22
-			IL_03a2: ldloc.s 22
-			IL_03a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03a9: stloc.s 23
-			IL_03ab: ldloc.s 23
-			IL_03ad: brfalse IL_07a5
+			IL_0364: ldloc.s 25
+			IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_036b: stloc.s 22
+			IL_036d: ldloc.s 22
+			IL_036f: castclass [System.Runtime]System.String
+			IL_0374: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0379: stloc.s 26
+			IL_037b: ldloc.s 26
+			IL_037d: stloc.s 9
+			IL_037f: ldstr ""
+			IL_0384: stloc.s 10
+			IL_0386: ldloc.1
+			IL_0387: ldstr "auto"
+			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0391: stloc.s 22
+			IL_0393: ldloc.s 22
+			IL_0395: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_039a: stloc.s 23
+			IL_039c: ldloc.s 23
+			IL_039e: brfalse IL_0791
 
-			IL_03b2: ldloc.1
-			IL_03b3: ldstr "indexUrl"
-			IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03bd: stloc.s 22
-			IL_03bf: ldloc.s 22
-			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03c6: stloc.s 22
-			IL_03c8: ldloc.s 22
-			IL_03ca: ldstr "trim"
-			IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_03d4: stloc.s 11
-			IL_03d6: ldarg.0
-			IL_03d7: ldc.i4.1
-			IL_03d8: ldelem.ref
-			IL_03d9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_03de: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_03e3: ldc.i4.1
-			IL_03e4: newarr [System.Runtime]System.Object
-			IL_03e9: dup
-			IL_03ea: ldc.i4.0
-			IL_03eb: ldarg.0
-			IL_03ec: ldc.i4.1
-			IL_03ed: ldelem.ref
-			IL_03ee: stelem.ref
-			IL_03ef: stloc.s 21
-			IL_03f1: ldloc.s 21
-			IL_03f3: ldloc.s 11
-			IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_03fa: stloc.s 22
-			IL_03fc: ldloc.0
-			IL_03fd: ldc.i4.1
-			IL_03fe: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0403: ldloc.0
-			IL_0404: ldloc.s 22
-			IL_0406: ldarg.0
-			IL_0407: ldc.i4.1
-			IL_0408: ldloc.0
-			IL_0409: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_040e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0413: ldloc.0
-			IL_0414: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0419: dup
-			IL_041a: ldc.i4.0
-			IL_041b: ldloc.1
-			IL_041c: stelem.ref
-			IL_041d: dup
-			IL_041e: ldc.i4.1
-			IL_041f: ldloc.2
-			IL_0420: stelem.ref
-			IL_0421: dup
-			IL_0422: ldc.i4.2
-			IL_0423: ldloc.3
+			IL_03a3: ldloc.1
+			IL_03a4: ldstr "indexUrl"
+			IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03ae: stloc.s 22
+			IL_03b0: ldloc.s 22
+			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03b7: stloc.s 22
+			IL_03b9: ldloc.s 22
+			IL_03bb: ldstr "trim"
+			IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_03c5: stloc.s 11
+			IL_03c7: ldarg.0
+			IL_03c8: ldc.i4.1
+			IL_03c9: ldelem.ref
+			IL_03ca: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_03cf: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_03d4: ldc.i4.1
+			IL_03d5: newarr [System.Runtime]System.Object
+			IL_03da: dup
+			IL_03db: ldc.i4.0
+			IL_03dc: ldarg.0
+			IL_03dd: ldc.i4.1
+			IL_03de: ldelem.ref
+			IL_03df: stelem.ref
+			IL_03e0: stloc.s 21
+			IL_03e2: ldloc.s 21
+			IL_03e4: ldloc.s 11
+			IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_03eb: stloc.s 22
+			IL_03ed: ldloc.0
+			IL_03ee: ldc.i4.1
+			IL_03ef: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03f4: ldloc.0
+			IL_03f5: ldloc.s 22
+			IL_03f7: ldarg.0
+			IL_03f8: ldc.i4.1
+			IL_03f9: ldloc.0
+			IL_03fa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0404: ldloc.0
+			IL_0405: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_040a: dup
+			IL_040b: ldc.i4.0
+			IL_040c: ldloc.1
+			IL_040d: stelem.ref
+			IL_040e: dup
+			IL_040f: ldc.i4.1
+			IL_0410: ldloc.2
+			IL_0411: stelem.ref
+			IL_0412: dup
+			IL_0413: ldc.i4.2
+			IL_0414: ldloc.3
+			IL_0415: stelem.ref
+			IL_0416: dup
+			IL_0417: ldc.i4.3
+			IL_0418: ldloc.s 4
+			IL_041a: stelem.ref
+			IL_041b: dup
+			IL_041c: ldc.i4.4
+			IL_041d: ldloc.s 5
+			IL_041f: stelem.ref
+			IL_0420: dup
+			IL_0421: ldc.i4.5
+			IL_0422: ldloc.s 6
 			IL_0424: stelem.ref
 			IL_0425: dup
-			IL_0426: ldc.i4.3
-			IL_0427: ldloc.s 4
+			IL_0426: ldc.i4.6
+			IL_0427: ldloc.s 7
 			IL_0429: stelem.ref
 			IL_042a: dup
-			IL_042b: ldc.i4.4
-			IL_042c: ldloc.s 5
+			IL_042b: ldc.i4.7
+			IL_042c: ldloc.s 8
 			IL_042e: stelem.ref
 			IL_042f: dup
-			IL_0430: ldc.i4.5
-			IL_0431: ldloc.s 6
+			IL_0430: ldc.i4.8
+			IL_0431: ldloc.s 9
 			IL_0433: stelem.ref
 			IL_0434: dup
-			IL_0435: ldc.i4.6
-			IL_0436: ldloc.s 7
-			IL_0438: stelem.ref
-			IL_0439: dup
-			IL_043a: ldc.i4.7
-			IL_043b: ldloc.s 8
-			IL_043d: stelem.ref
-			IL_043e: dup
-			IL_043f: ldc.i4.8
-			IL_0440: ldloc.s 9
-			IL_0442: stelem.ref
-			IL_0443: dup
-			IL_0444: ldc.i4.s 9
-			IL_0446: ldloc.s 10
-			IL_0448: stelem.ref
-			IL_0449: dup
-			IL_044a: ldc.i4.s 10
-			IL_044c: ldloc.s 11
-			IL_044e: stelem.ref
-			IL_044f: dup
-			IL_0450: ldc.i4.s 11
-			IL_0452: ldloc.s 12
-			IL_0454: stelem.ref
-			IL_0455: dup
-			IL_0456: ldc.i4.s 12
-			IL_0458: ldloc.s 13
-			IL_045a: stelem.ref
-			IL_045b: dup
-			IL_045c: ldc.i4.s 13
-			IL_045e: ldloc.s 14
-			IL_0460: stelem.ref
-			IL_0461: dup
-			IL_0462: ldc.i4.s 14
-			IL_0464: ldloc.s 15
-			IL_0466: stelem.ref
-			IL_0467: dup
-			IL_0468: ldc.i4.s 15
-			IL_046a: ldloc.s 16
-			IL_046c: stelem.ref
-			IL_046d: dup
-			IL_046e: ldc.i4.s 16
-			IL_0470: ldloc.s 17
-			IL_0472: stelem.ref
-			IL_0473: dup
-			IL_0474: ldc.i4.s 17
-			IL_0476: ldloc.s 18
-			IL_0478: stelem.ref
-			IL_0479: dup
-			IL_047a: ldc.i4.s 18
-			IL_047c: ldloc.s 19
-			IL_047e: stelem.ref
-			IL_047f: dup
-			IL_0480: ldc.i4.s 19
-			IL_0482: ldloc.s 20
-			IL_0484: stelem.ref
-			IL_0485: dup
-			IL_0486: ldc.i4.s 20
-			IL_0488: ldloc.s 21
-			IL_048a: stelem.ref
-			IL_048b: dup
-			IL_048c: ldc.i4.s 21
-			IL_048e: ldloc.s 22
-			IL_0490: stelem.ref
-			IL_0491: dup
-			IL_0492: ldc.i4.s 22
-			IL_0494: ldloc.s 23
-			IL_0496: box [System.Runtime]System.Boolean
-			IL_049b: stelem.ref
-			IL_049c: dup
-			IL_049d: ldc.i4.s 23
-			IL_049f: ldloc.s 24
-			IL_04a1: stelem.ref
-			IL_04a2: dup
-			IL_04a3: ldc.i4.s 24
-			IL_04a5: ldloc.s 25
-			IL_04a7: stelem.ref
-			IL_04a8: dup
-			IL_04a9: ldc.i4.s 25
-			IL_04ab: ldloc.s 26
-			IL_04ad: stelem.ref
-			IL_04ae: dup
-			IL_04af: ldc.i4.s 26
-			IL_04b1: ldloc.s 27
-			IL_04b3: stelem.ref
-			IL_04b4: dup
-			IL_04b5: ldc.i4.s 27
-			IL_04b7: ldloc.s 28
-			IL_04b9: stelem.ref
-			IL_04ba: dup
-			IL_04bb: ldc.i4.s 28
-			IL_04bd: ldloc.s 29
-			IL_04bf: stelem.ref
-			IL_04c0: dup
-			IL_04c1: ldc.i4.s 29
-			IL_04c3: ldloc.s 30
-			IL_04c5: stelem.ref
-			IL_04c6: dup
-			IL_04c7: ldc.i4.s 30
-			IL_04c9: ldloc.s 31
-			IL_04cb: stelem.ref
-			IL_04cc: dup
-			IL_04cd: ldc.i4.s 31
-			IL_04cf: ldloc.s 32
-			IL_04d1: stelem.ref
-			IL_04d2: pop
-			IL_04d3: ldloc.0
-			IL_04d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04d9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04de: ret
+			IL_0435: ldc.i4.s 9
+			IL_0437: ldloc.s 10
+			IL_0439: stelem.ref
+			IL_043a: dup
+			IL_043b: ldc.i4.s 10
+			IL_043d: ldloc.s 11
+			IL_043f: stelem.ref
+			IL_0440: dup
+			IL_0441: ldc.i4.s 11
+			IL_0443: ldloc.s 12
+			IL_0445: stelem.ref
+			IL_0446: dup
+			IL_0447: ldc.i4.s 12
+			IL_0449: ldloc.s 13
+			IL_044b: stelem.ref
+			IL_044c: dup
+			IL_044d: ldc.i4.s 13
+			IL_044f: ldloc.s 14
+			IL_0451: stelem.ref
+			IL_0452: dup
+			IL_0453: ldc.i4.s 14
+			IL_0455: ldloc.s 15
+			IL_0457: stelem.ref
+			IL_0458: dup
+			IL_0459: ldc.i4.s 15
+			IL_045b: ldloc.s 16
+			IL_045d: stelem.ref
+			IL_045e: dup
+			IL_045f: ldc.i4.s 16
+			IL_0461: ldloc.s 17
+			IL_0463: stelem.ref
+			IL_0464: dup
+			IL_0465: ldc.i4.s 17
+			IL_0467: ldloc.s 18
+			IL_0469: stelem.ref
+			IL_046a: dup
+			IL_046b: ldc.i4.s 18
+			IL_046d: ldloc.s 19
+			IL_046f: stelem.ref
+			IL_0470: dup
+			IL_0471: ldc.i4.s 19
+			IL_0473: ldloc.s 20
+			IL_0475: stelem.ref
+			IL_0476: dup
+			IL_0477: ldc.i4.s 20
+			IL_0479: ldloc.s 21
+			IL_047b: stelem.ref
+			IL_047c: dup
+			IL_047d: ldc.i4.s 21
+			IL_047f: ldloc.s 22
+			IL_0481: stelem.ref
+			IL_0482: dup
+			IL_0483: ldc.i4.s 22
+			IL_0485: ldloc.s 23
+			IL_0487: box [System.Runtime]System.Boolean
+			IL_048c: stelem.ref
+			IL_048d: dup
+			IL_048e: ldc.i4.s 23
+			IL_0490: ldloc.s 24
+			IL_0492: stelem.ref
+			IL_0493: dup
+			IL_0494: ldc.i4.s 24
+			IL_0496: ldloc.s 25
+			IL_0498: stelem.ref
+			IL_0499: dup
+			IL_049a: ldc.i4.s 25
+			IL_049c: ldloc.s 26
+			IL_049e: stelem.ref
+			IL_049f: dup
+			IL_04a0: ldc.i4.s 26
+			IL_04a2: ldloc.s 27
+			IL_04a4: stelem.ref
+			IL_04a5: dup
+			IL_04a6: ldc.i4.s 27
+			IL_04a8: ldloc.s 28
+			IL_04aa: stelem.ref
+			IL_04ab: dup
+			IL_04ac: ldc.i4.s 28
+			IL_04ae: ldloc.s 29
+			IL_04b0: stelem.ref
+			IL_04b1: dup
+			IL_04b2: ldc.i4.s 29
+			IL_04b4: ldloc.s 30
+			IL_04b6: stelem.ref
+			IL_04b7: dup
+			IL_04b8: ldc.i4.s 30
+			IL_04ba: ldloc.s 31
+			IL_04bc: stelem.ref
+			IL_04bd: dup
+			IL_04be: ldc.i4.s 31
+			IL_04c0: ldloc.s 32
+			IL_04c2: stelem.ref
+			IL_04c3: pop
+			IL_04c4: ldloc.0
+			IL_04c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04ca: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04cf: ret
 
-			IL_04df: ldloc.0
-			IL_04e0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_04e5: stloc.s 12
-			IL_04e7: ldarg.0
-			IL_04e8: ldc.i4.1
-			IL_04e9: ldelem.ref
-			IL_04ea: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_04ef: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
-			IL_04f4: ldc.i4.1
-			IL_04f5: newarr [System.Runtime]System.Object
-			IL_04fa: dup
-			IL_04fb: ldc.i4.0
-			IL_04fc: ldarg.0
-			IL_04fd: ldc.i4.1
-			IL_04fe: ldelem.ref
-			IL_04ff: stelem.ref
-			IL_0500: stloc.s 21
-			IL_0502: ldloc.1
-			IL_0503: ldstr "section"
-			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_050d: stloc.s 22
-			IL_050f: ldloc.s 22
-			IL_0511: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0516: stloc.s 22
-			IL_0518: ldloc.s 22
-			IL_051a: ldstr "trim"
-			IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0524: stloc.s 22
-			IL_0526: ldloc.s 21
-			IL_0528: ldloc.s 12
-			IL_052a: ldloc.s 22
-			IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0531: stloc.s 13
-			IL_0533: ldloc.s 13
-			IL_0535: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_053a: ldc.i4.0
-			IL_053b: ceq
-			IL_053d: stloc.s 23
-			IL_053f: ldloc.s 23
-			IL_0541: brfalse IL_05c2
+			IL_04d0: ldloc.0
+			IL_04d1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_04d6: stloc.s 12
+			IL_04d8: ldarg.0
+			IL_04d9: ldc.i4.1
+			IL_04da: ldelem.ref
+			IL_04db: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_04e0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+			IL_04e5: ldc.i4.1
+			IL_04e6: newarr [System.Runtime]System.Object
+			IL_04eb: dup
+			IL_04ec: ldc.i4.0
+			IL_04ed: ldarg.0
+			IL_04ee: ldc.i4.1
+			IL_04ef: ldelem.ref
+			IL_04f0: stelem.ref
+			IL_04f1: stloc.s 21
+			IL_04f3: ldloc.1
+			IL_04f4: ldstr "section"
+			IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04fe: stloc.s 22
+			IL_0500: ldloc.s 22
+			IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0507: stloc.s 22
+			IL_0509: ldloc.s 22
+			IL_050b: ldstr "trim"
+			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0515: stloc.s 22
+			IL_0517: ldloc.s 21
+			IL_0519: ldloc.s 12
+			IL_051b: ldloc.s 22
+			IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0522: stloc.s 13
+			IL_0524: ldloc.s 13
+			IL_0526: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_052b: ldc.i4.0
+			IL_052c: ceq
+			IL_052e: stloc.s 23
+			IL_0530: ldloc.s 23
+			IL_0532: brfalse IL_05ae
 
-			IL_0546: ldloc.1
-			IL_0547: ldstr "section"
-			IL_054c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0551: stloc.s 22
-			IL_0553: ldloc.s 22
-			IL_0555: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_055a: stloc.s 26
-			IL_055c: ldstr "Could not find section '"
-			IL_0561: ldloc.s 26
-			IL_0563: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0568: ldstr "' in multipage index: "
-			IL_056d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0572: ldloc.s 11
-			IL_0574: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0579: stloc.s 26
-			IL_057b: ldloc.s 26
-			IL_057d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0582: stloc.s 26
-			IL_0584: ldloc.s 26
-			IL_0586: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_058b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0590: stloc.s 14
-			IL_0592: ldloc.0
-			IL_0593: ldc.i4.m1
-			IL_0594: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0599: ldloc.0
-			IL_059a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_059f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_05a4: ldarg.0
-			IL_05a5: ldc.i4.1
-			IL_05a6: newarr [System.Runtime]System.Object
-			IL_05ab: dup
-			IL_05ac: ldc.i4.0
-			IL_05ad: ldloc.s 14
-			IL_05af: stelem.ref
-			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05b5: pop
-			IL_05b6: ldloc.0
-			IL_05b7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05bc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05c1: ret
+			IL_0537: ldloc.1
+			IL_0538: ldstr "section"
+			IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0542: stloc.s 22
+			IL_0544: ldloc.s 22
+			IL_0546: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_054b: stloc.s 26
+			IL_054d: ldstr "Could not find section '"
+			IL_0552: ldloc.s 26
+			IL_0554: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0559: ldstr "' in multipage index: "
+			IL_055e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0563: ldloc.s 11
+			IL_0565: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_056a: stloc.s 26
+			IL_056c: ldloc.s 26
+			IL_056e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0573: stloc.s 26
+			IL_0575: ldloc.s 26
+			IL_0577: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_057c: stloc.s 14
+			IL_057e: ldloc.0
+			IL_057f: ldc.i4.m1
+			IL_0580: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0585: ldloc.0
+			IL_0586: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_058b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0590: ldarg.0
+			IL_0591: ldc.i4.1
+			IL_0592: newarr [System.Runtime]System.Object
+			IL_0597: dup
+			IL_0598: ldc.i4.0
+			IL_0599: ldloc.s 14
+			IL_059b: stelem.ref
+			IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_05a1: pop
+			IL_05a2: ldloc.0
+			IL_05a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05a8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05ad: ret
 
-			IL_05c2: ldarg.0
-			IL_05c3: ldc.i4.1
-			IL_05c4: ldelem.ref
-			IL_05c5: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_05ca: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_05cf: stloc.s 22
-			IL_05d1: ldloc.s 13
-			IL_05d3: ldstr "filePart"
-			IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05dd: stloc.s 27
-			IL_05df: ldloc.s 27
-			IL_05e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05e6: stloc.s 23
-			IL_05e8: ldloc.s 23
-			IL_05ea: brtrue IL_0606
+			IL_05ae: ldarg.0
+			IL_05af: ldc.i4.1
+			IL_05b0: ldelem.ref
+			IL_05b1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_05b6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_05bb: stloc.s 22
+			IL_05bd: ldloc.s 13
+			IL_05bf: ldstr "filePart"
+			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05c9: stloc.s 27
+			IL_05cb: ldloc.s 27
+			IL_05cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05d2: stloc.s 23
+			IL_05d4: ldloc.s 23
+			IL_05d6: brtrue IL_05f2
 
-			IL_05ef: ldloc.s 13
-			IL_05f1: ldstr "href"
-			IL_05f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05fb: stloc.s 28
-			IL_05fd: ldloc.s 28
-			IL_05ff: stloc.s 29
-			IL_0601: br IL_060a
+			IL_05db: ldloc.s 13
+			IL_05dd: ldstr "href"
+			IL_05e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05e7: stloc.s 28
+			IL_05e9: ldloc.s 28
+			IL_05eb: stloc.s 29
+			IL_05ed: br IL_05f6
 
-			IL_0606: ldloc.s 27
-			IL_0608: stloc.s 29
+			IL_05f2: ldloc.s 27
+			IL_05f4: stloc.s 29
 
-			IL_060a: ldc.i4.2
-			IL_060b: newarr [System.Runtime]System.Object
-			IL_0610: dup
-			IL_0611: ldc.i4.0
-			IL_0612: ldloc.s 29
-			IL_0614: stelem.ref
-			IL_0615: dup
-			IL_0616: ldc.i4.1
-			IL_0617: ldloc.s 11
-			IL_0619: stelem.ref
-			IL_061a: stloc.s 21
+			IL_05f6: ldc.i4.2
+			IL_05f7: newarr [System.Runtime]System.Object
+			IL_05fc: dup
+			IL_05fd: ldc.i4.0
+			IL_05fe: ldloc.s 29
+			IL_0600: stelem.ref
+			IL_0601: dup
+			IL_0602: ldc.i4.1
+			IL_0603: ldloc.s 11
+			IL_0605: stelem.ref
+			IL_0606: stloc.s 21
+			IL_0608: ldloc.s 22
+			IL_060a: ldloc.s 21
+			IL_060c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+			IL_0611: stloc.s 22
+			IL_0613: ldloc.s 22
+			IL_0615: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_061a: stloc.s 22
 			IL_061c: ldloc.s 22
-			IL_061e: ldloc.s 21
-			IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-			IL_0625: stloc.s 22
-			IL_0627: ldloc.s 22
-			IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_062e: stloc.s 22
-			IL_0630: ldloc.s 22
-			IL_0632: ldstr "toString"
-			IL_0637: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_063c: stloc.s 15
-			IL_063e: ldarg.0
-			IL_063f: ldc.i4.1
-			IL_0640: ldelem.ref
-			IL_0641: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0646: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_064b: ldc.i4.1
-			IL_064c: newarr [System.Runtime]System.Object
-			IL_0651: dup
-			IL_0652: ldc.i4.0
-			IL_0653: ldarg.0
-			IL_0654: ldc.i4.1
-			IL_0655: ldelem.ref
-			IL_0656: stelem.ref
-			IL_0657: stloc.s 21
-			IL_0659: ldloc.s 21
-			IL_065b: ldloc.s 15
-			IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0662: stloc.s 22
-			IL_0664: ldloc.0
-			IL_0665: ldc.i4.2
-			IL_0666: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_066b: ldloc.0
-			IL_066c: ldloc.s 22
-			IL_066e: ldarg.0
-			IL_066f: ldc.i4.2
-			IL_0670: ldloc.0
-			IL_0671: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0676: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_067b: ldloc.0
-			IL_067c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0681: dup
-			IL_0682: ldc.i4.0
-			IL_0683: ldloc.1
-			IL_0684: stelem.ref
-			IL_0685: dup
-			IL_0686: ldc.i4.1
-			IL_0687: ldloc.2
-			IL_0688: stelem.ref
-			IL_0689: dup
-			IL_068a: ldc.i4.2
-			IL_068b: ldloc.3
+			IL_061e: ldstr "toString"
+			IL_0623: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0628: stloc.s 15
+			IL_062a: ldarg.0
+			IL_062b: ldc.i4.1
+			IL_062c: ldelem.ref
+			IL_062d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0632: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_0637: ldc.i4.1
+			IL_0638: newarr [System.Runtime]System.Object
+			IL_063d: dup
+			IL_063e: ldc.i4.0
+			IL_063f: ldarg.0
+			IL_0640: ldc.i4.1
+			IL_0641: ldelem.ref
+			IL_0642: stelem.ref
+			IL_0643: stloc.s 21
+			IL_0645: ldloc.s 21
+			IL_0647: ldloc.s 15
+			IL_0649: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_064e: stloc.s 22
+			IL_0650: ldloc.0
+			IL_0651: ldc.i4.2
+			IL_0652: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0657: ldloc.0
+			IL_0658: ldloc.s 22
+			IL_065a: ldarg.0
+			IL_065b: ldc.i4.2
+			IL_065c: ldloc.0
+			IL_065d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0662: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0667: ldloc.0
+			IL_0668: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_066d: dup
+			IL_066e: ldc.i4.0
+			IL_066f: ldloc.1
+			IL_0670: stelem.ref
+			IL_0671: dup
+			IL_0672: ldc.i4.1
+			IL_0673: ldloc.2
+			IL_0674: stelem.ref
+			IL_0675: dup
+			IL_0676: ldc.i4.2
+			IL_0677: ldloc.3
+			IL_0678: stelem.ref
+			IL_0679: dup
+			IL_067a: ldc.i4.3
+			IL_067b: ldloc.s 4
+			IL_067d: stelem.ref
+			IL_067e: dup
+			IL_067f: ldc.i4.4
+			IL_0680: ldloc.s 5
+			IL_0682: stelem.ref
+			IL_0683: dup
+			IL_0684: ldc.i4.5
+			IL_0685: ldloc.s 6
+			IL_0687: stelem.ref
+			IL_0688: dup
+			IL_0689: ldc.i4.6
+			IL_068a: ldloc.s 7
 			IL_068c: stelem.ref
 			IL_068d: dup
-			IL_068e: ldc.i4.3
-			IL_068f: ldloc.s 4
+			IL_068e: ldc.i4.7
+			IL_068f: ldloc.s 8
 			IL_0691: stelem.ref
 			IL_0692: dup
-			IL_0693: ldc.i4.4
-			IL_0694: ldloc.s 5
+			IL_0693: ldc.i4.8
+			IL_0694: ldloc.s 9
 			IL_0696: stelem.ref
 			IL_0697: dup
-			IL_0698: ldc.i4.5
-			IL_0699: ldloc.s 6
-			IL_069b: stelem.ref
-			IL_069c: dup
-			IL_069d: ldc.i4.6
-			IL_069e: ldloc.s 7
-			IL_06a0: stelem.ref
-			IL_06a1: dup
-			IL_06a2: ldc.i4.7
-			IL_06a3: ldloc.s 8
-			IL_06a5: stelem.ref
-			IL_06a6: dup
-			IL_06a7: ldc.i4.8
-			IL_06a8: ldloc.s 9
-			IL_06aa: stelem.ref
-			IL_06ab: dup
-			IL_06ac: ldc.i4.s 9
-			IL_06ae: ldloc.s 10
-			IL_06b0: stelem.ref
-			IL_06b1: dup
-			IL_06b2: ldc.i4.s 10
-			IL_06b4: ldloc.s 11
-			IL_06b6: stelem.ref
-			IL_06b7: dup
-			IL_06b8: ldc.i4.s 11
-			IL_06ba: ldloc.s 12
-			IL_06bc: stelem.ref
-			IL_06bd: dup
-			IL_06be: ldc.i4.s 12
-			IL_06c0: ldloc.s 13
-			IL_06c2: stelem.ref
-			IL_06c3: dup
-			IL_06c4: ldc.i4.s 13
-			IL_06c6: ldloc.s 14
-			IL_06c8: stelem.ref
-			IL_06c9: dup
-			IL_06ca: ldc.i4.s 14
-			IL_06cc: ldloc.s 15
-			IL_06ce: stelem.ref
-			IL_06cf: dup
-			IL_06d0: ldc.i4.s 15
-			IL_06d2: ldloc.s 16
-			IL_06d4: stelem.ref
-			IL_06d5: dup
-			IL_06d6: ldc.i4.s 16
-			IL_06d8: ldloc.s 17
-			IL_06da: stelem.ref
-			IL_06db: dup
-			IL_06dc: ldc.i4.s 17
-			IL_06de: ldloc.s 18
-			IL_06e0: stelem.ref
-			IL_06e1: dup
-			IL_06e2: ldc.i4.s 18
-			IL_06e4: ldloc.s 19
-			IL_06e6: stelem.ref
-			IL_06e7: dup
-			IL_06e8: ldc.i4.s 19
-			IL_06ea: ldloc.s 20
-			IL_06ec: stelem.ref
-			IL_06ed: dup
-			IL_06ee: ldc.i4.s 20
-			IL_06f0: ldloc.s 21
-			IL_06f2: stelem.ref
-			IL_06f3: dup
-			IL_06f4: ldc.i4.s 21
-			IL_06f6: ldloc.s 22
-			IL_06f8: stelem.ref
-			IL_06f9: dup
-			IL_06fa: ldc.i4.s 22
-			IL_06fc: ldloc.s 23
-			IL_06fe: box [System.Runtime]System.Boolean
-			IL_0703: stelem.ref
-			IL_0704: dup
-			IL_0705: ldc.i4.s 23
-			IL_0707: ldloc.s 24
-			IL_0709: stelem.ref
-			IL_070a: dup
-			IL_070b: ldc.i4.s 24
-			IL_070d: ldloc.s 25
-			IL_070f: stelem.ref
-			IL_0710: dup
-			IL_0711: ldc.i4.s 25
-			IL_0713: ldloc.s 26
-			IL_0715: stelem.ref
-			IL_0716: dup
-			IL_0717: ldc.i4.s 26
-			IL_0719: ldloc.s 27
-			IL_071b: stelem.ref
-			IL_071c: dup
-			IL_071d: ldc.i4.s 27
-			IL_071f: ldloc.s 28
-			IL_0721: stelem.ref
-			IL_0722: dup
-			IL_0723: ldc.i4.s 28
-			IL_0725: ldloc.s 29
-			IL_0727: stelem.ref
-			IL_0728: dup
-			IL_0729: ldc.i4.s 29
-			IL_072b: ldloc.s 30
-			IL_072d: stelem.ref
-			IL_072e: dup
-			IL_072f: ldc.i4.s 30
-			IL_0731: ldloc.s 31
-			IL_0733: stelem.ref
-			IL_0734: dup
-			IL_0735: ldc.i4.s 31
-			IL_0737: ldloc.s 32
-			IL_0739: stelem.ref
-			IL_073a: pop
-			IL_073b: ldloc.0
-			IL_073c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0741: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0746: ret
+			IL_0698: ldc.i4.s 9
+			IL_069a: ldloc.s 10
+			IL_069c: stelem.ref
+			IL_069d: dup
+			IL_069e: ldc.i4.s 10
+			IL_06a0: ldloc.s 11
+			IL_06a2: stelem.ref
+			IL_06a3: dup
+			IL_06a4: ldc.i4.s 11
+			IL_06a6: ldloc.s 12
+			IL_06a8: stelem.ref
+			IL_06a9: dup
+			IL_06aa: ldc.i4.s 12
+			IL_06ac: ldloc.s 13
+			IL_06ae: stelem.ref
+			IL_06af: dup
+			IL_06b0: ldc.i4.s 13
+			IL_06b2: ldloc.s 14
+			IL_06b4: stelem.ref
+			IL_06b5: dup
+			IL_06b6: ldc.i4.s 14
+			IL_06b8: ldloc.s 15
+			IL_06ba: stelem.ref
+			IL_06bb: dup
+			IL_06bc: ldc.i4.s 15
+			IL_06be: ldloc.s 16
+			IL_06c0: stelem.ref
+			IL_06c1: dup
+			IL_06c2: ldc.i4.s 16
+			IL_06c4: ldloc.s 17
+			IL_06c6: stelem.ref
+			IL_06c7: dup
+			IL_06c8: ldc.i4.s 17
+			IL_06ca: ldloc.s 18
+			IL_06cc: stelem.ref
+			IL_06cd: dup
+			IL_06ce: ldc.i4.s 18
+			IL_06d0: ldloc.s 19
+			IL_06d2: stelem.ref
+			IL_06d3: dup
+			IL_06d4: ldc.i4.s 19
+			IL_06d6: ldloc.s 20
+			IL_06d8: stelem.ref
+			IL_06d9: dup
+			IL_06da: ldc.i4.s 20
+			IL_06dc: ldloc.s 21
+			IL_06de: stelem.ref
+			IL_06df: dup
+			IL_06e0: ldc.i4.s 21
+			IL_06e2: ldloc.s 22
+			IL_06e4: stelem.ref
+			IL_06e5: dup
+			IL_06e6: ldc.i4.s 22
+			IL_06e8: ldloc.s 23
+			IL_06ea: box [System.Runtime]System.Boolean
+			IL_06ef: stelem.ref
+			IL_06f0: dup
+			IL_06f1: ldc.i4.s 23
+			IL_06f3: ldloc.s 24
+			IL_06f5: stelem.ref
+			IL_06f6: dup
+			IL_06f7: ldc.i4.s 24
+			IL_06f9: ldloc.s 25
+			IL_06fb: stelem.ref
+			IL_06fc: dup
+			IL_06fd: ldc.i4.s 25
+			IL_06ff: ldloc.s 26
+			IL_0701: stelem.ref
+			IL_0702: dup
+			IL_0703: ldc.i4.s 26
+			IL_0705: ldloc.s 27
+			IL_0707: stelem.ref
+			IL_0708: dup
+			IL_0709: ldc.i4.s 27
+			IL_070b: ldloc.s 28
+			IL_070d: stelem.ref
+			IL_070e: dup
+			IL_070f: ldc.i4.s 28
+			IL_0711: ldloc.s 29
+			IL_0713: stelem.ref
+			IL_0714: dup
+			IL_0715: ldc.i4.s 29
+			IL_0717: ldloc.s 30
+			IL_0719: stelem.ref
+			IL_071a: dup
+			IL_071b: ldc.i4.s 30
+			IL_071d: ldloc.s 31
+			IL_071f: stelem.ref
+			IL_0720: dup
+			IL_0721: ldc.i4.s 31
+			IL_0723: ldloc.s 32
+			IL_0725: stelem.ref
+			IL_0726: pop
+			IL_0727: ldloc.0
+			IL_0728: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_072d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0732: ret
 
-			IL_0747: ldloc.0
-			IL_0748: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_074d: stloc.s 22
-			IL_074f: ldloc.s 22
-			IL_0751: stloc.s 8
-			IL_0753: ldloc.s 15
-			IL_0755: stloc.s 22
-			IL_0757: ldloc.s 22
-			IL_0759: stloc.s 10
-			IL_075b: ldloc.s 9
-			IL_075d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0762: ldc.i4.0
-			IL_0763: ceq
-			IL_0765: stloc.s 23
-			IL_0767: ldloc.s 23
-			IL_0769: brfalse IL_07a0
+			IL_0733: ldloc.0
+			IL_0734: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_0739: stloc.s 22
+			IL_073b: ldloc.s 22
+			IL_073d: stloc.s 8
+			IL_073f: ldloc.s 15
+			IL_0741: stloc.s 22
+			IL_0743: ldloc.s 22
+			IL_0745: stloc.s 10
+			IL_0747: ldloc.s 9
+			IL_0749: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_074e: ldc.i4.0
+			IL_074f: ceq
+			IL_0751: stloc.s 23
+			IL_0753: ldloc.s 23
+			IL_0755: brfalse IL_078c
 
-			IL_076e: ldloc.s 13
-			IL_0770: ldstr "fragment"
-			IL_0775: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_077a: stloc.s 22
-			IL_077c: ldloc.s 22
-			IL_077e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0783: stloc.s 23
-			IL_0785: ldloc.s 23
-			IL_0787: brtrue IL_0798
+			IL_075a: ldloc.s 13
+			IL_075c: ldstr "fragment"
+			IL_0761: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0766: stloc.s 22
+			IL_0768: ldloc.s 22
+			IL_076a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_076f: stloc.s 23
+			IL_0771: ldloc.s 23
+			IL_0773: brtrue IL_0784
 
-			IL_078c: ldstr ""
-			IL_0791: stloc.s 30
-			IL_0793: br IL_079c
+			IL_0778: ldstr ""
+			IL_077d: stloc.s 30
+			IL_077f: br IL_0788
 
-			IL_0798: ldloc.s 22
-			IL_079a: stloc.s 30
+			IL_0784: ldloc.s 22
+			IL_0786: stloc.s 30
 
-			IL_079c: ldloc.s 30
-			IL_079e: stloc.s 9
+			IL_0788: ldloc.s 30
+			IL_078a: stloc.s 9
 
-			IL_07a0: br IL_08e6
+			IL_078c: br IL_08d2
 
-			IL_07a5: ldloc.1
-			IL_07a6: ldstr "url"
-			IL_07ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07b0: stloc.s 22
-			IL_07b2: ldloc.s 22
-			IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07b9: stloc.s 22
-			IL_07bb: ldloc.s 22
-			IL_07bd: ldstr "trim"
-			IL_07c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_07c7: stloc.s 16
-			IL_07c9: ldarg.0
-			IL_07ca: ldc.i4.1
-			IL_07cb: ldelem.ref
-			IL_07cc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_07d1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_07d6: ldc.i4.1
-			IL_07d7: newarr [System.Runtime]System.Object
-			IL_07dc: dup
-			IL_07dd: ldc.i4.0
-			IL_07de: ldarg.0
-			IL_07df: ldc.i4.1
-			IL_07e0: ldelem.ref
-			IL_07e1: stelem.ref
-			IL_07e2: stloc.s 21
-			IL_07e4: ldloc.s 21
-			IL_07e6: ldloc.s 16
-			IL_07e8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_07ed: stloc.s 22
-			IL_07ef: ldloc.0
-			IL_07f0: ldc.i4.3
-			IL_07f1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07f6: ldloc.0
-			IL_07f7: ldloc.s 22
-			IL_07f9: ldarg.0
-			IL_07fa: ldc.i4.3
-			IL_07fb: ldloc.0
-			IL_07fc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0801: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0806: ldloc.0
-			IL_0807: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_080c: dup
-			IL_080d: ldc.i4.0
-			IL_080e: ldloc.1
-			IL_080f: stelem.ref
-			IL_0810: dup
-			IL_0811: ldc.i4.1
-			IL_0812: ldloc.2
-			IL_0813: stelem.ref
-			IL_0814: dup
-			IL_0815: ldc.i4.2
-			IL_0816: ldloc.3
+			IL_0791: ldloc.1
+			IL_0792: ldstr "url"
+			IL_0797: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_079c: stloc.s 22
+			IL_079e: ldloc.s 22
+			IL_07a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07a5: stloc.s 22
+			IL_07a7: ldloc.s 22
+			IL_07a9: ldstr "trim"
+			IL_07ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_07b3: stloc.s 16
+			IL_07b5: ldarg.0
+			IL_07b6: ldc.i4.1
+			IL_07b7: ldelem.ref
+			IL_07b8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_07bd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_07c2: ldc.i4.1
+			IL_07c3: newarr [System.Runtime]System.Object
+			IL_07c8: dup
+			IL_07c9: ldc.i4.0
+			IL_07ca: ldarg.0
+			IL_07cb: ldc.i4.1
+			IL_07cc: ldelem.ref
+			IL_07cd: stelem.ref
+			IL_07ce: stloc.s 21
+			IL_07d0: ldloc.s 21
+			IL_07d2: ldloc.s 16
+			IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_07d9: stloc.s 22
+			IL_07db: ldloc.0
+			IL_07dc: ldc.i4.3
+			IL_07dd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07e2: ldloc.0
+			IL_07e3: ldloc.s 22
+			IL_07e5: ldarg.0
+			IL_07e6: ldc.i4.3
+			IL_07e7: ldloc.0
+			IL_07e8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_07f2: ldloc.0
+			IL_07f3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_07f8: dup
+			IL_07f9: ldc.i4.0
+			IL_07fa: ldloc.1
+			IL_07fb: stelem.ref
+			IL_07fc: dup
+			IL_07fd: ldc.i4.1
+			IL_07fe: ldloc.2
+			IL_07ff: stelem.ref
+			IL_0800: dup
+			IL_0801: ldc.i4.2
+			IL_0802: ldloc.3
+			IL_0803: stelem.ref
+			IL_0804: dup
+			IL_0805: ldc.i4.3
+			IL_0806: ldloc.s 4
+			IL_0808: stelem.ref
+			IL_0809: dup
+			IL_080a: ldc.i4.4
+			IL_080b: ldloc.s 5
+			IL_080d: stelem.ref
+			IL_080e: dup
+			IL_080f: ldc.i4.5
+			IL_0810: ldloc.s 6
+			IL_0812: stelem.ref
+			IL_0813: dup
+			IL_0814: ldc.i4.6
+			IL_0815: ldloc.s 7
 			IL_0817: stelem.ref
 			IL_0818: dup
-			IL_0819: ldc.i4.3
-			IL_081a: ldloc.s 4
+			IL_0819: ldc.i4.7
+			IL_081a: ldloc.s 8
 			IL_081c: stelem.ref
 			IL_081d: dup
-			IL_081e: ldc.i4.4
-			IL_081f: ldloc.s 5
+			IL_081e: ldc.i4.8
+			IL_081f: ldloc.s 9
 			IL_0821: stelem.ref
 			IL_0822: dup
-			IL_0823: ldc.i4.5
-			IL_0824: ldloc.s 6
-			IL_0826: stelem.ref
-			IL_0827: dup
-			IL_0828: ldc.i4.6
-			IL_0829: ldloc.s 7
-			IL_082b: stelem.ref
-			IL_082c: dup
-			IL_082d: ldc.i4.7
-			IL_082e: ldloc.s 8
-			IL_0830: stelem.ref
-			IL_0831: dup
-			IL_0832: ldc.i4.8
-			IL_0833: ldloc.s 9
-			IL_0835: stelem.ref
-			IL_0836: dup
-			IL_0837: ldc.i4.s 9
-			IL_0839: ldloc.s 10
-			IL_083b: stelem.ref
-			IL_083c: dup
-			IL_083d: ldc.i4.s 10
-			IL_083f: ldloc.s 11
-			IL_0841: stelem.ref
-			IL_0842: dup
-			IL_0843: ldc.i4.s 11
-			IL_0845: ldloc.s 12
-			IL_0847: stelem.ref
-			IL_0848: dup
-			IL_0849: ldc.i4.s 12
-			IL_084b: ldloc.s 13
-			IL_084d: stelem.ref
-			IL_084e: dup
-			IL_084f: ldc.i4.s 13
-			IL_0851: ldloc.s 14
-			IL_0853: stelem.ref
-			IL_0854: dup
-			IL_0855: ldc.i4.s 14
-			IL_0857: ldloc.s 15
-			IL_0859: stelem.ref
-			IL_085a: dup
-			IL_085b: ldc.i4.s 15
-			IL_085d: ldloc.s 16
-			IL_085f: stelem.ref
-			IL_0860: dup
-			IL_0861: ldc.i4.s 16
-			IL_0863: ldloc.s 17
-			IL_0865: stelem.ref
-			IL_0866: dup
-			IL_0867: ldc.i4.s 17
-			IL_0869: ldloc.s 18
-			IL_086b: stelem.ref
-			IL_086c: dup
-			IL_086d: ldc.i4.s 18
-			IL_086f: ldloc.s 19
-			IL_0871: stelem.ref
-			IL_0872: dup
-			IL_0873: ldc.i4.s 19
-			IL_0875: ldloc.s 20
-			IL_0877: stelem.ref
-			IL_0878: dup
-			IL_0879: ldc.i4.s 20
-			IL_087b: ldloc.s 21
-			IL_087d: stelem.ref
-			IL_087e: dup
-			IL_087f: ldc.i4.s 21
-			IL_0881: ldloc.s 22
-			IL_0883: stelem.ref
-			IL_0884: dup
-			IL_0885: ldc.i4.s 22
-			IL_0887: ldloc.s 23
-			IL_0889: box [System.Runtime]System.Boolean
-			IL_088e: stelem.ref
-			IL_088f: dup
-			IL_0890: ldc.i4.s 23
-			IL_0892: ldloc.s 24
-			IL_0894: stelem.ref
-			IL_0895: dup
-			IL_0896: ldc.i4.s 24
-			IL_0898: ldloc.s 25
-			IL_089a: stelem.ref
-			IL_089b: dup
-			IL_089c: ldc.i4.s 25
-			IL_089e: ldloc.s 26
-			IL_08a0: stelem.ref
-			IL_08a1: dup
-			IL_08a2: ldc.i4.s 26
-			IL_08a4: ldloc.s 27
-			IL_08a6: stelem.ref
-			IL_08a7: dup
-			IL_08a8: ldc.i4.s 27
-			IL_08aa: ldloc.s 28
-			IL_08ac: stelem.ref
-			IL_08ad: dup
-			IL_08ae: ldc.i4.s 28
-			IL_08b0: ldloc.s 29
-			IL_08b2: stelem.ref
-			IL_08b3: dup
-			IL_08b4: ldc.i4.s 29
-			IL_08b6: ldloc.s 30
-			IL_08b8: stelem.ref
-			IL_08b9: dup
-			IL_08ba: ldc.i4.s 30
-			IL_08bc: ldloc.s 31
-			IL_08be: stelem.ref
-			IL_08bf: dup
-			IL_08c0: ldc.i4.s 31
-			IL_08c2: ldloc.s 32
-			IL_08c4: stelem.ref
-			IL_08c5: pop
-			IL_08c6: ldloc.0
-			IL_08c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08cc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08d1: ret
+			IL_0823: ldc.i4.s 9
+			IL_0825: ldloc.s 10
+			IL_0827: stelem.ref
+			IL_0828: dup
+			IL_0829: ldc.i4.s 10
+			IL_082b: ldloc.s 11
+			IL_082d: stelem.ref
+			IL_082e: dup
+			IL_082f: ldc.i4.s 11
+			IL_0831: ldloc.s 12
+			IL_0833: stelem.ref
+			IL_0834: dup
+			IL_0835: ldc.i4.s 12
+			IL_0837: ldloc.s 13
+			IL_0839: stelem.ref
+			IL_083a: dup
+			IL_083b: ldc.i4.s 13
+			IL_083d: ldloc.s 14
+			IL_083f: stelem.ref
+			IL_0840: dup
+			IL_0841: ldc.i4.s 14
+			IL_0843: ldloc.s 15
+			IL_0845: stelem.ref
+			IL_0846: dup
+			IL_0847: ldc.i4.s 15
+			IL_0849: ldloc.s 16
+			IL_084b: stelem.ref
+			IL_084c: dup
+			IL_084d: ldc.i4.s 16
+			IL_084f: ldloc.s 17
+			IL_0851: stelem.ref
+			IL_0852: dup
+			IL_0853: ldc.i4.s 17
+			IL_0855: ldloc.s 18
+			IL_0857: stelem.ref
+			IL_0858: dup
+			IL_0859: ldc.i4.s 18
+			IL_085b: ldloc.s 19
+			IL_085d: stelem.ref
+			IL_085e: dup
+			IL_085f: ldc.i4.s 19
+			IL_0861: ldloc.s 20
+			IL_0863: stelem.ref
+			IL_0864: dup
+			IL_0865: ldc.i4.s 20
+			IL_0867: ldloc.s 21
+			IL_0869: stelem.ref
+			IL_086a: dup
+			IL_086b: ldc.i4.s 21
+			IL_086d: ldloc.s 22
+			IL_086f: stelem.ref
+			IL_0870: dup
+			IL_0871: ldc.i4.s 22
+			IL_0873: ldloc.s 23
+			IL_0875: box [System.Runtime]System.Boolean
+			IL_087a: stelem.ref
+			IL_087b: dup
+			IL_087c: ldc.i4.s 23
+			IL_087e: ldloc.s 24
+			IL_0880: stelem.ref
+			IL_0881: dup
+			IL_0882: ldc.i4.s 24
+			IL_0884: ldloc.s 25
+			IL_0886: stelem.ref
+			IL_0887: dup
+			IL_0888: ldc.i4.s 25
+			IL_088a: ldloc.s 26
+			IL_088c: stelem.ref
+			IL_088d: dup
+			IL_088e: ldc.i4.s 26
+			IL_0890: ldloc.s 27
+			IL_0892: stelem.ref
+			IL_0893: dup
+			IL_0894: ldc.i4.s 27
+			IL_0896: ldloc.s 28
+			IL_0898: stelem.ref
+			IL_0899: dup
+			IL_089a: ldc.i4.s 28
+			IL_089c: ldloc.s 29
+			IL_089e: stelem.ref
+			IL_089f: dup
+			IL_08a0: ldc.i4.s 29
+			IL_08a2: ldloc.s 30
+			IL_08a4: stelem.ref
+			IL_08a5: dup
+			IL_08a6: ldc.i4.s 30
+			IL_08a8: ldloc.s 31
+			IL_08aa: stelem.ref
+			IL_08ab: dup
+			IL_08ac: ldc.i4.s 31
+			IL_08ae: ldloc.s 32
+			IL_08b0: stelem.ref
+			IL_08b1: pop
+			IL_08b2: ldloc.0
+			IL_08b3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08b8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08bd: ret
 
-			IL_08d2: ldloc.0
-			IL_08d3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_08d8: stloc.s 22
-			IL_08da: ldloc.s 22
-			IL_08dc: stloc.s 8
-			IL_08de: ldloc.s 16
-			IL_08e0: stloc.s 22
-			IL_08e2: ldloc.s 22
-			IL_08e4: stloc.s 10
+			IL_08be: ldloc.0
+			IL_08bf: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_08c4: stloc.s 22
+			IL_08c6: ldloc.s 22
+			IL_08c8: stloc.s 8
+			IL_08ca: ldloc.s 16
+			IL_08cc: stloc.s 22
+			IL_08ce: ldloc.s 22
+			IL_08d0: stloc.s 10
 
-			IL_08e6: ldloc.s 9
-			IL_08e8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_08ed: ldc.i4.0
-			IL_08ee: ceq
-			IL_08f0: stloc.s 23
-			IL_08f2: ldloc.s 23
-			IL_08f4: brfalse IL_0965
+			IL_08d2: ldloc.s 9
+			IL_08d4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08d9: ldc.i4.0
+			IL_08da: ceq
+			IL_08dc: stloc.s 23
+			IL_08de: ldloc.s 23
+			IL_08e0: brfalse IL_094c
 
-			IL_08f9: ldloc.1
-			IL_08fa: ldstr "section"
-			IL_08ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0904: stloc.s 22
-			IL_0906: ldloc.s 22
-			IL_0908: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_090d: stloc.s 26
-			IL_090f: ldstr "Could not infer an element id for section '"
-			IL_0914: ldloc.s 26
-			IL_0916: call string [System.Runtime]System.String::Concat(string, string)
-			IL_091b: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0920: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0925: stloc.s 26
-			IL_0927: ldloc.s 26
-			IL_0929: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_092e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0933: stloc.s 17
-			IL_0935: ldloc.0
-			IL_0936: ldc.i4.m1
-			IL_0937: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_093c: ldloc.0
-			IL_093d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0942: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0947: ldarg.0
-			IL_0948: ldc.i4.1
-			IL_0949: newarr [System.Runtime]System.Object
-			IL_094e: dup
-			IL_094f: ldc.i4.0
-			IL_0950: ldloc.s 17
-			IL_0952: stelem.ref
-			IL_0953: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0958: pop
-			IL_0959: ldloc.0
-			IL_095a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_095f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0964: ret
+			IL_08e5: ldloc.1
+			IL_08e6: ldstr "section"
+			IL_08eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08f0: stloc.s 22
+			IL_08f2: ldloc.s 22
+			IL_08f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08f9: stloc.s 26
+			IL_08fb: ldstr "Could not infer an element id for section '"
+			IL_0900: ldloc.s 26
+			IL_0902: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0907: ldstr "'. Try passing --id sec-... explicitly."
+			IL_090c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0911: stloc.s 26
+			IL_0913: ldloc.s 26
+			IL_0915: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_091a: stloc.s 17
+			IL_091c: ldloc.0
+			IL_091d: ldc.i4.m1
+			IL_091e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0923: ldloc.0
+			IL_0924: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0929: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_092e: ldarg.0
+			IL_092f: ldc.i4.1
+			IL_0930: newarr [System.Runtime]System.Object
+			IL_0935: dup
+			IL_0936: ldc.i4.0
+			IL_0937: ldloc.s 17
+			IL_0939: stelem.ref
+			IL_093a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_093f: pop
+			IL_0940: ldloc.0
+			IL_0941: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0946: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_094b: ret
 
-			IL_0965: ldarg.0
-			IL_0966: ldc.i4.1
-			IL_0967: ldelem.ref
-			IL_0968: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_096d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
-			IL_0972: ldc.i4.1
-			IL_0973: newarr [System.Runtime]System.Object
-			IL_0978: dup
-			IL_0979: ldc.i4.0
-			IL_097a: ldarg.0
-			IL_097b: ldc.i4.1
-			IL_097c: ldelem.ref
-			IL_097d: stelem.ref
-			IL_097e: stloc.s 21
-			IL_0980: ldloc.s 21
-			IL_0982: ldloc.s 8
-			IL_0984: ldloc.s 9
-			IL_0986: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_098b: stloc.s 18
-			IL_098d: ldarg.0
-			IL_098e: ldc.i4.1
-			IL_098f: ldelem.ref
-			IL_0990: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0995: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_099a: stloc.s 31
-			IL_099c: ldstr "process"
-			IL_09a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09a6: stloc.s 22
-			IL_09a8: ldloc.s 22
-			IL_09aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09af: stloc.s 22
-			IL_09b1: ldloc.s 22
-			IL_09b3: ldstr "cwd"
-			IL_09b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_09bd: stloc.s 22
-			IL_09bf: ldloc.1
-			IL_09c0: ldstr "outFile"
-			IL_09c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09ca: stloc.s 27
-			IL_09cc: ldloc.s 31
-			IL_09ce: ldc.i4.2
-			IL_09cf: newarr [System.Runtime]System.Object
-			IL_09d4: dup
-			IL_09d5: ldc.i4.0
-			IL_09d6: ldloc.s 22
-			IL_09d8: stelem.ref
-			IL_09d9: dup
-			IL_09da: ldc.i4.1
-			IL_09db: ldloc.s 27
-			IL_09dd: stelem.ref
-			IL_09de: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_09e3: stloc.s 19
-			IL_09e5: ldarg.0
-			IL_09e6: ldc.i4.1
-			IL_09e7: ldelem.ref
-			IL_09e8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_09ed: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_09f2: ldc.i4.1
-			IL_09f3: newarr [System.Runtime]System.Object
-			IL_09f8: dup
-			IL_09f9: ldc.i4.0
-			IL_09fa: ldarg.0
-			IL_09fb: ldc.i4.1
-			IL_09fc: ldelem.ref
-			IL_09fd: stelem.ref
-			IL_09fe: stloc.s 21
-			IL_0a00: ldloc.s 18
-			IL_0a02: ldstr "html"
-			IL_0a07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a0c: stloc.s 27
-			IL_0a0e: ldloc.1
-			IL_0a0f: ldstr "section"
-			IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a19: stloc.s 22
-			IL_0a1b: ldloc.s 22
-			IL_0a1d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a22: stloc.s 26
-			IL_0a24: ldstr "ECMA-262 "
-			IL_0a29: ldloc.s 26
-			IL_0a2b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a30: stloc.s 26
-			IL_0a32: ldloc.s 21
-			IL_0a34: ldloc.s 27
-			IL_0a36: ldloc.s 26
-			IL_0a38: ldloc.s 10
-			IL_0a3a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0a3f: stloc.s 20
-			IL_0a41: ldarg.0
-			IL_0a42: ldc.i4.1
-			IL_0a43: ldelem.ref
-			IL_0a44: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a49: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a4e: stloc.s 32
-			IL_0a50: ldloc.s 32
-			IL_0a52: ldloc.s 19
-			IL_0a54: ldloc.s 20
-			IL_0a56: ldstr "utf8"
-			IL_0a5b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0a60: ldstr "console"
-			IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a6a: stloc.s 27
-			IL_0a6c: ldloc.s 27
-			IL_0a6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a73: stloc.s 27
-			IL_0a75: ldarg.0
-			IL_0a76: ldc.i4.1
-			IL_0a77: ldelem.ref
-			IL_0a78: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a7d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0a82: ldc.i4.1
-			IL_0a83: newarr [System.Runtime]System.Object
-			IL_0a88: dup
-			IL_0a89: ldc.i4.0
-			IL_0a8a: ldarg.0
-			IL_0a8b: ldc.i4.1
-			IL_0a8c: ldelem.ref
-			IL_0a8d: stelem.ref
-			IL_0a8e: stloc.s 21
-			IL_0a90: ldloc.1
-			IL_0a91: ldstr "section"
-			IL_0a96: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a9b: stloc.s 22
-			IL_0a9d: ldloc.s 22
-			IL_0a9f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0aa4: stloc.s 26
-			IL_0aa6: ldstr "Extracted section "
-			IL_0aab: ldloc.s 26
-			IL_0aad: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ab2: ldstr " (id="
-			IL_0ab7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0abc: ldloc.s 9
-			IL_0abe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ac3: stloc.s 26
-			IL_0ac5: ldloc.s 26
-			IL_0ac7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0acc: ldstr ", tag="
-			IL_0ad1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ad6: ldloc.s 18
-			IL_0ad8: ldstr "tagName"
-			IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ae2: stloc.s 22
-			IL_0ae4: ldloc.s 22
-			IL_0ae6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0aeb: stloc.s 26
-			IL_0aed: ldloc.s 26
-			IL_0aef: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0af4: ldstr ") -> "
-			IL_0af9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0afe: ldloc.s 19
-			IL_0b00: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b05: stloc.s 26
-			IL_0b07: ldloc.s 26
-			IL_0b09: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b0e: stloc.s 26
-			IL_0b10: ldloc.s 21
-			IL_0b12: ldloc.s 26
-			IL_0b14: ldloc.s 19
-			IL_0b16: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b1b: stloc.s 22
-			IL_0b1d: ldloc.s 27
-			IL_0b1f: ldstr "log"
-			IL_0b24: ldloc.s 22
-			IL_0b26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0b2b: pop
-			IL_0b2c: ldstr "console"
-			IL_0b31: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b36: stloc.s 22
-			IL_0b38: ldloc.s 22
-			IL_0b3a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b3f: stloc.s 22
-			IL_0b41: ldarg.0
-			IL_0b42: ldc.i4.1
-			IL_0b43: ldelem.ref
-			IL_0b44: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b49: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0b4e: stloc.s 27
-			IL_0b50: ldc.i4.1
-			IL_0b51: newarr [System.Runtime]System.Object
-			IL_0b56: dup
-			IL_0b57: ldc.i4.0
-			IL_0b58: ldarg.0
-			IL_0b59: ldc.i4.1
-			IL_0b5a: ldelem.ref
-			IL_0b5b: stelem.ref
-			IL_0b5c: stloc.s 21
-			IL_0b5e: ldarg.0
-			IL_0b5f: ldc.i4.1
-			IL_0b60: ldelem.ref
-			IL_0b61: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b66: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0b6b: stloc.s 32
-			IL_0b6d: ldloc.s 32
-			IL_0b6f: ldloc.s 19
-			IL_0b71: ldstr "utf8"
-			IL_0b76: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0b7b: stloc.s 28
-			IL_0b7d: ldloc.s 27
-			IL_0b7f: ldloc.s 21
-			IL_0b81: ldloc.s 28
-			IL_0b83: ldloc.s 19
-			IL_0b85: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b8a: stloc.s 28
-			IL_0b8c: ldloc.s 22
-			IL_0b8e: ldstr "log"
-			IL_0b93: ldloc.s 28
-			IL_0b95: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0b9a: pop
-			IL_0b9b: ldloc.0
-			IL_0b9c: ldc.i4.m1
-			IL_0b9d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0ba2: ldloc.0
-			IL_0ba3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ba8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0bad: ldarg.0
-			IL_0bae: ldc.i4.1
-			IL_0baf: newarr [System.Runtime]System.Object
-			IL_0bb4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0bb9: pop
-			IL_0bba: ldloc.0
-			IL_0bbb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bc0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bc5: ret
+			IL_094c: ldarg.0
+			IL_094d: ldc.i4.1
+			IL_094e: ldelem.ref
+			IL_094f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0954: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+			IL_0959: ldc.i4.1
+			IL_095a: newarr [System.Runtime]System.Object
+			IL_095f: dup
+			IL_0960: ldc.i4.0
+			IL_0961: ldarg.0
+			IL_0962: ldc.i4.1
+			IL_0963: ldelem.ref
+			IL_0964: stelem.ref
+			IL_0965: stloc.s 21
+			IL_0967: ldloc.s 21
+			IL_0969: ldloc.s 8
+			IL_096b: ldloc.s 9
+			IL_096d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0972: stloc.s 18
+			IL_0974: ldarg.0
+			IL_0975: ldc.i4.1
+			IL_0976: ldelem.ref
+			IL_0977: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_097c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0981: stloc.s 31
+			IL_0983: ldstr "process"
+			IL_0988: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_098d: stloc.s 22
+			IL_098f: ldloc.s 22
+			IL_0991: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0996: stloc.s 22
+			IL_0998: ldloc.s 22
+			IL_099a: ldstr "cwd"
+			IL_099f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_09a4: stloc.s 22
+			IL_09a6: ldloc.1
+			IL_09a7: ldstr "outFile"
+			IL_09ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09b1: stloc.s 27
+			IL_09b3: ldloc.s 31
+			IL_09b5: ldc.i4.2
+			IL_09b6: newarr [System.Runtime]System.Object
+			IL_09bb: dup
+			IL_09bc: ldc.i4.0
+			IL_09bd: ldloc.s 22
+			IL_09bf: stelem.ref
+			IL_09c0: dup
+			IL_09c1: ldc.i4.1
+			IL_09c2: ldloc.s 27
+			IL_09c4: stelem.ref
+			IL_09c5: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_09ca: stloc.s 19
+			IL_09cc: ldarg.0
+			IL_09cd: ldc.i4.1
+			IL_09ce: ldelem.ref
+			IL_09cf: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_09d4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_09d9: ldc.i4.1
+			IL_09da: newarr [System.Runtime]System.Object
+			IL_09df: dup
+			IL_09e0: ldc.i4.0
+			IL_09e1: ldarg.0
+			IL_09e2: ldc.i4.1
+			IL_09e3: ldelem.ref
+			IL_09e4: stelem.ref
+			IL_09e5: stloc.s 21
+			IL_09e7: ldloc.s 18
+			IL_09e9: ldstr "html"
+			IL_09ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09f3: stloc.s 27
+			IL_09f5: ldloc.1
+			IL_09f6: ldstr "section"
+			IL_09fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a00: stloc.s 22
+			IL_0a02: ldloc.s 22
+			IL_0a04: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a09: stloc.s 26
+			IL_0a0b: ldstr "ECMA-262 "
+			IL_0a10: ldloc.s 26
+			IL_0a12: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a17: stloc.s 26
+			IL_0a19: ldloc.s 21
+			IL_0a1b: ldloc.s 27
+			IL_0a1d: ldloc.s 26
+			IL_0a1f: ldloc.s 10
+			IL_0a21: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0a26: stloc.s 20
+			IL_0a28: ldarg.0
+			IL_0a29: ldc.i4.1
+			IL_0a2a: ldelem.ref
+			IL_0a2b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a30: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0a35: stloc.s 32
+			IL_0a37: ldloc.s 32
+			IL_0a39: ldloc.s 19
+			IL_0a3b: ldloc.s 20
+			IL_0a3d: ldstr "utf8"
+			IL_0a42: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0a47: ldstr "console"
+			IL_0a4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a51: stloc.s 27
+			IL_0a53: ldloc.s 27
+			IL_0a55: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a5a: stloc.s 27
+			IL_0a5c: ldarg.0
+			IL_0a5d: ldc.i4.1
+			IL_0a5e: ldelem.ref
+			IL_0a5f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a64: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0a69: ldc.i4.1
+			IL_0a6a: newarr [System.Runtime]System.Object
+			IL_0a6f: dup
+			IL_0a70: ldc.i4.0
+			IL_0a71: ldarg.0
+			IL_0a72: ldc.i4.1
+			IL_0a73: ldelem.ref
+			IL_0a74: stelem.ref
+			IL_0a75: stloc.s 21
+			IL_0a77: ldloc.1
+			IL_0a78: ldstr "section"
+			IL_0a7d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a82: stloc.s 22
+			IL_0a84: ldloc.s 22
+			IL_0a86: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a8b: stloc.s 26
+			IL_0a8d: ldstr "Extracted section "
+			IL_0a92: ldloc.s 26
+			IL_0a94: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a99: ldstr " (id="
+			IL_0a9e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0aa3: ldloc.s 9
+			IL_0aa5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0aaa: stloc.s 26
+			IL_0aac: ldloc.s 26
+			IL_0aae: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ab3: ldstr ", tag="
+			IL_0ab8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0abd: ldloc.s 18
+			IL_0abf: ldstr "tagName"
+			IL_0ac4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ac9: stloc.s 22
+			IL_0acb: ldloc.s 22
+			IL_0acd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ad2: stloc.s 26
+			IL_0ad4: ldloc.s 26
+			IL_0ad6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0adb: ldstr ") -> "
+			IL_0ae0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ae5: ldloc.s 19
+			IL_0ae7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0aec: stloc.s 26
+			IL_0aee: ldloc.s 26
+			IL_0af0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0af5: stloc.s 26
+			IL_0af7: ldloc.s 21
+			IL_0af9: ldloc.s 26
+			IL_0afb: ldloc.s 19
+			IL_0afd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b02: stloc.s 22
+			IL_0b04: ldloc.s 27
+			IL_0b06: ldstr "log"
+			IL_0b0b: ldloc.s 22
+			IL_0b0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0b12: pop
+			IL_0b13: ldstr "console"
+			IL_0b18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b1d: stloc.s 22
+			IL_0b1f: ldloc.s 22
+			IL_0b21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b26: stloc.s 22
+			IL_0b28: ldarg.0
+			IL_0b29: ldc.i4.1
+			IL_0b2a: ldelem.ref
+			IL_0b2b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b30: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0b35: stloc.s 27
+			IL_0b37: ldc.i4.1
+			IL_0b38: newarr [System.Runtime]System.Object
+			IL_0b3d: dup
+			IL_0b3e: ldc.i4.0
+			IL_0b3f: ldarg.0
+			IL_0b40: ldc.i4.1
+			IL_0b41: ldelem.ref
+			IL_0b42: stelem.ref
+			IL_0b43: stloc.s 21
+			IL_0b45: ldarg.0
+			IL_0b46: ldc.i4.1
+			IL_0b47: ldelem.ref
+			IL_0b48: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b4d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0b52: stloc.s 32
+			IL_0b54: ldloc.s 32
+			IL_0b56: ldloc.s 19
+			IL_0b58: ldstr "utf8"
+			IL_0b5d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0b62: stloc.s 28
+			IL_0b64: ldloc.s 27
+			IL_0b66: ldloc.s 21
+			IL_0b68: ldloc.s 28
+			IL_0b6a: ldloc.s 19
+			IL_0b6c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b71: stloc.s 28
+			IL_0b73: ldloc.s 22
+			IL_0b75: ldstr "log"
+			IL_0b7a: ldloc.s 28
+			IL_0b7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0b81: pop
+			IL_0b82: ldloc.0
+			IL_0b83: ldc.i4.m1
+			IL_0b84: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b89: ldloc.0
+			IL_0b8a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b8f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0b94: ldarg.0
+			IL_0b95: ldc.i4.1
+			IL_0b96: newarr [System.Runtime]System.Object
+			IL_0b9b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0ba0: pop
+			IL_0ba1: ldloc.0
+			IL_0ba2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0ba7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0bac: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5371,7 +5359,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x456d
+			// Method begins at RVA 0x4535
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5627,7 +5615,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4738
+		// Method begins at RVA 0x4700
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x455b
+				// Method begins at RVA 0x4523
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4564
+				// Method begins at RVA 0x452c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -355,7 +355,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4552
+			// Method begins at RVA 0x451a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -470,7 +470,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x457f
+					// Method begins at RVA 0x4547
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -488,7 +488,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4576
+				// Method begins at RVA 0x453e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -633,7 +633,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4588
+				// Method begins at RVA 0x4550
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -661,7 +661,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45a3
+						// Method begins at RVA 0x456b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -681,7 +681,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45ac
+						// Method begins at RVA 0x4574
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -701,7 +701,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45b5
+						// Method begins at RVA 0x457d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -721,7 +721,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45be
+						// Method begins at RVA 0x4586
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -741,7 +741,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45c7
+						// Method begins at RVA 0x458f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -761,7 +761,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45d0
+						// Method begins at RVA 0x4598
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -779,7 +779,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x459a
+					// Method begins at RVA 0x4562
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -797,7 +797,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4591
+				// Method begins at RVA 0x4559
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1156,7 +1156,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x462a
+							// Method begins at RVA 0x45f2
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1181,7 +1181,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44cc
+						// Method begins at RVA 0x4494
 						// Header size: 12
 						// Code size: 38 (0x26)
 						.maxstack 8
@@ -1223,7 +1223,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4633
+							// Method begins at RVA 0x45fb
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1247,7 +1247,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4500
+						// Method begins at RVA 0x44c8
 						// Header size: 12
 						// Code size: 70 (0x46)
 						.maxstack 8
@@ -1326,7 +1326,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x4618
+								// Method begins at RVA 0x45e0
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1344,7 +1344,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x460f
+							// Method begins at RVA 0x45d7
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1364,7 +1364,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4621
+							// Method begins at RVA 0x45e9
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1386,7 +1386,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4606
+						// Method begins at RVA 0x45ce
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1411,9 +1411,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x4068
+					// Method begins at RVA 0x4038
 					// Header size: 12
-					// Code size: 1111 (0x457)
+					// Code size: 1101 (0x44d)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -1514,7 +1514,7 @@
 					IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00d0: stloc.s 5
 					IL_00d2: ldloc.s 5
-					IL_00d4: brfalse IL_0267
+					IL_00d4: brfalse IL_0262
 
 					IL_00d9: ldarg.0
 					IL_00da: ldc.i4.1
@@ -1526,7 +1526,7 @@
 					IL_00f4: cgt
 					IL_00f6: ldc.i4.0
 					IL_00f7: ceq
-					IL_00f9: brfalse IL_017a
+					IL_00f9: brfalse IL_0175
 
 					IL_00fe: ldarg.2
 					IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
@@ -1574,325 +1574,323 @@
 					IL_0157: call string [System.Runtime]System.String::Concat(string, string)
 					IL_015c: stloc.s 14
 					IL_015e: ldloc.s 14
-					IL_0160: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0165: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_016a: stloc.s 13
-					IL_016c: ldloc.s 4
-					IL_016e: ldloc.s 12
-					IL_0170: ldloc.s 13
-					IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0177: pop
-					IL_0178: ldnull
-					IL_0179: ret
+					IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0165: stloc.s 13
+					IL_0167: ldloc.s 4
+					IL_0169: ldloc.s 12
+					IL_016b: ldloc.s 13
+					IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0172: pop
+					IL_0173: ldnull
+					IL_0174: ret
 
-					IL_017a: ldarg.0
-					IL_017b: ldc.i4.0
-					IL_017c: ldelem.ref
-					IL_017d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0182: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-					IL_0187: stloc.s 13
-					IL_0189: ldarg.0
-					IL_018a: ldc.i4.2
-					IL_018b: ldelem.ref
-					IL_018c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0191: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_0196: stloc.s 4
-					IL_0198: ldloc.s 13
-					IL_019a: ldc.i4.2
-					IL_019b: newarr [System.Runtime]System.Object
-					IL_01a0: dup
-					IL_01a1: ldc.i4.0
-					IL_01a2: ldloc.2
+					IL_0175: ldarg.0
+					IL_0176: ldc.i4.0
+					IL_0177: ldelem.ref
+					IL_0178: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_017d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+					IL_0182: stloc.s 13
+					IL_0184: ldarg.0
+					IL_0185: ldc.i4.2
+					IL_0186: ldelem.ref
+					IL_0187: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_018c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_0191: stloc.s 4
+					IL_0193: ldloc.s 13
+					IL_0195: ldc.i4.2
+					IL_0196: newarr [System.Runtime]System.Object
+					IL_019b: dup
+					IL_019c: ldc.i4.0
+					IL_019d: ldloc.2
+					IL_019e: stelem.ref
+					IL_019f: dup
+					IL_01a0: ldc.i4.1
+					IL_01a1: ldloc.s 4
 					IL_01a3: stelem.ref
-					IL_01a4: dup
-					IL_01a5: ldc.i4.1
-					IL_01a6: ldloc.s 4
-					IL_01a8: stelem.ref
-					IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-					IL_01ae: stloc.s 13
-					IL_01b0: ldloc.s 13
-					IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01b7: ldstr "toString"
-					IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_01c1: stloc.3
-					IL_01c2: ldarg.2
-					IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01c8: ldstr "resume"
-					IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_01d2: pop
-					IL_01d3: ldarg.0
-					IL_01d4: ldc.i4.0
-					IL_01d5: ldelem.ref
-					IL_01d6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_01db: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-					IL_01e0: ldc.i4.3
-					IL_01e1: newarr [System.Runtime]System.Object
-					IL_01e6: dup
-					IL_01e7: ldc.i4.0
-					IL_01e8: ldarg.0
-					IL_01e9: ldc.i4.0
-					IL_01ea: ldelem.ref
-					IL_01eb: stelem.ref
-					IL_01ec: dup
-					IL_01ed: ldc.i4.1
-					IL_01ee: ldarg.0
-					IL_01ef: ldc.i4.1
-					IL_01f0: ldelem.ref
-					IL_01f1: stelem.ref
-					IL_01f2: dup
-					IL_01f3: ldc.i4.2
-					IL_01f4: ldarg.0
-					IL_01f5: ldc.i4.2
-					IL_01f6: ldelem.ref
-					IL_01f7: stelem.ref
-					IL_01f8: stloc.s 12
-					IL_01fa: ldarg.0
-					IL_01fb: ldc.i4.1
-					IL_01fc: ldelem.ref
-					IL_01fd: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0202: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_0207: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_020c: ldc.r8 1
-					IL_0215: sub
-					IL_0216: stloc.s 15
-					IL_0218: ldloc.s 15
-					IL_021a: box [System.Runtime]System.Double
-					IL_021f: stloc.s 16
-					IL_0221: ldloc.s 12
-					IL_0223: ldloc.3
-					IL_0224: ldloc.s 16
-					IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-					IL_022b: stloc.s 13
-					IL_022d: ldloc.s 13
-					IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0234: stloc.s 13
-					IL_0236: ldarg.0
-					IL_0237: ldc.i4.2
-					IL_0238: ldelem.ref
-					IL_0239: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_023e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_0243: stloc.s 4
-					IL_0245: ldarg.0
-					IL_0246: ldc.i4.2
-					IL_0247: ldelem.ref
-					IL_0248: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_024d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0252: stloc.s 17
-					IL_0254: ldloc.s 13
-					IL_0256: ldstr "then"
-					IL_025b: ldloc.s 4
-					IL_025d: ldloc.s 17
-					IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_0264: pop
-					IL_0265: ldnull
-					IL_0266: ret
+					IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+					IL_01a9: stloc.s 13
+					IL_01ab: ldloc.s 13
+					IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01b2: ldstr "toString"
+					IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_01bc: stloc.3
+					IL_01bd: ldarg.2
+					IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01c3: ldstr "resume"
+					IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_01cd: pop
+					IL_01ce: ldarg.0
+					IL_01cf: ldc.i4.0
+					IL_01d0: ldelem.ref
+					IL_01d1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_01d6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+					IL_01db: ldc.i4.3
+					IL_01dc: newarr [System.Runtime]System.Object
+					IL_01e1: dup
+					IL_01e2: ldc.i4.0
+					IL_01e3: ldarg.0
+					IL_01e4: ldc.i4.0
+					IL_01e5: ldelem.ref
+					IL_01e6: stelem.ref
+					IL_01e7: dup
+					IL_01e8: ldc.i4.1
+					IL_01e9: ldarg.0
+					IL_01ea: ldc.i4.1
+					IL_01eb: ldelem.ref
+					IL_01ec: stelem.ref
+					IL_01ed: dup
+					IL_01ee: ldc.i4.2
+					IL_01ef: ldarg.0
+					IL_01f0: ldc.i4.2
+					IL_01f1: ldelem.ref
+					IL_01f2: stelem.ref
+					IL_01f3: stloc.s 12
+					IL_01f5: ldarg.0
+					IL_01f6: ldc.i4.1
+					IL_01f7: ldelem.ref
+					IL_01f8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_01fd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_0202: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0207: ldc.r8 1
+					IL_0210: sub
+					IL_0211: stloc.s 15
+					IL_0213: ldloc.s 15
+					IL_0215: box [System.Runtime]System.Double
+					IL_021a: stloc.s 16
+					IL_021c: ldloc.s 12
+					IL_021e: ldloc.3
+					IL_021f: ldloc.s 16
+					IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+					IL_0226: stloc.s 13
+					IL_0228: ldloc.s 13
+					IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_022f: stloc.s 13
+					IL_0231: ldarg.0
+					IL_0232: ldc.i4.2
+					IL_0233: ldelem.ref
+					IL_0234: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0239: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_023e: stloc.s 4
+					IL_0240: ldarg.0
+					IL_0241: ldc.i4.2
+					IL_0242: ldelem.ref
+					IL_0243: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0248: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_024d: stloc.s 17
+					IL_024f: ldloc.s 13
+					IL_0251: ldstr "then"
+					IL_0256: ldloc.s 4
+					IL_0258: ldloc.s 17
+					IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_025f: pop
+					IL_0260: ldnull
+					IL_0261: ret
 
-					IL_0267: ldloc.1
-					IL_0268: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_026d: ldc.r8 200
-					IL_0276: clt
-					IL_0278: stloc.s 5
-					IL_027a: ldloc.s 5
-					IL_027c: box [System.Runtime]System.Boolean
-					IL_0281: stloc.s 8
-					IL_0283: ldloc.s 8
-					IL_0285: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_028a: stloc.s 5
-					IL_028c: ldloc.s 5
-					IL_028e: brtrue IL_02bb
+					IL_0262: ldloc.1
+					IL_0263: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0268: ldc.r8 200
+					IL_0271: clt
+					IL_0273: stloc.s 5
+					IL_0275: ldloc.s 5
+					IL_0277: box [System.Runtime]System.Boolean
+					IL_027c: stloc.s 8
+					IL_027e: ldloc.s 8
+					IL_0280: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0285: stloc.s 5
+					IL_0287: ldloc.s 5
+					IL_0289: brtrue IL_02b6
 
-					IL_0293: ldloc.1
-					IL_0294: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0299: ldc.r8 300
-					IL_02a2: clt
-					IL_02a4: ldc.i4.0
-					IL_02a5: ceq
-					IL_02a7: stloc.s 5
-					IL_02a9: ldloc.s 5
-					IL_02ab: box [System.Runtime]System.Boolean
-					IL_02b0: stloc.s 9
-					IL_02b2: ldloc.s 9
-					IL_02b4: stloc.s 18
-					IL_02b6: br IL_02bf
+					IL_028e: ldloc.1
+					IL_028f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0294: ldc.r8 300
+					IL_029d: clt
+					IL_029f: ldc.i4.0
+					IL_02a0: ceq
+					IL_02a2: stloc.s 5
+					IL_02a4: ldloc.s 5
+					IL_02a6: box [System.Runtime]System.Boolean
+					IL_02ab: stloc.s 9
+					IL_02ad: ldloc.s 9
+					IL_02af: stloc.s 18
+					IL_02b1: br IL_02ba
 
-					IL_02bb: ldloc.s 8
-					IL_02bd: stloc.s 18
+					IL_02b6: ldloc.s 8
+					IL_02b8: stloc.s 18
 
-					IL_02bf: ldloc.s 18
-					IL_02c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02c6: stloc.s 5
-					IL_02c8: ldloc.s 5
-					IL_02ca: brfalse IL_0364
+					IL_02ba: ldloc.s 18
+					IL_02bc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02c1: stloc.s 5
+					IL_02c3: ldloc.s 5
+					IL_02c5: brfalse IL_035a
 
-					IL_02cf: ldarg.2
-					IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02d5: ldstr "resume"
-					IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_02df: pop
-					IL_02e0: ldarg.0
-					IL_02e1: ldc.i4.2
-					IL_02e2: ldelem.ref
-					IL_02e3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_02e8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_02ed: stloc.s 17
-					IL_02ef: ldc.i4.3
-					IL_02f0: newarr [System.Runtime]System.Object
-					IL_02f5: dup
-					IL_02f6: ldc.i4.0
-					IL_02f7: ldarg.0
-					IL_02f8: ldc.i4.0
-					IL_02f9: ldelem.ref
-					IL_02fa: stelem.ref
-					IL_02fb: dup
-					IL_02fc: ldc.i4.1
-					IL_02fd: ldarg.0
-					IL_02fe: ldc.i4.1
-					IL_02ff: ldelem.ref
-					IL_0300: stelem.ref
-					IL_0301: dup
-					IL_0302: ldc.i4.2
-					IL_0303: ldarg.0
-					IL_0304: ldc.i4.2
-					IL_0305: ldelem.ref
-					IL_0306: stelem.ref
-					IL_0307: stloc.s 12
-					IL_0309: ldloc.1
-					IL_030a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_030f: stloc.s 14
-					IL_0311: ldstr "HTTP "
-					IL_0316: ldloc.s 14
-					IL_0318: call string [System.Runtime]System.String::Concat(string, string)
-					IL_031d: ldstr " fetching "
-					IL_0322: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0327: ldarg.0
-					IL_0328: ldc.i4.1
-					IL_0329: ldelem.ref
-					IL_032a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_032f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0334: stloc.s 4
-					IL_0336: ldloc.s 4
-					IL_0338: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_033d: stloc.s 14
-					IL_033f: ldloc.s 14
-					IL_0341: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0346: stloc.s 14
-					IL_0348: ldloc.s 14
-					IL_034a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_034f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0354: stloc.s 4
-					IL_0356: ldloc.s 17
-					IL_0358: ldloc.s 12
-					IL_035a: ldloc.s 4
-					IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0361: pop
-					IL_0362: ldnull
-					IL_0363: ret
+					IL_02ca: ldarg.2
+					IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02d0: ldstr "resume"
+					IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_02da: pop
+					IL_02db: ldarg.0
+					IL_02dc: ldc.i4.2
+					IL_02dd: ldelem.ref
+					IL_02de: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_02e3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_02e8: stloc.s 17
+					IL_02ea: ldc.i4.3
+					IL_02eb: newarr [System.Runtime]System.Object
+					IL_02f0: dup
+					IL_02f1: ldc.i4.0
+					IL_02f2: ldarg.0
+					IL_02f3: ldc.i4.0
+					IL_02f4: ldelem.ref
+					IL_02f5: stelem.ref
+					IL_02f6: dup
+					IL_02f7: ldc.i4.1
+					IL_02f8: ldarg.0
+					IL_02f9: ldc.i4.1
+					IL_02fa: ldelem.ref
+					IL_02fb: stelem.ref
+					IL_02fc: dup
+					IL_02fd: ldc.i4.2
+					IL_02fe: ldarg.0
+					IL_02ff: ldc.i4.2
+					IL_0300: ldelem.ref
+					IL_0301: stelem.ref
+					IL_0302: stloc.s 12
+					IL_0304: ldloc.1
+					IL_0305: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_030a: stloc.s 14
+					IL_030c: ldstr "HTTP "
+					IL_0311: ldloc.s 14
+					IL_0313: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0318: ldstr " fetching "
+					IL_031d: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0322: ldarg.0
+					IL_0323: ldc.i4.1
+					IL_0324: ldelem.ref
+					IL_0325: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_032a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_032f: stloc.s 4
+					IL_0331: ldloc.s 4
+					IL_0333: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0338: stloc.s 14
+					IL_033a: ldloc.s 14
+					IL_033c: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0341: stloc.s 14
+					IL_0343: ldloc.s 14
+					IL_0345: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_034a: stloc.s 4
+					IL_034c: ldloc.s 17
+					IL_034e: ldloc.s 12
+					IL_0350: ldloc.s 4
+					IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0357: pop
+					IL_0358: ldnull
+					IL_0359: ret
 
-					IL_0364: ldarg.2
-					IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_036a: ldstr "setEncoding"
-					IL_036f: ldstr "utf8"
-					IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0379: pop
-					IL_037a: ldloc.0
-					IL_037b: ldstr ""
-					IL_0380: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_0385: ldarg.2
-					IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_038b: stloc.s 4
-					IL_038d: ldnull
-					IL_038e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
-					IL_0394: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_0399: ldc.i4.4
-					IL_039a: newarr [System.Runtime]System.Object
-					IL_039f: dup
-					IL_03a0: ldc.i4.0
-					IL_03a1: ldarg.0
-					IL_03a2: ldc.i4.0
-					IL_03a3: ldelem.ref
-					IL_03a4: stelem.ref
-					IL_03a5: dup
-					IL_03a6: ldc.i4.1
-					IL_03a7: ldarg.0
-					IL_03a8: ldc.i4.1
-					IL_03a9: ldelem.ref
+					IL_035a: ldarg.2
+					IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0360: ldstr "setEncoding"
+					IL_0365: ldstr "utf8"
+					IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_036f: pop
+					IL_0370: ldloc.0
+					IL_0371: ldstr ""
+					IL_0376: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_037b: ldarg.2
+					IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0381: stloc.s 4
+					IL_0383: ldnull
+					IL_0384: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_038a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_038f: ldc.i4.4
+					IL_0390: newarr [System.Runtime]System.Object
+					IL_0395: dup
+					IL_0396: ldc.i4.0
+					IL_0397: ldarg.0
+					IL_0398: ldc.i4.0
+					IL_0399: ldelem.ref
+					IL_039a: stelem.ref
+					IL_039b: dup
+					IL_039c: ldc.i4.1
+					IL_039d: ldarg.0
+					IL_039e: ldc.i4.1
+					IL_039f: ldelem.ref
+					IL_03a0: stelem.ref
+					IL_03a1: dup
+					IL_03a2: ldc.i4.2
+					IL_03a3: ldarg.0
+					IL_03a4: ldc.i4.2
+					IL_03a5: ldelem.ref
+					IL_03a6: stelem.ref
+					IL_03a7: dup
+					IL_03a8: ldc.i4.3
+					IL_03a9: ldloc.0
 					IL_03aa: stelem.ref
-					IL_03ab: dup
-					IL_03ac: ldc.i4.2
-					IL_03ad: ldarg.0
-					IL_03ae: ldc.i4.2
-					IL_03af: ldelem.ref
-					IL_03b0: stelem.ref
-					IL_03b1: dup
-					IL_03b2: ldc.i4.3
-					IL_03b3: ldloc.0
-					IL_03b4: stelem.ref
-					IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_03bf: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-					IL_03c4: ldc.i4.1
-					IL_03c5: conv.r8
-					IL_03c6: ldstr ""
-					IL_03cb: ldc.i4.0
-					IL_03cc: ldc.i4.0
-					IL_03cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-					IL_03d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-					IL_03d7: stloc.s 19
-					IL_03d9: ldloc.s 4
-					IL_03db: ldstr "on"
-					IL_03e0: ldstr "data"
-					IL_03e5: ldloc.s 19
-					IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_03ec: pop
-					IL_03ed: ldarg.2
-					IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_03f3: stloc.s 4
-					IL_03f5: ldnull
-					IL_03f6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
-					IL_03fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_0401: ldc.i4.4
-					IL_0402: newarr [System.Runtime]System.Object
-					IL_0407: dup
-					IL_0408: ldc.i4.0
-					IL_0409: ldarg.0
-					IL_040a: ldc.i4.0
-					IL_040b: ldelem.ref
-					IL_040c: stelem.ref
-					IL_040d: dup
-					IL_040e: ldc.i4.1
-					IL_040f: ldarg.0
-					IL_0410: ldc.i4.1
-					IL_0411: ldelem.ref
+					IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03b5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+					IL_03ba: ldc.i4.1
+					IL_03bb: conv.r8
+					IL_03bc: ldstr ""
+					IL_03c1: ldc.i4.0
+					IL_03c2: ldc.i4.0
+					IL_03c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+					IL_03c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+					IL_03cd: stloc.s 19
+					IL_03cf: ldloc.s 4
+					IL_03d1: ldstr "on"
+					IL_03d6: ldstr "data"
+					IL_03db: ldloc.s 19
+					IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_03e2: pop
+					IL_03e3: ldarg.2
+					IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_03e9: stloc.s 4
+					IL_03eb: ldnull
+					IL_03ec: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_03f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_03f7: ldc.i4.4
+					IL_03f8: newarr [System.Runtime]System.Object
+					IL_03fd: dup
+					IL_03fe: ldc.i4.0
+					IL_03ff: ldarg.0
+					IL_0400: ldc.i4.0
+					IL_0401: ldelem.ref
+					IL_0402: stelem.ref
+					IL_0403: dup
+					IL_0404: ldc.i4.1
+					IL_0405: ldarg.0
+					IL_0406: ldc.i4.1
+					IL_0407: ldelem.ref
+					IL_0408: stelem.ref
+					IL_0409: dup
+					IL_040a: ldc.i4.2
+					IL_040b: ldarg.0
+					IL_040c: ldc.i4.2
+					IL_040d: ldelem.ref
+					IL_040e: stelem.ref
+					IL_040f: dup
+					IL_0410: ldc.i4.3
+					IL_0411: ldloc.0
 					IL_0412: stelem.ref
-					IL_0413: dup
-					IL_0414: ldc.i4.2
-					IL_0415: ldarg.0
-					IL_0416: ldc.i4.2
-					IL_0417: ldelem.ref
-					IL_0418: stelem.ref
-					IL_0419: dup
-					IL_041a: ldc.i4.3
-					IL_041b: ldloc.0
-					IL_041c: stelem.ref
-					IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_0427: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-					IL_042c: ldc.i4.0
-					IL_042d: conv.r8
-					IL_042e: ldstr ""
-					IL_0433: ldc.i4.0
-					IL_0434: ldc.i4.0
-					IL_0435: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-					IL_043a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-					IL_043f: stloc.s 20
-					IL_0441: ldloc.s 4
-					IL_0443: ldstr "on"
-					IL_0448: ldstr "end"
-					IL_044d: ldloc.s 20
-					IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_0454: pop
-					IL_0455: ldnull
-					IL_0456: ret
+					IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_041d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+					IL_0422: ldc.i4.0
+					IL_0423: conv.r8
+					IL_0424: ldstr ""
+					IL_0429: ldc.i4.0
+					IL_042a: ldc.i4.0
+					IL_042b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+					IL_0430: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+					IL_0435: stloc.s 20
+					IL_0437: ldloc.s 4
+					IL_0439: ldstr "on"
+					IL_043e: ldstr "end"
+					IL_0443: ldloc.s 20
+					IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_044a: pop
+					IL_044b: ldnull
+					IL_044c: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -1914,7 +1912,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45f4
+						// Method begins at RVA 0x45bc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1934,7 +1932,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45fd
+						// Method begins at RVA 0x45c5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1957,7 +1955,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45eb
+					// Method begins at RVA 0x45b3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1983,9 +1981,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e48
+				// Method begins at RVA 0x3e1c
 				// Header size: 12
-				// Code size: 516 (0x204)
+				// Code size: 511 (0x1ff)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope,
@@ -2043,7 +2041,7 @@
 					IL_004e: ldloc.0
 					IL_004f: ldloc.s 6
 					IL_0051: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_0056: leave IL_00c6
+					IL_0056: leave IL_00c1
 				} // end .try
 				catch [System.Runtime]System.Exception
 				{
@@ -2080,139 +2078,138 @@
 					IL_0097: call string [System.Runtime]System.String::Concat(string, string)
 					IL_009c: stloc.s 9
 					IL_009e: ldloc.s 9
-					IL_00a0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_00a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_00aa: stloc.s 7
-					IL_00ac: ldloc.s 6
-					IL_00ae: ldloc.s 8
-					IL_00b0: ldloc.s 7
-					IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_00b7: pop
-					IL_00b8: ldnull
-					IL_00b9: stloc.2
-					IL_00ba: ldnull
-					IL_00bb: stloc.2
-					IL_00bc: leave IL_0202
+					IL_00a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_00a5: stloc.s 7
+					IL_00a7: ldloc.s 6
+					IL_00a9: ldloc.s 8
+					IL_00ab: ldloc.s 7
+					IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_00b2: pop
+					IL_00b3: ldnull
+					IL_00b4: stloc.2
+					IL_00b5: ldnull
+					IL_00b6: stloc.2
+					IL_00b7: leave IL_01fd
 
-					IL_00c1: leave IL_00c6
+					IL_00bc: leave IL_00c1
 				} // end handler
 
-				IL_00c6: ldloc.0
-				IL_00c7: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_00cc: ldstr "protocol"
-				IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00d6: stloc.s 7
-				IL_00d8: ldloc.s 7
-				IL_00da: ldstr "https:"
-				IL_00df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00e4: stloc.s 10
-				IL_00e6: ldloc.s 10
-				IL_00e8: brfalse IL_0104
+				IL_00c1: ldloc.0
+				IL_00c2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_00c7: ldstr "protocol"
+				IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00d1: stloc.s 7
+				IL_00d3: ldloc.s 7
+				IL_00d5: ldstr "https:"
+				IL_00da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00df: stloc.s 10
+				IL_00e1: ldloc.s 10
+				IL_00e3: brfalse IL_00ff
 
-				IL_00ed: ldarg.0
-				IL_00ee: ldc.i4.0
-				IL_00ef: ldelem.ref
-				IL_00f0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_00f5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
-				IL_00fa: stloc.s 11
-				IL_00fc: ldloc.s 11
-				IL_00fe: stloc.3
-				IL_00ff: br IL_0116
+				IL_00e8: ldarg.0
+				IL_00e9: ldc.i4.0
+				IL_00ea: ldelem.ref
+				IL_00eb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_00f0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+				IL_00f5: stloc.s 11
+				IL_00f7: ldloc.s 11
+				IL_00f9: stloc.3
+				IL_00fa: br IL_0111
 
-				IL_0104: ldarg.0
-				IL_0105: ldc.i4.0
-				IL_0106: ldelem.ref
-				IL_0107: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_010c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
-				IL_0111: stloc.s 12
-				IL_0113: ldloc.s 12
-				IL_0115: stloc.3
+				IL_00ff: ldarg.0
+				IL_0100: ldc.i4.0
+				IL_0101: ldelem.ref
+				IL_0102: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_0107: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+				IL_010c: stloc.s 12
+				IL_010e: ldloc.s 12
+				IL_0110: stloc.3
 
-				IL_0116: ldloc.3
-				IL_0117: stloc.s 4
-				IL_0119: ldloc.s 4
-				IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0120: stloc.s 7
-				IL_0122: ldloc.0
-				IL_0123: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_0128: stloc.s 6
-				IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_012f: dup
-				IL_0130: ldstr "method"
-				IL_0135: ldstr "GET"
-				IL_013a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_013f: dup
-				IL_0140: ldstr "headers"
-				IL_0145: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_014a: dup
-				IL_014b: ldstr "Accept-Encoding"
-				IL_0150: ldstr "identity"
-				IL_0155: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_015a: dup
-				IL_015b: ldstr "User-Agent"
-				IL_0160: ldstr "jroc-docs-script"
+				IL_0111: ldloc.3
+				IL_0112: stloc.s 4
+				IL_0114: ldloc.s 4
+				IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_011b: stloc.s 7
+				IL_011d: ldloc.0
+				IL_011e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_0123: stloc.s 6
+				IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_012a: dup
+				IL_012b: ldstr "method"
+				IL_0130: ldstr "GET"
+				IL_0135: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_013a: dup
+				IL_013b: ldstr "headers"
+				IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0145: dup
+				IL_0146: ldstr "Accept-Encoding"
+				IL_014b: ldstr "identity"
+				IL_0150: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0155: dup
+				IL_0156: ldstr "User-Agent"
+				IL_015b: ldstr "jroc-docs-script"
+				IL_0160: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 				IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_016a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_016f: stloc.s 13
-				IL_0171: ldnull
-				IL_0172: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
-				IL_0178: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_017d: ldc.i4.3
-				IL_017e: newarr [System.Runtime]System.Object
-				IL_0183: dup
-				IL_0184: ldc.i4.0
-				IL_0185: ldarg.0
-				IL_0186: ldc.i4.0
-				IL_0187: ldelem.ref
-				IL_0188: stelem.ref
-				IL_0189: dup
-				IL_018a: ldc.i4.1
-				IL_018b: ldarg.0
-				IL_018c: ldc.i4.1
-				IL_018d: ldelem.ref
-				IL_018e: stelem.ref
-				IL_018f: dup
-				IL_0190: ldc.i4.2
-				IL_0191: ldloc.0
-				IL_0192: stelem.ref
-				IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_019d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-				IL_01a2: ldc.i4.1
-				IL_01a3: conv.r8
-				IL_01a4: ldstr ""
-				IL_01a9: ldc.i4.0
-				IL_01aa: ldc.i4.0
-				IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-				IL_01b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-				IL_01b5: stloc.s 14
-				IL_01b7: ldloc.s 7
-				IL_01b9: ldstr "request"
-				IL_01be: ldloc.s 6
-				IL_01c0: ldloc.s 13
-				IL_01c2: ldloc.s 14
-				IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-				IL_01c9: stloc.s 5
-				IL_01cb: ldloc.s 5
-				IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01d2: stloc.s 6
-				IL_01d4: ldloc.0
-				IL_01d5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-				IL_01da: stloc.s 7
-				IL_01dc: ldloc.s 6
-				IL_01de: ldstr "on"
-				IL_01e3: ldstr "error"
-				IL_01e8: ldloc.s 7
-				IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_01ef: pop
-				IL_01f0: ldloc.s 5
-				IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01f7: ldstr "end"
-				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0201: pop
+				IL_016a: stloc.s 13
+				IL_016c: ldnull
+				IL_016d: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
+				IL_0173: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_0178: ldc.i4.3
+				IL_0179: newarr [System.Runtime]System.Object
+				IL_017e: dup
+				IL_017f: ldc.i4.0
+				IL_0180: ldarg.0
+				IL_0181: ldc.i4.0
+				IL_0182: ldelem.ref
+				IL_0183: stelem.ref
+				IL_0184: dup
+				IL_0185: ldc.i4.1
+				IL_0186: ldarg.0
+				IL_0187: ldc.i4.1
+				IL_0188: ldelem.ref
+				IL_0189: stelem.ref
+				IL_018a: dup
+				IL_018b: ldc.i4.2
+				IL_018c: ldloc.0
+				IL_018d: stelem.ref
+				IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_0198: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+				IL_019d: ldc.i4.1
+				IL_019e: conv.r8
+				IL_019f: ldstr ""
+				IL_01a4: ldc.i4.0
+				IL_01a5: ldc.i4.0
+				IL_01a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+				IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+				IL_01b0: stloc.s 14
+				IL_01b2: ldloc.s 7
+				IL_01b4: ldstr "request"
+				IL_01b9: ldloc.s 6
+				IL_01bb: ldloc.s 13
+				IL_01bd: ldloc.s 14
+				IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+				IL_01c4: stloc.s 5
+				IL_01c6: ldloc.s 5
+				IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01cd: stloc.s 6
+				IL_01cf: ldloc.0
+				IL_01d0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+				IL_01d5: stloc.s 7
+				IL_01d7: ldloc.s 6
+				IL_01d9: ldstr "on"
+				IL_01de: ldstr "error"
+				IL_01e3: ldloc.s 7
+				IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_01ea: pop
+				IL_01eb: ldloc.s 5
+				IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01f2: ldstr "end"
+				IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_01fc: pop
 
-				IL_0202: ldloc.2
-				IL_0203: ret
+				IL_01fd: ldloc.2
+				IL_01fe: ret
 			} // end of method ArrowFunction_L72C22::__js_call__
 
 		} // end of class ArrowFunction_L72C22
@@ -2234,7 +2231,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45e2
+					// Method begins at RVA 0x45aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2256,7 +2253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45d9
+				// Method begins at RVA 0x45a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2353,7 +2350,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x463c
+				// Method begins at RVA 0x4604
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2420,7 +2417,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x464e
+					// Method begins at RVA 0x4616
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2444,7 +2441,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4660
+						// Method begins at RVA 0x4628
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2462,7 +2459,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4657
+					// Method begins at RVA 0x461f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2480,7 +2477,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4645
+				// Method begins at RVA 0x460d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2745,7 +2742,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4672
+					// Method begins at RVA 0x463a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2765,7 +2762,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x467b
+					// Method begins at RVA 0x4643
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2785,7 +2782,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4684
+					// Method begins at RVA 0x464c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2805,7 +2802,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x468d
+					// Method begins at RVA 0x4655
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2829,7 +2826,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x469f
+						// Method begins at RVA 0x4667
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2849,7 +2846,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46a8
+						// Method begins at RVA 0x4670
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2873,7 +2870,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x46ba
+							// Method begins at RVA 0x4682
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2891,7 +2888,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46b1
+						// Method begins at RVA 0x4679
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2911,7 +2908,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46c3
+						// Method begins at RVA 0x468b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2929,7 +2926,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4696
+					// Method begins at RVA 0x465e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2947,7 +2944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4669
+				// Method begins at RVA 0x4631
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2977,7 +2974,7 @@
 			)
 			// Method begins at RVA 0x2c2c
 			// Header size: 12
-			// Code size: 964 (0x3c4)
+			// Code size: 944 (0x3b0)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -3052,7 +3049,7 @@
 			IL_0085: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_008a: ldc.r8 0.0
 			IL_0093: clt
-			IL_0095: brfalse IL_00dc
+			IL_0095: brfalse IL_00d7
 
 			IL_009a: ldarg.3
 			IL_009b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
@@ -3064,278 +3061,274 @@
 			IL_00b3: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00b8: stloc.s 14
 			IL_00ba: ldloc.s 14
-			IL_00bc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00c6: stloc.3
-			IL_00c7: ldloc.3
-			IL_00c8: isinst [System.Runtime]System.Exception
-			IL_00cd: dup
-			IL_00ce: brtrue IL_00db
+			IL_00bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00c1: stloc.3
+			IL_00c2: ldloc.3
+			IL_00c3: isinst [System.Runtime]System.Exception
+			IL_00c8: dup
+			IL_00c9: brtrue IL_00d6
 
-			IL_00d3: pop
-			IL_00d4: ldloc.3
-			IL_00d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00da: throw
+			IL_00ce: pop
+			IL_00cf: ldloc.3
+			IL_00d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00d5: throw
 
-			IL_00db: throw
+			IL_00d6: throw
 
-			IL_00dc: ldarg.2
-			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e2: ldstr "lastIndexOf"
-			IL_00e7: ldstr "<"
-			IL_00ec: ldloc.2
-			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00f2: stloc.s 4
-			IL_00f4: ldloc.s 4
-			IL_00f6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00fb: ldc.r8 0.0
-			IL_0104: clt
-			IL_0106: brfalse IL_0150
+			IL_00d7: ldarg.2
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00dd: ldstr "lastIndexOf"
+			IL_00e2: ldstr "<"
+			IL_00e7: ldloc.2
+			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00ed: stloc.s 4
+			IL_00ef: ldloc.s 4
+			IL_00f1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00f6: ldc.r8 0.0
+			IL_00ff: clt
+			IL_0101: brfalse IL_0146
 
-			IL_010b: ldarg.3
-			IL_010c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0111: stloc.s 14
-			IL_0113: ldstr "Could not locate tag start for id '"
-			IL_0118: ldloc.s 14
-			IL_011a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_011f: ldstr "'."
-			IL_0124: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0129: stloc.s 14
-			IL_012b: ldloc.s 14
-			IL_012d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0137: stloc.s 5
-			IL_0139: ldloc.s 5
-			IL_013b: isinst [System.Runtime]System.Exception
-			IL_0140: dup
-			IL_0141: brtrue IL_014f
+			IL_0106: ldarg.3
+			IL_0107: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_010c: stloc.s 14
+			IL_010e: ldstr "Could not locate tag start for id '"
+			IL_0113: ldloc.s 14
+			IL_0115: call string [System.Runtime]System.String::Concat(string, string)
+			IL_011a: ldstr "'."
+			IL_011f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0124: stloc.s 14
+			IL_0126: ldloc.s 14
+			IL_0128: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_012d: stloc.s 5
+			IL_012f: ldloc.s 5
+			IL_0131: isinst [System.Runtime]System.Exception
+			IL_0136: dup
+			IL_0137: brtrue IL_0145
 
-			IL_0146: pop
-			IL_0147: ldloc.s 5
-			IL_0149: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_014e: throw
+			IL_013c: pop
+			IL_013d: ldloc.s 5
+			IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0144: throw
 
-			IL_014f: throw
+			IL_0145: throw
 
-			IL_0150: ldarg.0
-			IL_0151: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
-			IL_0156: ldc.i4.1
-			IL_0157: newarr [System.Runtime]System.Object
-			IL_015c: dup
-			IL_015d: ldc.i4.0
-			IL_015e: ldarg.0
-			IL_015f: stelem.ref
-			IL_0160: stloc.s 16
-			IL_0162: ldloc.s 16
-			IL_0164: ldarg.2
-			IL_0165: ldloc.s 4
-			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_016c: stloc.s 6
-			IL_016e: ldloc.s 6
-			IL_0170: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0175: ldc.i4.0
-			IL_0176: ceq
-			IL_0178: stloc.s 17
-			IL_017a: ldloc.s 17
-			IL_017c: brfalse IL_01c6
+			IL_0146: ldarg.0
+			IL_0147: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
+			IL_014c: ldc.i4.1
+			IL_014d: newarr [System.Runtime]System.Object
+			IL_0152: dup
+			IL_0153: ldc.i4.0
+			IL_0154: ldarg.0
+			IL_0155: stelem.ref
+			IL_0156: stloc.s 16
+			IL_0158: ldloc.s 16
+			IL_015a: ldarg.2
+			IL_015b: ldloc.s 4
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0162: stloc.s 6
+			IL_0164: ldloc.s 6
+			IL_0166: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_016b: ldc.i4.0
+			IL_016c: ceq
+			IL_016e: stloc.s 17
+			IL_0170: ldloc.s 17
+			IL_0172: brfalse IL_01b7
 
-			IL_0181: ldarg.3
-			IL_0182: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0187: stloc.s 14
-			IL_0189: ldstr "Could not determine tag name for id '"
-			IL_018e: ldloc.s 14
+			IL_0177: ldarg.3
+			IL_0178: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_017d: stloc.s 14
+			IL_017f: ldstr "Could not determine tag name for id '"
+			IL_0184: ldloc.s 14
+			IL_0186: call string [System.Runtime]System.String::Concat(string, string)
+			IL_018b: ldstr "'."
 			IL_0190: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0195: ldstr "'."
-			IL_019a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_019f: stloc.s 14
-			IL_01a1: ldloc.s 14
-			IL_01a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01ad: stloc.s 7
-			IL_01af: ldloc.s 7
-			IL_01b1: isinst [System.Runtime]System.Exception
-			IL_01b6: dup
-			IL_01b7: brtrue IL_01c5
+			IL_0195: stloc.s 14
+			IL_0197: ldloc.s 14
+			IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_019e: stloc.s 7
+			IL_01a0: ldloc.s 7
+			IL_01a2: isinst [System.Runtime]System.Exception
+			IL_01a7: dup
+			IL_01a8: brtrue IL_01b6
 
-			IL_01bc: pop
-			IL_01bd: ldloc.s 7
-			IL_01bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_01c4: throw
+			IL_01ad: pop
+			IL_01ae: ldloc.s 7
+			IL_01b0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_01b5: throw
 
-			IL_01c5: throw
+			IL_01b6: throw
 
-			IL_01c6: ldarg.0
-			IL_01c7: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_01cc: ldc.i4.1
-			IL_01cd: newarr [System.Runtime]System.Object
-			IL_01d2: dup
-			IL_01d3: ldc.i4.0
-			IL_01d4: ldarg.0
-			IL_01d5: stelem.ref
-			IL_01d6: ldloc.s 6
-			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01dd: stloc.s 15
-			IL_01df: ldloc.s 15
-			IL_01e1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01e6: stloc.s 14
-			IL_01e8: ldstr "<\\/?"
-			IL_01ed: ldloc.s 14
-			IL_01ef: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01f4: ldstr "\\b[^>]*>"
-			IL_01f9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01fe: stloc.s 14
-			IL_0200: ldloc.s 14
-			IL_0202: ldstr "gi"
-			IL_0207: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_020c: stloc.s 8
-			IL_020e: ldloc.s 8
-			IL_0210: ldstr "lastIndex"
-			IL_0215: ldloc.s 4
-			IL_0217: ldc.i4.1
-			IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_021d: pop
-			IL_021e: ldc.r8 0.0
-			IL_0227: stloc.s 9
-			IL_0229: ldc.r8 1
-			IL_0232: neg
-			IL_0233: stloc.s 18
-			IL_0235: ldloc.s 18
-			IL_0237: box [System.Runtime]System.Double
-			IL_023c: stloc.s 10
-			// loop start (head: IL_023e)
-				IL_023e: ldc.i4.1
-				IL_023f: brfalse IL_0363
+			IL_01b7: ldarg.0
+			IL_01b8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_01bd: ldc.i4.1
+			IL_01be: newarr [System.Runtime]System.Object
+			IL_01c3: dup
+			IL_01c4: ldc.i4.0
+			IL_01c5: ldarg.0
+			IL_01c6: stelem.ref
+			IL_01c7: ldloc.s 6
+			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_01ce: stloc.s 15
+			IL_01d0: ldloc.s 15
+			IL_01d2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d7: stloc.s 14
+			IL_01d9: ldstr "<\\/?"
+			IL_01de: ldloc.s 14
+			IL_01e0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e5: ldstr "\\b[^>]*>"
+			IL_01ea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ef: stloc.s 14
+			IL_01f1: ldloc.s 14
+			IL_01f3: ldstr "gi"
+			IL_01f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_01fd: stloc.s 8
+			IL_01ff: ldloc.s 8
+			IL_0201: ldstr "lastIndex"
+			IL_0206: ldloc.s 4
+			IL_0208: ldc.i4.1
+			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_020e: pop
+			IL_020f: ldc.r8 0.0
+			IL_0218: stloc.s 9
+			IL_021a: ldc.r8 1
+			IL_0223: neg
+			IL_0224: stloc.s 18
+			IL_0226: ldloc.s 18
+			IL_0228: box [System.Runtime]System.Double
+			IL_022d: stloc.s 10
+			// loop start (head: IL_022f)
+				IL_022f: ldc.i4.1
+				IL_0230: brfalse IL_0354
 
-				IL_0244: ldloc.s 8
-				IL_0246: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-				IL_024b: stloc.s 19
-				IL_024d: ldloc.s 19
-				IL_024f: ldstr "exec"
-				IL_0254: ldarg.2
-				IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_025a: stloc.s 11
-				IL_025c: ldloc.s 11
-				IL_025e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0263: ldc.i4.0
-				IL_0264: ceq
-				IL_0266: stloc.s 17
-				IL_0268: ldloc.s 17
-				IL_026a: brfalse IL_0274
+				IL_0235: ldloc.s 8
+				IL_0237: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
+				IL_023c: stloc.s 19
+				IL_023e: ldloc.s 19
+				IL_0240: ldstr "exec"
+				IL_0245: ldarg.2
+				IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_024b: stloc.s 11
+				IL_024d: ldloc.s 11
+				IL_024f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0254: ldc.i4.0
+				IL_0255: ceq
+				IL_0257: stloc.s 17
+				IL_0259: ldloc.s 17
+				IL_025b: brfalse IL_0265
 
-				IL_026f: br IL_0363
+				IL_0260: br IL_0354
 
-				IL_0274: ldloc.s 11
-				IL_0276: ldc.r8 0.0
-				IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0284: stloc.s 12
-				IL_0286: ldloc.s 10
-				IL_0288: stloc.s 20
-				IL_028a: ldloc.s 20
-				IL_028c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0291: ldc.r8 0.0
-				IL_029a: clt
-				IL_029c: brfalse IL_02b3
+				IL_0265: ldloc.s 11
+				IL_0267: ldc.r8 0.0
+				IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0275: stloc.s 12
+				IL_0277: ldloc.s 10
+				IL_0279: stloc.s 20
+				IL_027b: ldloc.s 20
+				IL_027d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0282: ldc.r8 0.0
+				IL_028b: clt
+				IL_028d: brfalse IL_02a4
 
-				IL_02a1: ldloc.s 11
-				IL_02a3: ldstr "index"
-				IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02ad: stloc.s 15
-				IL_02af: ldloc.s 15
-				IL_02b1: stloc.s 10
+				IL_0292: ldloc.s 11
+				IL_0294: ldstr "index"
+				IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_029e: stloc.s 15
+				IL_02a0: ldloc.s 15
+				IL_02a2: stloc.s 10
 
-				IL_02b3: ldloc.s 12
-				IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02ba: ldstr "startsWith"
-				IL_02bf: ldstr "</"
-				IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02c9: stloc.s 15
-				IL_02cb: ldloc.s 15
-				IL_02cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02d2: stloc.s 17
-				IL_02d4: ldloc.s 17
-				IL_02d6: brfalse IL_0350
+				IL_02a4: ldloc.s 12
+				IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02ab: ldstr "startsWith"
+				IL_02b0: ldstr "</"
+				IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02ba: stloc.s 15
+				IL_02bc: ldloc.s 15
+				IL_02be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02c3: stloc.s 17
+				IL_02c5: ldloc.s 17
+				IL_02c7: brfalse IL_0341
 
-				IL_02db: ldloc.s 9
-				IL_02dd: ldc.r8 1
-				IL_02e6: sub
-				IL_02e7: stloc.s 9
-				IL_02e9: ldloc.s 9
-				IL_02eb: stloc.s 18
-				IL_02ed: ldloc.s 18
-				IL_02ef: ldc.r8 0.0
-				IL_02f8: ceq
-				IL_02fa: brfalse IL_034b
+				IL_02cc: ldloc.s 9
+				IL_02ce: ldc.r8 1
+				IL_02d7: sub
+				IL_02d8: stloc.s 9
+				IL_02da: ldloc.s 9
+				IL_02dc: stloc.s 18
+				IL_02de: ldloc.s 18
+				IL_02e0: ldc.r8 0.0
+				IL_02e9: ceq
+				IL_02eb: brfalse IL_033c
 
-				IL_02ff: ldarg.2
-				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0305: stloc.s 15
-				IL_0307: ldloc.s 8
-				IL_0309: ldstr "lastIndex"
-				IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0313: stloc.s 21
-				IL_0315: ldloc.s 15
-				IL_0317: ldstr "substring"
-				IL_031c: ldloc.s 10
-				IL_031e: ldloc.s 21
-				IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0325: stloc.s 21
-				IL_0327: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_032c: dup
-				IL_032d: ldstr "tagName"
-				IL_0332: ldloc.s 6
-				IL_0334: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0339: dup
-				IL_033a: ldstr "html"
-				IL_033f: ldloc.s 21
-				IL_0341: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0346: stloc.s 22
-				IL_0348: ldloc.s 22
-				IL_034a: ret
+				IL_02f0: ldarg.2
+				IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02f6: stloc.s 15
+				IL_02f8: ldloc.s 8
+				IL_02fa: ldstr "lastIndex"
+				IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0304: stloc.s 21
+				IL_0306: ldloc.s 15
+				IL_0308: ldstr "substring"
+				IL_030d: ldloc.s 10
+				IL_030f: ldloc.s 21
+				IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0316: stloc.s 21
+				IL_0318: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_031d: dup
+				IL_031e: ldstr "tagName"
+				IL_0323: ldloc.s 6
+				IL_0325: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_032a: dup
+				IL_032b: ldstr "html"
+				IL_0330: ldloc.s 21
+				IL_0332: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0337: stloc.s 22
+				IL_0339: ldloc.s 22
+				IL_033b: ret
 
-				IL_034b: br IL_035e
+				IL_033c: br IL_034f
 
-				IL_0350: ldloc.s 9
-				IL_0352: ldc.r8 1
-				IL_035b: add
-				IL_035c: stloc.s 9
+				IL_0341: ldloc.s 9
+				IL_0343: ldc.r8 1
+				IL_034c: add
+				IL_034d: stloc.s 9
 
-				IL_035e: br IL_023e
+				IL_034f: br IL_022f
 			// end loop
 
-			IL_0363: ldloc.s 6
-			IL_0365: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_036a: stloc.s 14
-			IL_036c: ldstr "Could not find a matching closing </"
-			IL_0371: ldloc.s 14
-			IL_0373: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0378: ldstr "> for id '"
+			IL_0354: ldloc.s 6
+			IL_0356: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_035b: stloc.s 14
+			IL_035d: ldstr "Could not find a matching closing </"
+			IL_0362: ldloc.s 14
+			IL_0364: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0369: ldstr "> for id '"
+			IL_036e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0373: ldarg.3
+			IL_0374: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0379: stloc.s 14
+			IL_037b: ldloc.s 14
 			IL_037d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0382: ldarg.3
-			IL_0383: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0388: stloc.s 14
-			IL_038a: ldloc.s 14
-			IL_038c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0391: ldstr "'."
-			IL_0396: call string [System.Runtime]System.String::Concat(string, string)
-			IL_039b: stloc.s 14
-			IL_039d: ldloc.s 14
-			IL_039f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_03a9: stloc.s 13
-			IL_03ab: ldloc.s 13
-			IL_03ad: isinst [System.Runtime]System.Exception
-			IL_03b2: dup
-			IL_03b3: brtrue IL_03c1
+			IL_0382: ldstr "'."
+			IL_0387: call string [System.Runtime]System.String::Concat(string, string)
+			IL_038c: stloc.s 14
+			IL_038e: ldloc.s 14
+			IL_0390: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0395: stloc.s 13
+			IL_0397: ldloc.s 13
+			IL_0399: isinst [System.Runtime]System.Exception
+			IL_039e: dup
+			IL_039f: brtrue IL_03ad
 
-			IL_03b8: pop
-			IL_03b9: ldloc.s 13
-			IL_03bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03c0: throw
+			IL_03a4: pop
+			IL_03a5: ldloc.s 13
+			IL_03a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03ac: throw
 
-			IL_03c1: throw
+			IL_03ad: throw
 
-			IL_03c2: ldnull
-			IL_03c3: ret
+			IL_03ae: ldnull
+			IL_03af: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3355,7 +3348,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46d5
+					// Method begins at RVA 0x469d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3373,7 +3366,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46cc
+				// Method begins at RVA 0x4694
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3401,7 +3394,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2ffc
+			// Method begins at RVA 0x2fe8
 			// Header size: 12
 			// Code size: 476 (0x1dc)
 			.maxstack 8
@@ -3609,7 +3602,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46de
+				// Method begins at RVA 0x46a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3635,7 +3628,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31e4
+			// Method begins at RVA 0x31d0
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -3727,7 +3720,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46f0
+					// Method begins at RVA 0x46b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3747,7 +3740,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46f9
+					// Method begins at RVA 0x46c1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3767,7 +3760,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4702
+					// Method begins at RVA 0x46ca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3791,7 +3784,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4714
+						// Method begins at RVA 0x46dc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3811,7 +3804,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x471d
+						// Method begins at RVA 0x46e5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3829,7 +3822,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x470b
+					// Method begins at RVA 0x46d3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3849,7 +3842,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4726
+					// Method begins at RVA 0x46ee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3869,7 +3862,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x472f
+					// Method begins at RVA 0x46f7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3909,7 +3902,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46e7
+				// Method begins at RVA 0x46af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3933,9 +3926,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3274
+			// Method begins at RVA 0x3260
 			// Header size: 12
-			// Code size: 3014 (0xbc6)
+			// Code size: 2989 (0xbad)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -4152,7 +4145,7 @@
 
 			IL_0139: ldloc.0
 			IL_013a: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_013f: switch (IL_0154, IL_04df, IL_0747, IL_08d2)
+			IL_013f: switch (IL_0154, IL_04d0, IL_0733, IL_08be)
 
 			IL_0154: ldarg.0
 			IL_0155: ldc.i4.1
@@ -4189,1149 +4182,1144 @@
 			IL_01a8: ceq
 			IL_01aa: stloc.s 23
 			IL_01ac: ldloc.s 23
-			IL_01ae: brfalse IL_01f2
+			IL_01ae: brfalse IL_01ed
 
 			IL_01b3: ldstr "Missing required --section (e.g. 27.3)."
-			IL_01b8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01c2: stloc.2
-			IL_01c3: ldloc.0
-			IL_01c4: ldc.i4.m1
-			IL_01c5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01ca: ldloc.0
-			IL_01cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_01d5: ldarg.0
-			IL_01d6: ldc.i4.1
-			IL_01d7: newarr [System.Runtime]System.Object
-			IL_01dc: dup
-			IL_01dd: ldc.i4.0
-			IL_01de: ldloc.2
-			IL_01df: stelem.ref
-			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01e5: pop
-			IL_01e6: ldloc.0
-			IL_01e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ec: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01f1: ret
+			IL_01b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01bd: stloc.2
+			IL_01be: ldloc.0
+			IL_01bf: ldc.i4.m1
+			IL_01c0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01c5: ldloc.0
+			IL_01c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_01d0: ldarg.0
+			IL_01d1: ldc.i4.1
+			IL_01d2: newarr [System.Runtime]System.Object
+			IL_01d7: dup
+			IL_01d8: ldc.i4.0
+			IL_01d9: ldloc.2
+			IL_01da: stelem.ref
+			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01e0: pop
+			IL_01e1: ldloc.0
+			IL_01e2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01e7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01ec: ret
 
-			IL_01f2: ldloc.1
-			IL_01f3: ldstr "outFile"
-			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01fd: stloc.s 22
-			IL_01ff: ldloc.s 22
-			IL_0201: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0206: ldc.i4.0
-			IL_0207: ceq
-			IL_0209: stloc.s 23
-			IL_020b: ldloc.s 23
-			IL_020d: brfalse IL_0251
+			IL_01ed: ldloc.1
+			IL_01ee: ldstr "outFile"
+			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f8: stloc.s 22
+			IL_01fa: ldloc.s 22
+			IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0201: ldc.i4.0
+			IL_0202: ceq
+			IL_0204: stloc.s 23
+			IL_0206: ldloc.s 23
+			IL_0208: brfalse IL_0247
 
-			IL_0212: ldstr "Missing required --out <output.html>."
-			IL_0217: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_021c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0221: stloc.3
-			IL_0222: ldloc.0
-			IL_0223: ldc.i4.m1
-			IL_0224: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0229: ldloc.0
-			IL_022a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_022f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0234: ldarg.0
-			IL_0235: ldc.i4.1
-			IL_0236: newarr [System.Runtime]System.Object
-			IL_023b: dup
-			IL_023c: ldc.i4.0
-			IL_023d: ldloc.3
-			IL_023e: stelem.ref
-			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0244: pop
-			IL_0245: ldloc.0
-			IL_0246: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_024b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0250: ret
+			IL_020d: ldstr "Missing required --out <output.html>."
+			IL_0212: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0217: stloc.3
+			IL_0218: ldloc.0
+			IL_0219: ldc.i4.m1
+			IL_021a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_021f: ldloc.0
+			IL_0220: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0225: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_022a: ldarg.0
+			IL_022b: ldc.i4.1
+			IL_022c: newarr [System.Runtime]System.Object
+			IL_0231: dup
+			IL_0232: ldc.i4.0
+			IL_0233: ldloc.3
+			IL_0234: stelem.ref
+			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_023a: pop
+			IL_023b: ldloc.0
+			IL_023c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0241: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0246: ret
 
-			IL_0251: ldloc.1
-			IL_0252: ldstr "url"
-			IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_025c: stloc.s 22
-			IL_025e: ldloc.s 22
-			IL_0260: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0265: stloc.s 23
-			IL_0267: ldloc.s 23
-			IL_0269: brfalse IL_0283
+			IL_0247: ldloc.1
+			IL_0248: ldstr "url"
+			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0252: stloc.s 22
+			IL_0254: ldloc.s 22
+			IL_0256: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_025b: stloc.s 23
+			IL_025d: ldloc.s 23
+			IL_025f: brfalse IL_0279
 
-			IL_026e: ldc.r8 1
-			IL_0277: box [System.Runtime]System.Double
-			IL_027c: stloc.s 4
-			IL_027e: br IL_0293
+			IL_0264: ldc.r8 1
+			IL_026d: box [System.Runtime]System.Double
+			IL_0272: stloc.s 4
+			IL_0274: br IL_0289
 
-			IL_0283: ldc.r8 0.0
-			IL_028c: box [System.Runtime]System.Double
-			IL_0291: stloc.s 4
+			IL_0279: ldc.r8 0.0
+			IL_0282: box [System.Runtime]System.Double
+			IL_0287: stloc.s 4
 
-			IL_0293: ldloc.s 4
-			IL_0295: stloc.s 24
-			IL_0297: ldloc.1
-			IL_0298: ldstr "auto"
-			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a2: stloc.s 22
-			IL_02a4: ldloc.s 22
-			IL_02a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02ab: stloc.s 23
-			IL_02ad: ldloc.s 23
-			IL_02af: brfalse IL_02c9
+			IL_0289: ldloc.s 4
+			IL_028b: stloc.s 24
+			IL_028d: ldloc.1
+			IL_028e: ldstr "auto"
+			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0298: stloc.s 22
+			IL_029a: ldloc.s 22
+			IL_029c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02a1: stloc.s 23
+			IL_02a3: ldloc.s 23
+			IL_02a5: brfalse IL_02bf
 
-			IL_02b4: ldc.r8 1
-			IL_02bd: box [System.Runtime]System.Double
-			IL_02c2: stloc.s 5
-			IL_02c4: br IL_02d9
+			IL_02aa: ldc.r8 1
+			IL_02b3: box [System.Runtime]System.Double
+			IL_02b8: stloc.s 5
+			IL_02ba: br IL_02cf
 
-			IL_02c9: ldc.r8 0.0
-			IL_02d2: box [System.Runtime]System.Double
-			IL_02d7: stloc.s 5
+			IL_02bf: ldc.r8 0.0
+			IL_02c8: box [System.Runtime]System.Double
+			IL_02cd: stloc.s 5
 
-			IL_02d9: ldloc.s 24
-			IL_02db: ldloc.s 5
-			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02e2: stloc.s 6
-			IL_02e4: ldloc.s 6
-			IL_02e6: ldc.r8 1
-			IL_02ef: box [System.Runtime]System.Double
-			IL_02f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_02f9: stloc.s 23
-			IL_02fb: ldloc.s 23
-			IL_02fd: brfalse IL_0343
+			IL_02cf: ldloc.s 24
+			IL_02d1: ldloc.s 5
+			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02d8: stloc.s 6
+			IL_02da: ldloc.s 6
+			IL_02dc: ldc.r8 1
+			IL_02e5: box [System.Runtime]System.Double
+			IL_02ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_02ef: stloc.s 23
+			IL_02f1: ldloc.s 23
+			IL_02f3: brfalse IL_0334
 
-			IL_0302: ldstr "Provide exactly one input mode: --url or --auto."
-			IL_0307: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_030c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0311: stloc.s 7
-			IL_0313: ldloc.0
-			IL_0314: ldc.i4.m1
-			IL_0315: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_031a: ldloc.0
-			IL_031b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0320: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0325: ldarg.0
-			IL_0326: ldc.i4.1
-			IL_0327: newarr [System.Runtime]System.Object
-			IL_032c: dup
-			IL_032d: ldc.i4.0
-			IL_032e: ldloc.s 7
-			IL_0330: stelem.ref
-			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0336: pop
-			IL_0337: ldloc.0
-			IL_0338: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_033d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0342: ret
+			IL_02f8: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_02fd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0302: stloc.s 7
+			IL_0304: ldloc.0
+			IL_0305: ldc.i4.m1
+			IL_0306: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_030b: ldloc.0
+			IL_030c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0311: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0316: ldarg.0
+			IL_0317: ldc.i4.1
+			IL_0318: newarr [System.Runtime]System.Object
+			IL_031d: dup
+			IL_031e: ldc.i4.0
+			IL_031f: ldloc.s 7
+			IL_0321: stelem.ref
+			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0327: pop
+			IL_0328: ldloc.0
+			IL_0329: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_032e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0333: ret
 
-			IL_0343: ldnull
-			IL_0344: stloc.s 8
-			IL_0346: ldloc.1
-			IL_0347: ldstr "id"
-			IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0351: stloc.s 22
-			IL_0353: ldloc.s 22
-			IL_0355: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_035a: stloc.s 23
-			IL_035c: ldloc.s 23
-			IL_035e: brtrue IL_036f
+			IL_0334: ldnull
+			IL_0335: stloc.s 8
+			IL_0337: ldloc.1
+			IL_0338: ldstr "id"
+			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0342: stloc.s 22
+			IL_0344: ldloc.s 22
+			IL_0346: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_034b: stloc.s 23
+			IL_034d: ldloc.s 23
+			IL_034f: brtrue IL_0360
 
-			IL_0363: ldstr ""
-			IL_0368: stloc.s 25
-			IL_036a: br IL_0373
+			IL_0354: ldstr ""
+			IL_0359: stloc.s 25
+			IL_035b: br IL_0364
 
-			IL_036f: ldloc.s 22
-			IL_0371: stloc.s 25
+			IL_0360: ldloc.s 22
+			IL_0362: stloc.s 25
 
-			IL_0373: ldloc.s 25
-			IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_037a: stloc.s 22
-			IL_037c: ldloc.s 22
-			IL_037e: castclass [System.Runtime]System.String
-			IL_0383: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0388: stloc.s 26
-			IL_038a: ldloc.s 26
-			IL_038c: stloc.s 9
-			IL_038e: ldstr ""
-			IL_0393: stloc.s 10
-			IL_0395: ldloc.1
-			IL_0396: ldstr "auto"
-			IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03a0: stloc.s 22
-			IL_03a2: ldloc.s 22
-			IL_03a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03a9: stloc.s 23
-			IL_03ab: ldloc.s 23
-			IL_03ad: brfalse IL_07a5
+			IL_0364: ldloc.s 25
+			IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_036b: stloc.s 22
+			IL_036d: ldloc.s 22
+			IL_036f: castclass [System.Runtime]System.String
+			IL_0374: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0379: stloc.s 26
+			IL_037b: ldloc.s 26
+			IL_037d: stloc.s 9
+			IL_037f: ldstr ""
+			IL_0384: stloc.s 10
+			IL_0386: ldloc.1
+			IL_0387: ldstr "auto"
+			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0391: stloc.s 22
+			IL_0393: ldloc.s 22
+			IL_0395: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_039a: stloc.s 23
+			IL_039c: ldloc.s 23
+			IL_039e: brfalse IL_0791
 
-			IL_03b2: ldloc.1
-			IL_03b3: ldstr "indexUrl"
-			IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03bd: stloc.s 22
-			IL_03bf: ldloc.s 22
-			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03c6: stloc.s 22
-			IL_03c8: ldloc.s 22
-			IL_03ca: ldstr "trim"
-			IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_03d4: stloc.s 11
-			IL_03d6: ldarg.0
-			IL_03d7: ldc.i4.1
-			IL_03d8: ldelem.ref
-			IL_03d9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_03de: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_03e3: ldc.i4.1
-			IL_03e4: newarr [System.Runtime]System.Object
-			IL_03e9: dup
-			IL_03ea: ldc.i4.0
-			IL_03eb: ldarg.0
-			IL_03ec: ldc.i4.1
-			IL_03ed: ldelem.ref
-			IL_03ee: stelem.ref
-			IL_03ef: stloc.s 21
-			IL_03f1: ldloc.s 21
-			IL_03f3: ldloc.s 11
-			IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_03fa: stloc.s 22
-			IL_03fc: ldloc.0
-			IL_03fd: ldc.i4.1
-			IL_03fe: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0403: ldloc.0
-			IL_0404: ldloc.s 22
-			IL_0406: ldarg.0
-			IL_0407: ldc.i4.1
-			IL_0408: ldloc.0
-			IL_0409: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_040e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0413: ldloc.0
-			IL_0414: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0419: dup
-			IL_041a: ldc.i4.0
-			IL_041b: ldloc.1
-			IL_041c: stelem.ref
-			IL_041d: dup
-			IL_041e: ldc.i4.1
-			IL_041f: ldloc.2
-			IL_0420: stelem.ref
-			IL_0421: dup
-			IL_0422: ldc.i4.2
-			IL_0423: ldloc.3
+			IL_03a3: ldloc.1
+			IL_03a4: ldstr "indexUrl"
+			IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03ae: stloc.s 22
+			IL_03b0: ldloc.s 22
+			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03b7: stloc.s 22
+			IL_03b9: ldloc.s 22
+			IL_03bb: ldstr "trim"
+			IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_03c5: stloc.s 11
+			IL_03c7: ldarg.0
+			IL_03c8: ldc.i4.1
+			IL_03c9: ldelem.ref
+			IL_03ca: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_03cf: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_03d4: ldc.i4.1
+			IL_03d5: newarr [System.Runtime]System.Object
+			IL_03da: dup
+			IL_03db: ldc.i4.0
+			IL_03dc: ldarg.0
+			IL_03dd: ldc.i4.1
+			IL_03de: ldelem.ref
+			IL_03df: stelem.ref
+			IL_03e0: stloc.s 21
+			IL_03e2: ldloc.s 21
+			IL_03e4: ldloc.s 11
+			IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_03eb: stloc.s 22
+			IL_03ed: ldloc.0
+			IL_03ee: ldc.i4.1
+			IL_03ef: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03f4: ldloc.0
+			IL_03f5: ldloc.s 22
+			IL_03f7: ldarg.0
+			IL_03f8: ldc.i4.1
+			IL_03f9: ldloc.0
+			IL_03fa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0404: ldloc.0
+			IL_0405: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_040a: dup
+			IL_040b: ldc.i4.0
+			IL_040c: ldloc.1
+			IL_040d: stelem.ref
+			IL_040e: dup
+			IL_040f: ldc.i4.1
+			IL_0410: ldloc.2
+			IL_0411: stelem.ref
+			IL_0412: dup
+			IL_0413: ldc.i4.2
+			IL_0414: ldloc.3
+			IL_0415: stelem.ref
+			IL_0416: dup
+			IL_0417: ldc.i4.3
+			IL_0418: ldloc.s 4
+			IL_041a: stelem.ref
+			IL_041b: dup
+			IL_041c: ldc.i4.4
+			IL_041d: ldloc.s 5
+			IL_041f: stelem.ref
+			IL_0420: dup
+			IL_0421: ldc.i4.5
+			IL_0422: ldloc.s 6
 			IL_0424: stelem.ref
 			IL_0425: dup
-			IL_0426: ldc.i4.3
-			IL_0427: ldloc.s 4
+			IL_0426: ldc.i4.6
+			IL_0427: ldloc.s 7
 			IL_0429: stelem.ref
 			IL_042a: dup
-			IL_042b: ldc.i4.4
-			IL_042c: ldloc.s 5
+			IL_042b: ldc.i4.7
+			IL_042c: ldloc.s 8
 			IL_042e: stelem.ref
 			IL_042f: dup
-			IL_0430: ldc.i4.5
-			IL_0431: ldloc.s 6
+			IL_0430: ldc.i4.8
+			IL_0431: ldloc.s 9
 			IL_0433: stelem.ref
 			IL_0434: dup
-			IL_0435: ldc.i4.6
-			IL_0436: ldloc.s 7
-			IL_0438: stelem.ref
-			IL_0439: dup
-			IL_043a: ldc.i4.7
-			IL_043b: ldloc.s 8
-			IL_043d: stelem.ref
-			IL_043e: dup
-			IL_043f: ldc.i4.8
-			IL_0440: ldloc.s 9
-			IL_0442: stelem.ref
-			IL_0443: dup
-			IL_0444: ldc.i4.s 9
-			IL_0446: ldloc.s 10
-			IL_0448: stelem.ref
-			IL_0449: dup
-			IL_044a: ldc.i4.s 10
-			IL_044c: ldloc.s 11
-			IL_044e: stelem.ref
-			IL_044f: dup
-			IL_0450: ldc.i4.s 11
-			IL_0452: ldloc.s 12
-			IL_0454: stelem.ref
-			IL_0455: dup
-			IL_0456: ldc.i4.s 12
-			IL_0458: ldloc.s 13
-			IL_045a: stelem.ref
-			IL_045b: dup
-			IL_045c: ldc.i4.s 13
-			IL_045e: ldloc.s 14
-			IL_0460: stelem.ref
-			IL_0461: dup
-			IL_0462: ldc.i4.s 14
-			IL_0464: ldloc.s 15
-			IL_0466: stelem.ref
-			IL_0467: dup
-			IL_0468: ldc.i4.s 15
-			IL_046a: ldloc.s 16
-			IL_046c: stelem.ref
-			IL_046d: dup
-			IL_046e: ldc.i4.s 16
-			IL_0470: ldloc.s 17
-			IL_0472: stelem.ref
-			IL_0473: dup
-			IL_0474: ldc.i4.s 17
-			IL_0476: ldloc.s 18
-			IL_0478: stelem.ref
-			IL_0479: dup
-			IL_047a: ldc.i4.s 18
-			IL_047c: ldloc.s 19
-			IL_047e: stelem.ref
-			IL_047f: dup
-			IL_0480: ldc.i4.s 19
-			IL_0482: ldloc.s 20
-			IL_0484: stelem.ref
-			IL_0485: dup
-			IL_0486: ldc.i4.s 20
-			IL_0488: ldloc.s 21
-			IL_048a: stelem.ref
-			IL_048b: dup
-			IL_048c: ldc.i4.s 21
-			IL_048e: ldloc.s 22
-			IL_0490: stelem.ref
-			IL_0491: dup
-			IL_0492: ldc.i4.s 22
-			IL_0494: ldloc.s 23
-			IL_0496: box [System.Runtime]System.Boolean
-			IL_049b: stelem.ref
-			IL_049c: dup
-			IL_049d: ldc.i4.s 23
-			IL_049f: ldloc.s 24
-			IL_04a1: stelem.ref
-			IL_04a2: dup
-			IL_04a3: ldc.i4.s 24
-			IL_04a5: ldloc.s 25
-			IL_04a7: stelem.ref
-			IL_04a8: dup
-			IL_04a9: ldc.i4.s 25
-			IL_04ab: ldloc.s 26
-			IL_04ad: stelem.ref
-			IL_04ae: dup
-			IL_04af: ldc.i4.s 26
-			IL_04b1: ldloc.s 27
-			IL_04b3: stelem.ref
-			IL_04b4: dup
-			IL_04b5: ldc.i4.s 27
-			IL_04b7: ldloc.s 28
-			IL_04b9: stelem.ref
-			IL_04ba: dup
-			IL_04bb: ldc.i4.s 28
-			IL_04bd: ldloc.s 29
-			IL_04bf: stelem.ref
-			IL_04c0: dup
-			IL_04c1: ldc.i4.s 29
-			IL_04c3: ldloc.s 30
-			IL_04c5: stelem.ref
-			IL_04c6: dup
-			IL_04c7: ldc.i4.s 30
-			IL_04c9: ldloc.s 31
-			IL_04cb: stelem.ref
-			IL_04cc: dup
-			IL_04cd: ldc.i4.s 31
-			IL_04cf: ldloc.s 32
-			IL_04d1: stelem.ref
-			IL_04d2: pop
-			IL_04d3: ldloc.0
-			IL_04d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04d9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04de: ret
+			IL_0435: ldc.i4.s 9
+			IL_0437: ldloc.s 10
+			IL_0439: stelem.ref
+			IL_043a: dup
+			IL_043b: ldc.i4.s 10
+			IL_043d: ldloc.s 11
+			IL_043f: stelem.ref
+			IL_0440: dup
+			IL_0441: ldc.i4.s 11
+			IL_0443: ldloc.s 12
+			IL_0445: stelem.ref
+			IL_0446: dup
+			IL_0447: ldc.i4.s 12
+			IL_0449: ldloc.s 13
+			IL_044b: stelem.ref
+			IL_044c: dup
+			IL_044d: ldc.i4.s 13
+			IL_044f: ldloc.s 14
+			IL_0451: stelem.ref
+			IL_0452: dup
+			IL_0453: ldc.i4.s 14
+			IL_0455: ldloc.s 15
+			IL_0457: stelem.ref
+			IL_0458: dup
+			IL_0459: ldc.i4.s 15
+			IL_045b: ldloc.s 16
+			IL_045d: stelem.ref
+			IL_045e: dup
+			IL_045f: ldc.i4.s 16
+			IL_0461: ldloc.s 17
+			IL_0463: stelem.ref
+			IL_0464: dup
+			IL_0465: ldc.i4.s 17
+			IL_0467: ldloc.s 18
+			IL_0469: stelem.ref
+			IL_046a: dup
+			IL_046b: ldc.i4.s 18
+			IL_046d: ldloc.s 19
+			IL_046f: stelem.ref
+			IL_0470: dup
+			IL_0471: ldc.i4.s 19
+			IL_0473: ldloc.s 20
+			IL_0475: stelem.ref
+			IL_0476: dup
+			IL_0477: ldc.i4.s 20
+			IL_0479: ldloc.s 21
+			IL_047b: stelem.ref
+			IL_047c: dup
+			IL_047d: ldc.i4.s 21
+			IL_047f: ldloc.s 22
+			IL_0481: stelem.ref
+			IL_0482: dup
+			IL_0483: ldc.i4.s 22
+			IL_0485: ldloc.s 23
+			IL_0487: box [System.Runtime]System.Boolean
+			IL_048c: stelem.ref
+			IL_048d: dup
+			IL_048e: ldc.i4.s 23
+			IL_0490: ldloc.s 24
+			IL_0492: stelem.ref
+			IL_0493: dup
+			IL_0494: ldc.i4.s 24
+			IL_0496: ldloc.s 25
+			IL_0498: stelem.ref
+			IL_0499: dup
+			IL_049a: ldc.i4.s 25
+			IL_049c: ldloc.s 26
+			IL_049e: stelem.ref
+			IL_049f: dup
+			IL_04a0: ldc.i4.s 26
+			IL_04a2: ldloc.s 27
+			IL_04a4: stelem.ref
+			IL_04a5: dup
+			IL_04a6: ldc.i4.s 27
+			IL_04a8: ldloc.s 28
+			IL_04aa: stelem.ref
+			IL_04ab: dup
+			IL_04ac: ldc.i4.s 28
+			IL_04ae: ldloc.s 29
+			IL_04b0: stelem.ref
+			IL_04b1: dup
+			IL_04b2: ldc.i4.s 29
+			IL_04b4: ldloc.s 30
+			IL_04b6: stelem.ref
+			IL_04b7: dup
+			IL_04b8: ldc.i4.s 30
+			IL_04ba: ldloc.s 31
+			IL_04bc: stelem.ref
+			IL_04bd: dup
+			IL_04be: ldc.i4.s 31
+			IL_04c0: ldloc.s 32
+			IL_04c2: stelem.ref
+			IL_04c3: pop
+			IL_04c4: ldloc.0
+			IL_04c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04ca: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04cf: ret
 
-			IL_04df: ldloc.0
-			IL_04e0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_04e5: stloc.s 12
-			IL_04e7: ldarg.0
-			IL_04e8: ldc.i4.1
-			IL_04e9: ldelem.ref
-			IL_04ea: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_04ef: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
-			IL_04f4: ldc.i4.1
-			IL_04f5: newarr [System.Runtime]System.Object
-			IL_04fa: dup
-			IL_04fb: ldc.i4.0
-			IL_04fc: ldarg.0
-			IL_04fd: ldc.i4.1
-			IL_04fe: ldelem.ref
-			IL_04ff: stelem.ref
-			IL_0500: stloc.s 21
-			IL_0502: ldloc.1
-			IL_0503: ldstr "section"
-			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_050d: stloc.s 22
-			IL_050f: ldloc.s 22
-			IL_0511: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0516: stloc.s 22
-			IL_0518: ldloc.s 22
-			IL_051a: ldstr "trim"
-			IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0524: stloc.s 22
-			IL_0526: ldloc.s 21
-			IL_0528: ldloc.s 12
-			IL_052a: ldloc.s 22
-			IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0531: stloc.s 13
-			IL_0533: ldloc.s 13
-			IL_0535: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_053a: ldc.i4.0
-			IL_053b: ceq
-			IL_053d: stloc.s 23
-			IL_053f: ldloc.s 23
-			IL_0541: brfalse IL_05c2
+			IL_04d0: ldloc.0
+			IL_04d1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_04d6: stloc.s 12
+			IL_04d8: ldarg.0
+			IL_04d9: ldc.i4.1
+			IL_04da: ldelem.ref
+			IL_04db: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_04e0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+			IL_04e5: ldc.i4.1
+			IL_04e6: newarr [System.Runtime]System.Object
+			IL_04eb: dup
+			IL_04ec: ldc.i4.0
+			IL_04ed: ldarg.0
+			IL_04ee: ldc.i4.1
+			IL_04ef: ldelem.ref
+			IL_04f0: stelem.ref
+			IL_04f1: stloc.s 21
+			IL_04f3: ldloc.1
+			IL_04f4: ldstr "section"
+			IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04fe: stloc.s 22
+			IL_0500: ldloc.s 22
+			IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0507: stloc.s 22
+			IL_0509: ldloc.s 22
+			IL_050b: ldstr "trim"
+			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0515: stloc.s 22
+			IL_0517: ldloc.s 21
+			IL_0519: ldloc.s 12
+			IL_051b: ldloc.s 22
+			IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0522: stloc.s 13
+			IL_0524: ldloc.s 13
+			IL_0526: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_052b: ldc.i4.0
+			IL_052c: ceq
+			IL_052e: stloc.s 23
+			IL_0530: ldloc.s 23
+			IL_0532: brfalse IL_05ae
 
-			IL_0546: ldloc.1
-			IL_0547: ldstr "section"
-			IL_054c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0551: stloc.s 22
-			IL_0553: ldloc.s 22
-			IL_0555: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_055a: stloc.s 26
-			IL_055c: ldstr "Could not find section '"
-			IL_0561: ldloc.s 26
-			IL_0563: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0568: ldstr "' in multipage index: "
-			IL_056d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0572: ldloc.s 11
-			IL_0574: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0579: stloc.s 26
-			IL_057b: ldloc.s 26
-			IL_057d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0582: stloc.s 26
-			IL_0584: ldloc.s 26
-			IL_0586: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_058b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0590: stloc.s 14
-			IL_0592: ldloc.0
-			IL_0593: ldc.i4.m1
-			IL_0594: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0599: ldloc.0
-			IL_059a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_059f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_05a4: ldarg.0
-			IL_05a5: ldc.i4.1
-			IL_05a6: newarr [System.Runtime]System.Object
-			IL_05ab: dup
-			IL_05ac: ldc.i4.0
-			IL_05ad: ldloc.s 14
-			IL_05af: stelem.ref
-			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05b5: pop
-			IL_05b6: ldloc.0
-			IL_05b7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05bc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05c1: ret
+			IL_0537: ldloc.1
+			IL_0538: ldstr "section"
+			IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0542: stloc.s 22
+			IL_0544: ldloc.s 22
+			IL_0546: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_054b: stloc.s 26
+			IL_054d: ldstr "Could not find section '"
+			IL_0552: ldloc.s 26
+			IL_0554: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0559: ldstr "' in multipage index: "
+			IL_055e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0563: ldloc.s 11
+			IL_0565: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_056a: stloc.s 26
+			IL_056c: ldloc.s 26
+			IL_056e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0573: stloc.s 26
+			IL_0575: ldloc.s 26
+			IL_0577: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_057c: stloc.s 14
+			IL_057e: ldloc.0
+			IL_057f: ldc.i4.m1
+			IL_0580: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0585: ldloc.0
+			IL_0586: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_058b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0590: ldarg.0
+			IL_0591: ldc.i4.1
+			IL_0592: newarr [System.Runtime]System.Object
+			IL_0597: dup
+			IL_0598: ldc.i4.0
+			IL_0599: ldloc.s 14
+			IL_059b: stelem.ref
+			IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_05a1: pop
+			IL_05a2: ldloc.0
+			IL_05a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05a8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05ad: ret
 
-			IL_05c2: ldarg.0
-			IL_05c3: ldc.i4.1
-			IL_05c4: ldelem.ref
-			IL_05c5: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_05ca: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_05cf: stloc.s 22
-			IL_05d1: ldloc.s 13
-			IL_05d3: ldstr "filePart"
-			IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05dd: stloc.s 27
-			IL_05df: ldloc.s 27
-			IL_05e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05e6: stloc.s 23
-			IL_05e8: ldloc.s 23
-			IL_05ea: brtrue IL_0606
+			IL_05ae: ldarg.0
+			IL_05af: ldc.i4.1
+			IL_05b0: ldelem.ref
+			IL_05b1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_05b6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_05bb: stloc.s 22
+			IL_05bd: ldloc.s 13
+			IL_05bf: ldstr "filePart"
+			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05c9: stloc.s 27
+			IL_05cb: ldloc.s 27
+			IL_05cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05d2: stloc.s 23
+			IL_05d4: ldloc.s 23
+			IL_05d6: brtrue IL_05f2
 
-			IL_05ef: ldloc.s 13
-			IL_05f1: ldstr "href"
-			IL_05f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05fb: stloc.s 28
-			IL_05fd: ldloc.s 28
-			IL_05ff: stloc.s 29
-			IL_0601: br IL_060a
+			IL_05db: ldloc.s 13
+			IL_05dd: ldstr "href"
+			IL_05e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05e7: stloc.s 28
+			IL_05e9: ldloc.s 28
+			IL_05eb: stloc.s 29
+			IL_05ed: br IL_05f6
 
-			IL_0606: ldloc.s 27
-			IL_0608: stloc.s 29
+			IL_05f2: ldloc.s 27
+			IL_05f4: stloc.s 29
 
-			IL_060a: ldc.i4.2
-			IL_060b: newarr [System.Runtime]System.Object
-			IL_0610: dup
-			IL_0611: ldc.i4.0
-			IL_0612: ldloc.s 29
-			IL_0614: stelem.ref
-			IL_0615: dup
-			IL_0616: ldc.i4.1
-			IL_0617: ldloc.s 11
-			IL_0619: stelem.ref
-			IL_061a: stloc.s 21
+			IL_05f6: ldc.i4.2
+			IL_05f7: newarr [System.Runtime]System.Object
+			IL_05fc: dup
+			IL_05fd: ldc.i4.0
+			IL_05fe: ldloc.s 29
+			IL_0600: stelem.ref
+			IL_0601: dup
+			IL_0602: ldc.i4.1
+			IL_0603: ldloc.s 11
+			IL_0605: stelem.ref
+			IL_0606: stloc.s 21
+			IL_0608: ldloc.s 22
+			IL_060a: ldloc.s 21
+			IL_060c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+			IL_0611: stloc.s 22
+			IL_0613: ldloc.s 22
+			IL_0615: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_061a: stloc.s 22
 			IL_061c: ldloc.s 22
-			IL_061e: ldloc.s 21
-			IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-			IL_0625: stloc.s 22
-			IL_0627: ldloc.s 22
-			IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_062e: stloc.s 22
-			IL_0630: ldloc.s 22
-			IL_0632: ldstr "toString"
-			IL_0637: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_063c: stloc.s 15
-			IL_063e: ldarg.0
-			IL_063f: ldc.i4.1
-			IL_0640: ldelem.ref
-			IL_0641: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0646: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_064b: ldc.i4.1
-			IL_064c: newarr [System.Runtime]System.Object
-			IL_0651: dup
-			IL_0652: ldc.i4.0
-			IL_0653: ldarg.0
-			IL_0654: ldc.i4.1
-			IL_0655: ldelem.ref
-			IL_0656: stelem.ref
-			IL_0657: stloc.s 21
-			IL_0659: ldloc.s 21
-			IL_065b: ldloc.s 15
-			IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0662: stloc.s 22
-			IL_0664: ldloc.0
-			IL_0665: ldc.i4.2
-			IL_0666: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_066b: ldloc.0
-			IL_066c: ldloc.s 22
-			IL_066e: ldarg.0
-			IL_066f: ldc.i4.2
-			IL_0670: ldloc.0
-			IL_0671: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0676: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_067b: ldloc.0
-			IL_067c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0681: dup
-			IL_0682: ldc.i4.0
-			IL_0683: ldloc.1
-			IL_0684: stelem.ref
-			IL_0685: dup
-			IL_0686: ldc.i4.1
-			IL_0687: ldloc.2
-			IL_0688: stelem.ref
-			IL_0689: dup
-			IL_068a: ldc.i4.2
-			IL_068b: ldloc.3
+			IL_061e: ldstr "toString"
+			IL_0623: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0628: stloc.s 15
+			IL_062a: ldarg.0
+			IL_062b: ldc.i4.1
+			IL_062c: ldelem.ref
+			IL_062d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0632: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_0637: ldc.i4.1
+			IL_0638: newarr [System.Runtime]System.Object
+			IL_063d: dup
+			IL_063e: ldc.i4.0
+			IL_063f: ldarg.0
+			IL_0640: ldc.i4.1
+			IL_0641: ldelem.ref
+			IL_0642: stelem.ref
+			IL_0643: stloc.s 21
+			IL_0645: ldloc.s 21
+			IL_0647: ldloc.s 15
+			IL_0649: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_064e: stloc.s 22
+			IL_0650: ldloc.0
+			IL_0651: ldc.i4.2
+			IL_0652: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0657: ldloc.0
+			IL_0658: ldloc.s 22
+			IL_065a: ldarg.0
+			IL_065b: ldc.i4.2
+			IL_065c: ldloc.0
+			IL_065d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0662: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0667: ldloc.0
+			IL_0668: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_066d: dup
+			IL_066e: ldc.i4.0
+			IL_066f: ldloc.1
+			IL_0670: stelem.ref
+			IL_0671: dup
+			IL_0672: ldc.i4.1
+			IL_0673: ldloc.2
+			IL_0674: stelem.ref
+			IL_0675: dup
+			IL_0676: ldc.i4.2
+			IL_0677: ldloc.3
+			IL_0678: stelem.ref
+			IL_0679: dup
+			IL_067a: ldc.i4.3
+			IL_067b: ldloc.s 4
+			IL_067d: stelem.ref
+			IL_067e: dup
+			IL_067f: ldc.i4.4
+			IL_0680: ldloc.s 5
+			IL_0682: stelem.ref
+			IL_0683: dup
+			IL_0684: ldc.i4.5
+			IL_0685: ldloc.s 6
+			IL_0687: stelem.ref
+			IL_0688: dup
+			IL_0689: ldc.i4.6
+			IL_068a: ldloc.s 7
 			IL_068c: stelem.ref
 			IL_068d: dup
-			IL_068e: ldc.i4.3
-			IL_068f: ldloc.s 4
+			IL_068e: ldc.i4.7
+			IL_068f: ldloc.s 8
 			IL_0691: stelem.ref
 			IL_0692: dup
-			IL_0693: ldc.i4.4
-			IL_0694: ldloc.s 5
+			IL_0693: ldc.i4.8
+			IL_0694: ldloc.s 9
 			IL_0696: stelem.ref
 			IL_0697: dup
-			IL_0698: ldc.i4.5
-			IL_0699: ldloc.s 6
-			IL_069b: stelem.ref
-			IL_069c: dup
-			IL_069d: ldc.i4.6
-			IL_069e: ldloc.s 7
-			IL_06a0: stelem.ref
-			IL_06a1: dup
-			IL_06a2: ldc.i4.7
-			IL_06a3: ldloc.s 8
-			IL_06a5: stelem.ref
-			IL_06a6: dup
-			IL_06a7: ldc.i4.8
-			IL_06a8: ldloc.s 9
-			IL_06aa: stelem.ref
-			IL_06ab: dup
-			IL_06ac: ldc.i4.s 9
-			IL_06ae: ldloc.s 10
-			IL_06b0: stelem.ref
-			IL_06b1: dup
-			IL_06b2: ldc.i4.s 10
-			IL_06b4: ldloc.s 11
-			IL_06b6: stelem.ref
-			IL_06b7: dup
-			IL_06b8: ldc.i4.s 11
-			IL_06ba: ldloc.s 12
-			IL_06bc: stelem.ref
-			IL_06bd: dup
-			IL_06be: ldc.i4.s 12
-			IL_06c0: ldloc.s 13
-			IL_06c2: stelem.ref
-			IL_06c3: dup
-			IL_06c4: ldc.i4.s 13
-			IL_06c6: ldloc.s 14
-			IL_06c8: stelem.ref
-			IL_06c9: dup
-			IL_06ca: ldc.i4.s 14
-			IL_06cc: ldloc.s 15
-			IL_06ce: stelem.ref
-			IL_06cf: dup
-			IL_06d0: ldc.i4.s 15
-			IL_06d2: ldloc.s 16
-			IL_06d4: stelem.ref
-			IL_06d5: dup
-			IL_06d6: ldc.i4.s 16
-			IL_06d8: ldloc.s 17
-			IL_06da: stelem.ref
-			IL_06db: dup
-			IL_06dc: ldc.i4.s 17
-			IL_06de: ldloc.s 18
-			IL_06e0: stelem.ref
-			IL_06e1: dup
-			IL_06e2: ldc.i4.s 18
-			IL_06e4: ldloc.s 19
-			IL_06e6: stelem.ref
-			IL_06e7: dup
-			IL_06e8: ldc.i4.s 19
-			IL_06ea: ldloc.s 20
-			IL_06ec: stelem.ref
-			IL_06ed: dup
-			IL_06ee: ldc.i4.s 20
-			IL_06f0: ldloc.s 21
-			IL_06f2: stelem.ref
-			IL_06f3: dup
-			IL_06f4: ldc.i4.s 21
-			IL_06f6: ldloc.s 22
-			IL_06f8: stelem.ref
-			IL_06f9: dup
-			IL_06fa: ldc.i4.s 22
-			IL_06fc: ldloc.s 23
-			IL_06fe: box [System.Runtime]System.Boolean
-			IL_0703: stelem.ref
-			IL_0704: dup
-			IL_0705: ldc.i4.s 23
-			IL_0707: ldloc.s 24
-			IL_0709: stelem.ref
-			IL_070a: dup
-			IL_070b: ldc.i4.s 24
-			IL_070d: ldloc.s 25
-			IL_070f: stelem.ref
-			IL_0710: dup
-			IL_0711: ldc.i4.s 25
-			IL_0713: ldloc.s 26
-			IL_0715: stelem.ref
-			IL_0716: dup
-			IL_0717: ldc.i4.s 26
-			IL_0719: ldloc.s 27
-			IL_071b: stelem.ref
-			IL_071c: dup
-			IL_071d: ldc.i4.s 27
-			IL_071f: ldloc.s 28
-			IL_0721: stelem.ref
-			IL_0722: dup
-			IL_0723: ldc.i4.s 28
-			IL_0725: ldloc.s 29
-			IL_0727: stelem.ref
-			IL_0728: dup
-			IL_0729: ldc.i4.s 29
-			IL_072b: ldloc.s 30
-			IL_072d: stelem.ref
-			IL_072e: dup
-			IL_072f: ldc.i4.s 30
-			IL_0731: ldloc.s 31
-			IL_0733: stelem.ref
-			IL_0734: dup
-			IL_0735: ldc.i4.s 31
-			IL_0737: ldloc.s 32
-			IL_0739: stelem.ref
-			IL_073a: pop
-			IL_073b: ldloc.0
-			IL_073c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0741: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0746: ret
+			IL_0698: ldc.i4.s 9
+			IL_069a: ldloc.s 10
+			IL_069c: stelem.ref
+			IL_069d: dup
+			IL_069e: ldc.i4.s 10
+			IL_06a0: ldloc.s 11
+			IL_06a2: stelem.ref
+			IL_06a3: dup
+			IL_06a4: ldc.i4.s 11
+			IL_06a6: ldloc.s 12
+			IL_06a8: stelem.ref
+			IL_06a9: dup
+			IL_06aa: ldc.i4.s 12
+			IL_06ac: ldloc.s 13
+			IL_06ae: stelem.ref
+			IL_06af: dup
+			IL_06b0: ldc.i4.s 13
+			IL_06b2: ldloc.s 14
+			IL_06b4: stelem.ref
+			IL_06b5: dup
+			IL_06b6: ldc.i4.s 14
+			IL_06b8: ldloc.s 15
+			IL_06ba: stelem.ref
+			IL_06bb: dup
+			IL_06bc: ldc.i4.s 15
+			IL_06be: ldloc.s 16
+			IL_06c0: stelem.ref
+			IL_06c1: dup
+			IL_06c2: ldc.i4.s 16
+			IL_06c4: ldloc.s 17
+			IL_06c6: stelem.ref
+			IL_06c7: dup
+			IL_06c8: ldc.i4.s 17
+			IL_06ca: ldloc.s 18
+			IL_06cc: stelem.ref
+			IL_06cd: dup
+			IL_06ce: ldc.i4.s 18
+			IL_06d0: ldloc.s 19
+			IL_06d2: stelem.ref
+			IL_06d3: dup
+			IL_06d4: ldc.i4.s 19
+			IL_06d6: ldloc.s 20
+			IL_06d8: stelem.ref
+			IL_06d9: dup
+			IL_06da: ldc.i4.s 20
+			IL_06dc: ldloc.s 21
+			IL_06de: stelem.ref
+			IL_06df: dup
+			IL_06e0: ldc.i4.s 21
+			IL_06e2: ldloc.s 22
+			IL_06e4: stelem.ref
+			IL_06e5: dup
+			IL_06e6: ldc.i4.s 22
+			IL_06e8: ldloc.s 23
+			IL_06ea: box [System.Runtime]System.Boolean
+			IL_06ef: stelem.ref
+			IL_06f0: dup
+			IL_06f1: ldc.i4.s 23
+			IL_06f3: ldloc.s 24
+			IL_06f5: stelem.ref
+			IL_06f6: dup
+			IL_06f7: ldc.i4.s 24
+			IL_06f9: ldloc.s 25
+			IL_06fb: stelem.ref
+			IL_06fc: dup
+			IL_06fd: ldc.i4.s 25
+			IL_06ff: ldloc.s 26
+			IL_0701: stelem.ref
+			IL_0702: dup
+			IL_0703: ldc.i4.s 26
+			IL_0705: ldloc.s 27
+			IL_0707: stelem.ref
+			IL_0708: dup
+			IL_0709: ldc.i4.s 27
+			IL_070b: ldloc.s 28
+			IL_070d: stelem.ref
+			IL_070e: dup
+			IL_070f: ldc.i4.s 28
+			IL_0711: ldloc.s 29
+			IL_0713: stelem.ref
+			IL_0714: dup
+			IL_0715: ldc.i4.s 29
+			IL_0717: ldloc.s 30
+			IL_0719: stelem.ref
+			IL_071a: dup
+			IL_071b: ldc.i4.s 30
+			IL_071d: ldloc.s 31
+			IL_071f: stelem.ref
+			IL_0720: dup
+			IL_0721: ldc.i4.s 31
+			IL_0723: ldloc.s 32
+			IL_0725: stelem.ref
+			IL_0726: pop
+			IL_0727: ldloc.0
+			IL_0728: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_072d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0732: ret
 
-			IL_0747: ldloc.0
-			IL_0748: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_074d: stloc.s 22
-			IL_074f: ldloc.s 22
-			IL_0751: stloc.s 8
-			IL_0753: ldloc.s 15
-			IL_0755: stloc.s 22
-			IL_0757: ldloc.s 22
-			IL_0759: stloc.s 10
-			IL_075b: ldloc.s 9
-			IL_075d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0762: ldc.i4.0
-			IL_0763: ceq
-			IL_0765: stloc.s 23
-			IL_0767: ldloc.s 23
-			IL_0769: brfalse IL_07a0
+			IL_0733: ldloc.0
+			IL_0734: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_0739: stloc.s 22
+			IL_073b: ldloc.s 22
+			IL_073d: stloc.s 8
+			IL_073f: ldloc.s 15
+			IL_0741: stloc.s 22
+			IL_0743: ldloc.s 22
+			IL_0745: stloc.s 10
+			IL_0747: ldloc.s 9
+			IL_0749: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_074e: ldc.i4.0
+			IL_074f: ceq
+			IL_0751: stloc.s 23
+			IL_0753: ldloc.s 23
+			IL_0755: brfalse IL_078c
 
-			IL_076e: ldloc.s 13
-			IL_0770: ldstr "fragment"
-			IL_0775: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_077a: stloc.s 22
-			IL_077c: ldloc.s 22
-			IL_077e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0783: stloc.s 23
-			IL_0785: ldloc.s 23
-			IL_0787: brtrue IL_0798
+			IL_075a: ldloc.s 13
+			IL_075c: ldstr "fragment"
+			IL_0761: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0766: stloc.s 22
+			IL_0768: ldloc.s 22
+			IL_076a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_076f: stloc.s 23
+			IL_0771: ldloc.s 23
+			IL_0773: brtrue IL_0784
 
-			IL_078c: ldstr ""
-			IL_0791: stloc.s 30
-			IL_0793: br IL_079c
+			IL_0778: ldstr ""
+			IL_077d: stloc.s 30
+			IL_077f: br IL_0788
 
-			IL_0798: ldloc.s 22
-			IL_079a: stloc.s 30
+			IL_0784: ldloc.s 22
+			IL_0786: stloc.s 30
 
-			IL_079c: ldloc.s 30
-			IL_079e: stloc.s 9
+			IL_0788: ldloc.s 30
+			IL_078a: stloc.s 9
 
-			IL_07a0: br IL_08e6
+			IL_078c: br IL_08d2
 
-			IL_07a5: ldloc.1
-			IL_07a6: ldstr "url"
-			IL_07ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07b0: stloc.s 22
-			IL_07b2: ldloc.s 22
-			IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07b9: stloc.s 22
-			IL_07bb: ldloc.s 22
-			IL_07bd: ldstr "trim"
-			IL_07c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_07c7: stloc.s 16
-			IL_07c9: ldarg.0
-			IL_07ca: ldc.i4.1
-			IL_07cb: ldelem.ref
-			IL_07cc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_07d1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_07d6: ldc.i4.1
-			IL_07d7: newarr [System.Runtime]System.Object
-			IL_07dc: dup
-			IL_07dd: ldc.i4.0
-			IL_07de: ldarg.0
-			IL_07df: ldc.i4.1
-			IL_07e0: ldelem.ref
-			IL_07e1: stelem.ref
-			IL_07e2: stloc.s 21
-			IL_07e4: ldloc.s 21
-			IL_07e6: ldloc.s 16
-			IL_07e8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_07ed: stloc.s 22
-			IL_07ef: ldloc.0
-			IL_07f0: ldc.i4.3
-			IL_07f1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07f6: ldloc.0
-			IL_07f7: ldloc.s 22
-			IL_07f9: ldarg.0
-			IL_07fa: ldc.i4.3
-			IL_07fb: ldloc.0
-			IL_07fc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0801: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0806: ldloc.0
-			IL_0807: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_080c: dup
-			IL_080d: ldc.i4.0
-			IL_080e: ldloc.1
-			IL_080f: stelem.ref
-			IL_0810: dup
-			IL_0811: ldc.i4.1
-			IL_0812: ldloc.2
-			IL_0813: stelem.ref
-			IL_0814: dup
-			IL_0815: ldc.i4.2
-			IL_0816: ldloc.3
+			IL_0791: ldloc.1
+			IL_0792: ldstr "url"
+			IL_0797: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_079c: stloc.s 22
+			IL_079e: ldloc.s 22
+			IL_07a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07a5: stloc.s 22
+			IL_07a7: ldloc.s 22
+			IL_07a9: ldstr "trim"
+			IL_07ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_07b3: stloc.s 16
+			IL_07b5: ldarg.0
+			IL_07b6: ldc.i4.1
+			IL_07b7: ldelem.ref
+			IL_07b8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_07bd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_07c2: ldc.i4.1
+			IL_07c3: newarr [System.Runtime]System.Object
+			IL_07c8: dup
+			IL_07c9: ldc.i4.0
+			IL_07ca: ldarg.0
+			IL_07cb: ldc.i4.1
+			IL_07cc: ldelem.ref
+			IL_07cd: stelem.ref
+			IL_07ce: stloc.s 21
+			IL_07d0: ldloc.s 21
+			IL_07d2: ldloc.s 16
+			IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_07d9: stloc.s 22
+			IL_07db: ldloc.0
+			IL_07dc: ldc.i4.3
+			IL_07dd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07e2: ldloc.0
+			IL_07e3: ldloc.s 22
+			IL_07e5: ldarg.0
+			IL_07e6: ldc.i4.3
+			IL_07e7: ldloc.0
+			IL_07e8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_07f2: ldloc.0
+			IL_07f3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_07f8: dup
+			IL_07f9: ldc.i4.0
+			IL_07fa: ldloc.1
+			IL_07fb: stelem.ref
+			IL_07fc: dup
+			IL_07fd: ldc.i4.1
+			IL_07fe: ldloc.2
+			IL_07ff: stelem.ref
+			IL_0800: dup
+			IL_0801: ldc.i4.2
+			IL_0802: ldloc.3
+			IL_0803: stelem.ref
+			IL_0804: dup
+			IL_0805: ldc.i4.3
+			IL_0806: ldloc.s 4
+			IL_0808: stelem.ref
+			IL_0809: dup
+			IL_080a: ldc.i4.4
+			IL_080b: ldloc.s 5
+			IL_080d: stelem.ref
+			IL_080e: dup
+			IL_080f: ldc.i4.5
+			IL_0810: ldloc.s 6
+			IL_0812: stelem.ref
+			IL_0813: dup
+			IL_0814: ldc.i4.6
+			IL_0815: ldloc.s 7
 			IL_0817: stelem.ref
 			IL_0818: dup
-			IL_0819: ldc.i4.3
-			IL_081a: ldloc.s 4
+			IL_0819: ldc.i4.7
+			IL_081a: ldloc.s 8
 			IL_081c: stelem.ref
 			IL_081d: dup
-			IL_081e: ldc.i4.4
-			IL_081f: ldloc.s 5
+			IL_081e: ldc.i4.8
+			IL_081f: ldloc.s 9
 			IL_0821: stelem.ref
 			IL_0822: dup
-			IL_0823: ldc.i4.5
-			IL_0824: ldloc.s 6
-			IL_0826: stelem.ref
-			IL_0827: dup
-			IL_0828: ldc.i4.6
-			IL_0829: ldloc.s 7
-			IL_082b: stelem.ref
-			IL_082c: dup
-			IL_082d: ldc.i4.7
-			IL_082e: ldloc.s 8
-			IL_0830: stelem.ref
-			IL_0831: dup
-			IL_0832: ldc.i4.8
-			IL_0833: ldloc.s 9
-			IL_0835: stelem.ref
-			IL_0836: dup
-			IL_0837: ldc.i4.s 9
-			IL_0839: ldloc.s 10
-			IL_083b: stelem.ref
-			IL_083c: dup
-			IL_083d: ldc.i4.s 10
-			IL_083f: ldloc.s 11
-			IL_0841: stelem.ref
-			IL_0842: dup
-			IL_0843: ldc.i4.s 11
-			IL_0845: ldloc.s 12
-			IL_0847: stelem.ref
-			IL_0848: dup
-			IL_0849: ldc.i4.s 12
-			IL_084b: ldloc.s 13
-			IL_084d: stelem.ref
-			IL_084e: dup
-			IL_084f: ldc.i4.s 13
-			IL_0851: ldloc.s 14
-			IL_0853: stelem.ref
-			IL_0854: dup
-			IL_0855: ldc.i4.s 14
-			IL_0857: ldloc.s 15
-			IL_0859: stelem.ref
-			IL_085a: dup
-			IL_085b: ldc.i4.s 15
-			IL_085d: ldloc.s 16
-			IL_085f: stelem.ref
-			IL_0860: dup
-			IL_0861: ldc.i4.s 16
-			IL_0863: ldloc.s 17
-			IL_0865: stelem.ref
-			IL_0866: dup
-			IL_0867: ldc.i4.s 17
-			IL_0869: ldloc.s 18
-			IL_086b: stelem.ref
-			IL_086c: dup
-			IL_086d: ldc.i4.s 18
-			IL_086f: ldloc.s 19
-			IL_0871: stelem.ref
-			IL_0872: dup
-			IL_0873: ldc.i4.s 19
-			IL_0875: ldloc.s 20
-			IL_0877: stelem.ref
-			IL_0878: dup
-			IL_0879: ldc.i4.s 20
-			IL_087b: ldloc.s 21
-			IL_087d: stelem.ref
-			IL_087e: dup
-			IL_087f: ldc.i4.s 21
-			IL_0881: ldloc.s 22
-			IL_0883: stelem.ref
-			IL_0884: dup
-			IL_0885: ldc.i4.s 22
-			IL_0887: ldloc.s 23
-			IL_0889: box [System.Runtime]System.Boolean
-			IL_088e: stelem.ref
-			IL_088f: dup
-			IL_0890: ldc.i4.s 23
-			IL_0892: ldloc.s 24
-			IL_0894: stelem.ref
-			IL_0895: dup
-			IL_0896: ldc.i4.s 24
-			IL_0898: ldloc.s 25
-			IL_089a: stelem.ref
-			IL_089b: dup
-			IL_089c: ldc.i4.s 25
-			IL_089e: ldloc.s 26
-			IL_08a0: stelem.ref
-			IL_08a1: dup
-			IL_08a2: ldc.i4.s 26
-			IL_08a4: ldloc.s 27
-			IL_08a6: stelem.ref
-			IL_08a7: dup
-			IL_08a8: ldc.i4.s 27
-			IL_08aa: ldloc.s 28
-			IL_08ac: stelem.ref
-			IL_08ad: dup
-			IL_08ae: ldc.i4.s 28
-			IL_08b0: ldloc.s 29
-			IL_08b2: stelem.ref
-			IL_08b3: dup
-			IL_08b4: ldc.i4.s 29
-			IL_08b6: ldloc.s 30
-			IL_08b8: stelem.ref
-			IL_08b9: dup
-			IL_08ba: ldc.i4.s 30
-			IL_08bc: ldloc.s 31
-			IL_08be: stelem.ref
-			IL_08bf: dup
-			IL_08c0: ldc.i4.s 31
-			IL_08c2: ldloc.s 32
-			IL_08c4: stelem.ref
-			IL_08c5: pop
-			IL_08c6: ldloc.0
-			IL_08c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08cc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08d1: ret
+			IL_0823: ldc.i4.s 9
+			IL_0825: ldloc.s 10
+			IL_0827: stelem.ref
+			IL_0828: dup
+			IL_0829: ldc.i4.s 10
+			IL_082b: ldloc.s 11
+			IL_082d: stelem.ref
+			IL_082e: dup
+			IL_082f: ldc.i4.s 11
+			IL_0831: ldloc.s 12
+			IL_0833: stelem.ref
+			IL_0834: dup
+			IL_0835: ldc.i4.s 12
+			IL_0837: ldloc.s 13
+			IL_0839: stelem.ref
+			IL_083a: dup
+			IL_083b: ldc.i4.s 13
+			IL_083d: ldloc.s 14
+			IL_083f: stelem.ref
+			IL_0840: dup
+			IL_0841: ldc.i4.s 14
+			IL_0843: ldloc.s 15
+			IL_0845: stelem.ref
+			IL_0846: dup
+			IL_0847: ldc.i4.s 15
+			IL_0849: ldloc.s 16
+			IL_084b: stelem.ref
+			IL_084c: dup
+			IL_084d: ldc.i4.s 16
+			IL_084f: ldloc.s 17
+			IL_0851: stelem.ref
+			IL_0852: dup
+			IL_0853: ldc.i4.s 17
+			IL_0855: ldloc.s 18
+			IL_0857: stelem.ref
+			IL_0858: dup
+			IL_0859: ldc.i4.s 18
+			IL_085b: ldloc.s 19
+			IL_085d: stelem.ref
+			IL_085e: dup
+			IL_085f: ldc.i4.s 19
+			IL_0861: ldloc.s 20
+			IL_0863: stelem.ref
+			IL_0864: dup
+			IL_0865: ldc.i4.s 20
+			IL_0867: ldloc.s 21
+			IL_0869: stelem.ref
+			IL_086a: dup
+			IL_086b: ldc.i4.s 21
+			IL_086d: ldloc.s 22
+			IL_086f: stelem.ref
+			IL_0870: dup
+			IL_0871: ldc.i4.s 22
+			IL_0873: ldloc.s 23
+			IL_0875: box [System.Runtime]System.Boolean
+			IL_087a: stelem.ref
+			IL_087b: dup
+			IL_087c: ldc.i4.s 23
+			IL_087e: ldloc.s 24
+			IL_0880: stelem.ref
+			IL_0881: dup
+			IL_0882: ldc.i4.s 24
+			IL_0884: ldloc.s 25
+			IL_0886: stelem.ref
+			IL_0887: dup
+			IL_0888: ldc.i4.s 25
+			IL_088a: ldloc.s 26
+			IL_088c: stelem.ref
+			IL_088d: dup
+			IL_088e: ldc.i4.s 26
+			IL_0890: ldloc.s 27
+			IL_0892: stelem.ref
+			IL_0893: dup
+			IL_0894: ldc.i4.s 27
+			IL_0896: ldloc.s 28
+			IL_0898: stelem.ref
+			IL_0899: dup
+			IL_089a: ldc.i4.s 28
+			IL_089c: ldloc.s 29
+			IL_089e: stelem.ref
+			IL_089f: dup
+			IL_08a0: ldc.i4.s 29
+			IL_08a2: ldloc.s 30
+			IL_08a4: stelem.ref
+			IL_08a5: dup
+			IL_08a6: ldc.i4.s 30
+			IL_08a8: ldloc.s 31
+			IL_08aa: stelem.ref
+			IL_08ab: dup
+			IL_08ac: ldc.i4.s 31
+			IL_08ae: ldloc.s 32
+			IL_08b0: stelem.ref
+			IL_08b1: pop
+			IL_08b2: ldloc.0
+			IL_08b3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08b8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08bd: ret
 
-			IL_08d2: ldloc.0
-			IL_08d3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_08d8: stloc.s 22
-			IL_08da: ldloc.s 22
-			IL_08dc: stloc.s 8
-			IL_08de: ldloc.s 16
-			IL_08e0: stloc.s 22
-			IL_08e2: ldloc.s 22
-			IL_08e4: stloc.s 10
+			IL_08be: ldloc.0
+			IL_08bf: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_08c4: stloc.s 22
+			IL_08c6: ldloc.s 22
+			IL_08c8: stloc.s 8
+			IL_08ca: ldloc.s 16
+			IL_08cc: stloc.s 22
+			IL_08ce: ldloc.s 22
+			IL_08d0: stloc.s 10
 
-			IL_08e6: ldloc.s 9
-			IL_08e8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_08ed: ldc.i4.0
-			IL_08ee: ceq
-			IL_08f0: stloc.s 23
-			IL_08f2: ldloc.s 23
-			IL_08f4: brfalse IL_0965
+			IL_08d2: ldloc.s 9
+			IL_08d4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08d9: ldc.i4.0
+			IL_08da: ceq
+			IL_08dc: stloc.s 23
+			IL_08de: ldloc.s 23
+			IL_08e0: brfalse IL_094c
 
-			IL_08f9: ldloc.1
-			IL_08fa: ldstr "section"
-			IL_08ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0904: stloc.s 22
-			IL_0906: ldloc.s 22
-			IL_0908: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_090d: stloc.s 26
-			IL_090f: ldstr "Could not infer an element id for section '"
-			IL_0914: ldloc.s 26
-			IL_0916: call string [System.Runtime]System.String::Concat(string, string)
-			IL_091b: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0920: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0925: stloc.s 26
-			IL_0927: ldloc.s 26
-			IL_0929: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_092e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0933: stloc.s 17
-			IL_0935: ldloc.0
-			IL_0936: ldc.i4.m1
-			IL_0937: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_093c: ldloc.0
-			IL_093d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0942: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0947: ldarg.0
-			IL_0948: ldc.i4.1
-			IL_0949: newarr [System.Runtime]System.Object
-			IL_094e: dup
-			IL_094f: ldc.i4.0
-			IL_0950: ldloc.s 17
-			IL_0952: stelem.ref
-			IL_0953: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0958: pop
-			IL_0959: ldloc.0
-			IL_095a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_095f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0964: ret
+			IL_08e5: ldloc.1
+			IL_08e6: ldstr "section"
+			IL_08eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08f0: stloc.s 22
+			IL_08f2: ldloc.s 22
+			IL_08f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08f9: stloc.s 26
+			IL_08fb: ldstr "Could not infer an element id for section '"
+			IL_0900: ldloc.s 26
+			IL_0902: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0907: ldstr "'. Try passing --id sec-... explicitly."
+			IL_090c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0911: stloc.s 26
+			IL_0913: ldloc.s 26
+			IL_0915: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_091a: stloc.s 17
+			IL_091c: ldloc.0
+			IL_091d: ldc.i4.m1
+			IL_091e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0923: ldloc.0
+			IL_0924: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0929: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_092e: ldarg.0
+			IL_092f: ldc.i4.1
+			IL_0930: newarr [System.Runtime]System.Object
+			IL_0935: dup
+			IL_0936: ldc.i4.0
+			IL_0937: ldloc.s 17
+			IL_0939: stelem.ref
+			IL_093a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_093f: pop
+			IL_0940: ldloc.0
+			IL_0941: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0946: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_094b: ret
 
-			IL_0965: ldarg.0
-			IL_0966: ldc.i4.1
-			IL_0967: ldelem.ref
-			IL_0968: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_096d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
-			IL_0972: ldc.i4.1
-			IL_0973: newarr [System.Runtime]System.Object
-			IL_0978: dup
-			IL_0979: ldc.i4.0
-			IL_097a: ldarg.0
-			IL_097b: ldc.i4.1
-			IL_097c: ldelem.ref
-			IL_097d: stelem.ref
-			IL_097e: stloc.s 21
-			IL_0980: ldloc.s 21
-			IL_0982: ldloc.s 8
-			IL_0984: ldloc.s 9
-			IL_0986: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_098b: stloc.s 18
-			IL_098d: ldarg.0
-			IL_098e: ldc.i4.1
-			IL_098f: ldelem.ref
-			IL_0990: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0995: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_099a: stloc.s 31
-			IL_099c: ldstr "process"
-			IL_09a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09a6: stloc.s 22
-			IL_09a8: ldloc.s 22
-			IL_09aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09af: stloc.s 22
-			IL_09b1: ldloc.s 22
-			IL_09b3: ldstr "cwd"
-			IL_09b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_09bd: stloc.s 22
-			IL_09bf: ldloc.1
-			IL_09c0: ldstr "outFile"
-			IL_09c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09ca: stloc.s 27
-			IL_09cc: ldloc.s 31
-			IL_09ce: ldc.i4.2
-			IL_09cf: newarr [System.Runtime]System.Object
-			IL_09d4: dup
-			IL_09d5: ldc.i4.0
-			IL_09d6: ldloc.s 22
-			IL_09d8: stelem.ref
-			IL_09d9: dup
-			IL_09da: ldc.i4.1
-			IL_09db: ldloc.s 27
-			IL_09dd: stelem.ref
-			IL_09de: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_09e3: stloc.s 19
-			IL_09e5: ldarg.0
-			IL_09e6: ldc.i4.1
-			IL_09e7: ldelem.ref
-			IL_09e8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_09ed: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_09f2: ldc.i4.1
-			IL_09f3: newarr [System.Runtime]System.Object
-			IL_09f8: dup
-			IL_09f9: ldc.i4.0
-			IL_09fa: ldarg.0
-			IL_09fb: ldc.i4.1
-			IL_09fc: ldelem.ref
-			IL_09fd: stelem.ref
-			IL_09fe: stloc.s 21
-			IL_0a00: ldloc.s 18
-			IL_0a02: ldstr "html"
-			IL_0a07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a0c: stloc.s 27
-			IL_0a0e: ldloc.1
-			IL_0a0f: ldstr "section"
-			IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a19: stloc.s 22
-			IL_0a1b: ldloc.s 22
-			IL_0a1d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a22: stloc.s 26
-			IL_0a24: ldstr "ECMA-262 "
-			IL_0a29: ldloc.s 26
-			IL_0a2b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a30: stloc.s 26
-			IL_0a32: ldloc.s 21
-			IL_0a34: ldloc.s 27
-			IL_0a36: ldloc.s 26
-			IL_0a38: ldloc.s 10
-			IL_0a3a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0a3f: stloc.s 20
-			IL_0a41: ldarg.0
-			IL_0a42: ldc.i4.1
-			IL_0a43: ldelem.ref
-			IL_0a44: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a49: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a4e: stloc.s 32
-			IL_0a50: ldloc.s 32
-			IL_0a52: ldloc.s 19
-			IL_0a54: ldloc.s 20
-			IL_0a56: ldstr "utf8"
-			IL_0a5b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0a60: ldstr "console"
-			IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a6a: stloc.s 27
-			IL_0a6c: ldloc.s 27
-			IL_0a6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a73: stloc.s 27
-			IL_0a75: ldarg.0
-			IL_0a76: ldc.i4.1
-			IL_0a77: ldelem.ref
-			IL_0a78: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a7d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0a82: ldc.i4.1
-			IL_0a83: newarr [System.Runtime]System.Object
-			IL_0a88: dup
-			IL_0a89: ldc.i4.0
-			IL_0a8a: ldarg.0
-			IL_0a8b: ldc.i4.1
-			IL_0a8c: ldelem.ref
-			IL_0a8d: stelem.ref
-			IL_0a8e: stloc.s 21
-			IL_0a90: ldloc.1
-			IL_0a91: ldstr "section"
-			IL_0a96: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a9b: stloc.s 22
-			IL_0a9d: ldloc.s 22
-			IL_0a9f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0aa4: stloc.s 26
-			IL_0aa6: ldstr "Extracted section "
-			IL_0aab: ldloc.s 26
-			IL_0aad: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ab2: ldstr " (id="
-			IL_0ab7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0abc: ldloc.s 9
-			IL_0abe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ac3: stloc.s 26
-			IL_0ac5: ldloc.s 26
-			IL_0ac7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0acc: ldstr ", tag="
-			IL_0ad1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ad6: ldloc.s 18
-			IL_0ad8: ldstr "tagName"
-			IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ae2: stloc.s 22
-			IL_0ae4: ldloc.s 22
-			IL_0ae6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0aeb: stloc.s 26
-			IL_0aed: ldloc.s 26
-			IL_0aef: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0af4: ldstr ") -> "
-			IL_0af9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0afe: ldloc.s 19
-			IL_0b00: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b05: stloc.s 26
-			IL_0b07: ldloc.s 26
-			IL_0b09: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b0e: stloc.s 26
-			IL_0b10: ldloc.s 21
-			IL_0b12: ldloc.s 26
-			IL_0b14: ldloc.s 19
-			IL_0b16: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b1b: stloc.s 22
-			IL_0b1d: ldloc.s 27
-			IL_0b1f: ldstr "log"
-			IL_0b24: ldloc.s 22
-			IL_0b26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0b2b: pop
-			IL_0b2c: ldstr "console"
-			IL_0b31: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b36: stloc.s 22
-			IL_0b38: ldloc.s 22
-			IL_0b3a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b3f: stloc.s 22
-			IL_0b41: ldarg.0
-			IL_0b42: ldc.i4.1
-			IL_0b43: ldelem.ref
-			IL_0b44: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b49: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0b4e: stloc.s 27
-			IL_0b50: ldc.i4.1
-			IL_0b51: newarr [System.Runtime]System.Object
-			IL_0b56: dup
-			IL_0b57: ldc.i4.0
-			IL_0b58: ldarg.0
-			IL_0b59: ldc.i4.1
-			IL_0b5a: ldelem.ref
-			IL_0b5b: stelem.ref
-			IL_0b5c: stloc.s 21
-			IL_0b5e: ldarg.0
-			IL_0b5f: ldc.i4.1
-			IL_0b60: ldelem.ref
-			IL_0b61: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b66: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0b6b: stloc.s 32
-			IL_0b6d: ldloc.s 32
-			IL_0b6f: ldloc.s 19
-			IL_0b71: ldstr "utf8"
-			IL_0b76: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0b7b: stloc.s 28
-			IL_0b7d: ldloc.s 27
-			IL_0b7f: ldloc.s 21
-			IL_0b81: ldloc.s 28
-			IL_0b83: ldloc.s 19
-			IL_0b85: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b8a: stloc.s 28
-			IL_0b8c: ldloc.s 22
-			IL_0b8e: ldstr "log"
-			IL_0b93: ldloc.s 28
-			IL_0b95: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0b9a: pop
-			IL_0b9b: ldloc.0
-			IL_0b9c: ldc.i4.m1
-			IL_0b9d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0ba2: ldloc.0
-			IL_0ba3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ba8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0bad: ldarg.0
-			IL_0bae: ldc.i4.1
-			IL_0baf: newarr [System.Runtime]System.Object
-			IL_0bb4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0bb9: pop
-			IL_0bba: ldloc.0
-			IL_0bbb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bc0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bc5: ret
+			IL_094c: ldarg.0
+			IL_094d: ldc.i4.1
+			IL_094e: ldelem.ref
+			IL_094f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0954: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+			IL_0959: ldc.i4.1
+			IL_095a: newarr [System.Runtime]System.Object
+			IL_095f: dup
+			IL_0960: ldc.i4.0
+			IL_0961: ldarg.0
+			IL_0962: ldc.i4.1
+			IL_0963: ldelem.ref
+			IL_0964: stelem.ref
+			IL_0965: stloc.s 21
+			IL_0967: ldloc.s 21
+			IL_0969: ldloc.s 8
+			IL_096b: ldloc.s 9
+			IL_096d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0972: stloc.s 18
+			IL_0974: ldarg.0
+			IL_0975: ldc.i4.1
+			IL_0976: ldelem.ref
+			IL_0977: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_097c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0981: stloc.s 31
+			IL_0983: ldstr "process"
+			IL_0988: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_098d: stloc.s 22
+			IL_098f: ldloc.s 22
+			IL_0991: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0996: stloc.s 22
+			IL_0998: ldloc.s 22
+			IL_099a: ldstr "cwd"
+			IL_099f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_09a4: stloc.s 22
+			IL_09a6: ldloc.1
+			IL_09a7: ldstr "outFile"
+			IL_09ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09b1: stloc.s 27
+			IL_09b3: ldloc.s 31
+			IL_09b5: ldc.i4.2
+			IL_09b6: newarr [System.Runtime]System.Object
+			IL_09bb: dup
+			IL_09bc: ldc.i4.0
+			IL_09bd: ldloc.s 22
+			IL_09bf: stelem.ref
+			IL_09c0: dup
+			IL_09c1: ldc.i4.1
+			IL_09c2: ldloc.s 27
+			IL_09c4: stelem.ref
+			IL_09c5: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_09ca: stloc.s 19
+			IL_09cc: ldarg.0
+			IL_09cd: ldc.i4.1
+			IL_09ce: ldelem.ref
+			IL_09cf: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_09d4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_09d9: ldc.i4.1
+			IL_09da: newarr [System.Runtime]System.Object
+			IL_09df: dup
+			IL_09e0: ldc.i4.0
+			IL_09e1: ldarg.0
+			IL_09e2: ldc.i4.1
+			IL_09e3: ldelem.ref
+			IL_09e4: stelem.ref
+			IL_09e5: stloc.s 21
+			IL_09e7: ldloc.s 18
+			IL_09e9: ldstr "html"
+			IL_09ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09f3: stloc.s 27
+			IL_09f5: ldloc.1
+			IL_09f6: ldstr "section"
+			IL_09fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a00: stloc.s 22
+			IL_0a02: ldloc.s 22
+			IL_0a04: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a09: stloc.s 26
+			IL_0a0b: ldstr "ECMA-262 "
+			IL_0a10: ldloc.s 26
+			IL_0a12: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a17: stloc.s 26
+			IL_0a19: ldloc.s 21
+			IL_0a1b: ldloc.s 27
+			IL_0a1d: ldloc.s 26
+			IL_0a1f: ldloc.s 10
+			IL_0a21: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0a26: stloc.s 20
+			IL_0a28: ldarg.0
+			IL_0a29: ldc.i4.1
+			IL_0a2a: ldelem.ref
+			IL_0a2b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a30: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0a35: stloc.s 32
+			IL_0a37: ldloc.s 32
+			IL_0a39: ldloc.s 19
+			IL_0a3b: ldloc.s 20
+			IL_0a3d: ldstr "utf8"
+			IL_0a42: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0a47: ldstr "console"
+			IL_0a4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a51: stloc.s 27
+			IL_0a53: ldloc.s 27
+			IL_0a55: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a5a: stloc.s 27
+			IL_0a5c: ldarg.0
+			IL_0a5d: ldc.i4.1
+			IL_0a5e: ldelem.ref
+			IL_0a5f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a64: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0a69: ldc.i4.1
+			IL_0a6a: newarr [System.Runtime]System.Object
+			IL_0a6f: dup
+			IL_0a70: ldc.i4.0
+			IL_0a71: ldarg.0
+			IL_0a72: ldc.i4.1
+			IL_0a73: ldelem.ref
+			IL_0a74: stelem.ref
+			IL_0a75: stloc.s 21
+			IL_0a77: ldloc.1
+			IL_0a78: ldstr "section"
+			IL_0a7d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a82: stloc.s 22
+			IL_0a84: ldloc.s 22
+			IL_0a86: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a8b: stloc.s 26
+			IL_0a8d: ldstr "Extracted section "
+			IL_0a92: ldloc.s 26
+			IL_0a94: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a99: ldstr " (id="
+			IL_0a9e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0aa3: ldloc.s 9
+			IL_0aa5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0aaa: stloc.s 26
+			IL_0aac: ldloc.s 26
+			IL_0aae: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ab3: ldstr ", tag="
+			IL_0ab8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0abd: ldloc.s 18
+			IL_0abf: ldstr "tagName"
+			IL_0ac4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ac9: stloc.s 22
+			IL_0acb: ldloc.s 22
+			IL_0acd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ad2: stloc.s 26
+			IL_0ad4: ldloc.s 26
+			IL_0ad6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0adb: ldstr ") -> "
+			IL_0ae0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ae5: ldloc.s 19
+			IL_0ae7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0aec: stloc.s 26
+			IL_0aee: ldloc.s 26
+			IL_0af0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0af5: stloc.s 26
+			IL_0af7: ldloc.s 21
+			IL_0af9: ldloc.s 26
+			IL_0afb: ldloc.s 19
+			IL_0afd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b02: stloc.s 22
+			IL_0b04: ldloc.s 27
+			IL_0b06: ldstr "log"
+			IL_0b0b: ldloc.s 22
+			IL_0b0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0b12: pop
+			IL_0b13: ldstr "console"
+			IL_0b18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b1d: stloc.s 22
+			IL_0b1f: ldloc.s 22
+			IL_0b21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b26: stloc.s 22
+			IL_0b28: ldarg.0
+			IL_0b29: ldc.i4.1
+			IL_0b2a: ldelem.ref
+			IL_0b2b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b30: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0b35: stloc.s 27
+			IL_0b37: ldc.i4.1
+			IL_0b38: newarr [System.Runtime]System.Object
+			IL_0b3d: dup
+			IL_0b3e: ldc.i4.0
+			IL_0b3f: ldarg.0
+			IL_0b40: ldc.i4.1
+			IL_0b41: ldelem.ref
+			IL_0b42: stelem.ref
+			IL_0b43: stloc.s 21
+			IL_0b45: ldarg.0
+			IL_0b46: ldc.i4.1
+			IL_0b47: ldelem.ref
+			IL_0b48: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b4d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0b52: stloc.s 32
+			IL_0b54: ldloc.s 32
+			IL_0b56: ldloc.s 19
+			IL_0b58: ldstr "utf8"
+			IL_0b5d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0b62: stloc.s 28
+			IL_0b64: ldloc.s 27
+			IL_0b66: ldloc.s 21
+			IL_0b68: ldloc.s 28
+			IL_0b6a: ldloc.s 19
+			IL_0b6c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b71: stloc.s 28
+			IL_0b73: ldloc.s 22
+			IL_0b75: ldstr "log"
+			IL_0b7a: ldloc.s 28
+			IL_0b7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0b81: pop
+			IL_0b82: ldloc.0
+			IL_0b83: ldc.i4.m1
+			IL_0b84: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b89: ldloc.0
+			IL_0b8a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b8f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0b94: ldarg.0
+			IL_0b95: ldc.i4.1
+			IL_0b96: newarr [System.Runtime]System.Object
+			IL_0b9b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0ba0: pop
+			IL_0ba1: ldloc.0
+			IL_0ba2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0ba7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0bac: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5371,7 +5359,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x456d
+			// Method begins at RVA 0x4535
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5627,7 +5615,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4738
+		// Method begins at RVA 0x4700
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_Error_Callable_CreatesInstances.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_Error_Callable_CreatesInstances.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2126
+			// Method begins at RVA 0x211c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 202 (0xca)
+		// Code size: 192 (0xc0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_Error_Callable_CreatesInstances/Scope,
@@ -55,64 +55,62 @@
 		IL_0005: stloc.0
 		IL_0006: nop
 		IL_0007: ldstr "boom"
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-		IL_0016: stloc.1
-		IL_0017: ldstr "console"
-		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0026: stloc.3
-		IL_0027: ldloc.1
-		IL_0028: ldstr "name"
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0032: stloc.s 4
-		IL_0034: ldloc.s 4
-		IL_0036: ldstr ":"
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0040: stloc.s 5
-		IL_0042: ldloc.1
-		IL_0043: ldstr "message"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_004d: stloc.s 4
-		IL_004f: ldloc.s 5
-		IL_0051: ldloc.s 4
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0058: stloc.s 5
-		IL_005a: ldloc.3
-		IL_005b: ldstr "log"
-		IL_0060: ldloc.s 5
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0067: pop
-		IL_0068: ldstr "oops"
-		IL_006d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_0077: stloc.2
-		IL_0078: ldstr "console"
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0087: stloc.3
-		IL_0088: ldloc.2
-		IL_0089: ldstr "name"
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0093: stloc.s 4
-		IL_0095: ldloc.s 4
-		IL_0097: ldstr ":"
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00a1: stloc.s 5
-		IL_00a3: ldloc.2
-		IL_00a4: ldstr "message"
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ae: stloc.s 4
-		IL_00b0: ldloc.s 5
-		IL_00b2: ldloc.s 4
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00b9: stloc.s 5
-		IL_00bb: ldloc.3
-		IL_00bc: ldstr "log"
-		IL_00c1: ldloc.s 5
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c8: pop
-		IL_00c9: ret
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_0011: stloc.1
+		IL_0012: ldstr "console"
+		IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0021: stloc.3
+		IL_0022: ldloc.1
+		IL_0023: ldstr "name"
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_002d: stloc.s 4
+		IL_002f: ldloc.s 4
+		IL_0031: ldstr ":"
+		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_003b: stloc.s 5
+		IL_003d: ldloc.1
+		IL_003e: ldstr "message"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0048: stloc.s 4
+		IL_004a: ldloc.s 5
+		IL_004c: ldloc.s 4
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0053: stloc.s 5
+		IL_0055: ldloc.3
+		IL_0056: ldstr "log"
+		IL_005b: ldloc.s 5
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0062: pop
+		IL_0063: ldstr "oops"
+		IL_0068: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+		IL_006d: stloc.2
+		IL_006e: ldstr "console"
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007d: stloc.3
+		IL_007e: ldloc.2
+		IL_007f: ldstr "name"
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0089: stloc.s 4
+		IL_008b: ldloc.s 4
+		IL_008d: ldstr ":"
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0097: stloc.s 5
+		IL_0099: ldloc.2
+		IL_009a: ldstr "message"
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a4: stloc.s 4
+		IL_00a6: ldloc.s 5
+		IL_00a8: ldloc.s 4
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00af: stloc.s 5
+		IL_00b1: ldloc.3
+		IL_00b2: ldstr "log"
+		IL_00b7: ldloc.s 5
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00be: pop
+		IL_00bf: ret
 	} // end of method IntrinsicCallables_Error_Callable_CreatesInstances::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_Error_Callable_CreatesInstances
@@ -124,7 +122,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212f
+		// Method begins at RVA 0x2125
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_TypeError_GlobalSurface.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_TypeError_GlobalSurface.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f1
+				// Method begins at RVA 0x22ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22fa
+				// Method begins at RVA 0x22f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e8
+			// Method begins at RVA 0x22e4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 634 (0x27a)
+		// Code size: 629 (0x275)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_TypeError_GlobalSurface/Scope,
@@ -105,206 +105,205 @@
 		IL_0005: stloc.0
 		IL_0006: nop
 		IL_0007: ldstr "oops"
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_0016: stloc.1
-		IL_0017: ldstr "console"
-		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0026: stloc.s 6
-		IL_0028: ldloc.1
-		IL_0029: ldstr "name"
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0033: stloc.s 7
-		IL_0035: ldloc.s 7
-		IL_0037: ldstr ":"
-		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0041: stloc.s 8
-		IL_0043: ldloc.1
-		IL_0044: ldstr "message"
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_004e: stloc.s 7
-		IL_0050: ldloc.s 8
-		IL_0052: ldloc.s 7
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0059: stloc.s 8
-		IL_005b: ldloc.s 6
-		IL_005d: ldstr "log"
-		IL_0062: ldloc.s 8
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0069: pop
-		IL_006a: ldstr "console"
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0079: stloc.s 6
-		IL_007b: ldstr "TypeError"
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0085: stloc.s 7
-		IL_0087: ldloc.1
-		IL_0088: ldloc.s 7
-		IL_008a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_008f: stloc.s 9
-		IL_0091: ldloc.s 9
-		IL_0093: box [System.Runtime]System.Boolean
-		IL_0098: stloc.s 10
-		IL_009a: ldloc.s 6
-		IL_009c: ldstr "log"
-		IL_00a1: ldloc.s 10
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a8: pop
-		IL_00a9: ldstr "console"
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b8: stloc.s 6
-		IL_00ba: ldstr "TypeError"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c4: ldstr "prototype"
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ce: stloc.s 7
-		IL_00d0: ldloc.s 7
-		IL_00d2: ldstr "constructor"
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00dc: stloc.s 7
-		IL_00de: ldstr "TypeError"
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e8: stloc.s 11
-		IL_00ea: ldloc.s 7
-		IL_00ec: ldloc.s 11
-		IL_00ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f3: stloc.s 9
-		IL_00f5: ldloc.s 9
-		IL_00f7: box [System.Runtime]System.Boolean
-		IL_00fc: stloc.s 10
-		IL_00fe: ldloc.s 6
-		IL_0100: ldstr "log"
-		IL_0105: ldloc.s 10
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010c: pop
-		IL_010d: ldstr "console"
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011c: stloc.s 6
-		IL_011e: ldstr "TypeError"
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0128: ldstr "prototype"
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0132: stloc.s 11
-		IL_0134: ldloc.s 11
-		IL_0136: ldstr "name"
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0140: stloc.s 11
-		IL_0142: ldloc.s 11
-		IL_0144: ldstr ":"
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_014e: stloc.s 8
-		IL_0150: ldstr "TypeError"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_015a: ldstr "prototype"
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0164: stloc.s 11
-		IL_0166: ldloc.s 11
-		IL_0168: ldstr "message"
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0172: stloc.s 11
-		IL_0174: ldloc.s 8
-		IL_0176: ldloc.s 11
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_017d: stloc.s 8
-		IL_017f: ldloc.s 6
-		IL_0181: ldstr "log"
-		IL_0186: ldloc.s 8
-		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018d: pop
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+		IL_0011: stloc.1
+		IL_0012: ldstr "console"
+		IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0021: stloc.s 6
+		IL_0023: ldloc.1
+		IL_0024: ldstr "name"
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_002e: stloc.s 7
+		IL_0030: ldloc.s 7
+		IL_0032: ldstr ":"
+		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_003c: stloc.s 8
+		IL_003e: ldloc.1
+		IL_003f: ldstr "message"
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0049: stloc.s 7
+		IL_004b: ldloc.s 8
+		IL_004d: ldloc.s 7
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0054: stloc.s 8
+		IL_0056: ldloc.s 6
+		IL_0058: ldstr "log"
+		IL_005d: ldloc.s 8
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0064: pop
+		IL_0065: ldstr "console"
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0074: stloc.s 6
+		IL_0076: ldstr "TypeError"
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0080: stloc.s 7
+		IL_0082: ldloc.1
+		IL_0083: ldloc.s 7
+		IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_008a: stloc.s 9
+		IL_008c: ldloc.s 9
+		IL_008e: box [System.Runtime]System.Boolean
+		IL_0093: stloc.s 10
+		IL_0095: ldloc.s 6
+		IL_0097: ldstr "log"
+		IL_009c: ldloc.s 10
+		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a3: pop
+		IL_00a4: ldstr "console"
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b3: stloc.s 6
+		IL_00b5: ldstr "TypeError"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00bf: ldstr "prototype"
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c9: stloc.s 7
+		IL_00cb: ldloc.s 7
+		IL_00cd: ldstr "constructor"
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d7: stloc.s 7
+		IL_00d9: ldstr "TypeError"
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e3: stloc.s 11
+		IL_00e5: ldloc.s 7
+		IL_00e7: ldloc.s 11
+		IL_00e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00ee: stloc.s 9
+		IL_00f0: ldloc.s 9
+		IL_00f2: box [System.Runtime]System.Boolean
+		IL_00f7: stloc.s 10
+		IL_00f9: ldloc.s 6
+		IL_00fb: ldstr "log"
+		IL_0100: ldloc.s 10
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0107: pop
+		IL_0108: ldstr "console"
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0117: stloc.s 6
+		IL_0119: ldstr "TypeError"
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0123: ldstr "prototype"
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012d: stloc.s 11
+		IL_012f: ldloc.s 11
+		IL_0131: ldstr "name"
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013b: stloc.s 11
+		IL_013d: ldloc.s 11
+		IL_013f: ldstr ":"
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0149: stloc.s 8
+		IL_014b: ldstr "TypeError"
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0155: ldstr "prototype"
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015f: stloc.s 11
+		IL_0161: ldloc.s 11
+		IL_0163: ldstr "message"
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_016d: stloc.s 11
+		IL_016f: ldloc.s 8
+		IL_0171: ldloc.s 11
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0178: stloc.s 8
+		IL_017a: ldloc.s 6
+		IL_017c: ldstr "log"
+		IL_0181: ldloc.s 8
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0188: pop
 		.try
 		{
-			IL_018e: nop
-			IL_018f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0194: stloc.s 12
-			IL_0196: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_019b: stloc.s 13
-			IL_019d: ldloc.s 12
-			IL_019f: ldloc.s 13
-			IL_01a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_01a6: pop
-			IL_01a7: leave IL_0276
+			IL_0189: nop
+			IL_018a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_018f: stloc.s 12
+			IL_0191: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0196: stloc.s 13
+			IL_0198: ldloc.s 12
+			IL_019a: ldloc.s 13
+			IL_019c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_01a1: pop
+			IL_01a2: leave IL_0271
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01ac: stloc.2
-			IL_01ad: ldloc.2
-			IL_01ae: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_01b3: dup
-			IL_01b4: brtrue IL_01c9
+			IL_01a7: stloc.2
+			IL_01a8: ldloc.2
+			IL_01a9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_01ae: dup
+			IL_01af: brtrue IL_01c4
 
-			IL_01b9: pop
-			IL_01ba: ldloc.2
-			IL_01bb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_01c0: dup
-			IL_01c1: brtrue IL_01d4
+			IL_01b4: pop
+			IL_01b5: ldloc.2
+			IL_01b6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_01bb: dup
+			IL_01bc: brtrue IL_01cf
 
-			IL_01c6: pop
-			IL_01c7: rethrow
+			IL_01c1: pop
+			IL_01c2: rethrow
 
-			IL_01c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_01ce: stloc.3
-			IL_01cf: br IL_01d5
+			IL_01c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_01c9: stloc.3
+			IL_01ca: br IL_01d0
 
-			IL_01d4: stloc.3
+			IL_01cf: stloc.3
 
-			IL_01d5: ldloc.3
-			IL_01d6: stloc.s 4
-			IL_01d8: ldstr "console"
-			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e7: stloc.s 6
-			IL_01e9: ldloc.s 4
-			IL_01eb: stloc.s 11
-			IL_01ed: ldstr "TypeError"
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01f7: stloc.s 7
-			IL_01f9: ldloc.s 11
-			IL_01fb: ldloc.s 7
-			IL_01fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0202: stloc.s 9
-			IL_0204: ldloc.s 9
-			IL_0206: box [System.Runtime]System.Boolean
-			IL_020b: stloc.s 10
-			IL_020d: ldloc.s 6
-			IL_020f: ldstr "log"
-			IL_0214: ldloc.s 10
-			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_021b: pop
-			IL_021c: ldstr "console"
-			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_022b: stloc.s 6
-			IL_022d: ldloc.s 4
-			IL_022f: ldstr "name"
-			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0239: stloc.s 7
-			IL_023b: ldloc.s 7
-			IL_023d: ldstr ":"
-			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0247: stloc.s 8
-			IL_0249: ldloc.s 4
-			IL_024b: ldstr "message"
-			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0255: stloc.s 7
-			IL_0257: ldloc.s 8
-			IL_0259: ldloc.s 7
-			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0260: stloc.s 8
-			IL_0262: ldloc.s 6
-			IL_0264: ldstr "log"
-			IL_0269: ldloc.s 8
-			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0270: pop
-			IL_0271: leave IL_0276
+			IL_01d0: ldloc.3
+			IL_01d1: stloc.s 4
+			IL_01d3: ldstr "console"
+			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01e2: stloc.s 6
+			IL_01e4: ldloc.s 4
+			IL_01e6: stloc.s 11
+			IL_01e8: ldstr "TypeError"
+			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01f2: stloc.s 7
+			IL_01f4: ldloc.s 11
+			IL_01f6: ldloc.s 7
+			IL_01f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_01fd: stloc.s 9
+			IL_01ff: ldloc.s 9
+			IL_0201: box [System.Runtime]System.Boolean
+			IL_0206: stloc.s 10
+			IL_0208: ldloc.s 6
+			IL_020a: ldstr "log"
+			IL_020f: ldloc.s 10
+			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0216: pop
+			IL_0217: ldstr "console"
+			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0226: stloc.s 6
+			IL_0228: ldloc.s 4
+			IL_022a: ldstr "name"
+			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0234: stloc.s 7
+			IL_0236: ldloc.s 7
+			IL_0238: ldstr ":"
+			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0242: stloc.s 8
+			IL_0244: ldloc.s 4
+			IL_0246: ldstr "message"
+			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0250: stloc.s 7
+			IL_0252: ldloc.s 8
+			IL_0254: ldloc.s 7
+			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_025b: stloc.s 8
+			IL_025d: ldloc.s 6
+			IL_025f: ldstr "log"
+			IL_0264: ldloc.s 8
+			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_026b: pop
+			IL_026c: leave IL_0271
 		} // end handler
 
-		IL_0276: ldnull
-		IL_0277: stloc.s 5
-		IL_0279: ret
+		IL_0271: ldnull
+		IL_0272: stloc.s 5
+		IL_0274: ret
 	} // end of method IntrinsicCallables_TypeError_GlobalSurface::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_TypeError_GlobalSurface
@@ -316,7 +315,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2303
+		// Method begins at RVA 0x22ff
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x311e
+					// Method begins at RVA 0x310e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2be6
+				// Method begins at RVA 0x2bda
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -76,7 +76,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3130
+						// Method begins at RVA 0x3120
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -100,7 +100,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2ecc
+					// Method begins at RVA 0x2ec0
 					// Header size: 12
 					// Code size: 145 (0x91)
 					.maxstack 8
@@ -183,7 +183,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3139
+						// Method begins at RVA 0x3129
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -207,7 +207,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2f6c
+					// Method begins at RVA 0x2f60
 					// Header size: 12
 					// Code size: 68 (0x44)
 					.maxstack 8
@@ -258,7 +258,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3127
+					// Method begins at RVA 0x3117
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -282,7 +282,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bf8
+				// Method begins at RVA 0x2bec
 				// Header size: 12
 				// Code size: 178 (0xb2)
 				.maxstack 8
@@ -393,7 +393,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3115
+				// Method begins at RVA 0x3105
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -531,7 +531,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3142
+				// Method begins at RVA 0x3132
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -584,7 +584,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x314b
+				// Method begins at RVA 0x313b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -610,30 +610,29 @@
 			)
 			// Method begins at RVA 0x29d4
 			// Header size: 12
-			// Code size: 39 (0x27)
+			// Code size: 34 (0x22)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldstr "boom"
-			IL_0005: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_000f: stloc.0
-			IL_0010: ldloc.0
-			IL_0011: isinst [System.Runtime]System.Exception
-			IL_0016: dup
-			IL_0017: brtrue IL_0024
+			IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_000a: stloc.0
+			IL_000b: ldloc.0
+			IL_000c: isinst [System.Runtime]System.Exception
+			IL_0011: dup
+			IL_0012: brtrue IL_001f
 
-			IL_001c: pop
-			IL_001d: ldloc.0
-			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0023: throw
+			IL_0017: pop
+			IL_0018: ldloc.0
+			IL_0019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_001e: throw
 
-			IL_0024: throw
+			IL_001f: throw
 
-			IL_0025: ldnull
-			IL_0026: ret
+			IL_0020: ldnull
+			IL_0021: ret
 		} // end of method ArrowFunction_L35C68::__js_call__
 
 	} // end of class ArrowFunction_L35C68
@@ -656,7 +655,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3166
+				// Method begins at RVA 0x3156
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -680,32 +679,31 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a08
+			// Method begins at RVA 0x2a04
 			// Header size: 12
-			// Code size: 39 (0x27)
+			// Code size: 34 (0x22)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldstr "boom"
-			IL_0005: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_000f: stloc.0
-			IL_0010: ldloc.0
-			IL_0011: isinst [System.Runtime]System.Exception
-			IL_0016: dup
-			IL_0017: brtrue IL_0024
+			IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_000a: stloc.0
+			IL_000b: ldloc.0
+			IL_000c: isinst [System.Runtime]System.Exception
+			IL_0011: dup
+			IL_0012: brtrue IL_001f
 
-			IL_001c: pop
-			IL_001d: ldloc.0
-			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0023: throw
+			IL_0017: pop
+			IL_0018: ldloc.0
+			IL_0019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_001e: throw
 
-			IL_0024: throw
+			IL_001f: throw
 
-			IL_0025: ldnull
-			IL_0026: ret
+			IL_0020: ldnull
+			IL_0021: ret
 		} // end of method ArrowFunction_L45C77::__js_call__
 
 	} // end of class ArrowFunction_L45C77
@@ -733,7 +731,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x319c
+							// Method begins at RVA 0x318c
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -751,7 +749,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3193
+						// Method begins at RVA 0x3183
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -775,7 +773,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2fbc
+					// Method begins at RVA 0x2fb0
 					// Header size: 12
 					// Code size: 110 (0x6e)
 					.maxstack 8
@@ -844,7 +842,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31a5
+						// Method begins at RVA 0x3195
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -868,7 +866,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3038
+					// Method begins at RVA 0x302c
 					// Header size: 12
 					// Code size: 68 (0x44)
 					.maxstack 8
@@ -919,7 +917,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x318a
+					// Method begins at RVA 0x317a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -943,7 +941,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2cb8
+				// Method begins at RVA 0x2cac
 				// Header size: 12
 				// Code size: 170 (0xaa)
 				.maxstack 8
@@ -1052,7 +1050,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3181
+				// Method begins at RVA 0x3171
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1079,7 +1077,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2a3c
+			// Method begins at RVA 0x2a34
 			// Header size: 12
 			// Code size: 93 (0x5d)
 			.maxstack 8
@@ -1152,7 +1150,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31ae
+				// Method begins at RVA 0x319e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1176,32 +1174,31 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2aa8
+			// Method begins at RVA 0x2aa0
 			// Header size: 12
-			// Code size: 39 (0x27)
+			// Code size: 34 (0x22)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldstr "boom"
-			IL_0005: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_000f: stloc.0
-			IL_0010: ldloc.0
-			IL_0011: isinst [System.Runtime]System.Exception
-			IL_0016: dup
-			IL_0017: brtrue IL_0024
+			IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_000a: stloc.0
+			IL_000b: ldloc.0
+			IL_000c: isinst [System.Runtime]System.Exception
+			IL_0011: dup
+			IL_0012: brtrue IL_001f
 
-			IL_001c: pop
-			IL_001d: ldloc.0
-			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0023: throw
+			IL_0017: pop
+			IL_0018: ldloc.0
+			IL_0019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_001e: throw
 
-			IL_0024: throw
+			IL_001f: throw
 
-			IL_0025: ldnull
-			IL_0026: ret
+			IL_0020: ldnull
+			IL_0021: ret
 		} // end of method ArrowFunction_L84C74::__js_call__
 
 	} // end of class ArrowFunction_L84C74
@@ -1225,7 +1222,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31db
+						// Method begins at RVA 0x31cb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1243,7 +1240,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31d2
+					// Method begins at RVA 0x31c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1267,7 +1264,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d70
+				// Method begins at RVA 0x2d64
 				// Header size: 12
 				// Code size: 102 (0x66)
 				.maxstack 8
@@ -1327,7 +1324,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31e4
+					// Method begins at RVA 0x31d4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1351,7 +1348,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2de4
+				// Method begins at RVA 0x2dd8
 				// Header size: 12
 				// Code size: 68 (0x44)
 				.maxstack 8
@@ -1402,7 +1399,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31c9
+				// Method begins at RVA 0x31b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1428,7 +1425,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2adc
+			// Method begins at RVA 0x2ad0
 			// Header size: 12
 			// Code size: 154 (0x9a)
 			.maxstack 8
@@ -1526,7 +1523,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31ff
+						// Method begins at RVA 0x31ef
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1549,32 +1546,31 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3088
+					// Method begins at RVA 0x307c
 					// Header size: 12
-					// Code size: 39 (0x27)
+					// Code size: 34 (0x22)
 					.maxstack 8
 					.locals init (
 						[0] object
 					)
 
 					IL_0000: ldstr "innerBoom"
-					IL_0005: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_000f: stloc.0
-					IL_0010: ldloc.0
-					IL_0011: isinst [System.Runtime]System.Exception
-					IL_0016: dup
-					IL_0017: brtrue IL_0024
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_000a: stloc.0
+					IL_000b: ldloc.0
+					IL_000c: isinst [System.Runtime]System.Exception
+					IL_0011: dup
+					IL_0012: brtrue IL_001f
 
-					IL_001c: pop
-					IL_001d: ldloc.0
-					IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-					IL_0023: throw
+					IL_0017: pop
+					IL_0018: ldloc.0
+					IL_0019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_001e: throw
 
-					IL_0024: throw
+					IL_001f: throw
 
-					IL_0025: ldnull
-					IL_0026: ret
+					IL_0020: ldnull
+					IL_0021: ret
 				} // end of method FunctionExpression_flatThrowHelper::__js_call__
 
 			} // end of class FunctionExpression_flatThrowHelper
@@ -1590,7 +1586,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3208
+						// Method begins at RVA 0x31f8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1614,7 +1610,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x30bc
+					// Method begins at RVA 0x30ac
 					// Header size: 12
 					// Code size: 68 (0x44)
 					.maxstack 8
@@ -1658,7 +1654,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31f6
+					// Method begins at RVA 0x31e6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1682,7 +1678,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e34
+				// Method begins at RVA 0x2e28
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -1770,7 +1766,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31ed
+				// Method begins at RVA 0x31dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1797,7 +1793,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2b84
+			// Method begins at RVA 0x2b78
 			// Header size: 12
 			// Code size: 86 (0x56)
 			.maxstack 8
@@ -1873,7 +1869,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3154
+				// Method begins at RVA 0x3144
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1893,7 +1889,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x315d
+				// Method begins at RVA 0x314d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1913,7 +1909,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x316f
+				// Method begins at RVA 0x315f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1933,7 +1929,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3178
+				// Method begins at RVA 0x3168
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1953,7 +1949,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31b7
+				// Method begins at RVA 0x31a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1973,7 +1969,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31c0
+				// Method begins at RVA 0x31b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1993,7 +1989,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3211
+				// Method begins at RVA 0x3201
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2013,7 +2009,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x321a
+				// Method begins at RVA 0x320a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2037,7 +2033,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x310c
+			// Method begins at RVA 0x30fc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2805,7 +2801,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3223
+		// Method begins at RVA 0x3213
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_ErrorMonitor.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_ErrorMonitor.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f4
+				// Method begins at RVA 0x22f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x222c
+			// Method begins at RVA 0x2228
 			// Header size: 12
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -86,7 +86,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22fd
+				// Method begins at RVA 0x22f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -110,7 +110,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2270
+			// Method begins at RVA 0x226c
 			// Header size: 12
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2306
+				// Method begins at RVA 0x2302
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -178,7 +178,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22b4
+			// Method begins at RVA 0x22b0
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -217,7 +217,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230f
+				// Method begins at RVA 0x230b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -237,7 +237,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2318
+				// Method begins at RVA 0x2314
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -255,7 +255,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22eb
+			// Method begins at RVA 0x22e7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -281,7 +281,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 447 (0x1bf)
+		// Code size: 442 (0x1ba)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_ErrorMonitor/Scope,
@@ -360,100 +360,99 @@
 		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00ac: stloc.s 10
 		IL_00ae: ldstr "boom"
-		IL_00b3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_00b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-		IL_00bd: stloc.s 9
-		IL_00bf: ldloc.s 10
-		IL_00c1: ldstr "emit"
-		IL_00c6: ldstr "error"
-		IL_00cb: ldloc.s 9
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00d2: pop
-		IL_00d3: ldloc.2
-		IL_00d4: ldc.i4.0
-		IL_00d5: newarr [System.Runtime]System.Object
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_00df: stloc.s 4
-		IL_00e1: ldloc.s 4
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e8: stloc.s 9
-		IL_00ea: ldloc.1
-		IL_00eb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Symbol [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule::get_errorMonitor()
-		IL_00f0: stloc.s 10
-		IL_00f2: ldnull
-		IL_00f3: ldftn object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33::__js_call__(object, object)
-		IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00fe: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0103: ldc.i4.1
-		IL_0104: conv.r8
-		IL_0105: ldstr ""
-		IL_010a: ldc.i4.0
-		IL_010b: ldc.i4.1
-		IL_010c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0111: stloc.s 11
-		IL_0113: ldloc.s 9
-		IL_0115: ldstr "on"
-		IL_011a: ldloc.s 10
-		IL_011c: ldloc.s 11
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0123: pop
+		IL_00b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_00b8: stloc.s 9
+		IL_00ba: ldloc.s 10
+		IL_00bc: ldstr "emit"
+		IL_00c1: ldstr "error"
+		IL_00c6: ldloc.s 9
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00cd: pop
+		IL_00ce: ldloc.2
+		IL_00cf: ldc.i4.0
+		IL_00d0: newarr [System.Runtime]System.Object
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_00da: stloc.s 4
+		IL_00dc: ldloc.s 4
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e3: stloc.s 9
+		IL_00e5: ldloc.1
+		IL_00e6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Symbol [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule::get_errorMonitor()
+		IL_00eb: stloc.s 10
+		IL_00ed: ldnull
+		IL_00ee: ldftn object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33::__js_call__(object, object)
+		IL_00f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00f9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_00fe: ldc.i4.1
+		IL_00ff: conv.r8
+		IL_0100: ldstr ""
+		IL_0105: ldc.i4.0
+		IL_0106: ldc.i4.1
+		IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_010c: stloc.s 11
+		IL_010e: ldloc.s 9
+		IL_0110: ldstr "on"
+		IL_0115: ldloc.s 10
+		IL_0117: ldloc.s 11
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_011e: pop
 		.try
 		{
-			IL_0124: nop
-			IL_0125: ldloc.s 4
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_012c: ldstr "emit"
-			IL_0131: ldstr "error"
-			IL_0136: ldstr "fatal"
-			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0140: pop
-			IL_0141: ldstr "console"
-			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0150: ldstr "log"
-			IL_0155: ldstr "NO_THROW"
-			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_015f: pop
-			IL_0160: leave IL_01bb
+			IL_011f: nop
+			IL_0120: ldloc.s 4
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0127: ldstr "emit"
+			IL_012c: ldstr "error"
+			IL_0131: ldstr "fatal"
+			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_013b: pop
+			IL_013c: ldstr "console"
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014b: ldstr "log"
+			IL_0150: ldstr "NO_THROW"
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_015a: pop
+			IL_015b: leave IL_01b6
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0165: stloc.s 5
-			IL_0167: ldloc.s 5
-			IL_0169: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_016e: dup
-			IL_016f: brtrue IL_0185
+			IL_0160: stloc.s 5
+			IL_0162: ldloc.s 5
+			IL_0164: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0169: dup
+			IL_016a: brtrue IL_0180
 
-			IL_0174: pop
-			IL_0175: ldloc.s 5
-			IL_0177: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_017c: dup
-			IL_017d: brtrue IL_0191
+			IL_016f: pop
+			IL_0170: ldloc.s 5
+			IL_0172: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0177: dup
+			IL_0178: brtrue IL_018c
 
-			IL_0182: pop
-			IL_0183: rethrow
+			IL_017d: pop
+			IL_017e: rethrow
 
-			IL_0185: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_018a: stloc.s 6
-			IL_018c: br IL_0193
+			IL_0180: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0185: stloc.s 6
+			IL_0187: br IL_018e
 
-			IL_0191: stloc.s 6
+			IL_018c: stloc.s 6
 
-			IL_0193: ldloc.s 6
-			IL_0195: stloc.s 7
-			IL_0197: ldstr "console"
-			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a6: ldstr "log"
-			IL_01ab: ldstr "thrown"
-			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01b5: pop
-			IL_01b6: leave IL_01bb
+			IL_018e: ldloc.s 6
+			IL_0190: stloc.s 7
+			IL_0192: ldstr "console"
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a1: ldstr "log"
+			IL_01a6: ldstr "thrown"
+			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01b0: pop
+			IL_01b1: leave IL_01b6
 		} // end handler
 
-		IL_01bb: ldnull
-		IL_01bc: stloc.s 8
-		IL_01be: ret
+		IL_01b6: ldnull
+		IL_01b7: stloc.s 8
+		IL_01b9: ret
 	} // end of method Events_EventEmitter_ErrorMonitor::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_ErrorMonitor
@@ -465,7 +464,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2321
+		// Method begins at RVA 0x231d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_DestroyError.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_DestroyError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2194
+				// Method begins at RVA 0x2190
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20f0
+			// Method begins at RVA 0x20ec
 			// Header size: 12
 			// Code size: 143 (0x8f)
 			.maxstack 8
@@ -125,7 +125,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x218b
+			// Method begins at RVA 0x2187
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -151,7 +151,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 148 (0x94)
+		// Code size: 143 (0x8f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Finished_Callback_DestroyError/Scope,
@@ -205,15 +205,14 @@
 		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0073: stloc.2
 		IL_0074: ldstr "read boom"
-		IL_0079: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_007e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-		IL_0083: stloc.s 4
-		IL_0085: ldloc.2
-		IL_0086: ldstr "destroy"
-		IL_008b: ldloc.s 4
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0092: pop
-		IL_0093: ret
+		IL_0079: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_007e: stloc.s 4
+		IL_0080: ldloc.2
+		IL_0081: ldstr "destroy"
+		IL_0086: ldloc.s 4
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008d: pop
+		IL_008e: ret
 	} // end of method Stream_Finished_Callback_DestroyError::__js_module_init__
 
 } // end of class Modules.Stream_Finished_Callback_DestroyError
@@ -225,7 +224,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x219d
+		// Method begins at RVA 0x2199
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f8
+				// Method begins at RVA 0x22f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,30 +43,29 @@
 			)
 			// Method begins at RVA 0x21a4
 			// Header size: 12
-			// Code size: 39 (0x27)
+			// Code size: 34 (0x22)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldstr "transform boom"
-			IL_0005: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_000f: stloc.0
-			IL_0010: ldloc.0
-			IL_0011: isinst [System.Runtime]System.Exception
-			IL_0016: dup
-			IL_0017: brtrue IL_0024
+			IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_000a: stloc.0
+			IL_000b: ldloc.0
+			IL_000c: isinst [System.Runtime]System.Exception
+			IL_0011: dup
+			IL_0012: brtrue IL_001f
 
-			IL_001c: pop
-			IL_001d: ldloc.0
-			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0023: throw
+			IL_0017: pop
+			IL_0018: ldloc.0
+			IL_0019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_001e: throw
 
-			IL_0024: throw
+			IL_001f: throw
 
-			IL_0025: ldnull
-			IL_0026: ret
+			IL_0020: ldnull
+			IL_0021: ret
 		} // end of method FunctionExpression_L9C23::__js_call__
 
 	} // end of class FunctionExpression_L9C23
@@ -82,7 +81,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2301
+				// Method begins at RVA 0x22fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,7 +104,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d7
+			// Method begins at RVA 0x21d2
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -127,7 +126,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230a
+				// Method begins at RVA 0x2306
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -154,7 +153,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x21dc
+			// Method begins at RVA 0x21d8
 			// Header size: 12
 			// Code size: 263 (0x107)
 			.maxstack 8
@@ -275,7 +274,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22ef
+			// Method begins at RVA 0x22eb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -454,7 +453,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2313
+		// Method begins at RVA 0x230f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error_PropagatesToPeers.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error_PropagatesToPeers.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x244c
+				// Method begins at RVA 0x2448
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,30 +43,29 @@
 			)
 			// Method begins at RVA 0x2230
 			// Header size: 12
-			// Code size: 39 (0x27)
+			// Code size: 34 (0x22)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldstr "write boom"
-			IL_0005: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_000f: stloc.0
-			IL_0010: ldloc.0
-			IL_0011: isinst [System.Runtime]System.Exception
-			IL_0016: dup
-			IL_0017: brtrue IL_0024
+			IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_000a: stloc.0
+			IL_000b: ldloc.0
+			IL_000c: isinst [System.Runtime]System.Exception
+			IL_0011: dup
+			IL_0012: brtrue IL_001f
 
-			IL_001c: pop
-			IL_001d: ldloc.0
-			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0023: throw
+			IL_0017: pop
+			IL_0018: ldloc.0
+			IL_0019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_001e: throw
 
-			IL_0024: throw
+			IL_001f: throw
 
-			IL_0025: ldnull
-			IL_0026: ret
+			IL_0020: ldnull
+			IL_0021: ret
 		} // end of method FunctionExpression_L9C18::__js_call__
 
 	} // end of class FunctionExpression_L9C18
@@ -82,7 +81,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2455
+				// Method begins at RVA 0x2451
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -106,7 +105,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2264
+			// Method begins at RVA 0x2260
 			// Header size: 12
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -150,7 +149,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245e
+				// Method begins at RVA 0x245a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -174,7 +173,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a8
+			// Method begins at RVA 0x22a4
 			// Header size: 12
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -218,7 +217,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2467
+				// Method begins at RVA 0x2463
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -242,7 +241,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22ec
+			// Method begins at RVA 0x22e8
 			// Header size: 12
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -286,7 +285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2470
+				// Method begins at RVA 0x246c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -313,7 +312,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2330
+			// Method begins at RVA 0x232c
 			// Header size: 12
 			// Code size: 263 (0x107)
 			.maxstack 8
@@ -433,7 +432,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2443
+			// Method begins at RVA 0x243f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -655,7 +654,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2479
+		// Method begins at RVA 0x2475
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2450
+				// Method begins at RVA 0x2443
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,30 +43,29 @@
 			)
 			// Method begins at RVA 0x21cc
 			// Header size: 12
-			// Code size: 39 (0x27)
+			// Code size: 34 (0x22)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldstr "boom-signal"
-			IL_0005: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_000f: stloc.0
-			IL_0010: ldloc.0
-			IL_0011: isinst [System.Runtime]System.Exception
-			IL_0016: dup
-			IL_0017: brtrue IL_0024
+			IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_000a: stloc.0
+			IL_000b: ldloc.0
+			IL_000c: isinst [System.Runtime]System.Exception
+			IL_0011: dup
+			IL_0012: brtrue IL_001f
 
-			IL_001c: pop
-			IL_001d: ldloc.0
-			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0023: throw
+			IL_0017: pop
+			IL_0018: ldloc.0
+			IL_0019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_001e: throw
 
-			IL_0024: throw
+			IL_001f: throw
 
-			IL_0025: ldnull
-			IL_0026: ret
+			IL_0020: ldnull
+			IL_0021: ret
 		} // end of method FunctionExpression_L7C7::__js_call__
 
 	} // end of class FunctionExpression_L7C7
@@ -82,7 +81,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2459
+				// Method begins at RVA 0x244c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,7 +104,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21ff
+			// Method begins at RVA 0x21fa
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -134,7 +133,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2462
+				// Method begins at RVA 0x2455
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +157,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2224
+			// Method begins at RVA 0x221c
 			// Header size: 12
 			// Code size: 84 (0x54)
 			.maxstack 8
@@ -214,7 +213,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2474
+					// Method begins at RVA 0x2467
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -237,7 +236,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2410
+				// Method begins at RVA 0x2408
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -259,7 +258,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x247d
+					// Method begins at RVA 0x2470
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -282,32 +281,31 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2414
+				// Method begins at RVA 0x240c
 				// Header size: 12
-				// Code size: 39 (0x27)
+				// Code size: 34 (0x22)
 				.maxstack 8
 				.locals init (
 					[0] object
 				)
 
 				IL_0000: ldstr "boom-aborted"
-				IL_0005: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_000f: stloc.0
-				IL_0010: ldloc.0
-				IL_0011: isinst [System.Runtime]System.Exception
-				IL_0016: dup
-				IL_0017: brtrue IL_0024
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_000a: stloc.0
+				IL_000b: ldloc.0
+				IL_000c: isinst [System.Runtime]System.Exception
+				IL_0011: dup
+				IL_0012: brtrue IL_001f
 
-				IL_001c: pop
-				IL_001d: ldloc.0
-				IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0023: throw
+				IL_0017: pop
+				IL_0018: ldloc.0
+				IL_0019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_001e: throw
 
-				IL_0024: throw
+				IL_001f: throw
 
-				IL_0025: ldnull
-				IL_0026: ret
+				IL_0020: ldnull
+				IL_0021: ret
 			} // end of method FunctionExpression_L29C11::__js_call__
 
 		} // end of class FunctionExpression_L29C11
@@ -323,7 +321,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2486
+					// Method begins at RVA 0x2479
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -343,7 +341,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x248f
+					// Method begins at RVA 0x2482
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -361,7 +359,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x246b
+				// Method begins at RVA 0x245e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -387,7 +385,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2284
+			// Method begins at RVA 0x227c
 			// Header size: 12
 			// Code size: 365 (0x16d)
 			.maxstack 8
@@ -551,7 +549,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2447
+			// Method begins at RVA 0x243a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -722,7 +720,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2498
+		// Method begins at RVA 0x248b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27e2
+						// Method begins at RVA 0x27da
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27d9
+					// Method begins at RVA 0x27d1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2570
+				// Method begins at RVA 0x2568
 				// Header size: 12
 				// Code size: 38 (0x26)
 				.maxstack 8
@@ -112,7 +112,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27f4
+						// Method begins at RVA 0x27ec
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -130,7 +130,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27eb
+					// Method begins at RVA 0x27e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -155,7 +155,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25a4
+				// Method begins at RVA 0x259c
 				// Header size: 12
 				// Code size: 113 (0x71)
 				.maxstack 8
@@ -234,7 +234,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2806
+						// Method begins at RVA 0x27fe
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -252,7 +252,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27fd
+					// Method begins at RVA 0x27f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -277,7 +277,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2624
+				// Method begins at RVA 0x261c
 				// Header size: 12
 				// Code size: 129 (0x81)
 				.maxstack 8
@@ -355,7 +355,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d0
+				// Method begins at RVA 0x27c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -494,7 +494,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2818
+					// Method begins at RVA 0x2810
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -517,7 +517,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26b1
+				// Method begins at RVA 0x26a9
 				// Header size: 1
 				// Code size: 33 (0x21)
 				.maxstack 8
@@ -546,7 +546,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2821
+					// Method begins at RVA 0x2819
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -570,7 +570,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26d4
+				// Method begins at RVA 0x26cc
 				// Header size: 12
 				// Code size: 231 (0xe7)
 				.maxstack 8
@@ -680,7 +680,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x280f
+				// Method begins at RVA 0x2807
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -706,7 +706,7 @@
 			)
 			// Method begins at RVA 0x21c8
 			// Header size: 12
-			// Code size: 921 (0x399)
+			// Code size: 916 (0x394)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope,
@@ -1037,96 +1037,95 @@
 			IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_02a1: stloc.s 7
 			IL_02a3: ldstr "boom-reason"
-			IL_02a8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_02b2: stloc.s 9
-			IL_02b4: ldloc.s 7
-			IL_02b6: ldstr "abort"
-			IL_02bb: ldloc.s 9
-			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02c2: pop
-			IL_02c3: ldloc.2
-			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02c9: stloc.s 9
-			IL_02cb: ldloc.s 9
-			IL_02cd: ldstr "next"
-			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_02d7: stloc.s 9
-			IL_02d9: ldloc.s 9
-			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e0: stloc.s 9
-			IL_02e2: ldc.i4.1
-			IL_02e3: newarr [System.Runtime]System.Object
-			IL_02e8: dup
-			IL_02e9: ldc.i4.0
-			IL_02ea: ldarg.0
-			IL_02eb: ldc.i4.1
-			IL_02ec: ldelem.ref
-			IL_02ed: stelem.ref
-			IL_02ee: stloc.s 5
-			IL_02f0: ldnull
-			IL_02f1: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
-			IL_02f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_02fc: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_0301: ldc.i4.0
-			IL_0302: conv.r8
-			IL_0303: ldstr ""
-			IL_0308: ldc.i4.0
-			IL_0309: ldc.i4.1
-			IL_030a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_030f: stloc.s 10
-			IL_0311: ldloc.s 9
-			IL_0313: ldstr "then"
-			IL_0318: ldloc.s 10
-			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_031f: stloc.s 9
-			IL_0321: ldloc.s 9
-			IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0328: stloc.s 9
-			IL_032a: ldc.i4.1
-			IL_032b: newarr [System.Runtime]System.Object
-			IL_0330: dup
-			IL_0331: ldc.i4.0
-			IL_0332: ldarg.0
-			IL_0333: ldc.i4.1
-			IL_0334: ldelem.ref
-			IL_0335: stelem.ref
-			IL_0336: stloc.s 5
-			IL_0338: ldnull
-			IL_0339: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
-			IL_033f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0344: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_0349: ldc.i4.1
-			IL_034a: conv.r8
-			IL_034b: ldstr ""
-			IL_0350: ldc.i4.0
-			IL_0351: ldc.i4.1
-			IL_0352: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_0357: stloc.s 11
-			IL_0359: ldloc.s 9
-			IL_035b: ldstr "catch"
-			IL_0360: ldloc.s 11
-			IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0367: stloc.s 9
-			IL_0369: ldloc.0
-			IL_036a: ldc.i4.m1
-			IL_036b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0370: ldloc.0
-			IL_0371: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0376: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_037b: ldarg.0
-			IL_037c: ldc.i4.1
-			IL_037d: newarr [System.Runtime]System.Object
-			IL_0382: dup
-			IL_0383: ldc.i4.0
-			IL_0384: ldloc.s 9
-			IL_0386: stelem.ref
-			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_038c: pop
-			IL_038d: ldloc.0
-			IL_038e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0393: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0398: ret
+			IL_02a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_02ad: stloc.s 9
+			IL_02af: ldloc.s 7
+			IL_02b1: ldstr "abort"
+			IL_02b6: ldloc.s 9
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02bd: pop
+			IL_02be: ldloc.2
+			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c4: stloc.s 9
+			IL_02c6: ldloc.s 9
+			IL_02c8: ldstr "next"
+			IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_02d2: stloc.s 9
+			IL_02d4: ldloc.s 9
+			IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02db: stloc.s 9
+			IL_02dd: ldc.i4.1
+			IL_02de: newarr [System.Runtime]System.Object
+			IL_02e3: dup
+			IL_02e4: ldc.i4.0
+			IL_02e5: ldarg.0
+			IL_02e6: ldc.i4.1
+			IL_02e7: ldelem.ref
+			IL_02e8: stelem.ref
+			IL_02e9: stloc.s 5
+			IL_02eb: ldnull
+			IL_02ec: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
+			IL_02f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_02f7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_02fc: ldc.i4.0
+			IL_02fd: conv.r8
+			IL_02fe: ldstr ""
+			IL_0303: ldc.i4.0
+			IL_0304: ldc.i4.1
+			IL_0305: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_030a: stloc.s 10
+			IL_030c: ldloc.s 9
+			IL_030e: ldstr "then"
+			IL_0313: ldloc.s 10
+			IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_031a: stloc.s 9
+			IL_031c: ldloc.s 9
+			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0323: stloc.s 9
+			IL_0325: ldc.i4.1
+			IL_0326: newarr [System.Runtime]System.Object
+			IL_032b: dup
+			IL_032c: ldc.i4.0
+			IL_032d: ldarg.0
+			IL_032e: ldc.i4.1
+			IL_032f: ldelem.ref
+			IL_0330: stelem.ref
+			IL_0331: stloc.s 5
+			IL_0333: ldnull
+			IL_0334: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
+			IL_033a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_033f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_0344: ldc.i4.1
+			IL_0345: conv.r8
+			IL_0346: ldstr ""
+			IL_034b: ldc.i4.0
+			IL_034c: ldc.i4.1
+			IL_034d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_0352: stloc.s 11
+			IL_0354: ldloc.s 9
+			IL_0356: ldstr "catch"
+			IL_035b: ldloc.s 11
+			IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0362: stloc.s 9
+			IL_0364: ldloc.0
+			IL_0365: ldc.i4.m1
+			IL_0366: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_036b: ldloc.0
+			IL_036c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0371: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0376: ldarg.0
+			IL_0377: ldc.i4.1
+			IL_0378: newarr [System.Runtime]System.Object
+			IL_037d: dup
+			IL_037e: ldc.i4.0
+			IL_037f: ldloc.s 9
+			IL_0381: stelem.ref
+			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0387: pop
+			IL_0388: ldloc.0
+			IL_0389: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_038e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0393: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1151,7 +1150,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27c7
+			// Method begins at RVA 0x27bf
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1245,7 +1244,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x282a
+		// Method begins at RVA 0x2822
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_ErrorHandling.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_ErrorHandling.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2342
+					// Method begins at RVA 0x233e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x234b
+					// Method begins at RVA 0x2347
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2339
+				// Method begins at RVA 0x2335
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -87,7 +87,7 @@
 			)
 			// Method begins at RVA 0x2218
 			// Header size: 12
-			// Code size: 76 (0x4c)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] bool,
@@ -99,33 +99,32 @@
 			IL_0001: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0006: stloc.0
 			IL_0007: ldloc.0
-			IL_0008: brfalse IL_0031
+			IL_0008: brfalse IL_002c
 
 			IL_000d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_0012: stloc.1
 			IL_0013: ldstr "Test error"
-			IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0022: stloc.2
-			IL_0023: ldarg.2
-			IL_0024: ldloc.1
-			IL_0025: ldloc.2
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_002b: pop
-			IL_002c: br IL_004a
+			IL_0018: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_001d: stloc.2
+			IL_001e: ldarg.2
+			IL_001f: ldloc.1
+			IL_0020: ldloc.2
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0026: pop
+			IL_0027: br IL_0045
 
-			IL_0031: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0036: stloc.1
-			IL_0037: ldarg.2
-			IL_0038: ldloc.1
-			IL_0039: ldc.i4.0
-			IL_003a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_003f: ldstr "success"
-			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0049: pop
+			IL_002c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0031: stloc.1
+			IL_0032: ldarg.2
+			IL_0033: ldloc.1
+			IL_0034: ldc.i4.0
+			IL_0035: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_003a: ldstr "success"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0044: pop
 
-			IL_004a: ldnull
-			IL_004b: ret
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method callbackFn::__js_call__
 
 	} // end of class callbackFn
@@ -148,7 +147,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2354
+				// Method begins at RVA 0x2350
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -172,7 +171,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2270
+			// Method begins at RVA 0x226b
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -209,7 +208,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x235d
+				// Method begins at RVA 0x2359
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -233,7 +232,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2294
+			// Method begins at RVA 0x2290
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -280,7 +279,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2366
+				// Method begins at RVA 0x2362
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -304,7 +303,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22d0
+			// Method begins at RVA 0x22cc
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -341,7 +340,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x236f
+				// Method begins at RVA 0x236b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -365,7 +364,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22f4
+			// Method begins at RVA 0x22f0
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -409,7 +408,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2330
+			// Method begins at RVA 0x232c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -611,7 +610,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2378
+		// Method begins at RVA 0x2374
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_FinallyThrows.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_FinallyThrows.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ef
+				// Method begins at RVA 0x21eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,30 +43,29 @@
 			)
 			// Method begins at RVA 0x2154
 			// Header size: 12
-			// Code size: 39 (0x27)
+			// Code size: 34 (0x22)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldstr "oops"
-			IL_0005: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_000f: stloc.0
-			IL_0010: ldloc.0
-			IL_0011: isinst [System.Runtime]System.Exception
-			IL_0016: dup
-			IL_0017: brtrue IL_0024
+			IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_000a: stloc.0
+			IL_000b: ldloc.0
+			IL_000c: isinst [System.Runtime]System.Exception
+			IL_0011: dup
+			IL_0012: brtrue IL_001f
 
-			IL_001c: pop
-			IL_001d: ldloc.0
-			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0023: throw
+			IL_0017: pop
+			IL_0018: ldloc.0
+			IL_0019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_001e: throw
 
-			IL_0024: throw
+			IL_001f: throw
 
-			IL_0025: ldnull
-			IL_0026: ret
+			IL_0020: ldnull
+			IL_0021: ret
 		} // end of method ArrowFunction_L3C55::__js_call__
 
 	} // end of class ArrowFunction_L3C55
@@ -89,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f8
+				// Method begins at RVA 0x21f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -113,7 +112,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2188
+			// Method begins at RVA 0x2184
 			// Header size: 12
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -153,7 +152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2201
+				// Method begins at RVA 0x21fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -177,7 +176,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21b8
+			// Method begins at RVA 0x21b4
 			// Header size: 12
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -206,7 +205,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e6
+			// Method begins at RVA 0x21e2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -341,7 +340,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220a
+		// Method begins at RVA 0x2206
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NewExpression_BuiltInErrors.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NewExpression_BuiltInErrors.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2259
+				// Method begins at RVA 0x2235
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2262
+				// Method begins at RVA 0x223e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2250
+			// Method begins at RVA 0x222c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 483 (0x1e3)
+		// Code size: 448 (0x1c0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryCatch_NewExpression_BuiltInErrors/Scope,
@@ -160,95 +160,88 @@
 		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0097: stloc.s 6
 		IL_0099: ldstr "boom"
-		IL_009e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_00a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-		IL_00a8: stloc.s 7
-		IL_00aa: ldloc.s 6
-		IL_00ac: ldstr "log"
-		IL_00b1: ldloc.s 7
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b8: pop
-		IL_00b9: ldstr "console"
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c8: stloc.s 7
-		IL_00ca: ldstr "eval"
-		IL_00cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_00d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.EvalError::.ctor(string)
-		IL_00d9: stloc.s 6
-		IL_00db: ldloc.s 7
-		IL_00dd: ldstr "log"
-		IL_00e2: ldloc.s 6
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e9: pop
-		IL_00ea: ldstr "console"
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f9: stloc.s 6
-		IL_00fb: ldstr "range"
-		IL_0100: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0105: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RangeError::.ctor(string)
-		IL_010a: stloc.s 7
-		IL_010c: ldloc.s 6
-		IL_010e: ldstr "log"
-		IL_0113: ldloc.s 7
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011a: pop
-		IL_011b: ldstr "console"
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012a: stloc.s 7
-		IL_012c: ldstr "ref"
-		IL_0131: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-		IL_013b: stloc.s 6
-		IL_013d: ldloc.s 7
-		IL_013f: ldstr "log"
-		IL_0144: ldloc.s 6
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014b: pop
-		IL_014c: ldstr "console"
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015b: stloc.s 6
-		IL_015d: ldstr "syntax"
-		IL_0162: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0167: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.SyntaxError::.ctor(string)
-		IL_016c: stloc.s 7
-		IL_016e: ldloc.s 6
-		IL_0170: ldstr "log"
-		IL_0175: ldloc.s 7
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017c: pop
-		IL_017d: ldstr "console"
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018c: stloc.s 7
-		IL_018e: ldstr "uri"
-		IL_0193: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0198: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.URIError::.ctor(string)
-		IL_019d: stloc.s 6
-		IL_019f: ldloc.s 7
-		IL_01a1: ldstr "log"
-		IL_01a6: ldloc.s 6
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ad: pop
-		IL_01ae: ldstr "console"
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bd: stloc.s 6
-		IL_01bf: ldstr "agg"
-		IL_01c4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_01c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.AggregateError::.ctor(string)
-		IL_01ce: stloc.s 7
-		IL_01d0: ldloc.s 6
-		IL_01d2: ldstr "log"
-		IL_01d7: ldloc.s 7
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01de: pop
-		IL_01df: ldnull
-		IL_01e0: stloc.s 5
-		IL_01e2: ret
+		IL_009e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_00a3: stloc.s 7
+		IL_00a5: ldloc.s 6
+		IL_00a7: ldstr "log"
+		IL_00ac: ldloc.s 7
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b3: pop
+		IL_00b4: ldstr "console"
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c3: stloc.s 7
+		IL_00c5: ldstr "eval"
+		IL_00ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.EvalError::.ctor(string)
+		IL_00cf: stloc.s 6
+		IL_00d1: ldloc.s 7
+		IL_00d3: ldstr "log"
+		IL_00d8: ldloc.s 6
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00df: pop
+		IL_00e0: ldstr "console"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ef: stloc.s 6
+		IL_00f1: ldstr "range"
+		IL_00f6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RangeError::.ctor(string)
+		IL_00fb: stloc.s 7
+		IL_00fd: ldloc.s 6
+		IL_00ff: ldstr "log"
+		IL_0104: ldloc.s 7
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010b: pop
+		IL_010c: ldstr "console"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011b: stloc.s 7
+		IL_011d: ldstr "ref"
+		IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+		IL_0127: stloc.s 6
+		IL_0129: ldloc.s 7
+		IL_012b: ldstr "log"
+		IL_0130: ldloc.s 6
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0137: pop
+		IL_0138: ldstr "console"
+		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0147: stloc.s 6
+		IL_0149: ldstr "syntax"
+		IL_014e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.SyntaxError::.ctor(string)
+		IL_0153: stloc.s 7
+		IL_0155: ldloc.s 6
+		IL_0157: ldstr "log"
+		IL_015c: ldloc.s 7
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0163: pop
+		IL_0164: ldstr "console"
+		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0173: stloc.s 7
+		IL_0175: ldstr "uri"
+		IL_017a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.URIError::.ctor(string)
+		IL_017f: stloc.s 6
+		IL_0181: ldloc.s 7
+		IL_0183: ldstr "log"
+		IL_0188: ldloc.s 6
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018f: pop
+		IL_0190: ldstr "console"
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019f: stloc.s 6
+		IL_01a1: ldstr "agg"
+		IL_01a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.AggregateError::.ctor(string)
+		IL_01ab: stloc.s 7
+		IL_01ad: ldloc.s 6
+		IL_01af: ldstr "log"
+		IL_01b4: ldloc.s 7
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bb: pop
+		IL_01bc: ldnull
+		IL_01bd: stloc.s 5
+		IL_01bf: ret
 	} // end of method TryCatch_NewExpression_BuiltInErrors::__js_module_init__
 
 } // end of class Modules.TryCatch_NewExpression_BuiltInErrors
@@ -260,7 +253,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x226b
+		// Method begins at RVA 0x2247
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NoBinding.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NoBinding.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x210d
+				// Method begins at RVA 0x2109
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2116
+				// Method begins at RVA 0x2112
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2104
+			// Method begins at RVA 0x2100
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 152 (0x98)
+		// Code size: 147 (0x93)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryCatch_NoBinding/Scope,
@@ -105,46 +105,45 @@
 			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_0026: pop
 			IL_0027: ldstr "test error message"
-			IL_002c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0036: stloc.1
-			IL_0037: ldloc.1
-			IL_0038: isinst [System.Runtime]System.Exception
-			IL_003d: dup
-			IL_003e: brtrue IL_004b
+			IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0031: stloc.1
+			IL_0032: ldloc.1
+			IL_0033: isinst [System.Runtime]System.Exception
+			IL_0038: dup
+			IL_0039: brtrue IL_0046
 
-			IL_0043: pop
-			IL_0044: ldloc.1
-			IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_004a: throw
+			IL_003e: pop
+			IL_003f: ldloc.1
+			IL_0040: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0045: throw
 
-			IL_004b: throw
+			IL_0046: throw
 
-			IL_004c: leave IL_0076
+			IL_0047: leave IL_0071
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0051: stloc.2
-			IL_0052: ldstr "console"
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0061: ldstr "log"
-			IL_0066: ldstr "in catch"
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0070: pop
-			IL_0071: leave IL_0076
+			IL_004c: stloc.2
+			IL_004d: ldstr "console"
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005c: ldstr "log"
+			IL_0061: ldstr "in catch"
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_006b: pop
+			IL_006c: leave IL_0071
 		} // end handler
 
-		IL_0076: ldstr "console"
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0085: ldstr "log"
-		IL_008a: ldstr "after catch"
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0094: pop
-		IL_0095: ldnull
-		IL_0096: stloc.3
-		IL_0097: ret
+		IL_0071: ldstr "console"
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0080: ldstr "log"
+		IL_0085: ldstr "after catch"
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008f: pop
+		IL_0090: ldnull
+		IL_0091: stloc.3
+		IL_0092: ret
 	} // end of method TryCatch_NoBinding::__js_module_init__
 
 } // end of class Modules.TryCatch_NoBinding
@@ -156,7 +155,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x211f
+		// Method begins at RVA 0x211b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryFinally_NoCatch_Throw.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryFinally_NoCatch_Throw.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2109
+				// Method begins at RVA 0x2105
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2112
+				// Method begins at RVA 0x210e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2100
+			// Method begins at RVA 0x20fc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 147 (0x93)
+		// Code size: 142 (0x8e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryFinally_NoCatch_Throw/Scope,
@@ -104,45 +104,44 @@
 			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_0026: pop
 			IL_0027: ldstr "boom"
-			IL_002c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0036: stloc.1
-			IL_0037: ldloc.1
-			IL_0038: isinst [System.Runtime]System.Exception
-			IL_003d: dup
-			IL_003e: brtrue IL_004b
+			IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0031: stloc.1
+			IL_0032: ldloc.1
+			IL_0033: isinst [System.Runtime]System.Exception
+			IL_0038: dup
+			IL_0039: brtrue IL_0046
 
-			IL_0043: pop
-			IL_0044: ldloc.1
-			IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_004a: throw
+			IL_003e: pop
+			IL_003f: ldloc.1
+			IL_0040: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0045: throw
 
-			IL_004b: throw
+			IL_0046: throw
 
-			IL_004c: leave IL_0071
+			IL_0047: leave IL_006c
 		} // end .try
 		finally
 		{
-			IL_0051: ldstr "console"
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0060: ldstr "log"
-			IL_0065: ldstr "in finally"
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_006f: pop
-			IL_0070: endfinally
+			IL_004c: ldstr "console"
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005b: ldstr "log"
+			IL_0060: ldstr "in finally"
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_006a: pop
+			IL_006b: endfinally
 		} // end handler
 
-		IL_0071: ldstr "console"
-		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0080: ldstr "log"
-		IL_0085: ldstr "after finally"
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008f: pop
-		IL_0090: ldnull
-		IL_0091: stloc.2
-		IL_0092: ret
+		IL_006c: ldstr "console"
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007b: ldstr "log"
+		IL_0080: ldstr "after finally"
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008a: pop
+		IL_008b: ldnull
+		IL_008c: stloc.2
+		IL_008d: ret
 	} // end of method TryFinally_NoCatch_Throw::__js_module_init__
 
 } // end of class Modules.TryFinally_NoCatch_Throw
@@ -154,7 +153,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x211b
+		// Method begins at RVA 0x2117
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29c0
+				// Method begins at RVA 0x29bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29c9
+				// Method begins at RVA 0x29c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29d2
+				// Method begins at RVA 0x29ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29e4
+					// Method begins at RVA 0x29e0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x29f6
+						// Method begins at RVA 0x29f2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x29ff
+						// Method begins at RVA 0x29fb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -144,7 +144,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29ed
+					// Method begins at RVA 0x29e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29db
+				// Method begins at RVA 0x29d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a08
+				// Method begins at RVA 0x2a04
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -327,7 +327,7 @@
 			)
 			// Method begins at RVA 0x25f4
 			// Header size: 12
-			// Code size: 863 (0x35f)
+			// Code size: 858 (0x35a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -400,294 +400,293 @@
 			IL_008f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0094: ldc.r8 16
 			IL_009d: cgt
-			IL_009f: brfalse IL_00c9
+			IL_009f: brfalse IL_00c4
 
 			IL_00a4: ldstr "not used in this test"
-			IL_00a9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00b3: stloc.1
-			IL_00b4: ldloc.1
-			IL_00b5: isinst [System.Runtime]System.Exception
-			IL_00ba: dup
-			IL_00bb: brtrue IL_00c8
+			IL_00a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00ae: stloc.1
+			IL_00af: ldloc.1
+			IL_00b0: isinst [System.Runtime]System.Exception
+			IL_00b5: dup
+			IL_00b6: brtrue IL_00c3
 
-			IL_00c0: pop
-			IL_00c1: ldloc.1
-			IL_00c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00c7: throw
+			IL_00bb: pop
+			IL_00bc: ldloc.1
+			IL_00bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00c2: throw
 
-			IL_00c8: throw
+			IL_00c3: throw
 
-			IL_00c9: ldarg.1
-			IL_00ca: stloc.2
-			IL_00cb: ldloc.2
-			IL_00cc: stloc.s 7
-			IL_00ce: ldloc.s 7
-			IL_00d0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00d5: stloc.s 8
-			IL_00d7: ldloc.s 8
-			IL_00d9: conv.i4
-			IL_00da: conv.u4
-			IL_00db: ldc.r8 5
-			IL_00e4: conv.i4
-			IL_00e5: shr.un
-			IL_00e6: conv.r.un
-			IL_00e7: stloc.3
-			IL_00e8: ldarg.0
-			IL_00e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_00ee: ldloc.3
-			IL_00ef: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_00f4: stloc.s 4
-			IL_00f6: ldstr "console"
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0105: ldstr "log"
-			IL_010a: ldc.i4.4
-			IL_010b: newarr [System.Runtime]System.Object
-			IL_0110: dup
-			IL_0111: ldc.i4.0
-			IL_0112: ldstr "init"
-			IL_0117: stelem.ref
-			IL_0118: dup
-			IL_0119: ldc.i4.1
-			IL_011a: ldloc.2
-			IL_011b: stelem.ref
-			IL_011c: dup
-			IL_011d: ldc.i4.2
-			IL_011e: ldloc.3
-			IL_011f: box [System.Runtime]System.Double
-			IL_0124: stelem.ref
-			IL_0125: dup
-			IL_0126: ldc.i4.3
-			IL_0127: ldloc.s 4
-			IL_0129: box [System.Runtime]System.Double
-			IL_012e: stelem.ref
-			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_0134: pop
-			// loop start (head: IL_0135)
-				IL_0135: ldloc.2
-				IL_0136: stloc.s 7
-				IL_0138: ldloc.s 7
-				IL_013a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_013f: ldarg.3
-				IL_0140: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0145: clt
-				IL_0147: brfalse IL_0288
+			IL_00c4: ldarg.1
+			IL_00c5: stloc.2
+			IL_00c6: ldloc.2
+			IL_00c7: stloc.s 7
+			IL_00c9: ldloc.s 7
+			IL_00cb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
+			IL_00d4: conv.i4
+			IL_00d5: conv.u4
+			IL_00d6: ldc.r8 5
+			IL_00df: conv.i4
+			IL_00e0: shr.un
+			IL_00e1: conv.r.un
+			IL_00e2: stloc.3
+			IL_00e3: ldarg.0
+			IL_00e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_00e9: ldloc.3
+			IL_00ea: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_00ef: stloc.s 4
+			IL_00f1: ldstr "console"
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0100: ldstr "log"
+			IL_0105: ldc.i4.4
+			IL_0106: newarr [System.Runtime]System.Object
+			IL_010b: dup
+			IL_010c: ldc.i4.0
+			IL_010d: ldstr "init"
+			IL_0112: stelem.ref
+			IL_0113: dup
+			IL_0114: ldc.i4.1
+			IL_0115: ldloc.2
+			IL_0116: stelem.ref
+			IL_0117: dup
+			IL_0118: ldc.i4.2
+			IL_0119: ldloc.3
+			IL_011a: box [System.Runtime]System.Double
+			IL_011f: stelem.ref
+			IL_0120: dup
+			IL_0121: ldc.i4.3
+			IL_0122: ldloc.s 4
+			IL_0124: box [System.Runtime]System.Double
+			IL_0129: stelem.ref
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_012f: pop
+			// loop start (head: IL_0130)
+				IL_0130: ldloc.2
+				IL_0131: stloc.s 7
+				IL_0133: ldloc.s 7
+				IL_0135: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_013a: ldarg.3
+				IL_013b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0140: clt
+				IL_0142: brfalse IL_0283
 
-				IL_014c: ldloc.2
-				IL_014d: stloc.s 7
-				IL_014f: ldloc.s 7
-				IL_0151: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0156: stloc.s 8
-				IL_0158: ldloc.s 8
-				IL_015a: conv.i4
-				IL_015b: ldc.r8 31
-				IL_0164: conv.i4
-				IL_0165: and
-				IL_0166: conv.r8
-				IL_0167: stloc.s 5
-				IL_0169: ldc.r8 1
-				IL_0172: conv.i4
-				IL_0173: ldloc.s 5
-				IL_0175: conv.i4
-				IL_0176: shl
-				IL_0177: conv.r8
-				IL_0178: stloc.s 8
-				IL_017a: ldloc.s 4
-				IL_017c: conv.i4
-				IL_017d: ldloc.s 8
-				IL_017f: conv.i4
-				IL_0180: or
-				IL_0181: conv.r8
-				IL_0182: stloc.s 8
-				IL_0184: ldloc.s 8
-				IL_0186: stloc.s 4
-				IL_0188: ldloc.2
-				IL_0189: stloc.s 7
-				IL_018b: ldloc.s 7
-				IL_018d: ldarg.1
-				IL_018e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0193: stloc.s 9
-				IL_0195: ldloc.s 9
-				IL_0197: brfalse IL_01dc
+				IL_0147: ldloc.2
+				IL_0148: stloc.s 7
+				IL_014a: ldloc.s 7
+				IL_014c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0151: stloc.s 8
+				IL_0153: ldloc.s 8
+				IL_0155: conv.i4
+				IL_0156: ldc.r8 31
+				IL_015f: conv.i4
+				IL_0160: and
+				IL_0161: conv.r8
+				IL_0162: stloc.s 5
+				IL_0164: ldc.r8 1
+				IL_016d: conv.i4
+				IL_016e: ldloc.s 5
+				IL_0170: conv.i4
+				IL_0171: shl
+				IL_0172: conv.r8
+				IL_0173: stloc.s 8
+				IL_0175: ldloc.s 4
+				IL_0177: conv.i4
+				IL_0178: ldloc.s 8
+				IL_017a: conv.i4
+				IL_017b: or
+				IL_017c: conv.r8
+				IL_017d: stloc.s 8
+				IL_017f: ldloc.s 8
+				IL_0181: stloc.s 4
+				IL_0183: ldloc.2
+				IL_0184: stloc.s 7
+				IL_0186: ldloc.s 7
+				IL_0188: ldarg.1
+				IL_0189: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_018e: stloc.s 9
+				IL_0190: ldloc.s 9
+				IL_0192: brfalse IL_01d7
 
-				IL_019c: ldstr "console"
-				IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01ab: ldstr "log"
-				IL_01b0: ldc.i4.4
-				IL_01b1: newarr [System.Runtime]System.Object
-				IL_01b6: dup
-				IL_01b7: ldc.i4.0
-				IL_01b8: ldstr "iter0"
-				IL_01bd: stelem.ref
-				IL_01be: dup
-				IL_01bf: ldc.i4.1
-				IL_01c0: ldloc.2
-				IL_01c1: stelem.ref
-				IL_01c2: dup
-				IL_01c3: ldc.i4.2
-				IL_01c4: ldloc.s 5
-				IL_01c6: box [System.Runtime]System.Double
-				IL_01cb: stelem.ref
-				IL_01cc: dup
-				IL_01cd: ldc.i4.3
-				IL_01ce: ldloc.s 4
-				IL_01d0: box [System.Runtime]System.Double
-				IL_01d5: stelem.ref
-				IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-				IL_01db: pop
+				IL_0197: ldstr "console"
+				IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01a6: ldstr "log"
+				IL_01ab: ldc.i4.4
+				IL_01ac: newarr [System.Runtime]System.Object
+				IL_01b1: dup
+				IL_01b2: ldc.i4.0
+				IL_01b3: ldstr "iter0"
+				IL_01b8: stelem.ref
+				IL_01b9: dup
+				IL_01ba: ldc.i4.1
+				IL_01bb: ldloc.2
+				IL_01bc: stelem.ref
+				IL_01bd: dup
+				IL_01be: ldc.i4.2
+				IL_01bf: ldloc.s 5
+				IL_01c1: box [System.Runtime]System.Double
+				IL_01c6: stelem.ref
+				IL_01c7: dup
+				IL_01c8: ldc.i4.3
+				IL_01c9: ldloc.s 4
+				IL_01cb: box [System.Runtime]System.Double
+				IL_01d0: stelem.ref
+				IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+				IL_01d6: pop
 
-				IL_01dc: ldloc.2
-				IL_01dd: ldarg.2
-				IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_01e3: stloc.s 10
-				IL_01e5: ldloc.s 10
-				IL_01e7: stloc.2
-				IL_01e8: ldloc.2
-				IL_01e9: stloc.s 10
-				IL_01eb: ldloc.s 10
-				IL_01ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01f2: stloc.s 8
-				IL_01f4: ldloc.s 8
-				IL_01f6: conv.i4
-				IL_01f7: conv.u4
-				IL_01f8: ldc.r8 5
-				IL_0201: conv.i4
-				IL_0202: shr.un
-				IL_0203: conv.r.un
-				IL_0204: stloc.s 6
-				IL_0206: ldloc.s 6
-				IL_0208: ldloc.3
-				IL_0209: ceq
-				IL_020b: ldc.i4.0
-				IL_020c: ceq
-				IL_020e: brfalse IL_0283
+				IL_01d7: ldloc.2
+				IL_01d8: ldarg.2
+				IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_01de: stloc.s 10
+				IL_01e0: ldloc.s 10
+				IL_01e2: stloc.2
+				IL_01e3: ldloc.2
+				IL_01e4: stloc.s 10
+				IL_01e6: ldloc.s 10
+				IL_01e8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01ed: stloc.s 8
+				IL_01ef: ldloc.s 8
+				IL_01f1: conv.i4
+				IL_01f2: conv.u4
+				IL_01f3: ldc.r8 5
+				IL_01fc: conv.i4
+				IL_01fd: shr.un
+				IL_01fe: conv.r.un
+				IL_01ff: stloc.s 6
+				IL_0201: ldloc.s 6
+				IL_0203: ldloc.3
+				IL_0204: ceq
+				IL_0206: ldc.i4.0
+				IL_0207: ceq
+				IL_0209: brfalse IL_027e
 
-				IL_0213: ldstr "console"
-				IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0222: ldstr "log"
-				IL_0227: ldc.i4.5
-				IL_0228: newarr [System.Runtime]System.Object
-				IL_022d: dup
-				IL_022e: ldc.i4.0
-				IL_022f: ldstr "commit"
-				IL_0234: stelem.ref
-				IL_0235: dup
-				IL_0236: ldc.i4.1
-				IL_0237: ldloc.3
-				IL_0238: box [System.Runtime]System.Double
-				IL_023d: stelem.ref
-				IL_023e: dup
-				IL_023f: ldc.i4.2
-				IL_0240: ldloc.s 4
-				IL_0242: box [System.Runtime]System.Double
-				IL_0247: stelem.ref
-				IL_0248: dup
-				IL_0249: ldc.i4.3
-				IL_024a: ldstr "->"
-				IL_024f: stelem.ref
-				IL_0250: dup
-				IL_0251: ldc.i4.4
-				IL_0252: ldloc.s 6
-				IL_0254: box [System.Runtime]System.Double
-				IL_0259: stelem.ref
-				IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-				IL_025f: pop
-				IL_0260: ldarg.0
-				IL_0261: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-				IL_0266: ldloc.3
-				IL_0267: ldloc.s 4
-				IL_0269: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_026e: ldloc.s 6
-				IL_0270: stloc.3
-				IL_0271: ldarg.0
-				IL_0272: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-				IL_0277: ldloc.3
-				IL_0278: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_027d: stloc.s 8
-				IL_027f: ldloc.s 8
-				IL_0281: stloc.s 4
+				IL_020e: ldstr "console"
+				IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_021d: ldstr "log"
+				IL_0222: ldc.i4.5
+				IL_0223: newarr [System.Runtime]System.Object
+				IL_0228: dup
+				IL_0229: ldc.i4.0
+				IL_022a: ldstr "commit"
+				IL_022f: stelem.ref
+				IL_0230: dup
+				IL_0231: ldc.i4.1
+				IL_0232: ldloc.3
+				IL_0233: box [System.Runtime]System.Double
+				IL_0238: stelem.ref
+				IL_0239: dup
+				IL_023a: ldc.i4.2
+				IL_023b: ldloc.s 4
+				IL_023d: box [System.Runtime]System.Double
+				IL_0242: stelem.ref
+				IL_0243: dup
+				IL_0244: ldc.i4.3
+				IL_0245: ldstr "->"
+				IL_024a: stelem.ref
+				IL_024b: dup
+				IL_024c: ldc.i4.4
+				IL_024d: ldloc.s 6
+				IL_024f: box [System.Runtime]System.Double
+				IL_0254: stelem.ref
+				IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+				IL_025a: pop
+				IL_025b: ldarg.0
+				IL_025c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+				IL_0261: ldloc.3
+				IL_0262: ldloc.s 4
+				IL_0264: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_0269: ldloc.s 6
+				IL_026b: stloc.3
+				IL_026c: ldarg.0
+				IL_026d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+				IL_0272: ldloc.3
+				IL_0273: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_0278: stloc.s 8
+				IL_027a: ldloc.s 8
+				IL_027c: stloc.s 4
 
-				IL_0283: br IL_0135
+				IL_027e: br IL_0130
 			// end loop
 
-			IL_0288: ldstr "console"
-			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0297: ldstr "log"
-			IL_029c: ldc.i4.4
-			IL_029d: newarr [System.Runtime]System.Object
-			IL_02a2: dup
-			IL_02a3: ldc.i4.0
-			IL_02a4: ldstr "end"
-			IL_02a9: stelem.ref
-			IL_02aa: dup
-			IL_02ab: ldc.i4.1
-			IL_02ac: ldloc.2
-			IL_02ad: stelem.ref
-			IL_02ae: dup
-			IL_02af: ldc.i4.2
-			IL_02b0: ldloc.3
-			IL_02b1: box [System.Runtime]System.Double
-			IL_02b6: stelem.ref
-			IL_02b7: dup
-			IL_02b8: ldc.i4.3
-			IL_02b9: ldloc.s 4
-			IL_02bb: box [System.Runtime]System.Double
-			IL_02c0: stelem.ref
-			IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_02c6: pop
-			IL_02c7: ldarg.0
-			IL_02c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_02cd: ldloc.3
-			IL_02ce: ldloc.s 4
-			IL_02d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_02d5: ldstr "console"
-			IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e4: ldarg.0
-			IL_02e5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_02ea: ldc.r8 0.0
-			IL_02f3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_02f8: box [System.Runtime]System.Double
-			IL_02fd: stloc.s 11
-			IL_02ff: ldarg.0
-			IL_0300: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_0305: ldc.r8 1
-			IL_030e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0313: box [System.Runtime]System.Double
-			IL_0318: stloc.s 12
-			IL_031a: ldarg.0
-			IL_031b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_0320: ldc.r8 2
-			IL_0329: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_032e: box [System.Runtime]System.Double
-			IL_0333: stloc.s 13
-			IL_0335: ldstr "log"
-			IL_033a: ldc.i4.4
-			IL_033b: newarr [System.Runtime]System.Object
-			IL_0340: dup
-			IL_0341: ldc.i4.0
-			IL_0342: ldstr "after"
+			IL_0283: ldstr "console"
+			IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0292: ldstr "log"
+			IL_0297: ldc.i4.4
+			IL_0298: newarr [System.Runtime]System.Object
+			IL_029d: dup
+			IL_029e: ldc.i4.0
+			IL_029f: ldstr "end"
+			IL_02a4: stelem.ref
+			IL_02a5: dup
+			IL_02a6: ldc.i4.1
+			IL_02a7: ldloc.2
+			IL_02a8: stelem.ref
+			IL_02a9: dup
+			IL_02aa: ldc.i4.2
+			IL_02ab: ldloc.3
+			IL_02ac: box [System.Runtime]System.Double
+			IL_02b1: stelem.ref
+			IL_02b2: dup
+			IL_02b3: ldc.i4.3
+			IL_02b4: ldloc.s 4
+			IL_02b6: box [System.Runtime]System.Double
+			IL_02bb: stelem.ref
+			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_02c1: pop
+			IL_02c2: ldarg.0
+			IL_02c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_02c8: ldloc.3
+			IL_02c9: ldloc.s 4
+			IL_02cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_02d0: ldstr "console"
+			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02df: ldarg.0
+			IL_02e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_02e5: ldc.r8 0.0
+			IL_02ee: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_02f3: box [System.Runtime]System.Double
+			IL_02f8: stloc.s 11
+			IL_02fa: ldarg.0
+			IL_02fb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_0300: ldc.r8 1
+			IL_0309: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_030e: box [System.Runtime]System.Double
+			IL_0313: stloc.s 12
+			IL_0315: ldarg.0
+			IL_0316: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_031b: ldc.r8 2
+			IL_0324: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_0329: box [System.Runtime]System.Double
+			IL_032e: stloc.s 13
+			IL_0330: ldstr "log"
+			IL_0335: ldc.i4.4
+			IL_0336: newarr [System.Runtime]System.Object
+			IL_033b: dup
+			IL_033c: ldc.i4.0
+			IL_033d: ldstr "after"
+			IL_0342: stelem.ref
+			IL_0343: dup
+			IL_0344: ldc.i4.1
+			IL_0345: ldloc.s 11
 			IL_0347: stelem.ref
 			IL_0348: dup
-			IL_0349: ldc.i4.1
-			IL_034a: ldloc.s 11
+			IL_0349: ldc.i4.2
+			IL_034a: ldloc.s 12
 			IL_034c: stelem.ref
 			IL_034d: dup
-			IL_034e: ldc.i4.2
-			IL_034f: ldloc.s 12
+			IL_034e: ldc.i4.3
+			IL_034f: ldloc.s 13
 			IL_0351: stelem.ref
-			IL_0352: dup
-			IL_0353: ldc.i4.3
-			IL_0354: ldloc.s 13
-			IL_0356: stelem.ref
-			IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_035c: pop
-			IL_035d: ldnull
-			IL_035e: ret
+			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_0357: pop
+			IL_0358: ldnull
+			IL_0359: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -698,7 +697,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2960
+			// Method begins at RVA 0x295c
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -759,7 +758,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29b7
+			// Method begins at RVA 0x29b3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1225,7 +1224,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a11
+		// Method begins at RVA 0x2a0d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericLetLocalSpecialization.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericLetLocalSpecialization.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27a8
+					// Method begins at RVA 0x27a4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27b1
+					// Method begins at RVA 0x27ad
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x278d
+				// Method begins at RVA 0x2789
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -84,7 +84,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x279f
+					// Method begins at RVA 0x279b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2796
+				// Method begins at RVA 0x2792
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -215,7 +215,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27c3
+					// Method begins at RVA 0x27bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -235,7 +235,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27cc
+					// Method begins at RVA 0x27c8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -253,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27ba
+				// Method begins at RVA 0x27b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -281,7 +281,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27e7
+						// Method begins at RVA 0x27e3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -299,7 +299,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27de
+					// Method begins at RVA 0x27da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -317,7 +317,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d5
+				// Method begins at RVA 0x27d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -472,7 +472,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27f9
+					// Method begins at RVA 0x27f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -492,7 +492,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2802
+					// Method begins at RVA 0x27fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -510,7 +510,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27f0
+				// Method begins at RVA 0x27ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -535,7 +535,7 @@
 			)
 			// Method begins at RVA 0x2520
 			// Header size: 12
-			// Code size: 147 (0x93)
+			// Code size: 142 (0x8e)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -550,72 +550,71 @@
 			{
 				IL_0000: nop
 				IL_0001: ldstr "Cannot access 'value' before initialization"
-				IL_0006: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_000b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-				IL_0010: stloc.s 5
-				IL_0012: ldloc.s 5
-				IL_0014: isinst [System.Runtime]System.Exception
-				IL_0019: dup
-				IL_001a: brtrue IL_0028
+				IL_0006: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+				IL_000b: stloc.s 5
+				IL_000d: ldloc.s 5
+				IL_000f: isinst [System.Runtime]System.Exception
+				IL_0014: dup
+				IL_0015: brtrue IL_0023
 
-				IL_001f: pop
-				IL_0020: ldloc.s 5
-				IL_0022: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0027: throw
+				IL_001a: pop
+				IL_001b: ldloc.s 5
+				IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0022: throw
 
-				IL_0028: throw
+				IL_0023: throw
 
-				IL_0029: ldnull
-				IL_002a: stloc.0
-				IL_002b: ldnull
-				IL_002c: stloc.0
-				IL_002d: leave IL_0091
+				IL_0024: ldnull
+				IL_0025: stloc.0
+				IL_0026: ldnull
+				IL_0027: stloc.0
+				IL_0028: leave IL_008c
 
-				IL_0032: leave IL_0086
+				IL_002d: leave IL_0081
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0037: stloc.1
-				IL_0038: ldloc.1
-				IL_0039: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_003e: dup
-				IL_003f: brtrue IL_0054
+				IL_0032: stloc.1
+				IL_0033: ldloc.1
+				IL_0034: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0039: dup
+				IL_003a: brtrue IL_004f
 
-				IL_0044: pop
-				IL_0045: ldloc.1
-				IL_0046: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_004b: dup
-				IL_004c: brtrue IL_005f
+				IL_003f: pop
+				IL_0040: ldloc.1
+				IL_0041: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0046: dup
+				IL_0047: brtrue IL_005a
 
-				IL_0051: pop
-				IL_0052: rethrow
+				IL_004c: pop
+				IL_004d: rethrow
 
-				IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0059: stloc.2
-				IL_005a: br IL_0060
+				IL_004f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0054: stloc.2
+				IL_0055: br IL_005b
 
-				IL_005f: stloc.2
+				IL_005a: stloc.2
 
-				IL_0060: ldloc.2
-				IL_0061: stloc.3
-				IL_0062: ldloc.3
-				IL_0063: ldstr "constructor"
-				IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_006d: stloc.s 5
-				IL_006f: ldloc.s 5
-				IL_0071: ldstr "name"
-				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_007b: stloc.0
-				IL_007c: leave IL_0091
+				IL_005b: ldloc.2
+				IL_005c: stloc.3
+				IL_005d: ldloc.3
+				IL_005e: ldstr "constructor"
+				IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0068: stloc.s 5
+				IL_006a: ldloc.s 5
+				IL_006c: ldstr "name"
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0076: stloc.0
+				IL_0077: leave IL_008c
 
-				IL_0081: leave IL_0086
+				IL_007c: leave IL_0081
 			} // end handler
 
-			IL_0086: ldc.r8 1
-			IL_008f: stloc.s 4
+			IL_0081: ldc.r8 1
+			IL_008a: stloc.s 4
 
-			IL_0091: ldloc.0
-			IL_0092: ret
+			IL_008c: ldloc.0
+			IL_008d: ret
 		} // end of method temporalDeadZoneRead::__js_call__
 
 	} // end of class temporalDeadZoneRead
@@ -635,7 +634,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2814
+					// Method begins at RVA 0x2810
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -653,7 +652,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x280b
+				// Method begins at RVA 0x2807
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -677,7 +676,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25d0
+			// Method begins at RVA 0x25cc
 			// Header size: 12
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -722,7 +721,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2826
+					// Method begins at RVA 0x2822
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -740,7 +739,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x281d
+				// Method begins at RVA 0x2819
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -764,7 +763,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2600
+			// Method begins at RVA 0x25fc
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -810,7 +809,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2838
+					// Method begins at RVA 0x2834
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -834,7 +833,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2744
+				// Method begins at RVA 0x2740
 				// Header size: 12
 				// Code size: 52 (0x34)
 				.maxstack 8
@@ -881,7 +880,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x282f
+				// Method begins at RVA 0x282b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -907,7 +906,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2630
+			// Method begins at RVA 0x262c
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -966,7 +965,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x284a
+					// Method begins at RVA 0x2846
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -984,7 +983,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2841
+				// Method begins at RVA 0x283d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1010,7 +1009,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x268c
+			// Method begins at RVA 0x2688
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -1056,7 +1055,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2853
+				// Method begins at RVA 0x284f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1080,7 +1079,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2865
+					// Method begins at RVA 0x2861
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1098,7 +1097,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x285c
+				// Method begins at RVA 0x2858
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1125,7 +1124,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x26c0
+			// Method begins at RVA 0x26bc
 			// Header size: 12
 			// Code size: 119 (0x77)
 			.maxstack 8
@@ -1228,7 +1227,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2784
+			// Method begins at RVA 0x2780
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1540,7 +1539,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x286e
+		// Method begins at RVA 0x286a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneAccess.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneAccess.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2149
+				// Method begins at RVA 0x2141
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2152
+				// Method begins at RVA 0x214a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2140
+			// Method begins at RVA 0x2138
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 209 (0xd1)
+		// Code size: 204 (0xcc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneAccess/Scope,
@@ -106,75 +106,74 @@
 			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0017: stloc.s 6
 			IL_0019: ldstr "Cannot access 'a' before initialization"
-			IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0023: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_0028: stloc.s 7
-			IL_002a: ldloc.s 7
-			IL_002c: isinst [System.Runtime]System.Exception
-			IL_0031: dup
-			IL_0032: brtrue IL_0040
+			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_0023: stloc.s 7
+			IL_0025: ldloc.s 7
+			IL_0027: isinst [System.Runtime]System.Exception
+			IL_002c: dup
+			IL_002d: brtrue IL_003b
 
-			IL_0037: pop
-			IL_0038: ldloc.s 7
-			IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_003f: throw
+			IL_0032: pop
+			IL_0033: ldloc.s 7
+			IL_0035: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_003a: throw
 
-			IL_0040: throw
+			IL_003b: throw
 
-			IL_0041: ldloc.s 6
-			IL_0043: ldstr "log"
-			IL_0048: ldnull
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_004e: pop
-			IL_004f: ldc.r8 3
-			IL_0058: stloc.1
-			IL_0059: ldstr "console"
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0068: ldstr "log"
-			IL_006d: ldstr "NO_TDZ"
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0077: pop
-			IL_0078: leave IL_00cd
+			IL_003c: ldloc.s 6
+			IL_003e: ldstr "log"
+			IL_0043: ldnull
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0049: pop
+			IL_004a: ldc.r8 3
+			IL_0053: stloc.1
+			IL_0054: ldstr "console"
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0063: ldstr "log"
+			IL_0068: ldstr "NO_TDZ"
+			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0072: pop
+			IL_0073: leave IL_00c8
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_007d: stloc.2
-			IL_007e: ldloc.2
-			IL_007f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0084: dup
-			IL_0085: brtrue IL_009a
+			IL_0078: stloc.2
+			IL_0079: ldloc.2
+			IL_007a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_007f: dup
+			IL_0080: brtrue IL_0095
 
-			IL_008a: pop
-			IL_008b: ldloc.2
-			IL_008c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0091: dup
-			IL_0092: brtrue IL_00a5
+			IL_0085: pop
+			IL_0086: ldloc.2
+			IL_0087: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_008c: dup
+			IL_008d: brtrue IL_00a0
 
-			IL_0097: pop
-			IL_0098: rethrow
+			IL_0092: pop
+			IL_0093: rethrow
 
-			IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_009f: stloc.3
-			IL_00a0: br IL_00a6
+			IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_009a: stloc.3
+			IL_009b: br IL_00a1
 
-			IL_00a5: stloc.3
+			IL_00a0: stloc.3
 
-			IL_00a6: ldloc.3
-			IL_00a7: stloc.s 4
-			IL_00a9: ldstr "console"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b8: ldstr "log"
-			IL_00bd: ldstr "TDZ_ERROR"
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00c7: pop
-			IL_00c8: leave IL_00cd
+			IL_00a1: ldloc.3
+			IL_00a2: stloc.s 4
+			IL_00a4: ldstr "console"
+			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b3: ldstr "log"
+			IL_00b8: ldstr "TDZ_ERROR"
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00c2: pop
+			IL_00c3: leave IL_00c8
 		} // end handler
 
-		IL_00cd: ldnull
-		IL_00ce: stloc.s 5
-		IL_00d0: ret
+		IL_00c8: ldnull
+		IL_00c9: stloc.s 5
+		IL_00cb: ret
 	} // end of method Variable_TemporalDeadZoneAccess::__js_module_init__
 
 } // end of class Modules.Variable_TemporalDeadZoneAccess
@@ -186,7 +185,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x215b
+		// Method begins at RVA 0x2153
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneShadowing.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneShadowing.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x218a
+					// Method begins at RVA 0x2186
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2193
+					// Method begins at RVA 0x218f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2181
+				// Method begins at RVA 0x217d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2178
+			// Method begins at RVA 0x2174
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -104,7 +104,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 268 (0x10c)
+		// Code size: 263 (0x107)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneShadowing/Scope,
@@ -132,89 +132,88 @@
 			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_001e: stloc.s 7
 			IL_0020: ldstr "Cannot access 'value' before initialization"
-			IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_002a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_002f: stloc.s 8
-			IL_0031: ldloc.s 8
-			IL_0033: isinst [System.Runtime]System.Exception
-			IL_0038: dup
-			IL_0039: brtrue IL_0047
+			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_002a: stloc.s 8
+			IL_002c: ldloc.s 8
+			IL_002e: isinst [System.Runtime]System.Exception
+			IL_0033: dup
+			IL_0034: brtrue IL_0042
 
-			IL_003e: pop
-			IL_003f: ldloc.s 8
-			IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0046: throw
+			IL_0039: pop
+			IL_003a: ldloc.s 8
+			IL_003c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0041: throw
 
-			IL_0047: throw
+			IL_0042: throw
 
-			IL_0048: ldloc.s 7
-			IL_004a: ldstr "log"
-			IL_004f: ldnull
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0055: pop
-			IL_0056: ldstr "console"
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0065: ldstr "log"
-			IL_006a: ldstr "NO_TDZ"
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0074: pop
-			IL_0075: leave IL_00ca
+			IL_0043: ldloc.s 7
+			IL_0045: ldstr "log"
+			IL_004a: ldnull
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0050: pop
+			IL_0051: ldstr "console"
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0060: ldstr "log"
+			IL_0065: ldstr "NO_TDZ"
+			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_006f: pop
+			IL_0070: leave IL_00c5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_007a: stloc.2
-			IL_007b: ldloc.2
-			IL_007c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0081: dup
-			IL_0082: brtrue IL_0097
+			IL_0075: stloc.2
+			IL_0076: ldloc.2
+			IL_0077: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_007c: dup
+			IL_007d: brtrue IL_0092
 
-			IL_0087: pop
-			IL_0088: ldloc.2
-			IL_0089: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_008e: dup
-			IL_008f: brtrue IL_00a2
+			IL_0082: pop
+			IL_0083: ldloc.2
+			IL_0084: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0089: dup
+			IL_008a: brtrue IL_009d
 
-			IL_0094: pop
-			IL_0095: rethrow
+			IL_008f: pop
+			IL_0090: rethrow
 
-			IL_0097: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_009c: stloc.3
-			IL_009d: br IL_00a3
+			IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0097: stloc.3
+			IL_0098: br IL_009e
 
-			IL_00a2: stloc.3
+			IL_009d: stloc.3
 
-			IL_00a3: ldloc.3
-			IL_00a4: stloc.s 4
-			IL_00a6: ldstr "console"
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b5: ldstr "log"
-			IL_00ba: ldstr "INNER_TDZ"
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00c4: pop
-			IL_00c5: leave IL_00ca
+			IL_009e: ldloc.3
+			IL_009f: stloc.s 4
+			IL_00a1: ldstr "console"
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b0: ldstr "log"
+			IL_00b5: ldstr "INNER_TDZ"
+			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00bf: pop
+			IL_00c0: leave IL_00c5
 		} // end handler
 
-		IL_00ca: ldstr "inner"
-		IL_00cf: stloc.s 5
-		IL_00d1: ldstr "console"
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e0: ldstr "log"
-		IL_00e5: ldloc.s 5
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ec: pop
-		IL_00ed: ldstr "console"
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fc: ldstr "log"
-		IL_0101: ldloc.1
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0107: pop
-		IL_0108: ldnull
-		IL_0109: stloc.s 6
-		IL_010b: ret
+		IL_00c5: ldstr "inner"
+		IL_00ca: stloc.s 5
+		IL_00cc: ldstr "console"
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00db: ldstr "log"
+		IL_00e0: ldloc.s 5
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e7: pop
+		IL_00e8: ldstr "console"
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f7: ldstr "log"
+		IL_00fc: ldloc.1
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0102: pop
+		IL_0103: ldnull
+		IL_0104: stloc.s 6
+		IL_0106: ret
 	} // end of method Variable_TemporalDeadZoneShadowing::__js_module_init__
 
 } // end of class Modules.Variable_TemporalDeadZoneShadowing
@@ -226,7 +225,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x219c
+		// Method begins at RVA 0x2198
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneSwitchScope.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneSwitchScope.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2172
+					// Method begins at RVA 0x216e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x217b
+					// Method begins at RVA 0x2177
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2169
+				// Method begins at RVA 0x2165
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2160
+			// Method begins at RVA 0x215c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -104,7 +104,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 243 (0xf3)
+		// Code size: 238 (0xee)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneSwitchScope/Scope,
@@ -129,84 +129,83 @@
 			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_001c: stloc.s 6
 			IL_001e: ldstr "Cannot access 'value' before initialization"
-			IL_0023: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0028: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_002d: stloc.s 7
-			IL_002f: ldloc.s 7
-			IL_0031: isinst [System.Runtime]System.Exception
-			IL_0036: dup
-			IL_0037: brtrue IL_0045
+			IL_0023: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_0028: stloc.s 7
+			IL_002a: ldloc.s 7
+			IL_002c: isinst [System.Runtime]System.Exception
+			IL_0031: dup
+			IL_0032: brtrue IL_0040
 
-			IL_003c: pop
-			IL_003d: ldloc.s 7
-			IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0044: throw
+			IL_0037: pop
+			IL_0038: ldloc.s 7
+			IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_003f: throw
 
-			IL_0045: throw
+			IL_0040: throw
 
-			IL_0046: ldloc.s 6
-			IL_0048: ldstr "log"
-			IL_004d: ldnull
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0053: pop
-			IL_0054: ldstr "console"
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0063: ldstr "log"
-			IL_0068: ldstr "NO_TDZ"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0072: pop
-			IL_0073: leave IL_00c7
+			IL_0041: ldloc.s 6
+			IL_0043: ldstr "log"
+			IL_0048: ldnull
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_004e: pop
+			IL_004f: ldstr "console"
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005e: ldstr "log"
+			IL_0063: ldstr "NO_TDZ"
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_006d: pop
+			IL_006e: leave IL_00c2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0078: stloc.1
-			IL_0079: ldloc.1
-			IL_007a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_007f: dup
-			IL_0080: brtrue IL_0095
+			IL_0073: stloc.1
+			IL_0074: ldloc.1
+			IL_0075: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_007a: dup
+			IL_007b: brtrue IL_0090
 
-			IL_0085: pop
-			IL_0086: ldloc.1
-			IL_0087: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_008c: dup
-			IL_008d: brtrue IL_00a0
+			IL_0080: pop
+			IL_0081: ldloc.1
+			IL_0082: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0087: dup
+			IL_0088: brtrue IL_009b
 
-			IL_0092: pop
-			IL_0093: rethrow
+			IL_008d: pop
+			IL_008e: rethrow
 
-			IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_009a: stloc.2
-			IL_009b: br IL_00a1
+			IL_0090: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0095: stloc.2
+			IL_0096: br IL_009c
 
-			IL_00a0: stloc.2
+			IL_009b: stloc.2
 
-			IL_00a1: ldloc.2
-			IL_00a2: stloc.3
-			IL_00a3: ldstr "console"
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b2: ldstr "log"
-			IL_00b7: ldstr "SWITCH_TDZ"
-			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00c1: pop
-			IL_00c2: leave IL_00c7
+			IL_009c: ldloc.2
+			IL_009d: stloc.3
+			IL_009e: ldstr "console"
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ad: ldstr "log"
+			IL_00b2: ldstr "SWITCH_TDZ"
+			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00bc: pop
+			IL_00bd: leave IL_00c2
 		} // end handler
 
-		IL_00c7: ldstr "ready"
-		IL_00cc: stloc.s 4
-		IL_00ce: ldstr "console"
-		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00dd: ldstr "log"
-		IL_00e2: ldloc.s 4
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e9: pop
-		IL_00ea: br IL_00ef
+		IL_00c2: ldstr "ready"
+		IL_00c7: stloc.s 4
+		IL_00c9: ldstr "console"
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d8: ldstr "log"
+		IL_00dd: ldloc.s 4
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e4: pop
+		IL_00e5: br IL_00ea
 
-		IL_00ef: ldnull
-		IL_00f0: stloc.s 5
-		IL_00f2: ret
+		IL_00ea: ldnull
+		IL_00eb: stloc.s 5
+		IL_00ed: ret
 	} // end of method Variable_TemporalDeadZoneSwitchScope::__js_module_init__
 
 } // end of class Modules.Variable_TemporalDeadZoneSwitchScope
@@ -218,7 +217,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2184
+		// Method begins at RVA 0x2180
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary

- preserve statically known CLR strings when emitting built-in Error construction
- retain JavaScript string conversion for all other Error message values
- refresh the Timers Promises Error-construction IL regression snapshot

## Validation

- `dotnet build jroc.sln --no-restore --nologo`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --nologo --filter 'FullyQualifiedName~TimersPromises_Abort_GetterErrors_SurfaceCorrectly|FullyQualifiedName~ExecutionTests.TryCatch_NewExpression_BuiltInErrors'`

Fixes #1680
