### PR TITLE
perf(il): omit coercion guards for constructed receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   constructor receives a value already known to be a CLR `string`.
 - compiler: preserve concrete built-in Error types through construction and
   throw slots instead of widening them to `object`.
+- compiler: omit member-call object-coercibility guards for receivers proven
+  non-null by object construction, preserving their concrete CLR types for
+  direct instance calls.
 
 ## v0.12.1 - 2026-08-02
 

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.Helpers.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.Helpers.cs
@@ -37,6 +37,11 @@ public sealed partial class HIRToLIRLowerer
     private TempVariable RequireObjectCoercible(TempVariable receiverTemp)
     {
         var objectReceiver = EnsureObject(receiverTemp);
+        if (IsProvenNonNullReference(objectReceiver))
+        {
+            return objectReceiver;
+        }
+
         var receiverStorage = GetTempStorage(objectReceiver);
         var preservesKnownReferenceType = receiverStorage.Kind == ValueStorageKind.Reference
             && receiverStorage.ClrType != null
@@ -54,6 +59,52 @@ public sealed partial class HIRToLIRLowerer
                 ? receiverStorage
                 : new ValueStorage(ValueStorageKind.Reference, typeof(object)));
         return checkedReceiver;
+    }
+
+    private bool IsProvenNonNullReference(TempVariable temp)
+    {
+        if (GetTempStorage(temp).Kind != ValueStorageKind.Reference)
+        {
+            return false;
+        }
+
+        return IsProvenNonNullReference(temp, new HashSet<int>());
+    }
+
+    private bool IsProvenNonNullReference(TempVariable temp, HashSet<int> visitedTemps)
+    {
+        if (GetTempStorage(temp).Kind != ValueStorageKind.Reference
+            || !visitedTemps.Add(temp.Index))
+        {
+            return false;
+        }
+
+        for (var i = _methodBodyIR.Instructions.Count - 1; i >= 0; i--)
+        {
+            switch (_methodBodyIR.Instructions[i])
+            {
+                case LIRCopyTemp { Destination: var destination, Source: var source }
+                    when destination == temp:
+                    return IsProvenNonNullReference(source, visitedTemps);
+
+                // These instructions all materialize a CLR object. They either produce a
+                // non-null receiver or throw before a member call can be evaluated.
+                case LIRConstString constString when constString.Result == temp:
+                case LIRBuildArray buildArray when buildArray.Result == temp:
+                case LIRNewJsArray newJsArray when newJsArray.Result == temp:
+                case LIRNewJsObject newJsObject when newJsObject.Result == temp:
+                case LIRNewInferredJsObject newInferredJsObject when newInferredJsObject.Result == temp:
+                case LIRNewIntrinsicObject newIntrinsicObject when newIntrinsicObject.Result == temp:
+                case LIRNewBuiltInError newBuiltInError when newBuiltInError.Result == temp:
+                case LIRCreateBoundArrowFunction createBoundArrow when createBoundArrow.Result == temp:
+                case LIRCreateBoundFunctionExpression createBoundFunction when createBoundFunction.Result == temp:
+                case LIRCreateScopeInstance createScope when createScope.Result == temp:
+                    return true;
+            }
+        }
+
+        // Typed bindings and arbitrary helper calls may still hold JavaScript null or undefined.
+        return false;
     }
 
     private bool TryLowerCallArgumentsToArgsArray(IReadOnlyList<HIRExpression> arguments, out TempVariable argsArrayTemp)

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5245
+				// Method begins at RVA 0x523d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5260
+						// Method begins at RVA 0x5258
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5269
+						// Method begins at RVA 0x5261
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5272
+						// Method begins at RVA 0x526a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x527b
+						// Method begins at RVA 0x5273
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5284
+						// Method begins at RVA 0x527c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -146,7 +146,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x528d
+						// Method begins at RVA 0x5285
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -164,7 +164,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5257
+					// Method begins at RVA 0x524f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x524e
+				// Method begins at RVA 0x5246
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -500,7 +500,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5296
+				// Method begins at RVA 0x528e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -610,7 +610,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x529f
+				// Method begins at RVA 0x5297
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -739,7 +739,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52b1
+					// Method begins at RVA 0x52a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -757,7 +757,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52a8
+				// Method begins at RVA 0x52a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -881,7 +881,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52ba
+				// Method begins at RVA 0x52b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -944,7 +944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52c3
+				// Method begins at RVA 0x52bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1041,7 +1041,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52d5
+					// Method begins at RVA 0x52cd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1059,7 +1059,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52cc
+				// Method begins at RVA 0x52c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1185,7 +1185,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52e7
+					// Method begins at RVA 0x52df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1203,7 +1203,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52de
+				// Method begins at RVA 0x52d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1231,7 +1231,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5302
+						// Method begins at RVA 0x52fa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1249,7 +1249,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52f9
+					// Method begins at RVA 0x52f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1267,7 +1267,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52f0
+				// Method begins at RVA 0x52e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1510,7 +1510,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x530b
+				// Method begins at RVA 0x5303
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1538,7 +1538,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5326
+						// Method begins at RVA 0x531e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1556,7 +1556,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x531d
+					// Method begins at RVA 0x5315
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1574,7 +1574,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5314
+				// Method begins at RVA 0x530c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1730,7 +1730,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5338
+					// Method begins at RVA 0x5330
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1750,7 +1750,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5341
+					// Method begins at RVA 0x5339
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1770,7 +1770,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x534a
+					// Method begins at RVA 0x5342
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1788,7 +1788,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x532f
+				// Method begins at RVA 0x5327
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1817,7 +1817,7 @@
 			)
 			// Method begins at RVA 0x3000
 			// Header size: 12
-			// Code size: 1248 (0x4e0)
+			// Code size: 1239 (0x4d7)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Error,
@@ -2291,46 +2291,43 @@
 			IL_0472: ldstr "i"
 			IL_0477: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_047c: stloc.s 13
-			IL_047e: ldloc.s 13
-			IL_0480: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_0485: stloc.s 13
-			IL_0487: ldarg.2
-			IL_0488: ldstr "upstream"
-			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0492: stloc.s 9
-			IL_0494: ldloc.s 9
-			IL_0496: ldstr "commit"
-			IL_049b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04a0: stloc.s 9
-			IL_04a2: ldloc.s 13
+			IL_047e: ldarg.2
+			IL_047f: ldstr "upstream"
+			IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0489: stloc.s 9
+			IL_048b: ldloc.s 9
+			IL_048d: ldstr "commit"
+			IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0497: stloc.s 9
+			IL_0499: ldloc.s 13
+			IL_049b: ldloc.s 9
+			IL_049d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_04a2: stloc.s 9
 			IL_04a4: ldloc.s 9
-			IL_04a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_04ab: stloc.s 9
-			IL_04ad: ldloc.s 9
-			IL_04af: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_04b4: ldc.i4.0
-			IL_04b5: ceq
-			IL_04b7: stloc.3
-			IL_04b8: ldloc.3
-			IL_04b9: brfalse IL_04de
+			IL_04a6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04ab: ldc.i4.0
+			IL_04ac: ceq
+			IL_04ae: stloc.3
+			IL_04af: ldloc.3
+			IL_04b0: brfalse IL_04d5
 
-			IL_04be: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
-			IL_04c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_04c8: stloc.2
-			IL_04c9: ldloc.2
-			IL_04ca: isinst [System.Runtime]System.Exception
-			IL_04cf: dup
-			IL_04d0: brtrue IL_04dd
+			IL_04b5: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
+			IL_04ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_04bf: stloc.2
+			IL_04c0: ldloc.2
+			IL_04c1: isinst [System.Runtime]System.Exception
+			IL_04c6: dup
+			IL_04c7: brtrue IL_04d4
 
-			IL_04d5: pop
-			IL_04d6: ldloc.2
-			IL_04d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_04dc: throw
+			IL_04cc: pop
+			IL_04cd: ldloc.2
+			IL_04ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_04d3: throw
 
-			IL_04dd: throw
+			IL_04d4: throw
 
-			IL_04de: ldnull
-			IL_04df: ret
+			IL_04d5: ldnull
+			IL_04d6: ret
 		} // end of method validatePin::__js_call__
 
 	} // end of class validatePin
@@ -2346,7 +2343,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5353
+				// Method begins at RVA 0x534b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2373,7 +2370,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x34ec
+			// Method begins at RVA 0x34e4
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -2447,7 +2444,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x535c
+				// Method begins at RVA 0x5354
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2475,7 +2472,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3564
+			// Method begins at RVA 0x355c
 			// Header size: 12
 			// Code size: 139 (0x8b)
 			.maxstack 8
@@ -2567,7 +2564,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5365
+				// Method begins at RVA 0x535d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2594,7 +2591,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x35fc
+			// Method begins at RVA 0x35f4
 			// Header size: 12
 			// Code size: 158 (0x9e)
 			.maxstack 8
@@ -2692,7 +2689,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5377
+					// Method begins at RVA 0x536f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2710,7 +2707,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x536e
+				// Method begins at RVA 0x5366
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2738,7 +2735,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x36a8
+			// Method begins at RVA 0x36a0
 			// Header size: 12
 			// Code size: 242 (0xf2)
 			.maxstack 8
@@ -2872,7 +2869,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5389
+					// Method begins at RVA 0x5381
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2890,7 +2887,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5380
+				// Method begins at RVA 0x5378
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2918,7 +2915,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x37a8
+			// Method begins at RVA 0x37a0
 			// Header size: 12
 			// Code size: 1135 (0x46f)
 			.maxstack 8
@@ -3334,7 +3331,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5392
+				// Method begins at RVA 0x538a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3361,7 +3358,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3c24
+			// Method begins at RVA 0x3c1c
 			// Header size: 12
 			// Code size: 83 (0x53)
 			.maxstack 8
@@ -3427,7 +3424,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53a4
+					// Method begins at RVA 0x539c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3445,7 +3442,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x539b
+				// Method begins at RVA 0x5393
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3472,7 +3469,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3c84
+			// Method begins at RVA 0x3c7c
 			// Header size: 12
 			// Code size: 175 (0xaf)
 			.maxstack 8
@@ -3580,7 +3577,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53b6
+					// Method begins at RVA 0x53ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3600,7 +3597,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53bf
+					// Method begins at RVA 0x53b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3618,7 +3615,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53ad
+				// Method begins at RVA 0x53a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3646,7 +3643,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3d40
+			// Method begins at RVA 0x3d38
 			// Header size: 12
 			// Code size: 686 (0x2ae)
 			.maxstack 8
@@ -3930,7 +3927,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53c8
+				// Method begins at RVA 0x53c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3954,7 +3951,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53da
+					// Method begins at RVA 0x53d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3972,7 +3969,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53d1
+				// Method begins at RVA 0x53c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3996,7 +3993,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53ec
+					// Method begins at RVA 0x53e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4014,7 +4011,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53e3
+				// Method begins at RVA 0x53db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4041,7 +4038,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3ffc
+			// Method begins at RVA 0x3ff4
 			// Header size: 12
 			// Code size: 397 (0x18d)
 			.maxstack 11
@@ -4256,7 +4253,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x543d
+						// Method begins at RVA 0x5435
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4276,7 +4273,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5446
+						// Method begins at RVA 0x543e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4294,7 +4291,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5434
+					// Method begins at RVA 0x542c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4314,7 +4311,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x544f
+					// Method begins at RVA 0x5447
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4332,7 +4329,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53f5
+				// Method begins at RVA 0x53ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4360,7 +4357,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5410
+						// Method begins at RVA 0x5408
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4378,7 +4375,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5407
+					// Method begins at RVA 0x53ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4396,7 +4393,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53fe
+				// Method begins at RVA 0x53f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4424,7 +4421,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x542b
+						// Method begins at RVA 0x5423
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4442,7 +4439,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5422
+					// Method begins at RVA 0x541a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4460,7 +4457,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5419
+				// Method begins at RVA 0x5411
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4488,7 +4485,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x41b4
+			// Method begins at RVA 0x41ac
 			// Header size: 12
 			// Code size: 1836 (0x72c)
 			.maxstack 11
@@ -5250,7 +5247,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x546a
+						// Method begins at RVA 0x5462
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5268,7 +5265,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5461
+					// Method begins at RVA 0x5459
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5288,7 +5285,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5473
+					// Method begins at RVA 0x546b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5306,7 +5303,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5458
+				// Method begins at RVA 0x5450
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5335,7 +5332,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4920
+			// Method begins at RVA 0x4918
 			// Header size: 12
 			// Code size: 1048 (0x418)
 			.maxstack 8
@@ -5783,7 +5780,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x548e
+						// Method begins at RVA 0x5486
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5801,7 +5798,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5485
+					// Method begins at RVA 0x547d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5819,7 +5816,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x547c
+				// Method begins at RVA 0x5474
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5848,7 +5845,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4d44
+			// Method begins at RVA 0x4d3c
 			// Header size: 12
 			// Code size: 368 (0x170)
 			.maxstack 8
@@ -6034,7 +6031,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54a0
+					// Method begins at RVA 0x5498
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6052,7 +6049,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5497
+				// Method begins at RVA 0x548f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6081,7 +6078,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4ec0
+			// Method begins at RVA 0x4eb8
 			// Header size: 12
 			// Code size: 419 (0x1a3)
 			.maxstack 8
@@ -6270,7 +6267,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54b2
+					// Method begins at RVA 0x54aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6290,7 +6287,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54bb
+					// Method begins at RVA 0x54b3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6308,7 +6305,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54a9
+				// Method begins at RVA 0x54a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6334,7 +6331,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x5070
+			// Method begins at RVA 0x5068
 			// Header size: 12
 			// Code size: 448 (0x1c0)
 			.maxstack 9
@@ -6573,7 +6570,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54cd
+					// Method begins at RVA 0x54c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6593,7 +6590,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54d6
+					// Method begins at RVA 0x54ce
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6611,7 +6608,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54c4
+				// Method begins at RVA 0x54bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6659,7 +6656,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x523c
+			// Method begins at RVA 0x5234
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -7317,7 +7314,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x54df
+		// Method begins at RVA 0x54d7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65b7
+				// Method begins at RVA 0x65a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65c9
+					// Method begins at RVA 0x65b9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -153,7 +153,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65d2
+					// Method begins at RVA 0x65c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -173,7 +173,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65db
+					// Method begins at RVA 0x65cb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65c0
+				// Method begins at RVA 0x65b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -296,7 +296,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65ed
+					// Method begins at RVA 0x65dd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -314,7 +314,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65e4
+				// Method begins at RVA 0x65d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -434,7 +434,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65ff
+					// Method begins at RVA 0x65ef
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -452,7 +452,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65f6
+				// Method begins at RVA 0x65e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -593,7 +593,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6608
+				// Method begins at RVA 0x65f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2459,7 +2459,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x65ae
+			// Method begins at RVA 0x659e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2759,7 +2759,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x661a
+				// Method begins at RVA 0x660a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2847,7 +2847,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6635
+						// Method begins at RVA 0x6625
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2865,7 +2865,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x662c
+					// Method begins at RVA 0x661c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2883,7 +2883,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6623
+				// Method begins at RVA 0x6613
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3012,7 +3012,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6650
+						// Method begins at RVA 0x6640
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3030,7 +3030,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6647
+					// Method begins at RVA 0x6637
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3048,7 +3048,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x663e
+				// Method begins at RVA 0x662e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3240,7 +3240,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6662
+					// Method begins at RVA 0x6652
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3258,7 +3258,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6659
+				// Method begins at RVA 0x6649
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3286,7 +3286,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x667d
+						// Method begins at RVA 0x666d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3304,7 +3304,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6674
+					// Method begins at RVA 0x6664
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3322,7 +3322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x666b
+				// Method begins at RVA 0x665b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3491,7 +3491,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x668f
+					// Method begins at RVA 0x667f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3509,7 +3509,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6686
+				// Method begins at RVA 0x6676
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3637,7 +3637,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6698
+				// Method begins at RVA 0x6688
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3665,7 +3665,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66b3
+						// Method begins at RVA 0x66a3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3685,7 +3685,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66bc
+						// Method begins at RVA 0x66ac
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3705,7 +3705,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66c5
+						// Method begins at RVA 0x66b5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3725,7 +3725,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66ce
+						// Method begins at RVA 0x66be
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3743,7 +3743,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66aa
+					// Method begins at RVA 0x669a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3761,7 +3761,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66a1
+				// Method begins at RVA 0x6691
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3790,7 +3790,7 @@
 			)
 			// Method begins at RVA 0x42f4
 			// Header size: 12
-			// Code size: 302 (0x12e)
+			// Code size: 293 (0x125)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -3800,10 +3800,10 @@
 				[4] float64,
 				[5] float64,
 				[6] bool,
-				[7] string,
+				[7] object,
 				[8] object,
 				[9] object,
-				[10] object
+				[10] string
 			)
 
 			IL_0000: ldc.i4.0
@@ -3822,7 +3822,7 @@
 				IL_0026: ldloc.s 4
 				IL_0028: ldloc.s 5
 				IL_002a: clt
-				IL_002c: brfalse IL_0115
+				IL_002c: brfalse IL_010c
 
 				IL_0031: ldarg.2
 				IL_0032: ldloc.2
@@ -3839,7 +3839,7 @@
 				IL_004e: ldc.r8 1
 				IL_0057: add
 				IL_0058: stloc.1
-				IL_0059: br IL_0104
+				IL_0059: br IL_00fb
 
 				IL_005e: ldloc.0
 				IL_005f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
@@ -3851,72 +3851,69 @@
 				IL_0075: ldloc.3
 				IL_0076: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 				IL_007b: pop
-				IL_007c: br IL_00fa
+				IL_007c: br IL_00f1
 
 				IL_0081: ldloc.1
 				IL_0082: stloc.s 5
 				IL_0084: ldloc.s 5
 				IL_0086: ldc.r8 0.0
 				IL_008f: cgt
-				IL_0091: brfalse IL_00e4
+				IL_0091: brfalse IL_00db
 
-				IL_0096: ldstr "\n"
-				IL_009b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-				IL_00a0: stloc.s 7
-				IL_00a2: ldloc.1
-				IL_00a3: stloc.s 5
-				IL_00a5: ldloc.s 5
-				IL_00a7: ldc.r8 1
-				IL_00b0: add
-				IL_00b1: stloc.s 5
-				IL_00b3: ldloc.s 5
-				IL_00b5: box [System.Runtime]System.Double
-				IL_00ba: stloc.s 8
-				IL_00bc: ldloc.s 7
-				IL_00be: ldstr "repeat"
+				IL_0096: ldloc.1
+				IL_0097: stloc.s 5
+				IL_0099: ldloc.s 5
+				IL_009b: ldc.r8 1
+				IL_00a4: add
+				IL_00a5: stloc.s 5
+				IL_00a7: ldloc.s 5
+				IL_00a9: box [System.Runtime]System.Double
+				IL_00ae: stloc.s 7
+				IL_00b0: ldstr "\n"
+				IL_00b5: ldstr "repeat"
+				IL_00ba: ldloc.s 7
+				IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00c1: stloc.s 8
 				IL_00c3: ldloc.s 8
-				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00ca: stloc.s 9
-				IL_00cc: ldloc.s 9
-				IL_00ce: ldloc.3
-				IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00d4: stloc.s 10
-				IL_00d6: ldloc.0
-				IL_00d7: ldloc.s 10
-				IL_00d9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_00de: pop
-				IL_00df: br IL_00fa
+				IL_00c5: ldloc.3
+				IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00cb: stloc.s 9
+				IL_00cd: ldloc.0
+				IL_00ce: ldloc.s 9
+				IL_00d0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_00d5: pop
+				IL_00d6: br IL_00f1
 
-				IL_00e4: ldstr " "
-				IL_00e9: ldloc.3
-				IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00ef: stloc.s 10
-				IL_00f1: ldloc.0
-				IL_00f2: ldloc.s 10
-				IL_00f4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_00f9: pop
+				IL_00db: ldstr " "
+				IL_00e0: ldloc.3
+				IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00e6: stloc.s 9
+				IL_00e8: ldloc.0
+				IL_00e9: ldloc.s 9
+				IL_00eb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_00f0: pop
 
-				IL_00fa: ldc.r8 0.0
-				IL_0103: stloc.1
+				IL_00f1: ldc.r8 0.0
+				IL_00fa: stloc.1
 
-				IL_0104: ldloc.2
-				IL_0105: ldc.r8 1
-				IL_010e: add
-				IL_010f: stloc.2
-				IL_0110: br IL_001b
+				IL_00fb: ldloc.2
+				IL_00fc: ldc.r8 1
+				IL_0105: add
+				IL_0106: stloc.2
+				IL_0107: br IL_001b
 			// end loop
 
-			IL_0115: ldloc.0
-			IL_0116: ldc.i4.1
-			IL_0117: newarr [System.Runtime]System.Object
-			IL_011c: dup
-			IL_011d: ldc.i4.0
-			IL_011e: ldstr ""
-			IL_0123: stelem.ref
-			IL_0124: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0129: stloc.s 7
-			IL_012b: ldloc.s 7
-			IL_012d: ret
+			IL_010c: ldloc.0
+			IL_010d: ldc.i4.1
+			IL_010e: newarr [System.Runtime]System.Object
+			IL_0113: dup
+			IL_0114: ldc.i4.0
+			IL_0115: ldstr ""
+			IL_011a: stelem.ref
+			IL_011b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0120: stloc.s 10
+			IL_0122: ldloc.s 10
+			IL_0124: ret
 		} // end of method foldBlockLines::__js_call__
 
 	} // end of class foldBlockLines
@@ -3940,7 +3937,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66e9
+						// Method begins at RVA 0x66d9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3960,7 +3957,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66f2
+						// Method begins at RVA 0x66e2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3980,7 +3977,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66fb
+						// Method begins at RVA 0x66eb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3998,7 +3995,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66e0
+					// Method begins at RVA 0x66d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4016,7 +4013,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66d7
+				// Method begins at RVA 0x66c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4046,7 +4043,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4430
+			// Method begins at RVA 0x4428
 			// Header size: 12
 			// Code size: 438 (0x1b6)
 			.maxstack 8
@@ -4248,7 +4245,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x670d
+					// Method begins at RVA 0x66fd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4268,7 +4265,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6716
+					// Method begins at RVA 0x6706
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4288,7 +4285,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x671f
+					// Method begins at RVA 0x670f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4306,7 +4303,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6704
+				// Method begins at RVA 0x66f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4335,7 +4332,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x45f4
+			// Method begins at RVA 0x45ec
 			// Header size: 12
 			// Code size: 368 (0x170)
 			.maxstack 8
@@ -4535,7 +4532,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x673a
+						// Method begins at RVA 0x672a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4555,7 +4552,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6743
+						// Method begins at RVA 0x6733
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4575,7 +4572,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x674c
+						// Method begins at RVA 0x673c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4595,7 +4592,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6755
+						// Method begins at RVA 0x6745
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4615,7 +4612,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x675e
+						// Method begins at RVA 0x674e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4635,7 +4632,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6767
+						// Method begins at RVA 0x6757
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4655,7 +4652,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6770
+						// Method begins at RVA 0x6760
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4673,7 +4670,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6731
+					// Method begins at RVA 0x6721
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4691,7 +4688,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6728
+				// Method begins at RVA 0x6718
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4720,9 +4717,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4770
+			// Method begins at RVA 0x4768
 			// Header size: 12
-			// Code size: 882 (0x372)
+			// Code size: 873 (0x369)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -4765,7 +4762,7 @@
 				IL_0027: ldloc.s 11
 				IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_002e: clt
-				IL_0030: brfalse IL_0370
+				IL_0030: brfalse IL_0367
 
 				IL_0035: ldarg.3
 				IL_0036: ldstr "index"
@@ -4822,7 +4819,7 @@
 				IL_00c4: clt
 				IL_00c6: brfalse IL_00d0
 
-				IL_00cb: br IL_0370
+				IL_00cb: br IL_0367
 
 				IL_00d0: ldloc.2
 				IL_00d1: ldarg.s baseIndent
@@ -4875,207 +4872,204 @@
 				IL_015d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 				IL_0162: stloc.s 17
 				IL_0164: ldloc.s 17
-				IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-				IL_016b: stloc.s 17
-				IL_016d: ldloc.s 17
-				IL_016f: ldstr "exec"
-				IL_0174: ldloc.s 4
-				IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_017b: stloc.s 5
-				IL_017d: ldloc.s 5
-				IL_017f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0184: ldc.i4.0
-				IL_0185: ceq
-				IL_0187: stloc.s 12
-				IL_0189: ldloc.s 12
-				IL_018b: brfalse IL_0200
+				IL_0166: ldstr "exec"
+				IL_016b: ldloc.s 4
+				IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0172: stloc.s 5
+				IL_0174: ldloc.s 5
+				IL_0176: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_017b: ldc.i4.0
+				IL_017c: ceq
+				IL_017e: stloc.s 12
+				IL_0180: ldloc.s 12
+				IL_0182: brfalse IL_01f7
 
-				IL_0190: ldarg.3
-				IL_0191: ldstr "index"
-				IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_019b: stloc.s 11
-				IL_019d: ldloc.s 11
-				IL_019f: ldc.r8 1
-				IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_01ad: stloc.s 14
-				IL_01af: ldloc.s 14
-				IL_01b1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01b6: stloc.s 15
-				IL_01b8: ldstr "Invalid frontmatter line "
-				IL_01bd: ldloc.s 15
-				IL_01bf: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01c4: ldstr ": "
-				IL_01c9: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01ce: ldloc.s 4
-				IL_01d0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0187: ldarg.3
+				IL_0188: ldstr "index"
+				IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0192: stloc.s 11
+				IL_0194: ldloc.s 11
+				IL_0196: ldc.r8 1
+				IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_01a4: stloc.s 14
+				IL_01a6: ldloc.s 14
+				IL_01a8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01ad: stloc.s 15
+				IL_01af: ldstr "Invalid frontmatter line "
+				IL_01b4: ldloc.s 15
+				IL_01b6: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01bb: ldstr ": "
+				IL_01c0: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01c5: ldloc.s 4
+				IL_01c7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01cc: stloc.s 15
+				IL_01ce: ldloc.s 15
+				IL_01d0: call string [System.Runtime]System.String::Concat(string, string)
 				IL_01d5: stloc.s 15
 				IL_01d7: ldloc.s 15
-				IL_01d9: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01de: stloc.s 15
-				IL_01e0: ldloc.s 15
-				IL_01e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_01e7: stloc.s 6
-				IL_01e9: ldloc.s 6
-				IL_01eb: isinst [System.Runtime]System.Exception
-				IL_01f0: dup
-				IL_01f1: brtrue IL_01ff
+				IL_01d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_01de: stloc.s 6
+				IL_01e0: ldloc.s 6
+				IL_01e2: isinst [System.Runtime]System.Exception
+				IL_01e7: dup
+				IL_01e8: brtrue IL_01f6
 
-				IL_01f6: pop
-				IL_01f7: ldloc.s 6
-				IL_01f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_01fe: throw
+				IL_01ed: pop
+				IL_01ee: ldloc.s 6
+				IL_01f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_01f5: throw
 
-				IL_01ff: throw
+				IL_01f6: throw
 
-				IL_0200: ldloc.s 5
-				IL_0202: ldc.r8 1
-				IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0210: stloc.s 7
-				IL_0212: ldloc.s 5
-				IL_0214: ldc.r8 2
-				IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0222: stloc.s 11
-				IL_0224: ldloc.s 11
-				IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_022b: ldstr "trim"
-				IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0235: stloc.s 8
-				IL_0237: ldarg.3
-				IL_0238: ldstr "index"
-				IL_023d: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0242: stloc.s 13
-				IL_0244: ldloc.s 13
-				IL_0246: ldc.r8 1
-				IL_024f: add
-				IL_0250: stloc.s 13
-				IL_0252: ldarg.3
-				IL_0253: ldstr "index"
-				IL_0258: ldloc.s 13
-				IL_025a: ldc.i4.1
-				IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_0260: pop
-				IL_0261: ldnull
-				IL_0262: stloc.s 9
-				IL_0264: ldloc.s 8
-				IL_0266: ldstr "|"
-				IL_026b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0270: stloc.s 12
-				IL_0272: ldloc.s 12
-				IL_0274: box [System.Runtime]System.Boolean
-				IL_0279: stloc.s 18
-				IL_027b: ldloc.s 18
-				IL_027d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0282: stloc.s 12
-				IL_0284: ldloc.s 12
-				IL_0286: brtrue IL_02ab
+				IL_01f7: ldloc.s 5
+				IL_01f9: ldc.r8 1
+				IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0207: stloc.s 7
+				IL_0209: ldloc.s 5
+				IL_020b: ldc.r8 2
+				IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0219: stloc.s 11
+				IL_021b: ldloc.s 11
+				IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0222: ldstr "trim"
+				IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_022c: stloc.s 8
+				IL_022e: ldarg.3
+				IL_022f: ldstr "index"
+				IL_0234: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0239: stloc.s 13
+				IL_023b: ldloc.s 13
+				IL_023d: ldc.r8 1
+				IL_0246: add
+				IL_0247: stloc.s 13
+				IL_0249: ldarg.3
+				IL_024a: ldstr "index"
+				IL_024f: ldloc.s 13
+				IL_0251: ldc.i4.1
+				IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_0257: pop
+				IL_0258: ldnull
+				IL_0259: stloc.s 9
+				IL_025b: ldloc.s 8
+				IL_025d: ldstr "|"
+				IL_0262: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0267: stloc.s 12
+				IL_0269: ldloc.s 12
+				IL_026b: box [System.Runtime]System.Boolean
+				IL_0270: stloc.s 18
+				IL_0272: ldloc.s 18
+				IL_0274: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0279: stloc.s 12
+				IL_027b: ldloc.s 12
+				IL_027d: brtrue IL_02a2
 
-				IL_028b: ldloc.s 8
-				IL_028d: ldstr ">"
-				IL_0292: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0297: stloc.s 12
-				IL_0299: ldloc.s 12
-				IL_029b: box [System.Runtime]System.Boolean
-				IL_02a0: stloc.s 19
-				IL_02a2: ldloc.s 19
+				IL_0282: ldloc.s 8
+				IL_0284: ldstr ">"
+				IL_0289: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_028e: stloc.s 12
+				IL_0290: ldloc.s 12
+				IL_0292: box [System.Runtime]System.Boolean
+				IL_0297: stloc.s 19
+				IL_0299: ldloc.s 19
+				IL_029b: stloc.s 20
+				IL_029d: br IL_02a6
+
+				IL_02a2: ldloc.s 18
 				IL_02a4: stloc.s 20
-				IL_02a6: br IL_02af
 
-				IL_02ab: ldloc.s 18
-				IL_02ad: stloc.s 20
+				IL_02a6: ldloc.s 20
+				IL_02a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02ad: stloc.s 12
+				IL_02af: ldloc.s 12
+				IL_02b1: brfalse IL_02f7
 
-				IL_02af: ldloc.s 20
-				IL_02b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02b6: stloc.s 12
-				IL_02b8: ldloc.s 12
-				IL_02ba: brfalse IL_0300
+				IL_02b6: ldarg.0
+				IL_02b7: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
+				IL_02bc: ldc.i4.1
+				IL_02bd: newarr [System.Runtime]System.Object
+				IL_02c2: dup
+				IL_02c3: ldc.i4.0
+				IL_02c4: ldarg.0
+				IL_02c5: stelem.ref
+				IL_02c6: stloc.s 21
+				IL_02c8: ldloc.s 21
+				IL_02ca: ldc.i4.4
+				IL_02cb: newarr [System.Runtime]System.Object
+				IL_02d0: dup
+				IL_02d1: ldc.i4.0
+				IL_02d2: ldarg.2
+				IL_02d3: stelem.ref
+				IL_02d4: dup
+				IL_02d5: ldc.i4.1
+				IL_02d6: ldarg.3
+				IL_02d7: stelem.ref
+				IL_02d8: dup
+				IL_02d9: ldc.i4.2
+				IL_02da: ldarg.s baseIndent
+				IL_02dc: box [System.Runtime]System.Double
+				IL_02e1: stelem.ref
+				IL_02e2: dup
+				IL_02e3: ldc.i4.3
+				IL_02e4: ldloc.s 8
+				IL_02e6: stelem.ref
+				IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_02ec: stloc.s 11
+				IL_02ee: ldloc.s 11
+				IL_02f0: stloc.s 9
+				IL_02f2: br IL_0356
 
-				IL_02bf: ldarg.0
-				IL_02c0: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
-				IL_02c5: ldc.i4.1
-				IL_02c6: newarr [System.Runtime]System.Object
-				IL_02cb: dup
-				IL_02cc: ldc.i4.0
-				IL_02cd: ldarg.0
-				IL_02ce: stelem.ref
-				IL_02cf: stloc.s 21
-				IL_02d1: ldloc.s 21
-				IL_02d3: ldc.i4.4
-				IL_02d4: newarr [System.Runtime]System.Object
-				IL_02d9: dup
-				IL_02da: ldc.i4.0
-				IL_02db: ldarg.2
-				IL_02dc: stelem.ref
-				IL_02dd: dup
-				IL_02de: ldc.i4.1
-				IL_02df: ldarg.3
-				IL_02e0: stelem.ref
-				IL_02e1: dup
-				IL_02e2: ldc.i4.2
-				IL_02e3: ldarg.s baseIndent
-				IL_02e5: box [System.Runtime]System.Double
-				IL_02ea: stelem.ref
-				IL_02eb: dup
-				IL_02ec: ldc.i4.3
-				IL_02ed: ldloc.s 8
-				IL_02ef: stelem.ref
-				IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_02f5: stloc.s 11
-				IL_02f7: ldloc.s 11
-				IL_02f9: stloc.s 9
-				IL_02fb: br IL_035f
+				IL_02f7: ldloc.s 8
+				IL_02f9: ldstr ""
+				IL_02fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0303: stloc.s 12
+				IL_0305: ldloc.s 12
+				IL_0307: brfalse IL_0339
 
-				IL_0300: ldloc.s 8
-				IL_0302: ldstr ""
-				IL_0307: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_030c: stloc.s 12
-				IL_030e: ldloc.s 12
-				IL_0310: brfalse IL_0342
+				IL_030c: ldarg.0
+				IL_030d: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
+				IL_0312: ldc.i4.1
+				IL_0313: newarr [System.Runtime]System.Object
+				IL_0318: dup
+				IL_0319: ldc.i4.0
+				IL_031a: ldarg.0
+				IL_031b: stelem.ref
+				IL_031c: stloc.s 21
+				IL_031e: ldloc.s 21
+				IL_0320: ldarg.2
+				IL_0321: ldarg.3
+				IL_0322: ldarg.s baseIndent
+				IL_0324: box [System.Runtime]System.Double
+				IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_032e: stloc.s 11
+				IL_0330: ldloc.s 11
+				IL_0332: stloc.s 9
+				IL_0334: br IL_0356
 
-				IL_0315: ldarg.0
-				IL_0316: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
-				IL_031b: ldc.i4.1
-				IL_031c: newarr [System.Runtime]System.Object
-				IL_0321: dup
-				IL_0322: ldc.i4.0
-				IL_0323: ldarg.0
-				IL_0324: stelem.ref
-				IL_0325: stloc.s 21
-				IL_0327: ldloc.s 21
-				IL_0329: ldarg.2
-				IL_032a: ldarg.3
-				IL_032b: ldarg.s baseIndent
-				IL_032d: box [System.Runtime]System.Double
-				IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_0337: stloc.s 11
-				IL_0339: ldloc.s 11
-				IL_033b: stloc.s 9
-				IL_033d: br IL_035f
+				IL_0339: ldarg.0
+				IL_033a: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
+				IL_033f: ldc.i4.1
+				IL_0340: newarr [System.Runtime]System.Object
+				IL_0345: dup
+				IL_0346: ldc.i4.0
+				IL_0347: ldarg.0
+				IL_0348: stelem.ref
+				IL_0349: ldloc.s 8
+				IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0350: stloc.s 11
+				IL_0352: ldloc.s 11
+				IL_0354: stloc.s 9
 
-				IL_0342: ldarg.0
-				IL_0343: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
-				IL_0348: ldc.i4.1
-				IL_0349: newarr [System.Runtime]System.Object
-				IL_034e: dup
-				IL_034f: ldc.i4.0
-				IL_0350: ldarg.0
-				IL_0351: stelem.ref
-				IL_0352: ldloc.s 8
-				IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0359: stloc.s 11
-				IL_035b: ldloc.s 11
-				IL_035d: stloc.s 9
-
-				IL_035f: ldloc.0
-				IL_0360: ldloc.s 7
-				IL_0362: ldloc.s 9
-				IL_0364: ldc.i4.1
-				IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_036a: pop
-				IL_036b: br IL_0006
+				IL_0356: ldloc.0
+				IL_0357: ldloc.s 7
+				IL_0359: ldloc.s 9
+				IL_035b: ldc.i4.1
+				IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_0361: pop
+				IL_0362: br IL_0006
 			// end loop
 
-			IL_0370: ldloc.0
-			IL_0371: ret
+			IL_0367: ldloc.0
+			IL_0368: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -5091,7 +5085,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6779
+				// Method begins at RVA 0x6769
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5118,7 +5112,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4af0
+			// Method begins at RVA 0x4ae0
 			// Header size: 12
 			// Code size: 114 (0x72)
 			.maxstack 8
@@ -5194,7 +5188,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x678b
+					// Method begins at RVA 0x677b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5214,7 +5208,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6794
+					// Method begins at RVA 0x6784
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5234,7 +5228,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x679d
+					// Method begins at RVA 0x678d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5252,7 +5246,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6782
+				// Method begins at RVA 0x6772
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5279,7 +5273,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4b70
+			// Method begins at RVA 0x4b60
 			// Header size: 12
 			// Code size: 299 (0x12b)
 			.maxstack 8
@@ -5410,7 +5404,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67a6
+				// Method begins at RVA 0x6796
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5434,7 +5428,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4ca8
+			// Method begins at RVA 0x4c98
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -5493,7 +5487,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67b8
+					// Method begins at RVA 0x67a8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5511,7 +5505,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67af
+				// Method begins at RVA 0x679f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5535,7 +5529,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4cfc
+			// Method begins at RVA 0x4cec
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -5603,7 +5597,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67c1
+				// Method begins at RVA 0x67b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5628,7 +5622,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4d78
+			// Method begins at RVA 0x4d68
 			// Header size: 12
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -5665,7 +5659,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67ca
+				// Method begins at RVA 0x67ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5692,7 +5686,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4db0
+			// Method begins at RVA 0x4da0
 			// Header size: 12
 			// Code size: 53 (0x35)
 			.maxstack 8
@@ -5739,7 +5733,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67dc
+					// Method begins at RVA 0x67cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5759,7 +5753,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67e5
+					// Method begins at RVA 0x67d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5777,7 +5771,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67d3
+				// Method begins at RVA 0x67c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5805,7 +5799,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6800
+						// Method begins at RVA 0x67f0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5823,7 +5817,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67f7
+					// Method begins at RVA 0x67e7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5841,7 +5835,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67ee
+				// Method begins at RVA 0x67de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5870,7 +5864,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4df4
+			// Method begins at RVA 0x4de4
 			// Header size: 12
 			// Code size: 452 (0x1c4)
 			.maxstack 8
@@ -6113,7 +6107,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6812
+					// Method begins at RVA 0x6802
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6133,7 +6127,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x681b
+					// Method begins at RVA 0x680b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6151,7 +6145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6809
+				// Method begins at RVA 0x67f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6180,7 +6174,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4fc4
+			// Method begins at RVA 0x4fb4
 			// Header size: 12
 			// Code size: 247 (0xf7)
 			.maxstack 8
@@ -6327,7 +6321,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x682d
+					// Method begins at RVA 0x681d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6347,7 +6341,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6836
+					// Method begins at RVA 0x6826
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6367,7 +6361,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x683f
+					// Method begins at RVA 0x682f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6387,7 +6381,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6863
+					// Method begins at RVA 0x6853
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6405,7 +6399,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6824
+				// Method begins at RVA 0x6814
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6433,7 +6427,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x685a
+						// Method begins at RVA 0x684a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6451,7 +6445,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6851
+					// Method begins at RVA 0x6841
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6469,7 +6463,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6848
+				// Method begins at RVA 0x6838
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6497,7 +6491,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x50c8
+			// Method begins at RVA 0x50b8
 			// Header size: 12
 			// Code size: 1063 (0x427)
 			.maxstack 8
@@ -6981,7 +6975,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6899
+						// Method begins at RVA 0x6889
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7001,7 +6995,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68a2
+						// Method begins at RVA 0x6892
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7021,7 +7015,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68ab
+						// Method begins at RVA 0x689b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7039,7 +7033,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6890
+					// Method begins at RVA 0x6880
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7059,7 +7053,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68b4
+					// Method begins at RVA 0x68a4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7079,7 +7073,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68bd
+					// Method begins at RVA 0x68ad
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7097,7 +7091,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x686c
+				// Method begins at RVA 0x685c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7125,7 +7119,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6887
+						// Method begins at RVA 0x6877
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7143,7 +7137,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x687e
+					// Method begins at RVA 0x686e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7161,7 +7155,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6875
+				// Method begins at RVA 0x6865
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7189,7 +7183,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68d8
+						// Method begins at RVA 0x68c8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7207,7 +7201,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68cf
+					// Method begins at RVA 0x68bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7225,7 +7219,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x68c6
+				// Method begins at RVA 0x68b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7254,7 +7248,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x54fc
+			// Method begins at RVA 0x54ec
 			// Header size: 12
 			// Code size: 1583 (0x62f)
 			.maxstack 8
@@ -7913,7 +7907,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68ea
+					// Method begins at RVA 0x68da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7933,7 +7927,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68f3
+					// Method begins at RVA 0x68e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7953,7 +7947,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68fc
+					// Method begins at RVA 0x68ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7973,7 +7967,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6905
+					// Method begins at RVA 0x68f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7993,7 +7987,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x690e
+					// Method begins at RVA 0x68fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8013,7 +8007,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6917
+					// Method begins at RVA 0x6907
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8033,7 +8027,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6920
+					// Method begins at RVA 0x6910
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8051,7 +8045,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x68e1
+				// Method begins at RVA 0x68d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8080,7 +8074,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5b38
+			// Method begins at RVA 0x5b28
 			// Header size: 12
 			// Code size: 769 (0x301)
 			.maxstack 8
@@ -8482,7 +8476,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6968
+					// Method begins at RVA 0x6958
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8500,7 +8494,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6929
+				// Method begins at RVA 0x6919
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8528,7 +8522,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6944
+						// Method begins at RVA 0x6934
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8546,7 +8540,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x693b
+					// Method begins at RVA 0x692b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8564,7 +8558,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6932
+				// Method begins at RVA 0x6922
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8592,7 +8586,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x695f
+						// Method begins at RVA 0x694f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8610,7 +8604,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6956
+					// Method begins at RVA 0x6946
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8628,7 +8622,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x694d
+				// Method begins at RVA 0x693d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8656,7 +8650,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5e48
+			// Method begins at RVA 0x5e38
 			// Header size: 12
 			// Code size: 1799 (0x707)
 			.maxstack 8
@@ -9421,7 +9415,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6971
+				// Method begins at RVA 0x6961
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -9448,7 +9442,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x655c
+			// Method begins at RVA 0x654c
 			// Header size: 12
 			// Code size: 70 (0x46)
 			.maxstack 8
@@ -9554,7 +9548,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x6611
+			// Method begins at RVA 0x6601
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -10093,7 +10087,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x697a
+		// Method begins at RVA 0x696a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_JsObject_NamedProperties.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_JsObject_NamedProperties.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2814
+				// Method begins at RVA 0x2802
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x281d
+				// Method begins at RVA 0x280b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -59,7 +59,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27ce
+			// Method begins at RVA 0x27bc
 			// Header size: 1
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -89,7 +89,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27f9
+			// Method begins at RVA 0x27e7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -113,7 +113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x280b
+				// Method begins at RVA 0x27f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,7 +131,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2802
+			// Method begins at RVA 0x27f0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -157,7 +157,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1906 (0x772)
+		// Code size: 1888 (0x760)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Array_JsObject_NamedProperties/Scope,
@@ -182,9 +182,8 @@
 			[19] object,
 			[20] string,
 			[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[22] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
-			[23] object[],
-			[24] class [System.Runtime]System.Type
+			[22] object[],
+			[23] class [System.Runtime]System.Type
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -515,231 +514,225 @@
 		IL_0441: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakMap::.ctor()
 		IL_0446: stloc.s 8
 		IL_0448: ldloc.s 8
-		IL_044a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_044f: stloc.s 22
-		IL_0451: ldloc.s 22
-		IL_0453: ldstr "set"
-		IL_0458: ldloc.1
-		IL_0459: ldstr "identity"
-		IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0463: pop
-		IL_0464: ldstr "console"
-		IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0473: stloc.s 13
-		IL_0475: ldloc.s 8
-		IL_0477: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_047c: stloc.s 22
-		IL_047e: ldloc.s 22
-		IL_0480: ldstr "get"
-		IL_0485: ldloc.1
-		IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_048b: stloc.s 19
-		IL_048d: ldloc.s 13
-		IL_048f: ldstr "log"
-		IL_0494: ldloc.s 19
-		IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_049b: pop
-		IL_049c: ldstr "console"
-		IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04ab: stloc.s 19
-		IL_04ad: ldloc.1
-		IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b8: ldstr "join"
-		IL_04bd: ldstr ","
-		IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04c7: stloc.s 13
-		IL_04c9: ldloc.s 19
-		IL_04cb: ldstr "log"
-		IL_04d0: ldloc.s 13
-		IL_04d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04d7: pop
-		IL_04d8: ldloc.1
-		IL_04d9: ldstr "custom"
-		IL_04de: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
-		IL_04e3: stloc.s 15
-		IL_04e5: ldstr "console"
-		IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04f4: stloc.s 13
-		IL_04f6: ldloc.1
-		IL_04f7: ldstr "custom"
-		IL_04fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0501: stloc.s 19
-		IL_0503: ldloc.s 13
-		IL_0505: ldstr "log"
-		IL_050a: ldloc.s 19
-		IL_050c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0511: pop
-		IL_0512: ldloc.1
-		IL_0513: ldc.r8 5
-		IL_051c: ldstr "sparse"
-		IL_0521: ldc.i4.0
-		IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_0527: pop
-		IL_0528: ldstr "console"
-		IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0537: stloc.s 19
-		IL_0539: ldloc.1
-		IL_053a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_053f: box [System.Runtime]System.Double
-		IL_0544: stloc.s 14
-		IL_0546: ldloc.1
-		IL_0547: ldc.r8 5
-		IL_0550: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0555: stloc.s 13
-		IL_0557: ldc.r8 4
-		IL_0560: box [System.Runtime]System.Double
-		IL_0565: ldloc.1
-		IL_0566: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_056b: stloc.s 15
-		IL_056d: ldloc.s 15
-		IL_056f: box [System.Runtime]System.Boolean
-		IL_0574: stloc.s 18
-		IL_0576: ldloc.s 19
-		IL_0578: ldstr "log"
-		IL_057d: ldloc.s 14
-		IL_057f: ldloc.s 13
-		IL_0581: ldloc.s 18
-		IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0588: pop
-		IL_0589: ldloc.1
-		IL_058a: ldc.r8 2
-		IL_0593: ldc.i4.0
-		IL_0594: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
-		IL_0599: ldstr "console"
-		IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05a8: stloc.s 13
-		IL_05aa: ldloc.1
-		IL_05ab: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_05b0: box [System.Runtime]System.Double
-		IL_05b5: stloc.s 14
-		IL_05b7: ldc.r8 2
-		IL_05c0: box [System.Runtime]System.Double
-		IL_05c5: ldloc.1
-		IL_05c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_05cb: stloc.s 15
-		IL_05cd: ldloc.s 15
-		IL_05cf: box [System.Runtime]System.Boolean
-		IL_05d4: stloc.s 18
-		IL_05d6: ldc.r8 5
-		IL_05df: box [System.Runtime]System.Double
-		IL_05e4: ldloc.1
-		IL_05e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_05ea: stloc.s 15
-		IL_05ec: ldloc.s 15
-		IL_05ee: box [System.Runtime]System.Boolean
-		IL_05f3: stloc.s 17
-		IL_05f5: ldloc.s 13
-		IL_05f7: ldstr "log"
-		IL_05fc: ldloc.s 14
-		IL_05fe: ldloc.s 18
-		IL_0600: ldloc.s 17
-		IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0607: pop
-		IL_0608: ldc.i4.1
-		IL_0609: newarr [System.Runtime]System.Object
-		IL_060e: dup
-		IL_060f: ldc.i4.0
-		IL_0610: ldloc.0
-		IL_0611: stelem.ref
-		IL_0612: stloc.s 23
-		IL_0614: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
-		IL_0619: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_061e: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
-		IL_0623: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0628: stloc.s 24
-		IL_062a: ldloc.s 24
-		IL_062c: ldloc.s 23
-		IL_062e: ldc.r8 0.0
-		IL_0637: box [System.Runtime]System.Double
-		IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0641: stloc.s 13
-		IL_0643: ldstr "Array"
-		IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_064d: stloc.s 19
-		IL_064f: ldloc.s 13
-		IL_0651: ldloc.s 19
-		IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0658: stloc.s 19
-		IL_065a: ldloc.s 19
-		IL_065c: stloc.s 9
-		IL_065e: ldc.i4.0
-		IL_065f: newarr [System.Runtime]System.Object
-		IL_0664: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0669: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_066e: newobj instance void Modules.Array_JsObject_NamedProperties/DerivedArray::.ctor()
-		IL_0673: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0678: stloc.s 10
-		IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_067f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_0684: stloc.s 10
-		IL_0686: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_068b: ldloc.s 10
-		IL_068d: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
-		IL_0692: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0697: ldstr "prototype"
-		IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_06a1: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_06a6: ldloc.s 10
-		IL_06a8: ldc.r8 1
-		IL_06b1: ldc.r8 42
-		IL_06ba: ldc.i4.0
-		IL_06bb: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_06c0: ldstr "console"
-		IL_06c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06cf: stloc.s 19
-		IL_06d1: ldloc.s 10
-		IL_06d3: ldstr "length"
-		IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06dd: stloc.s 13
-		IL_06df: ldloc.s 10
-		IL_06e1: ldc.r8 1
-		IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_06ef: stloc.s 12
-		IL_06f1: ldloc.s 19
-		IL_06f3: ldstr "log"
-		IL_06f8: ldloc.s 13
-		IL_06fa: ldloc.s 12
-		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0701: pop
-		IL_0702: ldstr "console"
-		IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_070c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0711: ldloc.1
-		IL_0712: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0717: stloc.s 12
-		IL_0719: ldstr "log"
-		IL_071e: ldloc.s 12
-		IL_0720: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0725: pop
-		IL_0726: ldstr "console"
-		IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0735: ldstr "log"
-		IL_073a: ldloc.1
-		IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0740: pop
-		IL_0741: ldloc.1
-		IL_0742: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_0747: pop
-		IL_0748: ldstr "console"
-		IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0752: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0757: ldloc.1
-		IL_0758: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_075d: box [System.Runtime]System.Boolean
-		IL_0762: stloc.s 17
-		IL_0764: ldstr "log"
-		IL_0769: ldloc.s 17
-		IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0770: pop
-		IL_0771: ret
+		IL_044a: ldstr "set"
+		IL_044f: ldloc.1
+		IL_0450: ldstr "identity"
+		IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_045a: pop
+		IL_045b: ldstr "console"
+		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_046a: stloc.s 13
+		IL_046c: ldloc.s 8
+		IL_046e: ldstr "get"
+		IL_0473: ldloc.1
+		IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0479: stloc.s 19
+		IL_047b: ldloc.s 13
+		IL_047d: ldstr "log"
+		IL_0482: ldloc.s 19
+		IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0489: pop
+		IL_048a: ldstr "console"
+		IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0499: stloc.s 19
+		IL_049b: ldloc.1
+		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04a6: ldstr "join"
+		IL_04ab: ldstr ","
+		IL_04b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04b5: stloc.s 13
+		IL_04b7: ldloc.s 19
+		IL_04b9: ldstr "log"
+		IL_04be: ldloc.s 13
+		IL_04c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04c5: pop
+		IL_04c6: ldloc.1
+		IL_04c7: ldstr "custom"
+		IL_04cc: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
+		IL_04d1: stloc.s 15
+		IL_04d3: ldstr "console"
+		IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04e2: stloc.s 13
+		IL_04e4: ldloc.1
+		IL_04e5: ldstr "custom"
+		IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04ef: stloc.s 19
+		IL_04f1: ldloc.s 13
+		IL_04f3: ldstr "log"
+		IL_04f8: ldloc.s 19
+		IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04ff: pop
+		IL_0500: ldloc.1
+		IL_0501: ldc.r8 5
+		IL_050a: ldstr "sparse"
+		IL_050f: ldc.i4.0
+		IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_0515: pop
+		IL_0516: ldstr "console"
+		IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0525: stloc.s 19
+		IL_0527: ldloc.1
+		IL_0528: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_052d: box [System.Runtime]System.Double
+		IL_0532: stloc.s 14
+		IL_0534: ldloc.1
+		IL_0535: ldc.r8 5
+		IL_053e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0543: stloc.s 13
+		IL_0545: ldc.r8 4
+		IL_054e: box [System.Runtime]System.Double
+		IL_0553: ldloc.1
+		IL_0554: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0559: stloc.s 15
+		IL_055b: ldloc.s 15
+		IL_055d: box [System.Runtime]System.Boolean
+		IL_0562: stloc.s 18
+		IL_0564: ldloc.s 19
+		IL_0566: ldstr "log"
+		IL_056b: ldloc.s 14
+		IL_056d: ldloc.s 13
+		IL_056f: ldloc.s 18
+		IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0576: pop
+		IL_0577: ldloc.1
+		IL_0578: ldc.r8 2
+		IL_0581: ldc.i4.0
+		IL_0582: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+		IL_0587: ldstr "console"
+		IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0591: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0596: stloc.s 13
+		IL_0598: ldloc.1
+		IL_0599: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_059e: box [System.Runtime]System.Double
+		IL_05a3: stloc.s 14
+		IL_05a5: ldc.r8 2
+		IL_05ae: box [System.Runtime]System.Double
+		IL_05b3: ldloc.1
+		IL_05b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_05b9: stloc.s 15
+		IL_05bb: ldloc.s 15
+		IL_05bd: box [System.Runtime]System.Boolean
+		IL_05c2: stloc.s 18
+		IL_05c4: ldc.r8 5
+		IL_05cd: box [System.Runtime]System.Double
+		IL_05d2: ldloc.1
+		IL_05d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_05d8: stloc.s 15
+		IL_05da: ldloc.s 15
+		IL_05dc: box [System.Runtime]System.Boolean
+		IL_05e1: stloc.s 17
+		IL_05e3: ldloc.s 13
+		IL_05e5: ldstr "log"
+		IL_05ea: ldloc.s 14
+		IL_05ec: ldloc.s 18
+		IL_05ee: ldloc.s 17
+		IL_05f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_05f5: pop
+		IL_05f6: ldc.i4.1
+		IL_05f7: newarr [System.Runtime]System.Object
+		IL_05fc: dup
+		IL_05fd: ldc.i4.0
+		IL_05fe: ldloc.0
+		IL_05ff: stelem.ref
+		IL_0600: stloc.s 22
+		IL_0602: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
+		IL_0607: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_060c: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
+		IL_0611: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0616: stloc.s 23
+		IL_0618: ldloc.s 23
+		IL_061a: ldloc.s 22
+		IL_061c: ldc.r8 0.0
+		IL_0625: box [System.Runtime]System.Double
+		IL_062a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_062f: stloc.s 13
+		IL_0631: ldstr "Array"
+		IL_0636: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_063b: stloc.s 19
+		IL_063d: ldloc.s 13
+		IL_063f: ldloc.s 19
+		IL_0641: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_0646: stloc.s 19
+		IL_0648: ldloc.s 19
+		IL_064a: stloc.s 9
+		IL_064c: ldc.i4.0
+		IL_064d: newarr [System.Runtime]System.Object
+		IL_0652: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0657: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_065c: newobj instance void Modules.Array_JsObject_NamedProperties/DerivedArray::.ctor()
+		IL_0661: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0666: stloc.s 10
+		IL_0668: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0672: stloc.s 10
+		IL_0674: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_0679: ldloc.s 10
+		IL_067b: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
+		IL_0680: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0685: ldstr "prototype"
+		IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_068f: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0694: ldloc.s 10
+		IL_0696: ldc.r8 1
+		IL_069f: ldc.r8 42
+		IL_06a8: ldc.i4.0
+		IL_06a9: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_06ae: ldstr "console"
+		IL_06b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06bd: stloc.s 19
+		IL_06bf: ldloc.s 10
+		IL_06c1: ldstr "length"
+		IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06cb: stloc.s 13
+		IL_06cd: ldloc.s 10
+		IL_06cf: ldc.r8 1
+		IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_06dd: stloc.s 12
+		IL_06df: ldloc.s 19
+		IL_06e1: ldstr "log"
+		IL_06e6: ldloc.s 13
+		IL_06e8: ldloc.s 12
+		IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_06ef: pop
+		IL_06f0: ldstr "console"
+		IL_06f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06ff: ldloc.1
+		IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0705: stloc.s 12
+		IL_0707: ldstr "log"
+		IL_070c: ldloc.s 12
+		IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0713: pop
+		IL_0714: ldstr "console"
+		IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_071e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0723: ldstr "log"
+		IL_0728: ldloc.1
+		IL_0729: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_072e: pop
+		IL_072f: ldloc.1
+		IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_0735: pop
+		IL_0736: ldstr "console"
+		IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0740: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0745: ldloc.1
+		IL_0746: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_074b: box [System.Runtime]System.Boolean
+		IL_0750: stloc.s 17
+		IL_0752: ldstr "log"
+		IL_0757: ldloc.s 17
+		IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_075e: pop
+		IL_075f: ret
 	} // end of method Array_JsObject_NamedProperties::__js_module_init__
 
 } // end of class Modules.Array_JsObject_NamedProperties
@@ -751,7 +744,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2826
+		// Method begins at RVA 0x2814
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Prototype_CustomMethod_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Prototype_CustomMethod_Dispatch.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ec
+					// Method begins at RVA 0x21e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e3
+				// Method begins at RVA 0x21db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2154
+			// Method begins at RVA 0x214c
 			// Header size: 12
 			// Code size: 122 (0x7a)
 			.maxstack 8
@@ -125,7 +125,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21da
+			// Method begins at RVA 0x21d2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -151,16 +151,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 247 (0xf7)
+		// Code size: 238 (0xee)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Prototype_CustomMethod_Dispatch/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[2] object,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] object,
-			[6] string
+			[4] object,
+			[5] string
 		)
 
 		IL_0000: newobj instance void Modules.Array_Prototype_CustomMethod_Dispatch/Scope::.ctor()
@@ -205,38 +204,35 @@
 		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_008d: stloc.2
 		IL_008e: ldloc.1
-		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
-		IL_0094: stloc.s 4
-		IL_0096: ldloc.s 4
-		IL_0098: ldstr "removeGraphNode"
-		IL_009d: ldc.r8 2
-		IL_00a6: box [System.Runtime]System.Double
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b0: stloc.s 5
-		IL_00b2: ldloc.2
-		IL_00b3: ldstr "log"
-		IL_00b8: ldloc.s 5
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bf: pop
-		IL_00c0: ldstr "console"
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cf: stloc.s 5
-		IL_00d1: ldloc.1
-		IL_00d2: ldc.i4.1
-		IL_00d3: newarr [System.Runtime]System.Object
-		IL_00d8: dup
-		IL_00d9: ldc.i4.0
-		IL_00da: ldstr ","
-		IL_00df: stelem.ref
-		IL_00e0: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_00e5: stloc.s 6
-		IL_00e7: ldloc.s 5
-		IL_00e9: ldstr "log"
-		IL_00ee: ldloc.s 6
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f5: pop
-		IL_00f6: ret
+		IL_008f: ldstr "removeGraphNode"
+		IL_0094: ldc.r8 2
+		IL_009d: box [System.Runtime]System.Double
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a7: stloc.s 4
+		IL_00a9: ldloc.2
+		IL_00aa: ldstr "log"
+		IL_00af: ldloc.s 4
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b6: pop
+		IL_00b7: ldstr "console"
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c6: stloc.s 4
+		IL_00c8: ldloc.1
+		IL_00c9: ldc.i4.1
+		IL_00ca: newarr [System.Runtime]System.Object
+		IL_00cf: dup
+		IL_00d0: ldc.i4.0
+		IL_00d1: ldstr ","
+		IL_00d6: stelem.ref
+		IL_00d7: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_00dc: stloc.s 5
+		IL_00de: ldloc.s 4
+		IL_00e0: ldstr "log"
+		IL_00e5: ldloc.s 5
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ec: pop
+		IL_00ed: ret
 	} // end of method Array_Prototype_CustomMethod_Dispatch::__js_module_init__
 
 } // end of class Modules.Array_Prototype_CustomMethod_Dispatch
@@ -248,7 +244,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f5
+		// Method begins at RVA 0x21ed
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ForOfIterableArrowCallback.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ForOfIterableArrowCallback.verified.txt
@@ -28,7 +28,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2255
+					// Method begins at RVA 0x224e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -54,7 +54,7 @@
 				)
 				// Method begins at RVA 0x2204
 				// Header size: 12
-				// Code size: 33 (0x21)
+				// Code size: 26 (0x1a)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -66,14 +66,11 @@
 				IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 				IL_000f: stloc.0
 				IL_0010: ldloc.0
-				IL_0011: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-				IL_0016: stloc.0
-				IL_0017: ldloc.0
-				IL_0018: ldarg.1
-				IL_0019: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-				IL_001e: stloc.1
-				IL_001f: ldloc.1
-				IL_0020: ret
+				IL_0011: ldarg.1
+				IL_0012: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_0017: stloc.1
+				IL_0018: ldloc.1
+				IL_0019: ret
 			} // end of method ArrowFunction_L2C48::__js_call__
 
 		} // end of class ArrowFunction_L2C48
@@ -92,7 +89,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x223a
+				// Method begins at RVA 0x2233
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -116,7 +113,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x224c
+					// Method begins at RVA 0x2245
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -134,7 +131,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2243
+				// Method begins at RVA 0x223c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -273,7 +270,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2231
+			// Method begins at RVA 0x222a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -375,7 +372,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x225e
+		// Method begins at RVA 0x2257
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ConstructorAssigned.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ConstructorAssigned.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222e
+				// Method begins at RVA 0x2226
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x219a
+			// Method begins at RVA 0x2191
 			// Header size: 1
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x221c
+				// Method begins at RVA 0x2214
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2225
+				// Method begins at RVA 0x221d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x21a4
 			// Header size: 12
 			// Code size: 91 (0x5b)
 			.maxstack 8
@@ -173,7 +173,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2213
+			// Method begins at RVA 0x220b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -199,7 +199,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 318 (0x13e)
+		// Code size: 309 (0x135)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Scope,
@@ -210,8 +210,7 @@
 			[5] class [System.Runtime]System.Type,
 			[6] object,
 			[7] class Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter,
-			[8] object,
-			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Scope::.ctor()
@@ -298,18 +297,15 @@
 		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0116: stloc.s 8
 		IL_0118: ldloc.3
-		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
-		IL_011e: stloc.s 9
-		IL_0120: ldloc.s 9
-		IL_0122: ldstr "getX"
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_012c: stloc.s 6
-		IL_012e: ldloc.s 8
-		IL_0130: ldstr "log"
-		IL_0135: ldloc.s 6
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013c: pop
-		IL_013d: ret
+		IL_0119: ldstr "getX"
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0123: stloc.s 6
+		IL_0125: ldloc.s 8
+		IL_0127: ldstr "log"
+		IL_012c: ldloc.s 6
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0133: pop
+		IL_0134: ret
 	} // end of method ArrowFunction_LexicalThis_ConstructorAssigned::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalThis_ConstructorAssigned
@@ -321,7 +317,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2237
+		// Method begins at RVA 0x222f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_CreatedInMethod.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_CreatedInMethod.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2204
+				// Method begins at RVA 0x21f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2179
+			// Method begins at RVA 0x2167
 			// Header size: 1
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e9
+				// Method begins at RVA 0x21d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f2
+				// Method begins at RVA 0x21de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fb
+				// Method begins at RVA 0x21e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,7 +131,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x218a
+			// Method begins at RVA 0x2178
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -150,7 +150,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x219c
+			// Method begins at RVA 0x2188
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -189,7 +189,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e0
+			// Method begins at RVA 0x21cc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -215,7 +215,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 285 (0x11d)
+		// Code size: 267 (0x10b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_LexicalThis_CreatedInMethod/Scope,
@@ -225,8 +225,7 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] class Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter,
 			[6] object,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[8] object
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_LexicalThis_CreatedInMethod/Scope::.ctor()
@@ -282,34 +281,28 @@
 		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00be: stloc.s 6
 		IL_00c0: ldloc.3
-		IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
-		IL_00c6: stloc.s 7
-		IL_00c8: ldloc.s 7
-		IL_00ca: ldstr "g"
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00d4: stloc.s 8
-		IL_00d6: ldloc.s 6
-		IL_00d8: ldstr "log"
-		IL_00dd: ldloc.s 8
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e4: pop
-		IL_00e5: ldstr "console"
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f4: stloc.s 8
-		IL_00f6: ldloc.s 4
-		IL_00f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
-		IL_00fd: stloc.s 7
-		IL_00ff: ldloc.s 7
-		IL_0101: ldstr "g"
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_010b: stloc.s 6
-		IL_010d: ldloc.s 8
-		IL_010f: ldstr "log"
-		IL_0114: ldloc.s 6
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011b: pop
-		IL_011c: ret
+		IL_00c1: ldstr "g"
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00cb: stloc.s 7
+		IL_00cd: ldloc.s 6
+		IL_00cf: ldstr "log"
+		IL_00d4: ldloc.s 7
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00db: pop
+		IL_00dc: ldstr "console"
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00eb: stloc.s 7
+		IL_00ed: ldloc.s 4
+		IL_00ef: ldstr "g"
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00f9: stloc.s 6
+		IL_00fb: ldloc.s 7
+		IL_00fd: ldstr "log"
+		IL_0102: ldloc.s 6
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0109: pop
+		IL_010a: ret
 	} // end of method ArrowFunction_LexicalThis_CreatedInMethod::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalThis_CreatedInMethod
@@ -321,7 +314,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220d
+		// Method begins at RVA 0x21f9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2375
+				// Method begins at RVA 0x236d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x216c
+			// Method begins at RVA 0x2163
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -89,7 +89,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x236c
+				// Method begins at RVA 0x2364
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -113,7 +113,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2190
+			// Method begins at RVA 0x2188
 			// Header size: 12
 			// Code size: 345 (0x159)
 			.maxstack 8
@@ -265,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2351
+				// Method begins at RVA 0x2349
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -285,7 +285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x235a
+				// Method begins at RVA 0x2352
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -305,7 +305,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2363
+				// Method begins at RVA 0x235b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -331,7 +331,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22f5
+			// Method begins at RVA 0x22ed
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -350,7 +350,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2304
+			// Method begins at RVA 0x22fc
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -389,7 +389,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2348
+			// Method begins at RVA 0x2340
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -415,7 +415,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 272 (0x110)
+		// Code size: 263 (0x107)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ArrowFunction_LexicalThis/Scope,
@@ -423,9 +423,8 @@
 			[2] object,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] class Modules.Async_ArrowFunction_LexicalThis/Counter,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[6] object,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[5] object,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		)
 
 		IL_0000: newobj instance void Modules.Async_ArrowFunction_LexicalThis/Scope::.ctor()
@@ -467,48 +466,45 @@
 		IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_0087: stloc.3
 		IL_0088: ldloc.3
-		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
-		IL_008e: stloc.s 5
-		IL_0090: ldloc.s 5
-		IL_0092: ldstr "g"
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_009c: stloc.s 6
-		IL_009e: ldloc.s 6
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a5: stloc.s 6
-		IL_00a7: ldnull
-		IL_00a8: ldftn object Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L23C16::__js_call__(object, object)
-		IL_00ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00b3: ldc.i4.1
-		IL_00b4: newarr [System.Runtime]System.Object
-		IL_00b9: dup
-		IL_00ba: ldc.i4.0
-		IL_00bb: ldloc.0
-		IL_00bc: stelem.ref
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00c7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_00cc: ldc.i4.1
-		IL_00cd: conv.r8
-		IL_00ce: ldstr ""
-		IL_00d3: ldc.i4.0
-		IL_00d4: ldc.i4.0
-		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_00df: stloc.s 7
-		IL_00e1: ldloc.s 6
-		IL_00e3: ldstr "then"
-		IL_00e8: ldloc.s 7
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ef: pop
-		IL_00f0: ldstr "console"
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ff: ldstr "log"
-		IL_0104: ldstr "After calling async getter"
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010e: pop
-		IL_010f: ret
+		IL_0089: ldstr "g"
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0093: stloc.s 5
+		IL_0095: ldloc.s 5
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009c: stloc.s 5
+		IL_009e: ldnull
+		IL_009f: ldftn object Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L23C16::__js_call__(object, object)
+		IL_00a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00aa: ldc.i4.1
+		IL_00ab: newarr [System.Runtime]System.Object
+		IL_00b0: dup
+		IL_00b1: ldc.i4.0
+		IL_00b2: ldloc.0
+		IL_00b3: stelem.ref
+		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00be: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_00c3: ldc.i4.1
+		IL_00c4: conv.r8
+		IL_00c5: ldstr ""
+		IL_00ca: ldc.i4.0
+		IL_00cb: ldc.i4.0
+		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_00d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_00d6: stloc.s 6
+		IL_00d8: ldloc.s 5
+		IL_00da: ldstr "then"
+		IL_00df: ldloc.s 6
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e6: pop
+		IL_00e7: ldstr "console"
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f6: ldstr "log"
+		IL_00fb: ldstr "After calling async getter"
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0105: pop
+		IL_0106: ret
 	} // end of method Async_ArrowFunction_LexicalThis::__js_module_init__
 
 } // end of class Modules.Async_ArrowFunction_LexicalThis
@@ -520,7 +516,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x237e
+		// Method begins at RVA 0x2376
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2301
+						// Method begins at RVA 0x22fd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -50,7 +50,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x228c
+					// Method begins at RVA 0x2288
 					// Header size: 12
 					// Code size: 78 (0x4e)
 					.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22f8
+					// Method begins at RVA 0x22f4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -139,7 +139,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x21ec
+				// Method begins at RVA 0x21e8
 				// Header size: 12
 				// Code size: 111 (0x6f)
 				.maxstack 8
@@ -209,7 +209,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x230a
+					// Method begins at RVA 0x2306
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -232,7 +232,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2267
+				// Method begins at RVA 0x2263
 				// Header size: 1
 				// Code size: 33 (0x21)
 				.maxstack 8
@@ -257,7 +257,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ef
+				// Method begins at RVA 0x22eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -285,7 +285,7 @@
 			)
 			// Method begins at RVA 0x2104
 			// Header size: 12
-			// Code size: 186 (0xba)
+			// Code size: 179 (0xb3)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_RealSuspension_SetTimeout/run/Scope,
@@ -331,36 +331,33 @@
 			IL_0062: ldloc.1
 			IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
 			IL_0068: stloc.2
-			IL_0069: ldloc.2
-			IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
-			IL_006f: stloc.2
-			IL_0070: ldnull
-			IL_0071: ldftn object Modules.Async_RealSuspension_SetTimeout/run/ArrowFunction_L13C13::__js_call__(object)
-			IL_0077: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_007c: ldc.i4.1
-			IL_007d: newarr [System.Runtime]System.Object
-			IL_0082: dup
-			IL_0083: ldc.i4.0
-			IL_0084: ldarg.0
-			IL_0085: stelem.ref
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0090: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_0069: ldnull
+			IL_006a: ldftn object Modules.Async_RealSuspension_SetTimeout/run/ArrowFunction_L13C13::__js_call__(object)
+			IL_0070: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0075: ldc.i4.1
+			IL_0076: newarr [System.Runtime]System.Object
+			IL_007b: dup
+			IL_007c: ldc.i4.0
+			IL_007d: ldarg.0
+			IL_007e: stelem.ref
+			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0089: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_008e: ldc.i4.0
+			IL_008f: conv.r8
+			IL_0090: ldstr ""
 			IL_0095: ldc.i4.0
-			IL_0096: conv.r8
-			IL_0097: ldstr ""
-			IL_009c: ldc.i4.0
-			IL_009d: ldc.i4.0
-			IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-			IL_00a8: stloc.3
-			IL_00a9: ldloc.2
-			IL_00aa: ldstr "then"
-			IL_00af: ldloc.3
-			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00b5: stloc.s 4
-			IL_00b7: ldloc.s 4
-			IL_00b9: ret
+			IL_0096: ldc.i4.0
+			IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_009c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+			IL_00a1: stloc.3
+			IL_00a2: ldloc.2
+			IL_00a3: ldstr "then"
+			IL_00a8: ldloc.3
+			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ae: stloc.s 4
+			IL_00b0: ldloc.s 4
+			IL_00b2: ret
 		} // end of method run::__js_call__
 
 	} // end of class run
@@ -376,7 +373,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2313
+				// Method begins at RVA 0x230f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -399,7 +396,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21ca
+			// Method begins at RVA 0x21c3
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -431,7 +428,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e6
+			// Method begins at RVA 0x22e2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -533,7 +530,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x231c
+		// Method begins at RVA 0x2318
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a7
+				// Method begins at RVA 0x219b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2188
+			// Method begins at RVA 0x217c
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b0
+				// Method begins at RVA 0x21a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b9
+				// Method begins at RVA 0x21ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -116,7 +116,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c2
+				// Method begins at RVA 0x21b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -136,7 +136,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cb
+				// Method begins at RVA 0x21bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -157,7 +157,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x219e
+			// Method begins at RVA 0x2192
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -183,14 +183,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 299 (0x12b)
+		// Code size: 286 (0x11e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
 			[2] object,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[4] object
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/Scope::.ctor()
@@ -209,78 +208,75 @@
 		IL_0026: nop
 		IL_0027: nop
 		IL_0028: ldloc.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
-		IL_002e: stloc.3
-		IL_002f: ldloc.3
-		IL_0030: ldstr "bind"
-		IL_0035: ldc.i4.0
-		IL_0036: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_003b: ldc.r8 1
-		IL_0044: box [System.Runtime]System.Double
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_004e: stloc.2
-		IL_004f: ldloc.2
-		IL_0050: isinst [System.Runtime]System.Delegate
-		IL_0055: brfalse IL_0079
+		IL_0029: ldstr "bind"
+		IL_002e: ldc.i4.0
+		IL_002f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0034: ldc.r8 1
+		IL_003d: box [System.Runtime]System.Double
+		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0047: stloc.2
+		IL_0048: ldloc.2
+		IL_0049: isinst [System.Runtime]System.Delegate
+		IL_004e: brfalse IL_0072
 
-		IL_005a: ldstr "console"
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0069: ldstr "log"
-		IL_006e: ldstr "bound function"
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0078: pop
+		IL_0053: ldstr "console"
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0062: ldstr "log"
+		IL_0067: ldstr "bound function"
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0071: pop
 
-		IL_0079: ldarg.1
-		IL_007a: isinst [System.Runtime]System.Delegate
-		IL_007f: brfalse IL_00a3
+		IL_0072: ldarg.1
+		IL_0073: isinst [System.Runtime]System.Delegate
+		IL_0078: brfalse IL_009c
 
-		IL_0084: ldstr "console"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0093: ldstr "log"
-		IL_0098: ldstr "require function"
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a2: pop
+		IL_007d: ldstr "console"
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008c: ldstr "log"
+		IL_0091: ldstr "require function"
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009b: pop
 
-		IL_00a3: ldarg.2
-		IL_00a4: ldstr "require"
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ae: stloc.s 4
-		IL_00b0: ldloc.s 4
-		IL_00b2: isinst [System.Runtime]System.Delegate
-		IL_00b7: brfalse IL_00db
+		IL_009c: ldarg.2
+		IL_009d: ldstr "require"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a7: stloc.3
+		IL_00a8: ldloc.3
+		IL_00a9: isinst [System.Runtime]System.Delegate
+		IL_00ae: brfalse IL_00d2
 
-		IL_00bc: ldstr "console"
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cb: ldstr "log"
-		IL_00d0: ldstr "module.require function"
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00da: pop
+		IL_00b3: ldstr "console"
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c2: ldstr "log"
+		IL_00c7: ldstr "module.require function"
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d1: pop
 
-		IL_00db: ldstr "Function"
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e5: ldstr "prototype"
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ef: stloc.s 4
-		IL_00f1: ldloc.s 4
-		IL_00f3: ldstr "bind"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fd: stloc.s 4
-		IL_00ff: ldloc.s 4
-		IL_0101: isinst [System.Runtime]System.Delegate
-		IL_0106: brfalse IL_012a
+		IL_00d2: ldstr "Function"
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00dc: ldstr "prototype"
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e6: stloc.3
+		IL_00e7: ldloc.3
+		IL_00e8: ldstr "bind"
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f2: stloc.3
+		IL_00f3: ldloc.3
+		IL_00f4: isinst [System.Runtime]System.Delegate
+		IL_00f9: brfalse IL_011d
 
-		IL_010b: ldstr "console"
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011a: ldstr "log"
-		IL_011f: ldstr "prototype bind function"
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0129: pop
+		IL_00fe: ldstr "console"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010d: ldstr "log"
+		IL_0112: ldstr "prototype bind function"
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011c: pop
 
-		IL_012a: ret
+		IL_011d: ret
 	} // end of method BinaryOperator_TypeofFunctionStrictEqual_CallableShapes::__js_module_init__
 
 } // end of class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes
@@ -292,7 +288,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d4
+		// Method begins at RVA 0x21c8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ef
+				// Method begins at RVA 0x21eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2160
+			// Method begins at RVA 0x215c
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -91,7 +91,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e6
+			// Method begins at RVA 0x21e2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -118,7 +118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f8
+				// Method begins at RVA 0x21f4
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -131,7 +131,7 @@
 			.method public hidebysig 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1 get_value () cil managed 
 			{
-				// Method begins at RVA 0x2200
+				// Method begins at RVA 0x21fc
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -146,7 +146,7 @@
 					class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x2208
+				// Method begins at RVA 0x2204
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -179,7 +179,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 130 (0x82)
+		// Code size: 125 (0x7d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope,
@@ -221,17 +221,16 @@
 		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_005b: stloc.2
 		IL_005c: ldloc.1
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0062: ldstr "value"
-		IL_0067: ldstr "child"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0071: stloc.s 4
-		IL_0073: ldloc.2
-		IL_0074: ldstr "log"
-		IL_0079: ldloc.s 4
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0080: pop
-		IL_0081: ret
+		IL_005d: ldstr "value"
+		IL_0062: ldstr "child"
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006c: stloc.s 4
+		IL_006e: ldloc.2
+		IL_006f: ldstr "log"
+		IL_0074: ldloc.s 4
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007b: pop
+		IL_007c: ret
 	} // end of method CommonJS_Require_Captures_Shadowed_Global_URL::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Captures_Shadowed_Global_URL
@@ -251,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2226
+				// Method begins at RVA 0x2222
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -275,7 +274,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x219c
+			// Method begins at RVA 0x2198
 			// Header size: 1
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -303,7 +302,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222f
+				// Method begins at RVA 0x222b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -327,7 +326,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21b4
+			// Method begins at RVA 0x21b0
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -368,7 +367,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x221d
+			// Method begins at RVA 0x2219
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -392,7 +391,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20e0
+		// Method begins at RVA 0x20dc
 		// Header size: 12
 		// Code size: 113 (0x71)
 		.maxstack 8
@@ -457,7 +456,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2238
+		// Method begins at RVA 0x2234
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LetClosureCapture.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LetClosureCapture.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2250
+				// Method begins at RVA 0x2229
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2226
+			// Method begins at RVA 0x21ff
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -64,7 +64,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2235
+			// Method begins at RVA 0x220e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2247
+				// Method begins at RVA 0x2220
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -113,7 +113,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x223e
+			// Method begins at RVA 0x2217
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -139,7 +139,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 458 (0x1ca)
+		// Code size: 419 (0x1a3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_LetClosureCapture/Scope,
@@ -150,9 +150,7 @@
 			[5] class Modules.ControlFlow_ForLoop_LetClosureCapture/Scope_For_L5C5,
 			[6] float64,
 			[7] object,
-			[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[9] object[],
-			[10] object
+			[8] object[]
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_LetClosureCapture/Scope::.ctor()
@@ -237,67 +235,52 @@
 		IL_00ee: ldstr "console"
 		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fd: stloc.s 4
-		IL_00ff: ldloc.1
-		IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
-		IL_0105: stloc.s 8
-		IL_0107: ldc.i4.0
-		IL_0108: newarr [System.Runtime]System.Object
-		IL_010d: stloc.s 9
-		IL_010f: ldloc.s 8
-		IL_0111: ldc.r8 0.0
-		IL_011a: box [System.Runtime]System.Double
-		IL_011f: ldloc.s 9
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0126: stloc.s 10
-		IL_0128: ldloc.s 4
-		IL_012a: ldstr "log"
-		IL_012f: ldloc.s 10
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0136: pop
-		IL_0137: ldstr "console"
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0146: stloc.s 10
-		IL_0148: ldloc.1
-		IL_0149: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
-		IL_014e: stloc.s 8
-		IL_0150: ldc.i4.0
-		IL_0151: newarr [System.Runtime]System.Object
-		IL_0156: stloc.s 9
-		IL_0158: ldloc.s 8
-		IL_015a: ldc.r8 1
-		IL_0163: box [System.Runtime]System.Double
-		IL_0168: ldloc.s 9
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_016f: stloc.s 4
-		IL_0171: ldloc.s 10
-		IL_0173: ldstr "log"
-		IL_0178: ldloc.s 4
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017f: pop
-		IL_0180: ldstr "console"
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018f: stloc.s 4
-		IL_0191: ldloc.1
-		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
-		IL_0197: stloc.s 8
-		IL_0199: ldc.i4.0
-		IL_019a: newarr [System.Runtime]System.Object
-		IL_019f: stloc.s 9
-		IL_01a1: ldloc.s 8
-		IL_01a3: ldc.r8 2
-		IL_01ac: box [System.Runtime]System.Double
-		IL_01b1: ldloc.s 9
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_01b8: stloc.s 10
-		IL_01ba: ldloc.s 4
-		IL_01bc: ldstr "log"
-		IL_01c1: ldloc.s 10
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c8: pop
-		IL_01c9: ret
+		IL_00fd: ldc.i4.0
+		IL_00fe: newarr [System.Runtime]System.Object
+		IL_0103: stloc.s 8
+		IL_0105: ldloc.1
+		IL_0106: ldc.r8 0.0
+		IL_010f: box [System.Runtime]System.Double
+		IL_0114: ldloc.s 8
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_011b: stloc.s 4
+		IL_011d: ldstr "log"
+		IL_0122: ldloc.s 4
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0129: pop
+		IL_012a: ldstr "console"
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0139: ldc.i4.0
+		IL_013a: newarr [System.Runtime]System.Object
+		IL_013f: stloc.s 8
+		IL_0141: ldloc.1
+		IL_0142: ldc.r8 1
+		IL_014b: box [System.Runtime]System.Double
+		IL_0150: ldloc.s 8
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0157: stloc.s 4
+		IL_0159: ldstr "log"
+		IL_015e: ldloc.s 4
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0165: pop
+		IL_0166: ldstr "console"
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0175: ldc.i4.0
+		IL_0176: newarr [System.Runtime]System.Object
+		IL_017b: stloc.s 8
+		IL_017d: ldloc.1
+		IL_017e: ldc.r8 2
+		IL_0187: box [System.Runtime]System.Double
+		IL_018c: ldloc.s 8
+		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0193: stloc.s 4
+		IL_0195: ldstr "log"
+		IL_019a: ldloc.s 4
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a1: pop
+		IL_01a2: ret
 	} // end of method ControlFlow_ForLoop_LetClosureCapture::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_LetClosureCapture
@@ -309,7 +292,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2259
+		// Method begins at RVA 0x2232
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LetClosureCapture_Continue.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LetClosureCapture_Continue.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2280
+				// Method begins at RVA 0x2259
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2256
+			// Method begins at RVA 0x222f
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -64,7 +64,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2265
+			// Method begins at RVA 0x223e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -96,7 +96,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2289
+					// Method begins at RVA 0x2262
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -114,7 +114,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2277
+				// Method begins at RVA 0x2250
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -135,7 +135,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x226e
+			// Method begins at RVA 0x2247
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -161,7 +161,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 506 (0x1fa)
+		// Code size: 467 (0x1d3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope,
@@ -173,9 +173,7 @@
 			[6] class Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope_For_L5C5,
 			[7] float64,
 			[8] object,
-			[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[10] object[],
-			[11] object
+			[9] object[]
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope::.ctor()
@@ -274,67 +272,52 @@
 		IL_011e: ldstr "console"
 		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012d: stloc.s 4
-		IL_012f: ldloc.1
-		IL_0130: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
-		IL_0135: stloc.s 9
-		IL_0137: ldc.i4.0
-		IL_0138: newarr [System.Runtime]System.Object
-		IL_013d: stloc.s 10
-		IL_013f: ldloc.s 9
-		IL_0141: ldc.r8 0.0
-		IL_014a: box [System.Runtime]System.Double
-		IL_014f: ldloc.s 10
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0156: stloc.s 11
-		IL_0158: ldloc.s 4
-		IL_015a: ldstr "log"
-		IL_015f: ldloc.s 11
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0166: pop
-		IL_0167: ldstr "console"
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0176: stloc.s 11
-		IL_0178: ldloc.1
-		IL_0179: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
-		IL_017e: stloc.s 9
-		IL_0180: ldc.i4.0
-		IL_0181: newarr [System.Runtime]System.Object
-		IL_0186: stloc.s 10
-		IL_0188: ldloc.s 9
-		IL_018a: ldc.r8 1
-		IL_0193: box [System.Runtime]System.Double
-		IL_0198: ldloc.s 10
-		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_019f: stloc.s 4
-		IL_01a1: ldloc.s 11
-		IL_01a3: ldstr "log"
-		IL_01a8: ldloc.s 4
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01af: pop
-		IL_01b0: ldstr "console"
-		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bf: stloc.s 4
-		IL_01c1: ldloc.1
-		IL_01c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
-		IL_01c7: stloc.s 9
-		IL_01c9: ldc.i4.0
-		IL_01ca: newarr [System.Runtime]System.Object
-		IL_01cf: stloc.s 10
-		IL_01d1: ldloc.s 9
-		IL_01d3: ldc.r8 2
-		IL_01dc: box [System.Runtime]System.Double
-		IL_01e1: ldloc.s 10
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_01e8: stloc.s 11
-		IL_01ea: ldloc.s 4
-		IL_01ec: ldstr "log"
-		IL_01f1: ldloc.s 11
-		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f8: pop
-		IL_01f9: ret
+		IL_012d: ldc.i4.0
+		IL_012e: newarr [System.Runtime]System.Object
+		IL_0133: stloc.s 9
+		IL_0135: ldloc.1
+		IL_0136: ldc.r8 0.0
+		IL_013f: box [System.Runtime]System.Double
+		IL_0144: ldloc.s 9
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_014b: stloc.s 4
+		IL_014d: ldstr "log"
+		IL_0152: ldloc.s 4
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0159: pop
+		IL_015a: ldstr "console"
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0169: ldc.i4.0
+		IL_016a: newarr [System.Runtime]System.Object
+		IL_016f: stloc.s 9
+		IL_0171: ldloc.1
+		IL_0172: ldc.r8 1
+		IL_017b: box [System.Runtime]System.Double
+		IL_0180: ldloc.s 9
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0187: stloc.s 4
+		IL_0189: ldstr "log"
+		IL_018e: ldloc.s 4
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0195: pop
+		IL_0196: ldstr "console"
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a5: ldc.i4.0
+		IL_01a6: newarr [System.Runtime]System.Object
+		IL_01ab: stloc.s 9
+		IL_01ad: ldloc.1
+		IL_01ae: ldc.r8 2
+		IL_01b7: box [System.Runtime]System.Double
+		IL_01bc: ldloc.s 9
+		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_01c3: stloc.s 4
+		IL_01c5: ldstr "log"
+		IL_01ca: ldloc.s 4
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d1: pop
+		IL_01d2: ret
 	} // end of method ControlFlow_ForLoop_LetClosureCapture_Continue::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_LetClosureCapture_Continue
@@ -346,7 +329,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2292
+		// Method begins at RVA 0x226b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_VarClosureCapture.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_VarClosureCapture.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2200
+				// Method begins at RVA 0x21d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x21e6
+			// Method begins at RVA 0x21bf
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f7
+				// Method begins at RVA 0x21d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -91,7 +91,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ee
+			// Method begins at RVA 0x21c7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -117,7 +117,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 394 (0x18a)
+		// Code size: 355 (0x163)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_VarClosureCapture/Scope,
@@ -125,10 +125,8 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[3] float64,
 			[4] object,
-			[5] object,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[7] object[],
-			[8] object
+			[5] object[],
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_VarClosureCapture/Scope::.ctor()
@@ -192,67 +190,52 @@
 		IL_00ae: ldstr "console"
 		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bd: stloc.s 5
-		IL_00bf: ldloc.1
-		IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
-		IL_00c5: stloc.s 6
-		IL_00c7: ldc.i4.0
-		IL_00c8: newarr [System.Runtime]System.Object
-		IL_00cd: stloc.s 7
-		IL_00cf: ldloc.s 6
-		IL_00d1: ldc.r8 0.0
-		IL_00da: box [System.Runtime]System.Double
-		IL_00df: ldloc.s 7
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_00e6: stloc.s 8
-		IL_00e8: ldloc.s 5
-		IL_00ea: ldstr "log"
-		IL_00ef: ldloc.s 8
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f6: pop
-		IL_00f7: ldstr "console"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0106: stloc.s 8
-		IL_0108: ldloc.1
-		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
-		IL_010e: stloc.s 6
-		IL_0110: ldc.i4.0
-		IL_0111: newarr [System.Runtime]System.Object
-		IL_0116: stloc.s 7
-		IL_0118: ldloc.s 6
-		IL_011a: ldc.r8 1
-		IL_0123: box [System.Runtime]System.Double
-		IL_0128: ldloc.s 7
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_012f: stloc.s 5
-		IL_0131: ldloc.s 8
-		IL_0133: ldstr "log"
-		IL_0138: ldloc.s 5
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013f: pop
-		IL_0140: ldstr "console"
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014f: stloc.s 5
-		IL_0151: ldloc.1
-		IL_0152: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
-		IL_0157: stloc.s 6
-		IL_0159: ldc.i4.0
-		IL_015a: newarr [System.Runtime]System.Object
-		IL_015f: stloc.s 7
-		IL_0161: ldloc.s 6
-		IL_0163: ldc.r8 2
-		IL_016c: box [System.Runtime]System.Double
-		IL_0171: ldloc.s 7
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0178: stloc.s 8
-		IL_017a: ldloc.s 5
-		IL_017c: ldstr "log"
-		IL_0181: ldloc.s 8
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0188: pop
-		IL_0189: ret
+		IL_00bd: ldc.i4.0
+		IL_00be: newarr [System.Runtime]System.Object
+		IL_00c3: stloc.s 5
+		IL_00c5: ldloc.1
+		IL_00c6: ldc.r8 0.0
+		IL_00cf: box [System.Runtime]System.Double
+		IL_00d4: ldloc.s 5
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_00db: stloc.s 6
+		IL_00dd: ldstr "log"
+		IL_00e2: ldloc.s 6
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e9: pop
+		IL_00ea: ldstr "console"
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f9: ldc.i4.0
+		IL_00fa: newarr [System.Runtime]System.Object
+		IL_00ff: stloc.s 5
+		IL_0101: ldloc.1
+		IL_0102: ldc.r8 1
+		IL_010b: box [System.Runtime]System.Double
+		IL_0110: ldloc.s 5
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0117: stloc.s 6
+		IL_0119: ldstr "log"
+		IL_011e: ldloc.s 6
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0125: pop
+		IL_0126: ldstr "console"
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0135: ldc.i4.0
+		IL_0136: newarr [System.Runtime]System.Object
+		IL_013b: stloc.s 5
+		IL_013d: ldloc.1
+		IL_013e: ldc.r8 2
+		IL_0147: box [System.Runtime]System.Double
+		IL_014c: ldloc.s 5
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0153: stloc.s 6
+		IL_0155: ldstr "log"
+		IL_015a: ldloc.s 6
+		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0161: pop
+		IL_0162: ret
 	} // end of method ControlFlow_ForLoop_VarClosureCapture::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_VarClosureCapture
@@ -264,7 +247,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2209
+		// Method begins at RVA 0x21e2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Array_SymbolIterator_SparseLiteral.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Array_SymbolIterator_SparseLiteral.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222d
+				// Method begins at RVA 0x2219
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -36,7 +36,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2224
+			// Method begins at RVA 0x2210
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -62,7 +62,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 438 (0x1b6)
+		// Code size: 417 (0x1a1)
 		.maxstack 16
 		.locals init (
 			[0] class Modules.ControlFlow_ForOf_Array_SymbolIterator_SparseLiteral/Scope,
@@ -74,9 +74,8 @@
 			[6] object,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[8] object,
-			[9] object[],
-			[10] bool,
-			[11] float64
+			[9] bool,
+			[10] float64
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForOf_Array_SymbolIterator_SparseLiteral/Scope::.ctor()
@@ -138,92 +137,83 @@
 		IL_00d2: box [System.Runtime]System.Double
 		IL_00d7: stloc.2
 		IL_00d8: ldloc.1
-		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
-		IL_00de: stloc.s 7
-		IL_00e0: ldstr "iterator"
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_00ea: stloc.s 8
-		IL_00ec: ldc.i4.0
-		IL_00ed: newarr [System.Runtime]System.Object
-		IL_00f2: stloc.s 9
-		IL_00f4: ldloc.s 7
-		IL_00f6: ldloc.s 8
-		IL_00f8: ldloc.s 9
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_00ff: stloc.s 8
-		IL_0101: ldloc.s 8
-		IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-		IL_0108: stloc.3
-		IL_0109: ldc.i4.0
-		IL_010a: stloc.s 4
-		IL_010c: ldc.i4.0
-		IL_010d: stloc.s 5
+		IL_00d9: ldstr "iterator"
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_00e3: ldc.i4.0
+		IL_00e4: newarr [System.Runtime]System.Object
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+		IL_00f3: stloc.3
+		IL_00f4: ldc.i4.0
+		IL_00f5: stloc.s 4
+		IL_00f7: ldc.i4.0
+		IL_00f8: stloc.s 5
 		.try
 		{
-			// loop start (head: IL_010f)
-				IL_010f: ldloc.3
-				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-				IL_0115: stloc.s 8
-				IL_0117: ldloc.s 8
-				IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-				IL_011e: stloc.s 10
-				IL_0120: ldloc.s 10
-				IL_0122: brtrue IL_017d
+			// loop start (head: IL_00fa)
+				IL_00fa: ldloc.3
+				IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+				IL_0100: stloc.s 8
+				IL_0102: ldloc.s 8
+				IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+				IL_0109: stloc.s 9
+				IL_010b: ldloc.s 9
+				IL_010d: brtrue IL_0168
 
-				IL_0127: ldloc.s 8
-				IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-				IL_012e: stloc.s 8
-				IL_0130: ldloc.s 8
-				IL_0132: stloc.s 6
-				IL_0134: ldstr "console"
-				IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0143: ldstr "log"
-				IL_0148: ldloc.s 6
-				IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_014f: pop
-				IL_0150: ldloc.2
-				IL_0151: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0156: ldc.r8 1
-				IL_015f: add
-				IL_0160: stloc.s 11
-				IL_0162: ldloc.s 11
-				IL_0164: box [System.Runtime]System.Double
-				IL_0169: stloc.2
-				IL_016a: br IL_010f
+				IL_0112: ldloc.s 8
+				IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+				IL_0119: stloc.s 8
+				IL_011b: ldloc.s 8
+				IL_011d: stloc.s 6
+				IL_011f: ldstr "console"
+				IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_012e: ldstr "log"
+				IL_0133: ldloc.s 6
+				IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_013a: pop
+				IL_013b: ldloc.2
+				IL_013c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0141: ldc.r8 1
+				IL_014a: add
+				IL_014b: stloc.s 10
+				IL_014d: ldloc.s 10
+				IL_014f: box [System.Runtime]System.Double
+				IL_0154: stloc.2
+				IL_0155: br IL_00fa
 			// end loop
-			IL_016f: ldloc.3
-			IL_0170: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-			IL_0175: ldc.i4.1
-			IL_0176: stloc.s 5
-			IL_0178: leave IL_019a
+			IL_015a: ldloc.3
+			IL_015b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+			IL_0160: ldc.i4.1
+			IL_0161: stloc.s 5
+			IL_0163: leave IL_0185
 
-			IL_017d: ldc.i4.1
-			IL_017e: stloc.s 4
-			IL_0180: leave IL_019a
+			IL_0168: ldc.i4.1
+			IL_0169: stloc.s 4
+			IL_016b: leave IL_0185
 		} // end .try
 		finally
 		{
-			IL_0185: ldloc.s 4
-			IL_0187: brtrue IL_0199
+			IL_0170: ldloc.s 4
+			IL_0172: brtrue IL_0184
 
-			IL_018c: ldloc.s 5
-			IL_018e: brtrue IL_0199
+			IL_0177: ldloc.s 5
+			IL_0179: brtrue IL_0184
 
-			IL_0193: ldloc.3
-			IL_0194: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+			IL_017e: ldloc.3
+			IL_017f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-			IL_0199: endfinally
+			IL_0184: endfinally
 		} // end handler
 
-		IL_019a: ldstr "console"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a9: ldstr "log"
-		IL_01ae: ldloc.2
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b4: pop
-		IL_01b5: ret
+		IL_0185: ldstr "console"
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0194: ldstr "log"
+		IL_0199: ldloc.2
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019f: pop
+		IL_01a0: ret
 	} // end of method ControlFlow_ForOf_Array_SymbolIterator_SparseLiteral::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_Array_SymbolIterator_SparseLiteral
@@ -235,7 +225,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2236
+		// Method begins at RVA 0x2222
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2465
+				// Method begins at RVA 0x245d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x234c
+			// Method begins at RVA 0x2344
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -89,7 +89,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2480
+				// Method begins at RVA 0x2478
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -115,7 +115,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2378
+			// Method begins at RVA 0x2370
 			// Header size: 12
 			// Code size: 61 (0x3d)
 			.maxstack 8
@@ -167,7 +167,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2489
+				// Method begins at RVA 0x2481
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -191,7 +191,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23c4
+			// Method begins at RVA 0x23bc
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -220,7 +220,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2492
+				// Method begins at RVA 0x248a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -246,7 +246,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23e0
+			// Method begins at RVA 0x23d8
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -277,7 +277,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x249b
+				// Method begins at RVA 0x2493
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2404
+			// Method begins at RVA 0x23fc
 			// Header size: 12
 			// Code size: 76 (0x4c)
 			.maxstack 8
@@ -361,7 +361,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x246e
+				// Method begins at RVA 0x2466
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -381,7 +381,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2477
+				// Method begins at RVA 0x246f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -403,7 +403,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x245c
+			// Method begins at RVA 0x2454
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -429,7 +429,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 734 (0x2de)
+		// Code size: 725 (0x2d5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FinalizationRegistry_Cleanup_Order/Scope,
@@ -637,66 +637,63 @@
 		IL_0227: ldloc.s 7
 		IL_0229: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
 		IL_022e: stloc.s 13
-		IL_0230: ldloc.s 13
-		IL_0232: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
-		IL_0237: stloc.s 13
-		IL_0239: ldloc.0
-		IL_023a: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_023f: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_0245: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_024a: ldc.i4.1
-		IL_024b: newarr [System.Runtime]System.Object
-		IL_0250: dup
-		IL_0251: ldc.i4.0
-		IL_0252: ldloc.0
-		IL_0253: stelem.ref
-		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_025e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0263: ldc.i4.0
-		IL_0264: conv.r8
-		IL_0265: ldstr ""
-		IL_026a: ldc.i4.0
-		IL_026b: ldc.i4.0
-		IL_026c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0271: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0276: stloc.s 11
-		IL_0278: ldloc.s 13
-		IL_027a: ldstr "then"
-		IL_027f: ldloc.s 11
-		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0286: pop
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
-		IL_028c: pop
-		IL_028d: ldloc.0
-		IL_028e: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_0293: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_0299: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_029e: ldc.i4.1
-		IL_029f: newarr [System.Runtime]System.Object
-		IL_02a4: dup
-		IL_02a5: ldc.i4.0
-		IL_02a6: ldloc.0
-		IL_02a7: stelem.ref
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02b2: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_02b7: ldc.i4.0
-		IL_02b8: conv.r8
-		IL_02b9: ldstr ""
-		IL_02be: ldc.i4.0
-		IL_02bf: ldc.i4.0
-		IL_02c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_02c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_02ca: stloc.s 11
-		IL_02cc: ldloc.s 11
-		IL_02ce: ldc.i4.0
-		IL_02cf: newarr [System.Runtime]System.Object
-		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_02d9: pop
-		IL_02da: ldnull
-		IL_02db: stloc.s 5
-		IL_02dd: ret
+		IL_0230: ldloc.0
+		IL_0231: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_0236: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+		IL_023c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0241: ldc.i4.1
+		IL_0242: newarr [System.Runtime]System.Object
+		IL_0247: dup
+		IL_0248: ldc.i4.0
+		IL_0249: ldloc.0
+		IL_024a: stelem.ref
+		IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0255: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_025a: ldc.i4.0
+		IL_025b: conv.r8
+		IL_025c: ldstr ""
+		IL_0261: ldc.i4.0
+		IL_0262: ldc.i4.0
+		IL_0263: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0268: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_026d: stloc.s 11
+		IL_026f: ldloc.s 13
+		IL_0271: ldstr "then"
+		IL_0276: ldloc.s 11
+		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027d: pop
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
+		IL_0283: pop
+		IL_0284: ldloc.0
+		IL_0285: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_028a: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+		IL_0290: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0295: ldc.i4.1
+		IL_0296: newarr [System.Runtime]System.Object
+		IL_029b: dup
+		IL_029c: ldc.i4.0
+		IL_029d: ldloc.0
+		IL_029e: stelem.ref
+		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02a9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_02ae: ldc.i4.0
+		IL_02af: conv.r8
+		IL_02b0: ldstr ""
+		IL_02b5: ldc.i4.0
+		IL_02b6: ldc.i4.0
+		IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_02bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_02c1: stloc.s 11
+		IL_02c3: ldloc.s 11
+		IL_02c5: ldc.i4.0
+		IL_02c6: newarr [System.Runtime]System.Object
+		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_02d0: pop
+		IL_02d1: ldnull
+		IL_02d2: stloc.s 5
+		IL_02d4: ret
 	} // end of method FinalizationRegistry_Cleanup_Order::__js_module_init__
 
 } // end of class Modules.FinalizationRegistry_Cleanup_Order
@@ -708,7 +705,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24a4
+		// Method begins at RVA 0x249c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2107
+				// Method begins at RVA 0x20fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e8
+			// Method begins at RVA 0x20dc
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -75,7 +75,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20fe
+			// Method begins at RVA 0x20f2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -101,15 +101,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 137 (0x89)
+		// Code size: 128 (0x80)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Apply_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
 			[2] object,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Apply_Basic/Scope::.ctor()
@@ -131,31 +130,28 @@
 		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0037: stloc.2
-		IL_0038: ldloc.1
-		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
-		IL_003e: stloc.3
-		IL_003f: ldc.i4.2
-		IL_0040: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0045: dup
-		IL_0046: ldc.r8 1
-		IL_004f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0054: dup
-		IL_0055: ldc.r8 2
-		IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0063: stloc.s 4
-		IL_0065: ldloc.3
-		IL_0066: ldstr "apply"
-		IL_006b: ldc.i4.0
-		IL_006c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0071: ldloc.s 4
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0078: stloc.s 5
-		IL_007a: ldloc.2
-		IL_007b: ldstr "log"
-		IL_0080: ldloc.s 5
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0087: pop
-		IL_0088: ret
+		IL_0038: ldc.i4.2
+		IL_0039: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_003e: dup
+		IL_003f: ldc.r8 1
+		IL_0048: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_004d: dup
+		IL_004e: ldc.r8 2
+		IL_0057: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_005c: stloc.3
+		IL_005d: ldloc.1
+		IL_005e: ldstr "apply"
+		IL_0063: ldc.i4.0
+		IL_0064: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0069: ldloc.3
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_006f: stloc.s 4
+		IL_0071: ldloc.2
+		IL_0072: ldstr "log"
+		IL_0077: ldloc.s 4
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: pop
+		IL_007f: ret
 	} // end of method Function_Apply_Basic::__js_module_init__
 
 } // end of class Modules.Function_Apply_Basic
@@ -167,7 +163,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2110
+		// Method begins at RVA 0x2104
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_NullArgArray_TreatedAsEmpty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_NullArgArray_TreatedAsEmpty.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2101
+				// Method begins at RVA 0x20f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,7 +48,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20c4
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -91,7 +91,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f8
+			// Method begins at RVA 0x20f0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -117,14 +117,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 103 (0x67)
+		// Code size: 94 (0x5e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Apply_NullArgArray_TreatedAsEmpty/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[2] object,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
-			[4] object
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Apply_NullArgArray_TreatedAsEmpty/Scope::.ctor()
@@ -147,22 +146,19 @@
 		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0037: stloc.2
 		IL_0038: ldloc.1
-		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_003e: stloc.3
-		IL_003f: ldloc.3
-		IL_0040: ldstr "apply"
-		IL_0045: ldc.i4.0
-		IL_0046: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_004b: ldc.i4.0
-		IL_004c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0056: stloc.s 4
-		IL_0058: ldloc.2
-		IL_0059: ldstr "log"
-		IL_005e: ldloc.s 4
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0065: pop
-		IL_0066: ret
+		IL_0039: ldstr "apply"
+		IL_003e: ldc.i4.0
+		IL_003f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0044: ldc.i4.0
+		IL_0045: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_004f: stloc.3
+		IL_0050: ldloc.2
+		IL_0051: ldstr "log"
+		IL_0056: ldloc.3
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005c: pop
+		IL_005d: ret
 	} // end of method Function_Apply_NullArgArray_TreatedAsEmpty::__js_module_init__
 
 } // end of class Modules.Function_Apply_NullArgArray_TreatedAsEmpty
@@ -174,7 +170,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x210a
+		// Method begins at RVA 0x2102
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_ThisArg.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_ThisArg.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x211f
+				// Method begins at RVA 0x2113
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20f0
+			// Method begins at RVA 0x20e4
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -79,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2116
+			// Method begins at RVA 0x210a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -105,16 +105,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 145 (0x91)
+		// Code size: 136 (0x88)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Apply_ThisArg/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[6] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Apply_ThisArg/Scope::.ctor()
@@ -142,27 +141,24 @@
 		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0051: stloc.3
-		IL_0052: ldloc.1
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_0058: stloc.s 4
-		IL_005a: ldc.i4.1
-		IL_005b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0060: dup
-		IL_0061: ldc.r8 5
-		IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_006f: stloc.s 5
-		IL_0071: ldloc.s 4
-		IL_0073: ldstr "apply"
-		IL_0078: ldloc.2
-		IL_0079: ldloc.s 5
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0080: stloc.s 6
-		IL_0082: ldloc.3
-		IL_0083: ldstr "log"
-		IL_0088: ldloc.s 6
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008f: pop
-		IL_0090: ret
+		IL_0052: ldc.i4.1
+		IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0058: dup
+		IL_0059: ldc.r8 5
+		IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0067: stloc.s 4
+		IL_0069: ldloc.1
+		IL_006a: ldstr "apply"
+		IL_006f: ldloc.2
+		IL_0070: ldloc.s 4
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0077: stloc.s 5
+		IL_0079: ldloc.3
+		IL_007a: ldstr "log"
+		IL_007f: ldloc.s 5
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0086: pop
+		IL_0087: ret
 	} // end of method Function_Apply_ThisArg::__js_module_init__
 
 } // end of class Modules.Function_Apply_ThisArg
@@ -174,7 +170,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2128
+		// Method begins at RVA 0x211c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Basic_PartialApplication.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Basic_PartialApplication.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2123
+				// Method begins at RVA 0x2117
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20fc
+			// Method begins at RVA 0x20f0
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -80,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211a
+			// Method begins at RVA 0x210e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -106,16 +106,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 157 (0x9d)
+		// Code size: 148 (0x94)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_Basic_PartialApplication/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3,
 			[2] object,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3,
-			[4] object,
-			[5] object[],
-			[6] object
+			[3] object,
+			[4] object[],
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Bind_Basic_PartialApplication/Scope::.ctor()
@@ -134,36 +133,33 @@
 		IL_0026: nop
 		IL_0027: nop
 		IL_0028: ldloc.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3>(!!0)
-		IL_002e: stloc.3
-		IL_002f: ldloc.3
-		IL_0030: ldstr "bind"
-		IL_0035: ldc.i4.0
-		IL_0036: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_003b: ldc.r8 1
-		IL_0044: box [System.Runtime]System.Double
-		IL_0049: ldc.r8 2
-		IL_0052: box [System.Runtime]System.Double
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_005c: stloc.2
-		IL_005d: ldstr "console"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006c: stloc.s 4
-		IL_006e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0073: stloc.s 5
-		IL_0075: ldloc.2
-		IL_0076: ldloc.s 5
-		IL_0078: ldc.r8 3
-		IL_0081: box [System.Runtime]System.Double
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_008b: stloc.s 6
-		IL_008d: ldloc.s 4
-		IL_008f: ldstr "log"
-		IL_0094: ldloc.s 6
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009b: pop
-		IL_009c: ret
+		IL_0029: ldstr "bind"
+		IL_002e: ldc.i4.0
+		IL_002f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0034: ldc.r8 1
+		IL_003d: box [System.Runtime]System.Double
+		IL_0042: ldc.r8 2
+		IL_004b: box [System.Runtime]System.Double
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0055: stloc.2
+		IL_0056: ldstr "console"
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0065: stloc.3
+		IL_0066: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006b: stloc.s 4
+		IL_006d: ldloc.2
+		IL_006e: ldloc.s 4
+		IL_0070: ldc.r8 3
+		IL_0079: box [System.Runtime]System.Double
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0083: stloc.s 5
+		IL_0085: ldloc.3
+		IL_0086: ldstr "log"
+		IL_008b: ldloc.s 5
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0092: pop
+		IL_0093: ret
 	} // end of method Function_Bind_Basic_PartialApplication::__js_module_init__
 
 } // end of class Modules.Function_Bind_Basic_PartialApplication
@@ -175,7 +171,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212c
+		// Method begins at RVA 0x2120
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Metadata_LengthNameAndPrototype.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Metadata_LengthNameAndPrototype.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x242f
+				// Method begins at RVA 0x2427
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2408
+			// Method begins at RVA 0x2400
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -80,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2426
+			// Method begins at RVA 0x241e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -106,7 +106,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 939 (0x3ab)
+		// Code size: 930 (0x3a2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_Metadata_LengthNameAndPrototype/Scope,
@@ -115,12 +115,11 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[7] object,
 			[8] object,
 			[9] object,
-			[10] object,
-			[11] bool
+			[10] bool
 		)
 
 		IL_0000: newobj instance void Modules.Function_Bind_Metadata_LengthNameAndPrototype/Scope::.ctor()
@@ -138,259 +137,256 @@
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
-		IL_0028: ldloc.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3>(!!0)
-		IL_002e: stloc.s 6
-		IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0035: dup
-		IL_0036: ldstr "ignored"
-		IL_003b: ldc.i4.1
-		IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0041: stloc.s 7
-		IL_0043: ldloc.s 6
-		IL_0045: ldstr "bind"
-		IL_004a: ldloc.s 7
-		IL_004c: ldc.r8 1
-		IL_0055: box [System.Runtime]System.Double
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_005f: stloc.2
-		IL_0060: ldloc.2
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_006b: dup
-		IL_006c: ldstr "ignoredAgain"
-		IL_0071: ldc.i4.1
-		IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0077: stloc.s 7
-		IL_0079: ldstr "bind"
-		IL_007e: ldloc.s 7
-		IL_0080: ldc.r8 2
-		IL_0089: box [System.Runtime]System.Double
-		IL_008e: ldc.r8 3
-		IL_0097: box [System.Runtime]System.Double
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00a1: stloc.3
-		IL_00a2: ldloc.2
-		IL_00a3: ldstr "length"
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_00ad: stloc.s 4
-		IL_00af: ldloc.2
-		IL_00b0: ldstr "name"
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_00ba: stloc.s 5
-		IL_00bc: ldstr "console"
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cb: stloc.s 8
-		IL_00cd: ldloc.2
-		IL_00ce: ldstr "length"
-		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d8: stloc.s 9
-		IL_00da: ldloc.s 8
-		IL_00dc: ldstr "log"
-		IL_00e1: ldloc.s 9
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e8: pop
-		IL_00e9: ldstr "console"
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f8: stloc.s 9
-		IL_00fa: ldloc.2
-		IL_00fb: ldstr "name"
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0105: stloc.s 8
-		IL_0107: ldloc.s 9
-		IL_0109: ldstr "log"
-		IL_010e: ldloc.s 8
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0115: pop
-		IL_0116: ldstr "console"
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0125: stloc.s 8
-		IL_0127: ldloc.s 4
-		IL_0129: ldstr "value"
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0133: stloc.s 9
-		IL_0135: ldloc.s 8
-		IL_0137: ldstr "log"
-		IL_013c: ldloc.s 9
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0143: pop
-		IL_0144: ldstr "console"
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0153: stloc.s 9
-		IL_0155: ldloc.s 4
-		IL_0157: ldstr "writable"
-		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0161: stloc.s 8
-		IL_0163: ldloc.s 9
-		IL_0165: ldstr "log"
-		IL_016a: ldloc.s 8
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0171: pop
-		IL_0172: ldstr "console"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0181: stloc.s 8
-		IL_0183: ldloc.s 4
-		IL_0185: ldstr "enumerable"
-		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018f: stloc.s 9
-		IL_0191: ldloc.s 8
-		IL_0193: ldstr "log"
-		IL_0198: ldloc.s 9
-		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019f: pop
-		IL_01a0: ldstr "console"
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01af: stloc.s 9
-		IL_01b1: ldloc.s 4
-		IL_01b3: ldstr "configurable"
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01bd: stloc.s 8
-		IL_01bf: ldloc.s 9
-		IL_01c1: ldstr "log"
-		IL_01c6: ldloc.s 8
-		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01cd: pop
-		IL_01ce: ldstr "console"
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01dd: stloc.s 8
-		IL_01df: ldloc.s 5
-		IL_01e1: ldstr "value"
-		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01eb: stloc.s 9
-		IL_01ed: ldloc.s 8
-		IL_01ef: ldstr "log"
-		IL_01f4: ldloc.s 9
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fb: pop
-		IL_01fc: ldstr "console"
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020b: stloc.s 9
-		IL_020d: ldloc.s 5
-		IL_020f: ldstr "writable"
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0219: stloc.s 8
-		IL_021b: ldloc.s 9
-		IL_021d: ldstr "log"
-		IL_0222: ldloc.s 8
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0229: pop
-		IL_022a: ldstr "console"
-		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0239: stloc.s 8
-		IL_023b: ldloc.s 5
-		IL_023d: ldstr "enumerable"
-		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0247: stloc.s 9
-		IL_0249: ldloc.s 8
-		IL_024b: ldstr "log"
-		IL_0250: ldloc.s 9
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0257: pop
-		IL_0258: ldstr "console"
-		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0267: stloc.s 9
-		IL_0269: ldloc.s 5
-		IL_026b: ldstr "configurable"
-		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0275: stloc.s 8
-		IL_0277: ldloc.s 9
-		IL_0279: ldstr "log"
-		IL_027e: ldloc.s 8
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0285: pop
-		IL_0286: ldstr "console"
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0295: ldloc.2
-		IL_0296: ldstr "length"
-		IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_02a0: box [System.Runtime]System.Boolean
-		IL_02a5: stloc.s 10
-		IL_02a7: ldstr "log"
-		IL_02ac: ldloc.s 10
-		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b3: pop
-		IL_02b4: ldstr "console"
-		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c3: ldloc.2
-		IL_02c4: ldstr "name"
-		IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_02ce: box [System.Runtime]System.Boolean
-		IL_02d3: stloc.s 10
-		IL_02d5: ldstr "log"
-		IL_02da: ldloc.s 10
-		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e1: pop
-		IL_02e2: ldstr "console"
-		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f1: ldloc.2
-		IL_02f2: ldstr "prototype"
-		IL_02f7: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_02fc: box [System.Runtime]System.Boolean
-		IL_0301: stloc.s 10
-		IL_0303: ldstr "log"
-		IL_0308: ldloc.s 10
-		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_030f: pop
-		IL_0310: ldstr "console"
-		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_031f: stloc.s 8
-		IL_0321: ldloc.2
-		IL_0322: ldstr "prototype"
-		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_032c: stloc.s 9
-		IL_032e: ldloc.s 9
-		IL_0330: ldnull
-		IL_0331: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0336: stloc.s 11
-		IL_0338: ldloc.s 11
-		IL_033a: box [System.Runtime]System.Boolean
-		IL_033f: stloc.s 10
-		IL_0341: ldloc.s 8
-		IL_0343: ldstr "log"
-		IL_0348: ldloc.s 10
-		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_034f: pop
-		IL_0350: ldstr "console"
-		IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_035f: stloc.s 8
-		IL_0361: ldloc.3
-		IL_0362: ldstr "length"
-		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_036c: stloc.s 9
-		IL_036e: ldloc.s 8
-		IL_0370: ldstr "log"
-		IL_0375: ldloc.s 9
-		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_037c: pop
-		IL_037d: ldstr "console"
-		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_038c: stloc.s 9
-		IL_038e: ldloc.3
-		IL_038f: ldstr "name"
-		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0399: stloc.s 8
-		IL_039b: ldloc.s 9
-		IL_039d: ldstr "log"
-		IL_03a2: ldloc.s 8
-		IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03a9: pop
-		IL_03aa: ret
+		IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_002d: dup
+		IL_002e: ldstr "ignored"
+		IL_0033: ldc.i4.1
+		IL_0034: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0039: stloc.s 6
+		IL_003b: ldloc.1
+		IL_003c: ldstr "bind"
+		IL_0041: ldloc.s 6
+		IL_0043: ldc.r8 1
+		IL_004c: box [System.Runtime]System.Double
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0056: stloc.2
+		IL_0057: ldloc.2
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0062: dup
+		IL_0063: ldstr "ignoredAgain"
+		IL_0068: ldc.i4.1
+		IL_0069: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_006e: stloc.s 6
+		IL_0070: ldstr "bind"
+		IL_0075: ldloc.s 6
+		IL_0077: ldc.r8 2
+		IL_0080: box [System.Runtime]System.Double
+		IL_0085: ldc.r8 3
+		IL_008e: box [System.Runtime]System.Double
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0098: stloc.3
+		IL_0099: ldloc.2
+		IL_009a: ldstr "length"
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_00a4: stloc.s 4
+		IL_00a6: ldloc.2
+		IL_00a7: ldstr "name"
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_00b1: stloc.s 5
+		IL_00b3: ldstr "console"
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c2: stloc.s 7
+		IL_00c4: ldloc.2
+		IL_00c5: ldstr "length"
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00cf: stloc.s 8
+		IL_00d1: ldloc.s 7
+		IL_00d3: ldstr "log"
+		IL_00d8: ldloc.s 8
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00df: pop
+		IL_00e0: ldstr "console"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ef: stloc.s 8
+		IL_00f1: ldloc.2
+		IL_00f2: ldstr "name"
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00fc: stloc.s 7
+		IL_00fe: ldloc.s 8
+		IL_0100: ldstr "log"
+		IL_0105: ldloc.s 7
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010c: pop
+		IL_010d: ldstr "console"
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011c: stloc.s 7
+		IL_011e: ldloc.s 4
+		IL_0120: ldstr "value"
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012a: stloc.s 8
+		IL_012c: ldloc.s 7
+		IL_012e: ldstr "log"
+		IL_0133: ldloc.s 8
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013a: pop
+		IL_013b: ldstr "console"
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014a: stloc.s 8
+		IL_014c: ldloc.s 4
+		IL_014e: ldstr "writable"
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0158: stloc.s 7
+		IL_015a: ldloc.s 8
+		IL_015c: ldstr "log"
+		IL_0161: ldloc.s 7
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0168: pop
+		IL_0169: ldstr "console"
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0178: stloc.s 7
+		IL_017a: ldloc.s 4
+		IL_017c: ldstr "enumerable"
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0186: stloc.s 8
+		IL_0188: ldloc.s 7
+		IL_018a: ldstr "log"
+		IL_018f: ldloc.s 8
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0196: pop
+		IL_0197: ldstr "console"
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a6: stloc.s 8
+		IL_01a8: ldloc.s 4
+		IL_01aa: ldstr "configurable"
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01b4: stloc.s 7
+		IL_01b6: ldloc.s 8
+		IL_01b8: ldstr "log"
+		IL_01bd: ldloc.s 7
+		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c4: pop
+		IL_01c5: ldstr "console"
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d4: stloc.s 7
+		IL_01d6: ldloc.s 5
+		IL_01d8: ldstr "value"
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e2: stloc.s 8
+		IL_01e4: ldloc.s 7
+		IL_01e6: ldstr "log"
+		IL_01eb: ldloc.s 8
+		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f2: pop
+		IL_01f3: ldstr "console"
+		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0202: stloc.s 8
+		IL_0204: ldloc.s 5
+		IL_0206: ldstr "writable"
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0210: stloc.s 7
+		IL_0212: ldloc.s 8
+		IL_0214: ldstr "log"
+		IL_0219: ldloc.s 7
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0220: pop
+		IL_0221: ldstr "console"
+		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0230: stloc.s 7
+		IL_0232: ldloc.s 5
+		IL_0234: ldstr "enumerable"
+		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023e: stloc.s 8
+		IL_0240: ldloc.s 7
+		IL_0242: ldstr "log"
+		IL_0247: ldloc.s 8
+		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024e: pop
+		IL_024f: ldstr "console"
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025e: stloc.s 8
+		IL_0260: ldloc.s 5
+		IL_0262: ldstr "configurable"
+		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_026c: stloc.s 7
+		IL_026e: ldloc.s 8
+		IL_0270: ldstr "log"
+		IL_0275: ldloc.s 7
+		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027c: pop
+		IL_027d: ldstr "console"
+		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028c: ldloc.2
+		IL_028d: ldstr "length"
+		IL_0292: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0297: box [System.Runtime]System.Boolean
+		IL_029c: stloc.s 9
+		IL_029e: ldstr "log"
+		IL_02a3: ldloc.s 9
+		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02aa: pop
+		IL_02ab: ldstr "console"
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ba: ldloc.2
+		IL_02bb: ldstr "name"
+		IL_02c0: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_02c5: box [System.Runtime]System.Boolean
+		IL_02ca: stloc.s 9
+		IL_02cc: ldstr "log"
+		IL_02d1: ldloc.s 9
+		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d8: pop
+		IL_02d9: ldstr "console"
+		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02e8: ldloc.2
+		IL_02e9: ldstr "prototype"
+		IL_02ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_02f3: box [System.Runtime]System.Boolean
+		IL_02f8: stloc.s 9
+		IL_02fa: ldstr "log"
+		IL_02ff: ldloc.s 9
+		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0306: pop
+		IL_0307: ldstr "console"
+		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0316: stloc.s 7
+		IL_0318: ldloc.2
+		IL_0319: ldstr "prototype"
+		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0323: stloc.s 8
+		IL_0325: ldloc.s 8
+		IL_0327: ldnull
+		IL_0328: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_032d: stloc.s 10
+		IL_032f: ldloc.s 10
+		IL_0331: box [System.Runtime]System.Boolean
+		IL_0336: stloc.s 9
+		IL_0338: ldloc.s 7
+		IL_033a: ldstr "log"
+		IL_033f: ldloc.s 9
+		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0346: pop
+		IL_0347: ldstr "console"
+		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0356: stloc.s 7
+		IL_0358: ldloc.3
+		IL_0359: ldstr "length"
+		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0363: stloc.s 8
+		IL_0365: ldloc.s 7
+		IL_0367: ldstr "log"
+		IL_036c: ldloc.s 8
+		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0373: pop
+		IL_0374: ldstr "console"
+		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0383: stloc.s 8
+		IL_0385: ldloc.3
+		IL_0386: ldstr "name"
+		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0390: stloc.s 7
+		IL_0392: ldloc.s 8
+		IL_0394: ldstr "log"
+		IL_0399: ldloc.s 7
+		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a0: pop
+		IL_03a1: ret
 	} // end of method Function_Bind_Metadata_LengthNameAndPrototype::__js_module_init__
 
 } // end of class Modules.Function_Bind_Metadata_LengthNameAndPrototype
@@ -402,7 +398,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2438
+		// Method begins at RVA 0x2430
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_ThisBinding_IgnoresCallReceiver.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_ThisBinding_IgnoresCallReceiver.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2153
+				// Method begins at RVA 0x213f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2124
+			// Method begins at RVA 0x2110
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -79,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x214a
+			// Method begins at RVA 0x2136
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -105,7 +105,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 197 (0xc5)
+		// Code size: 179 (0xb3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/Scope,
@@ -113,10 +113,8 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
-			[6] object,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[8] object
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/Scope::.ctor()
@@ -141,42 +139,36 @@
 		IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_0041: stloc.2
 		IL_0042: ldloc.1
-		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_0048: stloc.s 5
-		IL_004a: ldloc.s 5
-		IL_004c: ldstr "bind"
-		IL_0051: ldloc.2
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0057: stloc.3
-		IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_005d: dup
-		IL_005e: ldstr "base"
-		IL_0063: ldc.r8 100
-		IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0071: dup
-		IL_0072: ldstr "m"
-		IL_0077: ldloc.3
-		IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_007d: stloc.s 4
-		IL_007f: ldstr "console"
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008e: stloc.s 6
-		IL_0090: ldloc.s 4
-		IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
-		IL_0097: stloc.s 7
-		IL_0099: ldloc.s 7
-		IL_009b: ldstr "m"
-		IL_00a0: ldc.r8 5
-		IL_00a9: box [System.Runtime]System.Double
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b3: stloc.s 8
-		IL_00b5: ldloc.s 6
-		IL_00b7: ldstr "log"
-		IL_00bc: ldloc.s 8
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c3: pop
-		IL_00c4: ret
+		IL_0043: ldstr "bind"
+		IL_0048: ldloc.2
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004e: stloc.3
+		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0054: dup
+		IL_0055: ldstr "base"
+		IL_005a: ldc.r8 100
+		IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0068: dup
+		IL_0069: ldstr "m"
+		IL_006e: ldloc.3
+		IL_006f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0074: stloc.s 4
+		IL_0076: ldstr "console"
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0085: stloc.s 5
+		IL_0087: ldloc.s 4
+		IL_0089: ldstr "m"
+		IL_008e: ldc.r8 5
+		IL_0097: box [System.Runtime]System.Double
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a1: stloc.s 6
+		IL_00a3: ldloc.s 5
+		IL_00a5: ldstr "log"
+		IL_00aa: ldloc.s 6
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b1: pop
+		IL_00b2: ret
 	} // end of method Function_Bind_ThisBinding_IgnoresCallReceiver::__js_module_init__
 
 } // end of class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver
@@ -188,7 +180,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x215c
+		// Method begins at RVA 0x2148
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x212b
+				// Method begins at RVA 0x2123
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20dc
+			// Method begins at RVA 0x20d4
 			// Header size: 12
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -91,7 +91,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2122
+			// Method begins at RVA 0x211a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -117,15 +117,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 126 (0x7e)
+		// Code size: 117 (0x75)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[5] object
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Call_Basic/Scope::.ctor()
@@ -154,21 +153,18 @@
 		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_004d: stloc.3
 		IL_004e: ldloc.1
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
-		IL_0054: stloc.s 4
-		IL_0056: ldloc.s 4
-		IL_0058: ldstr "call"
-		IL_005d: ldloc.2
-		IL_005e: ldstr "A"
-		IL_0063: ldstr "B"
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_006d: stloc.s 5
-		IL_006f: ldloc.3
-		IL_0070: ldstr "log"
-		IL_0075: ldloc.s 5
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007c: pop
-		IL_007d: ret
+		IL_004f: ldstr "call"
+		IL_0054: ldloc.2
+		IL_0055: ldstr "A"
+		IL_005a: ldstr "B"
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0064: stloc.s 4
+		IL_0066: ldloc.3
+		IL_0067: ldstr "log"
+		IL_006c: ldloc.s 4
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0073: pop
+		IL_0074: ret
 	} // end of method Function_Call_Basic::__js_module_init__
 
 } // end of class Modules.Function_Call_Basic
@@ -180,7 +176,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2134
+		// Method begins at RVA 0x212c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a98
+				// Method begins at RVA 0x2a8c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x291a
+			// Method begins at RVA 0x2911
 			// Header size: 1
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -77,7 +77,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa1
+				// Method begins at RVA 0x2a95
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -100,7 +100,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2944
+			// Method begins at RVA 0x2938
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -139,7 +139,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aaa
+				// Method begins at RVA 0x2a9e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x297a
+			// Method begins at RVA 0x296e
 			// Header size: 1
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -198,7 +198,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab3
+				// Method begins at RVA 0x2aa7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -221,7 +221,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29a8
+			// Method begins at RVA 0x299c
 			// Header size: 1
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -253,7 +253,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ac5
+					// Method begins at RVA 0x2ab9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -278,7 +278,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a30
+				// Method begins at RVA 0x2a24
 				// Header size: 12
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -323,7 +323,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2abc
+				// Method begins at RVA 0x2ab0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -350,7 +350,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x29cc
+			// Method begins at RVA 0x29c0
 			// Header size: 12
 			// Code size: 60 (0x3c)
 			.maxstack 8
@@ -401,7 +401,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ace
+				// Method begins at RVA 0x2ac2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -425,7 +425,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a14
+			// Method begins at RVA 0x2a08
 			// Header size: 1
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -453,7 +453,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad7
+				// Method begins at RVA 0x2acb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -476,7 +476,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a29
+			// Method begins at RVA 0x2a1d
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -498,7 +498,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae0
+				// Method begins at RVA 0x2ad4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -521,7 +521,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a2c
+			// Method begins at RVA 0x2a20
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -543,7 +543,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae9
+				// Method begins at RVA 0x2add
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -563,7 +563,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2af2
+				// Method begins at RVA 0x2ae6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -584,7 +584,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a66
+			// Method begins at RVA 0x2a5a
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -602,7 +602,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a70
+			// Method begins at RVA 0x2a64
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -651,7 +651,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a8f
+			// Method begins at RVA 0x2a83
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -677,7 +677,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2238 (0x8be)
+		// Code size: 2229 (0x8b5)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Function_ConstructedInstance_ObjectSemantics/Scope,
@@ -705,8 +705,7 @@
 			[22] object,
 			[23] object,
 			[24] object[],
-			[25] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[26] class [System.Runtime]System.Type
+			[25] class [System.Runtime]System.Type
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -1136,286 +1135,283 @@
 		IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0566: pop
 		IL_0567: ldloc.1
-		IL_0568: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
-		IL_056d: stloc.s 25
-		IL_056f: ldloc.s 25
-		IL_0571: ldstr "bind"
-		IL_0576: ldc.i4.0
-		IL_0577: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_057c: ldc.r8 10
-		IL_0585: box [System.Runtime]System.Double
-		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_058f: stloc.s 11
-		IL_0591: ldloc.s 11
-		IL_0593: ldc.i4.1
-		IL_0594: newarr [System.Runtime]System.Object
-		IL_0599: dup
-		IL_059a: ldc.i4.0
-		IL_059b: ldc.r8 5
-		IL_05a4: box [System.Runtime]System.Double
-		IL_05a9: stelem.ref
-		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_05af: stloc.s 12
-		IL_05b1: ldstr "console"
-		IL_05b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0568: ldstr "bind"
+		IL_056d: ldc.i4.0
+		IL_056e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0573: ldc.r8 10
+		IL_057c: box [System.Runtime]System.Double
+		IL_0581: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0586: stloc.s 11
+		IL_0588: ldloc.s 11
+		IL_058a: ldc.i4.1
+		IL_058b: newarr [System.Runtime]System.Object
+		IL_0590: dup
+		IL_0591: ldc.i4.0
+		IL_0592: ldc.r8 5
+		IL_059b: box [System.Runtime]System.Double
+		IL_05a0: stelem.ref
+		IL_05a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_05a6: stloc.s 12
+		IL_05a8: ldstr "console"
+		IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05b7: stloc.s 23
+		IL_05b9: ldloc.s 12
 		IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05c0: stloc.s 23
-		IL_05c2: ldloc.s 12
-		IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05c9: ldstr "sum"
-		IL_05ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_05d3: stloc.s 22
-		IL_05d5: ldloc.s 23
-		IL_05d7: ldstr "log"
-		IL_05dc: ldloc.s 22
-		IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05e3: pop
-		IL_05e4: ldstr "console"
-		IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05f3: stloc.s 22
-		IL_05f5: ldloc.s 12
-		IL_05f7: ldloc.1
-		IL_05f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_05fd: stloc.s 19
-		IL_05ff: ldloc.s 19
-		IL_0601: box [System.Runtime]System.Boolean
-		IL_0606: stloc.s 20
-		IL_0608: ldloc.s 22
-		IL_060a: ldstr "log"
-		IL_060f: ldloc.s 20
-		IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0616: pop
-		IL_0617: ldnull
-		IL_0618: ldftn object Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'::__js_call__(object, object)
-		IL_061e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0623: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0628: ldc.i4.1
-		IL_0629: conv.r8
-		IL_062a: ldstr ""
-		IL_062f: ldc.i4.0
-		IL_0630: ldc.i4.0
-		IL_0631: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0636: stloc.s 13
-		IL_0638: ldloc.s 13
-		IL_063a: ldc.i4.1
-		IL_063b: newarr [System.Runtime]System.Object
-		IL_0640: dup
-		IL_0641: ldc.i4.0
-		IL_0642: ldc.r8 9
-		IL_064b: box [System.Runtime]System.Double
-		IL_0650: stelem.ref
-		IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_0656: stloc.s 14
-		IL_0658: ldstr "console"
-		IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0662: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0667: stloc.s 22
-		IL_0669: ldloc.s 14
-		IL_066b: ldstr "value"
-		IL_0670: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0675: stloc.s 23
-		IL_0677: ldloc.s 22
-		IL_0679: ldstr "log"
-		IL_067e: ldloc.s 23
-		IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0685: pop
-		IL_0686: ldstr "console"
-		IL_068b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0695: stloc.s 23
-		IL_0697: ldloc.s 14
-		IL_0699: ldloc.s 13
-		IL_069b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_06a0: stloc.s 19
-		IL_06a2: ldloc.s 19
-		IL_06a4: box [System.Runtime]System.Boolean
-		IL_06a9: stloc.s 20
-		IL_06ab: ldloc.s 23
-		IL_06ad: ldstr "log"
-		IL_06b2: ldloc.s 20
-		IL_06b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06b9: pop
-		IL_06ba: nop
-		IL_06bb: ldloc.s 5
-		IL_06bd: ldstr "prototype"
-		IL_06c2: ldc.r8 3
-		IL_06cb: ldc.i4.1
-		IL_06cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_06d1: pop
-		IL_06d2: ldstr "console"
-		IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06e1: stloc.s 23
-		IL_06e3: ldloc.s 5
-		IL_06e5: ldc.i4.0
-		IL_06e6: newarr [System.Runtime]System.Object
-		IL_06eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_05c0: ldstr "sum"
+		IL_05c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_05ca: stloc.s 22
+		IL_05cc: ldloc.s 23
+		IL_05ce: ldstr "log"
+		IL_05d3: ldloc.s 22
+		IL_05d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05da: pop
+		IL_05db: ldstr "console"
+		IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05ea: stloc.s 22
+		IL_05ec: ldloc.s 12
+		IL_05ee: ldloc.1
+		IL_05ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_05f4: stloc.s 19
+		IL_05f6: ldloc.s 19
+		IL_05f8: box [System.Runtime]System.Boolean
+		IL_05fd: stloc.s 20
+		IL_05ff: ldloc.s 22
+		IL_0601: ldstr "log"
+		IL_0606: ldloc.s 20
+		IL_0608: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_060d: pop
+		IL_060e: ldnull
+		IL_060f: ldftn object Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'::__js_call__(object, object)
+		IL_0615: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_061a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_061f: ldc.i4.1
+		IL_0620: conv.r8
+		IL_0621: ldstr ""
+		IL_0626: ldc.i4.0
+		IL_0627: ldc.i4.0
+		IL_0628: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_062d: stloc.s 13
+		IL_062f: ldloc.s 13
+		IL_0631: ldc.i4.1
+		IL_0632: newarr [System.Runtime]System.Object
+		IL_0637: dup
+		IL_0638: ldc.i4.0
+		IL_0639: ldc.r8 9
+		IL_0642: box [System.Runtime]System.Double
+		IL_0647: stelem.ref
+		IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_064d: stloc.s 14
+		IL_064f: ldstr "console"
+		IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_065e: stloc.s 22
+		IL_0660: ldloc.s 14
+		IL_0662: ldstr "value"
+		IL_0667: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_066c: stloc.s 23
+		IL_066e: ldloc.s 22
+		IL_0670: ldstr "log"
+		IL_0675: ldloc.s 23
+		IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_067c: pop
+		IL_067d: ldstr "console"
+		IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_068c: stloc.s 23
+		IL_068e: ldloc.s 14
+		IL_0690: ldloc.s 13
+		IL_0692: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0697: stloc.s 19
+		IL_0699: ldloc.s 19
+		IL_069b: box [System.Runtime]System.Boolean
+		IL_06a0: stloc.s 20
+		IL_06a2: ldloc.s 23
+		IL_06a4: ldstr "log"
+		IL_06a9: ldloc.s 20
+		IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06b0: pop
+		IL_06b1: nop
+		IL_06b2: ldloc.s 5
+		IL_06b4: ldstr "prototype"
+		IL_06b9: ldc.r8 3
+		IL_06c2: ldc.i4.1
+		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_06c8: pop
+		IL_06c9: ldstr "console"
+		IL_06ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06d8: stloc.s 23
+		IL_06da: ldloc.s 5
+		IL_06dc: ldc.i4.0
+		IL_06dd: newarr [System.Runtime]System.Object
+		IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_06e7: stloc.s 22
+		IL_06e9: ldloc.s 22
+		IL_06eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
 		IL_06f0: stloc.s 22
-		IL_06f2: ldloc.s 22
-		IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_06f9: stloc.s 22
-		IL_06fb: ldstr "Object"
-		IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0705: ldstr "prototype"
-		IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_070f: stloc.s 18
-		IL_0711: ldloc.s 22
-		IL_0713: ldloc.s 18
-		IL_0715: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_071a: stloc.s 19
-		IL_071c: ldloc.s 19
-		IL_071e: box [System.Runtime]System.Boolean
-		IL_0723: stloc.s 20
-		IL_0725: ldloc.s 23
-		IL_0727: ldstr "log"
-		IL_072c: ldloc.s 20
-		IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0733: pop
-		IL_0734: nop
-		IL_0735: ldloc.s 6
-		IL_0737: ldstr "prototype"
-		IL_073c: ldc.i4.0
-		IL_073d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0742: ldc.i4.1
-		IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0748: pop
-		IL_0749: ldstr "console"
-		IL_074e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0758: stloc.s 23
-		IL_075a: ldloc.s 6
-		IL_075c: ldc.i4.0
-		IL_075d: newarr [System.Runtime]System.Object
-		IL_0762: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_06f2: ldstr "Object"
+		IL_06f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06fc: ldstr "prototype"
+		IL_0701: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0706: stloc.s 18
+		IL_0708: ldloc.s 22
+		IL_070a: ldloc.s 18
+		IL_070c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0711: stloc.s 19
+		IL_0713: ldloc.s 19
+		IL_0715: box [System.Runtime]System.Boolean
+		IL_071a: stloc.s 20
+		IL_071c: ldloc.s 23
+		IL_071e: ldstr "log"
+		IL_0723: ldloc.s 20
+		IL_0725: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_072a: pop
+		IL_072b: nop
+		IL_072c: ldloc.s 6
+		IL_072e: ldstr "prototype"
+		IL_0733: ldc.i4.0
+		IL_0734: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0739: ldc.i4.1
+		IL_073a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_073f: pop
+		IL_0740: ldstr "console"
+		IL_0745: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_074a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_074f: stloc.s 23
+		IL_0751: ldloc.s 6
+		IL_0753: ldc.i4.0
+		IL_0754: newarr [System.Runtime]System.Object
+		IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_075e: stloc.s 18
+		IL_0760: ldloc.s 18
+		IL_0762: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
 		IL_0767: stloc.s 18
-		IL_0769: ldloc.s 18
-		IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0770: stloc.s 18
-		IL_0772: ldstr "Object"
-		IL_0777: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_077c: ldstr "prototype"
-		IL_0781: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0786: stloc.s 22
-		IL_0788: ldloc.s 18
-		IL_078a: ldloc.s 22
-		IL_078c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0791: stloc.s 19
-		IL_0793: ldloc.s 19
-		IL_0795: box [System.Runtime]System.Boolean
-		IL_079a: stloc.s 20
-		IL_079c: ldloc.s 23
-		IL_079e: ldstr "log"
-		IL_07a3: ldloc.s 20
-		IL_07a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07aa: pop
-		IL_07ab: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
-		IL_07b0: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_07b5: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
-		IL_07ba: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_07bf: stloc.s 26
-		IL_07c1: ldc.i4.1
-		IL_07c2: newarr [System.Runtime]System.Object
-		IL_07c7: dup
-		IL_07c8: ldc.i4.0
-		IL_07c9: ldloc.0
-		IL_07ca: stelem.ref
-		IL_07cb: stloc.s 24
-		IL_07cd: ldc.i4.s 10
-		IL_07cf: newarr [System.Runtime]System.Object
-		IL_07d4: dup
-		IL_07d5: ldc.i4.0
-		IL_07d6: ldloc.s 26
-		IL_07d8: stelem.ref
-		IL_07d9: dup
-		IL_07da: ldc.i4.1
-		IL_07db: ldstr "read"
-		IL_07e0: stelem.ref
-		IL_07e1: dup
-		IL_07e2: ldc.i4.2
-		IL_07e3: ldstr "read"
-		IL_07e8: stelem.ref
-		IL_07e9: dup
-		IL_07ea: ldc.i4.3
-		IL_07eb: ldc.r8 1
-		IL_07f4: box [System.Runtime]System.Double
-		IL_07f9: stelem.ref
-		IL_07fa: dup
-		IL_07fb: ldc.i4.4
-		IL_07fc: ldstr "read"
+		IL_0769: ldstr "Object"
+		IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0773: ldstr "prototype"
+		IL_0778: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_077d: stloc.s 22
+		IL_077f: ldloc.s 18
+		IL_0781: ldloc.s 22
+		IL_0783: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0788: stloc.s 19
+		IL_078a: ldloc.s 19
+		IL_078c: box [System.Runtime]System.Boolean
+		IL_0791: stloc.s 20
+		IL_0793: ldloc.s 23
+		IL_0795: ldstr "log"
+		IL_079a: ldloc.s 20
+		IL_079c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07a1: pop
+		IL_07a2: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
+		IL_07a7: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_07ac: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
+		IL_07b1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_07b6: stloc.s 25
+		IL_07b8: ldc.i4.1
+		IL_07b9: newarr [System.Runtime]System.Object
+		IL_07be: dup
+		IL_07bf: ldc.i4.0
+		IL_07c0: ldloc.0
+		IL_07c1: stelem.ref
+		IL_07c2: stloc.s 24
+		IL_07c4: ldc.i4.s 10
+		IL_07c6: newarr [System.Runtime]System.Object
+		IL_07cb: dup
+		IL_07cc: ldc.i4.0
+		IL_07cd: ldloc.s 25
+		IL_07cf: stelem.ref
+		IL_07d0: dup
+		IL_07d1: ldc.i4.1
+		IL_07d2: ldstr "read"
+		IL_07d7: stelem.ref
+		IL_07d8: dup
+		IL_07d9: ldc.i4.2
+		IL_07da: ldstr "read"
+		IL_07df: stelem.ref
+		IL_07e0: dup
+		IL_07e1: ldc.i4.3
+		IL_07e2: ldc.r8 1
+		IL_07eb: box [System.Runtime]System.Double
+		IL_07f0: stelem.ref
+		IL_07f1: dup
+		IL_07f2: ldc.i4.4
+		IL_07f3: ldstr "read"
+		IL_07f8: stelem.ref
+		IL_07f9: dup
+		IL_07fa: ldc.i4.5
+		IL_07fb: ldc.i4.1
+		IL_07fc: box [System.Runtime]System.Boolean
 		IL_0801: stelem.ref
 		IL_0802: dup
-		IL_0803: ldc.i4.5
-		IL_0804: ldc.i4.1
+		IL_0803: ldc.i4.6
+		IL_0804: ldc.i4.0
 		IL_0805: box [System.Runtime]System.Boolean
 		IL_080a: stelem.ref
 		IL_080b: dup
-		IL_080c: ldc.i4.6
+		IL_080c: ldc.i4.7
 		IL_080d: ldc.i4.0
 		IL_080e: box [System.Runtime]System.Boolean
 		IL_0813: stelem.ref
 		IL_0814: dup
-		IL_0815: ldc.i4.7
+		IL_0815: ldc.i4.8
 		IL_0816: ldc.i4.0
 		IL_0817: box [System.Runtime]System.Boolean
 		IL_081c: stelem.ref
 		IL_081d: dup
-		IL_081e: ldc.i4.8
-		IL_081f: ldc.i4.0
-		IL_0820: box [System.Runtime]System.Boolean
-		IL_0825: stelem.ref
-		IL_0826: dup
-		IL_0827: ldc.i4.s 9
-		IL_0829: ldloc.s 24
-		IL_082b: stelem.ref
-		IL_082c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0831: pop
-		IL_0832: ldc.i4.1
-		IL_0833: newarr [System.Runtime]System.Object
-		IL_0838: dup
-		IL_0839: ldc.i4.0
-		IL_083a: ldloc.0
-		IL_083b: stelem.ref
-		IL_083c: stloc.s 24
-		IL_083e: ldloc.s 26
-		IL_0840: ldloc.s 24
-		IL_0842: ldc.r8 0.0
-		IL_084b: box [System.Runtime]System.Double
-		IL_0850: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0855: stloc.s 23
-		IL_0857: ldloc.s 23
-		IL_0859: stloc.s 15
-		IL_085b: ldstr "console"
-		IL_0860: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_086a: stloc.s 23
-		IL_086c: ldloc.1
-		IL_086d: ldc.i4.2
-		IL_086e: newarr [System.Runtime]System.Object
-		IL_0873: dup
-		IL_0874: ldc.i4.0
-		IL_0875: ldc.r8 6
-		IL_087e: box [System.Runtime]System.Double
-		IL_0883: stelem.ref
-		IL_0884: dup
-		IL_0885: ldc.i4.1
-		IL_0886: ldc.r8 1
-		IL_088f: box [System.Runtime]System.Double
-		IL_0894: stelem.ref
-		IL_0895: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_089a: stloc.s 22
-		IL_089c: ldloc.s 15
-		IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_08a3: stloc.s 18
-		IL_08a5: ldloc.s 22
-		IL_08a7: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
-		IL_08ac: stloc.s 22
-		IL_08ae: ldloc.s 23
-		IL_08b0: ldstr "log"
-		IL_08b5: ldloc.s 22
-		IL_08b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_08bc: pop
-		IL_08bd: ret
+		IL_081e: ldc.i4.s 9
+		IL_0820: ldloc.s 24
+		IL_0822: stelem.ref
+		IL_0823: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0828: pop
+		IL_0829: ldc.i4.1
+		IL_082a: newarr [System.Runtime]System.Object
+		IL_082f: dup
+		IL_0830: ldc.i4.0
+		IL_0831: ldloc.0
+		IL_0832: stelem.ref
+		IL_0833: stloc.s 24
+		IL_0835: ldloc.s 25
+		IL_0837: ldloc.s 24
+		IL_0839: ldc.r8 0.0
+		IL_0842: box [System.Runtime]System.Double
+		IL_0847: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_084c: stloc.s 23
+		IL_084e: ldloc.s 23
+		IL_0850: stloc.s 15
+		IL_0852: ldstr "console"
+		IL_0857: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_085c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0861: stloc.s 23
+		IL_0863: ldloc.1
+		IL_0864: ldc.i4.2
+		IL_0865: newarr [System.Runtime]System.Object
+		IL_086a: dup
+		IL_086b: ldc.i4.0
+		IL_086c: ldc.r8 6
+		IL_0875: box [System.Runtime]System.Double
+		IL_087a: stelem.ref
+		IL_087b: dup
+		IL_087c: ldc.i4.1
+		IL_087d: ldc.r8 1
+		IL_0886: box [System.Runtime]System.Double
+		IL_088b: stelem.ref
+		IL_088c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_0891: stloc.s 22
+		IL_0893: ldloc.s 15
+		IL_0895: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_089a: stloc.s 18
+		IL_089c: ldloc.s 22
+		IL_089e: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
+		IL_08a3: stloc.s 22
+		IL_08a5: ldloc.s 23
+		IL_08a7: ldstr "log"
+		IL_08ac: ldloc.s 22
+		IL_08ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_08b3: pop
+		IL_08b4: ret
 	} // end of method Function_ConstructedInstance_ObjectSemantics::__js_module_init__
 
 } // end of class Modules.Function_ConstructedInstance_ObjectSemantics
@@ -1427,7 +1423,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2afb
+		// Method begins at RVA 0x2aef
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x212a
+				// Method begins at RVA 0x2121
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2116
+			// Method begins at RVA 0x210d
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -68,7 +68,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2121
+			// Method begins at RVA 0x2118
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -94,16 +94,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 186 (0xba)
+		// Code size: 177 (0xb1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0,
 			[2] object,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0,
-			[5] bool,
-			[6] object
+			[4] bool,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/Scope::.ctor()
@@ -139,34 +138,31 @@
 		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0060: stloc.3
 		IL_0061: ldloc.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0>(!!0)
-		IL_0067: stloc.s 4
-		IL_0069: ldloc.s 4
-		IL_006b: ldstr "toString"
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0075: stloc.2
-		IL_0076: ldloc.2
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007c: ldstr "indexOf"
-		IL_0081: ldstr "DynamicFunction_L12C34"
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008b: stloc.2
-		IL_008c: ldloc.2
-		IL_008d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0092: ldc.r8 0.0
-		IL_009b: clt
-		IL_009d: ldc.i4.0
-		IL_009e: ceq
+		IL_0062: ldstr "toString"
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_006c: stloc.2
+		IL_006d: ldloc.2
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0073: ldstr "indexOf"
+		IL_0078: ldstr "DynamicFunction_L12C34"
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0082: stloc.2
+		IL_0083: ldloc.2
+		IL_0084: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0089: ldc.r8 0.0
+		IL_0092: clt
+		IL_0094: ldc.i4.0
+		IL_0095: ceq
+		IL_0097: stloc.s 4
+		IL_0099: ldloc.s 4
+		IL_009b: box [System.Runtime]System.Boolean
 		IL_00a0: stloc.s 5
-		IL_00a2: ldloc.s 5
-		IL_00a4: box [System.Runtime]System.Boolean
-		IL_00a9: stloc.s 6
-		IL_00ab: ldloc.3
-		IL_00ac: ldstr "log"
-		IL_00b1: ldloc.s 6
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b8: pop
-		IL_00b9: ret
+		IL_00a2: ldloc.3
+		IL_00a3: ldstr "log"
+		IL_00a8: ldloc.s 5
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00af: pop
+		IL_00b0: ret
 	} // end of method Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous::__js_module_init__
 
 } // end of class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous
@@ -178,7 +174,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2133
+		// Method begins at RVA 0x212a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralMethod_ThisBinding.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralMethod_ThisBinding.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2117
+				// Method begins at RVA 0x210f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e8
+			// Method begins at RVA 0x20e0
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -72,7 +72,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x210e
+			// Method begins at RVA 0x2106
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -98,15 +98,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 140 (0x8c)
+		// Code size: 131 (0x83)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ObjectLiteralMethod_ThisBinding/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[5] object
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_ObjectLiteralMethod_ThisBinding/Scope::.ctor()
@@ -138,20 +137,17 @@
 		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0058: stloc.3
 		IL_0059: ldloc.1
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
-		IL_005f: stloc.s 4
-		IL_0061: ldloc.s 4
-		IL_0063: ldstr "format"
-		IL_0068: ldc.r8 42
-		IL_0071: box [System.Runtime]System.Double
-		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007b: stloc.s 5
-		IL_007d: ldloc.3
-		IL_007e: ldstr "log"
-		IL_0083: ldloc.s 5
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008a: pop
-		IL_008b: ret
+		IL_005a: ldstr "format"
+		IL_005f: ldc.r8 42
+		IL_0068: box [System.Runtime]System.Double
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0072: stloc.s 4
+		IL_0074: ldloc.3
+		IL_0075: ldstr "log"
+		IL_007a: ldloc.s 4
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0081: pop
+		IL_0082: ret
 	} // end of method Function_ObjectLiteralMethod_ThisBinding::__js_module_init__
 
 } // end of class Modules.Function_ObjectLiteralMethod_ThisBinding
@@ -163,7 +159,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2120
+		// Method begins at RVA 0x2118
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b29
+				// Method begins at RVA 0x2b1d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b32
+				// Method begins at RVA 0x2b26
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +140,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b3b
+				// Method begins at RVA 0x2b2f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -202,7 +202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b44
+				// Method begins at RVA 0x2b38
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -271,7 +271,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b4d
+				// Method begins at RVA 0x2b41
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -345,7 +345,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b56
+				// Method begins at RVA 0x2b4a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -408,7 +408,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b5f
+				// Method begins at RVA 0x2b53
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -551,7 +551,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b68
+				// Method begins at RVA 0x2b5c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -680,7 +680,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b71
+				// Method begins at RVA 0x2b65
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -708,13 +708,11 @@
 			)
 			// Method begins at RVA 0x2900
 			// Header size: 12
-			// Code size: 82 (0x52)
-			.maxstack 9
+			// Code size: 69 (0x45)
+			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[3] object[]
+				[1] object
 			)
 
 			IL_0000: ldarg.0
@@ -732,21 +730,12 @@
 			IL_0020: dup
 			IL_0021: ldc.r8 1
 			IL_002a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_002f: stloc.2
-			IL_0030: ldloc.2
-			IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Array>(!!0)
-			IL_0036: stloc.2
-			IL_0037: ldstr "iterator"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-			IL_0041: stloc.0
-			IL_0042: ldc.i4.0
-			IL_0043: newarr [System.Runtime]System.Object
-			IL_0048: stloc.3
-			IL_0049: ldloc.2
-			IL_004a: ldloc.0
-			IL_004b: ldloc.3
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-			IL_0051: ret
+			IL_002f: ldstr "iterator"
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+			IL_0039: ldc.i4.0
+			IL_003a: newarr [System.Runtime]System.Object
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+			IL_0044: ret
 		} // end of method FunctionExpression_spread::__js_call__
 
 	} // end of class FunctionExpression_spread
@@ -762,7 +751,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b7a
+				// Method begins at RVA 0x2b6e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -788,7 +777,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2960
+			// Method begins at RVA 0x2954
 			// Header size: 12
 			// Code size: 162 (0xa2)
 			.maxstack 8
@@ -888,7 +877,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b8c
+					// Method begins at RVA 0x2b80
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -908,7 +897,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b95
+					// Method begins at RVA 0x2b89
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -926,7 +915,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b83
+				// Method begins at RVA 0x2b77
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -952,7 +941,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2a10
+			// Method begins at RVA 0x2a04
 			// Header size: 12
 			// Code size: 177 (0xb1)
 			.maxstack 8
@@ -1066,7 +1055,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b9e
+				// Method begins at RVA 0x2b92
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1093,7 +1082,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2ae0
+			// Method begins at RVA 0x2ad4
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -1169,7 +1158,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b20
+			// Method begins at RVA 0x2b14
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1651,7 +1640,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2ba7
+		// Method begins at RVA 0x2b9b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f44
+				// Method begins at RVA 0x4f34
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f4d
+				// Method begins at RVA 0x4f3d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f5f
+					// Method begins at RVA 0x4f4f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f56
+				// Method begins at RVA 0x4f46
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -191,7 +191,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f71
+					// Method begins at RVA 0x4f61
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -209,7 +209,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f68
+				// Method begins at RVA 0x4f58
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -265,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f7a
+				// Method begins at RVA 0x4f6a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -324,7 +324,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f95
+						// Method begins at RVA 0x4f85
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -344,7 +344,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f9e
+						// Method begins at RVA 0x4f8e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -362,7 +362,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f8c
+					// Method begins at RVA 0x4f7c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -380,7 +380,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f83
+				// Method begins at RVA 0x4f73
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -642,7 +642,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fa7
+				// Method begins at RVA 0x4f97
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -720,7 +720,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fb0
+				// Method begins at RVA 0x4fa0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -812,7 +812,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fb9
+				// Method begins at RVA 0x4fa9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -890,7 +890,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fc2
+				// Method begins at RVA 0x4fb2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -982,7 +982,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fcb
+				// Method begins at RVA 0x4fbb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1060,7 +1060,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fd4
+				// Method begins at RVA 0x4fc4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1152,7 +1152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fdd
+				// Method begins at RVA 0x4fcd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1230,7 +1230,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fe6
+				// Method begins at RVA 0x4fd6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1322,7 +1322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fef
+				// Method begins at RVA 0x4fdf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1392,7 +1392,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ff8
+				// Method begins at RVA 0x4fe8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1482,7 +1482,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5001
+				// Method begins at RVA 0x4ff1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1552,7 +1552,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x500a
+				// Method begins at RVA 0x4ffa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1645,7 +1645,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5013
+				// Method begins at RVA 0x5003
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1715,7 +1715,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x501c
+				// Method begins at RVA 0x500c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1808,7 +1808,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5025
+				// Method begins at RVA 0x5015
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1886,7 +1886,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x502e
+				// Method begins at RVA 0x501e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1978,7 +1978,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5037
+				// Method begins at RVA 0x5027
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2048,7 +2048,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5040
+				// Method begins at RVA 0x5030
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2138,7 +2138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5049
+				// Method begins at RVA 0x5039
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2208,7 +2208,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5052
+				// Method begins at RVA 0x5042
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2301,7 +2301,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x505b
+				// Method begins at RVA 0x504b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2371,7 +2371,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5064
+				// Method begins at RVA 0x5054
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2464,7 +2464,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x506d
+				// Method begins at RVA 0x505d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2538,7 +2538,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x507f
+					// Method begins at RVA 0x506f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2562,7 +2562,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4ee5
+				// Method begins at RVA 0x4ed5
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -2580,7 +2580,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5076
+				// Method begins at RVA 0x5066
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2688,7 +2688,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5088
+				// Method begins at RVA 0x5078
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2766,7 +2766,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5091
+				// Method begins at RVA 0x5081
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2858,7 +2858,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x509a
+				// Method begins at RVA 0x508a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2928,7 +2928,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50a3
+				// Method begins at RVA 0x5093
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3018,7 +3018,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50ac
+				// Method begins at RVA 0x509c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3088,7 +3088,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50b5
+				// Method begins at RVA 0x50a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3181,7 +3181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50be
+				// Method begins at RVA 0x50ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3251,7 +3251,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50c7
+				// Method begins at RVA 0x50b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3344,7 +3344,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50d0
+				// Method begins at RVA 0x50c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3422,7 +3422,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50d9
+				// Method begins at RVA 0x50c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3514,7 +3514,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50e2
+				// Method begins at RVA 0x50d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3584,7 +3584,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50eb
+				// Method begins at RVA 0x50db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3674,7 +3674,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50f4
+				// Method begins at RVA 0x50e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3744,7 +3744,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50fd
+				// Method begins at RVA 0x50ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3837,7 +3837,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5106
+				// Method begins at RVA 0x50f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3907,7 +3907,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x510f
+				// Method begins at RVA 0x50ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4000,7 +4000,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5118
+				// Method begins at RVA 0x5108
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4074,7 +4074,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x512a
+					// Method begins at RVA 0x511a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4098,7 +4098,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4eec
+				// Method begins at RVA 0x4edc
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -4116,7 +4116,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5121
+				// Method begins at RVA 0x5111
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4224,7 +4224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5133
+				// Method begins at RVA 0x5123
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4302,7 +4302,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x513c
+				// Method begins at RVA 0x512c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4394,7 +4394,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5145
+				// Method begins at RVA 0x5135
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4464,7 +4464,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x514e
+				// Method begins at RVA 0x513e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4557,7 +4557,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5157
+				// Method begins at RVA 0x5147
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4627,7 +4627,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5160
+				// Method begins at RVA 0x5150
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4720,7 +4720,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5169
+				// Method begins at RVA 0x5159
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4794,7 +4794,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x517b
+					// Method begins at RVA 0x516b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4819,7 +4819,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4ef4
+				// Method begins at RVA 0x4ee4
 				// Header size: 12
 				// Code size: 26 (0x1a)
 				.maxstack 8
@@ -4848,7 +4848,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5172
+				// Method begins at RVA 0x5162
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4956,7 +4956,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5184
+				// Method begins at RVA 0x5174
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5030,7 +5030,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5196
+					// Method begins at RVA 0x5186
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5055,7 +5055,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4f1c
+				// Method begins at RVA 0x4f0c
 				// Header size: 12
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -5081,7 +5081,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x518d
+				// Method begins at RVA 0x517d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5189,7 +5189,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x519f
+				// Method begins at RVA 0x518f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5259,7 +5259,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51a8
+				// Method begins at RVA 0x5198
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5353,7 +5353,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51b1
+				// Method begins at RVA 0x51a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5423,7 +5423,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51ba
+				// Method begins at RVA 0x51aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5451,7 +5451,7 @@
 			)
 			// Method begins at RVA 0x49d0
 			// Header size: 12
-			// Code size: 111 (0x6f)
+			// Code size: 104 (0x68)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -5469,38 +5469,35 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_006d
+				IL_0018: brfalse IL_0066
 
 				IL_001d: ldstr "aaaaaaaaaa"
 				IL_0022: ldstr "g"
 				IL_0027: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 				IL_002c: stloc.2
-				IL_002d: ldloc.2
-				IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-				IL_0033: stloc.2
-				IL_0034: ldarg.0
-				IL_0035: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_003a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_003f: ldloc.0
-				IL_0040: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0045: castclass [System.Runtime]System.String
-				IL_004a: stloc.3
-				IL_004b: ldloc.2
-				IL_004c: ldloc.3
-				IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-				IL_0052: stloc.s 4
-				IL_0054: ldarg.0
-				IL_0055: ldloc.s 4
-				IL_0057: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005c: ldloc.0
-				IL_005d: ldc.r8 1
-				IL_0066: add
-				IL_0067: stloc.0
-				IL_0068: br IL_000a
+				IL_002d: ldarg.0
+				IL_002e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0038: ldloc.0
+				IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_003e: castclass [System.Runtime]System.String
+				IL_0043: stloc.3
+				IL_0044: ldloc.2
+				IL_0045: ldloc.3
+				IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_004b: stloc.s 4
+				IL_004d: ldarg.0
+				IL_004e: ldloc.s 4
+				IL_0050: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0055: ldloc.0
+				IL_0056: ldc.r8 1
+				IL_005f: add
+				IL_0060: stloc.0
+				IL_0061: br IL_000a
 			// end loop
 
-			IL_006d: ldnull
-			IL_006e: ret
+			IL_0066: ldnull
+			IL_0067: ret
 		} // end of method FunctionExpression_L322C24::__js_call__
 
 	} // end of class FunctionExpression_L322C24
@@ -5516,7 +5513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51c3
+				// Method begins at RVA 0x51b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5542,7 +5539,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4a4c
+			// Method begins at RVA 0x4a44
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -5586,7 +5583,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51cc
+				// Method begins at RVA 0x51bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5612,7 +5609,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4a8c
+			// Method begins at RVA 0x4a84
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -5681,7 +5678,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51d5
+				// Method begins at RVA 0x51c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5707,7 +5704,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4b14
+			// Method begins at RVA 0x4b0c
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -5751,7 +5748,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51de
+				// Method begins at RVA 0x51ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5777,7 +5774,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4b54
+			// Method begins at RVA 0x4b4c
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -5846,7 +5843,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51e7
+				// Method begins at RVA 0x51d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5872,7 +5869,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4bdc
+			// Method begins at RVA 0x4bd4
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -5916,7 +5913,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51f0
+				// Method begins at RVA 0x51e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5942,7 +5939,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4c1c
+			// Method begins at RVA 0x4c14
 			// Header size: 12
 			// Code size: 116 (0x74)
 			.maxstack 8
@@ -6010,7 +6007,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51f9
+				// Method begins at RVA 0x51e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6036,7 +6033,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4c9c
+			// Method begins at RVA 0x4c94
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -6080,7 +6077,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5202
+				// Method begins at RVA 0x51f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6106,9 +6103,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4cdc
+			// Method begins at RVA 0x4cd4
 			// Header size: 12
-			// Code size: 111 (0x6f)
+			// Code size: 104 (0x68)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -6126,38 +6123,35 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_006d
+				IL_0018: brfalse IL_0066
 
 				IL_001d: ldstr "aaaaaaaaaa"
 				IL_0022: ldstr "g"
 				IL_0027: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 				IL_002c: stloc.2
-				IL_002d: ldloc.2
-				IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-				IL_0033: stloc.2
-				IL_0034: ldarg.0
-				IL_0035: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_003a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_003f: ldloc.0
-				IL_0040: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0045: castclass [System.Runtime]System.String
-				IL_004a: stloc.3
-				IL_004b: ldloc.2
-				IL_004c: ldloc.3
-				IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-				IL_0052: stloc.s 4
-				IL_0054: ldarg.0
-				IL_0055: ldloc.s 4
-				IL_0057: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005c: ldloc.0
-				IL_005d: ldc.r8 1
-				IL_0066: add
-				IL_0067: stloc.0
-				IL_0068: br IL_000a
+				IL_002d: ldarg.0
+				IL_002e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0038: ldloc.0
+				IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_003e: castclass [System.Runtime]System.String
+				IL_0043: stloc.3
+				IL_0044: ldloc.2
+				IL_0045: ldloc.3
+				IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_004b: stloc.s 4
+				IL_004d: ldarg.0
+				IL_004e: ldloc.s 4
+				IL_0050: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0055: ldloc.0
+				IL_0056: ldc.r8 1
+				IL_005f: add
+				IL_0060: stloc.0
+				IL_0061: br IL_000a
 			// end loop
 
-			IL_006d: ldnull
-			IL_006e: ret
+			IL_0066: ldnull
+			IL_0067: ret
 		} // end of method FunctionExpression_L358C31::__js_call__
 
 	} // end of class FunctionExpression_L358C31
@@ -6173,7 +6167,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x520b
+				// Method begins at RVA 0x51fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6199,7 +6193,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4d58
+			// Method begins at RVA 0x4d48
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -6243,7 +6237,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5214
+				// Method begins at RVA 0x5204
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6269,7 +6263,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4d98
+			// Method begins at RVA 0x4d88
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -6338,7 +6332,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x521d
+				// Method begins at RVA 0x520d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6364,7 +6358,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4e20
+			// Method begins at RVA 0x4e10
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -6408,7 +6402,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5226
+				// Method begins at RVA 0x5216
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6434,7 +6428,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4e60
+			// Method begins at RVA 0x4e50
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -6522,7 +6516,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4f3b
+			// Method begins at RVA 0x4f2b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -8091,7 +8085,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x522f
+		// Method begins at RVA 0x521f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37e2
+				// Method begins at RVA 0x37c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37eb
+				// Method begins at RVA 0x37cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +140,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37f4
+				// Method begins at RVA 0x37d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -247,7 +247,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3806
+					// Method begins at RVA 0x37e6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -271,7 +271,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36a4
+				// Method begins at RVA 0x3684
 				// Header size: 12
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -308,7 +308,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x380f
+					// Method begins at RVA 0x37ef
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -332,7 +332,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36cc
+				// Method begins at RVA 0x36ac
 				// Header size: 1
 				// Code size: 12 (0xc)
 				.maxstack 8
@@ -356,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3818
+					// Method begins at RVA 0x37f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -374,7 +374,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37fd
+				// Method begins at RVA 0x37dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -771,7 +771,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3821
+				// Method begins at RVA 0x3801
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -801,7 +801,7 @@
 			)
 			// Method begins at RVA 0x28c4
 			// Header size: 12
-			// Code size: 200 (0xc8)
+			// Code size: 186 (0xba)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Error,
@@ -840,68 +840,62 @@
 			IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_003f: stloc.3
 			IL_0040: ldloc.3
-			IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_0046: stloc.3
-			IL_0047: ldloc.3
-			IL_0048: ldarg.2
-			IL_0049: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_004e: stloc.s 4
-			IL_0050: ldloc.s 4
-			IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0057: stloc.2
-			IL_0058: ldloc.2
-			IL_0059: brfalse IL_0075
+			IL_0041: ldarg.2
+			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0047: stloc.s 4
+			IL_0049: ldloc.s 4
+			IL_004b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0050: stloc.2
+			IL_0051: ldloc.2
+			IL_0052: brfalse IL_006e
 
-			IL_005e: ldc.i4.1
-			IL_005f: newarr [System.Runtime]System.Object
-			IL_0064: dup
-			IL_0065: ldc.i4.0
-			IL_0066: ldarg.0
-			IL_0067: stelem.ref
-			IL_0068: stloc.s 5
-			IL_006a: ldnull
-			IL_006b: ldarg.3
-			IL_006c: ldarg.2
-			IL_006d: tail.
-			IL_006f: call object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
-			IL_0074: ret
+			IL_0057: ldc.i4.1
+			IL_0058: newarr [System.Runtime]System.Object
+			IL_005d: dup
+			IL_005e: ldc.i4.0
+			IL_005f: ldarg.0
+			IL_0060: stelem.ref
+			IL_0061: stloc.s 5
+			IL_0063: ldnull
+			IL_0064: ldarg.3
+			IL_0065: ldarg.2
+			IL_0066: tail.
+			IL_0068: call object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
+			IL_006d: ret
 
-			IL_0075: ldstr "^\\d+\\.\\d+\\.\\d+$"
-			IL_007a: ldstr ""
-			IL_007f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0084: stloc.3
-			IL_0085: ldloc.3
-			IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_008b: stloc.3
-			IL_008c: ldloc.3
-			IL_008d: ldarg.2
-			IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0093: stloc.s 4
-			IL_0095: ldloc.s 4
-			IL_0097: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_009c: ldc.i4.0
-			IL_009d: ceq
-			IL_009f: stloc.2
-			IL_00a0: ldloc.2
-			IL_00a1: brfalse IL_00c6
+			IL_006e: ldstr "^\\d+\\.\\d+\\.\\d+$"
+			IL_0073: ldstr ""
+			IL_0078: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_007d: stloc.3
+			IL_007e: ldloc.3
+			IL_007f: ldarg.2
+			IL_0080: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0085: stloc.s 4
+			IL_0087: ldloc.s 4
+			IL_0089: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_008e: ldc.i4.0
+			IL_008f: ceq
+			IL_0091: stloc.2
+			IL_0092: ldloc.2
+			IL_0093: brfalse IL_00b8
 
-			IL_00a6: ldstr "Explicit version must be major.minor.patch"
-			IL_00ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00b0: stloc.1
-			IL_00b1: ldloc.1
-			IL_00b2: isinst [System.Runtime]System.Exception
-			IL_00b7: dup
-			IL_00b8: brtrue IL_00c5
+			IL_0098: ldstr "Explicit version must be major.minor.patch"
+			IL_009d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00a2: stloc.1
+			IL_00a3: ldloc.1
+			IL_00a4: isinst [System.Runtime]System.Exception
+			IL_00a9: dup
+			IL_00aa: brtrue IL_00b7
 
-			IL_00bd: pop
-			IL_00be: ldloc.1
-			IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00c4: throw
+			IL_00af: pop
+			IL_00b0: ldloc.1
+			IL_00b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00b6: throw
 
-			IL_00c5: throw
+			IL_00b7: throw
 
-			IL_00c6: ldarg.2
-			IL_00c7: ret
+			IL_00b8: ldarg.2
+			IL_00b9: ret
 		} // end of method resolveTargetVersion::__js_call__
 
 	} // end of class resolveTargetVersion
@@ -921,7 +915,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3833
+					// Method begins at RVA 0x3813
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -939,7 +933,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x382a
+				// Method begins at RVA 0x380a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -964,7 +958,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2998
+			// Method begins at RVA 0x298c
 			// Header size: 12
 			// Code size: 171 (0xab)
 			.maxstack 8
@@ -1055,7 +1049,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3845
+					// Method begins at RVA 0x3825
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1073,7 +1067,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x383c
+				// Method begins at RVA 0x381c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1098,17 +1092,16 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a50
+			// Method begins at RVA 0x2a44
 			// Header size: 12
-			// Code size: 137 (0x89)
+			// Code size: 128 (0x80)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Error,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[3] object,
-				[4] bool,
-				[5] string
+				[2] object,
+				[3] bool,
+				[4] string
 			)
 
 			IL_0000: ldstr "<JrocPackageVersion\\b([^>]*)>[^<]+<\\/JrocPackageVersion>"
@@ -1116,55 +1109,52 @@
 			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_000f: stloc.0
 			IL_0010: ldloc.0
-			IL_0011: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_0016: stloc.2
-			IL_0017: ldloc.2
-			IL_0018: ldarg.1
-			IL_0019: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_001e: stloc.3
-			IL_001f: ldloc.3
-			IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0025: ldc.i4.0
-			IL_0026: ceq
-			IL_0028: stloc.s 4
-			IL_002a: ldloc.s 4
-			IL_002c: brfalse IL_0051
+			IL_0011: ldarg.1
+			IL_0012: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0017: stloc.2
+			IL_0018: ldloc.2
+			IL_0019: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_001e: ldc.i4.0
+			IL_001f: ceq
+			IL_0021: stloc.3
+			IL_0022: ldloc.3
+			IL_0023: brfalse IL_0048
 
-			IL_0031: ldstr "Could not find <JrocPackageVersion> in samples/Directory.Build.props"
-			IL_0036: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_003b: stloc.1
-			IL_003c: ldloc.1
-			IL_003d: isinst [System.Runtime]System.Exception
-			IL_0042: dup
-			IL_0043: brtrue IL_0050
+			IL_0028: ldstr "Could not find <JrocPackageVersion> in samples/Directory.Build.props"
+			IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0032: stloc.1
+			IL_0033: ldloc.1
+			IL_0034: isinst [System.Runtime]System.Exception
+			IL_0039: dup
+			IL_003a: brtrue IL_0047
 
-			IL_0048: pop
-			IL_0049: ldloc.1
-			IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_004f: throw
+			IL_003f: pop
+			IL_0040: ldloc.1
+			IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0046: throw
 
-			IL_0050: throw
+			IL_0047: throw
 
-			IL_0051: ldarg.1
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0057: stloc.3
-			IL_0058: ldarg.2
-			IL_0059: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_005e: stloc.s 5
-			IL_0060: ldstr "<JrocPackageVersion$1>"
-			IL_0065: ldloc.s 5
-			IL_0067: call string [System.Runtime]System.String::Concat(string, string)
-			IL_006c: ldstr "</JrocPackageVersion>"
-			IL_0071: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0076: stloc.s 5
-			IL_0078: ldloc.3
-			IL_0079: ldstr "replace"
-			IL_007e: ldloc.0
-			IL_007f: ldloc.s 5
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0086: stloc.3
-			IL_0087: ldloc.3
-			IL_0088: ret
+			IL_0048: ldarg.1
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_004e: stloc.2
+			IL_004f: ldarg.2
+			IL_0050: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0055: stloc.s 4
+			IL_0057: ldstr "<JrocPackageVersion$1>"
+			IL_005c: ldloc.s 4
+			IL_005e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0063: ldstr "</JrocPackageVersion>"
+			IL_0068: call string [System.Runtime]System.String::Concat(string, string)
+			IL_006d: stloc.s 4
+			IL_006f: ldloc.2
+			IL_0070: ldstr "replace"
+			IL_0075: ldloc.0
+			IL_0076: ldloc.s 4
+			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_007d: stloc.2
+			IL_007e: ldloc.2
+			IL_007f: ret
 		} // end of method updateSamplesPropsVersion::__js_call__
 
 	} // end of class updateSamplesPropsVersion
@@ -1184,7 +1174,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3857
+					// Method begins at RVA 0x3837
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1202,7 +1192,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x384e
+				// Method begins at RVA 0x382e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1229,7 +1219,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2ae8
+			// Method begins at RVA 0x2ad0
 			// Header size: 12
 			// Code size: 529 (0x211)
 			.maxstack 8
@@ -1438,7 +1428,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3860
+				// Method begins at RVA 0x3840
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1462,9 +1452,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d08
+			// Method begins at RVA 0x2cf0
 			// Header size: 12
-			// Code size: 50 (0x32)
+			// Code size: 43 (0x2b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -1475,20 +1465,17 @@
 			IL_0005: ldstr "i"
 			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_000f: stloc.0
-			IL_0010: ldloc.0
-			IL_0011: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_0016: stloc.0
-			IL_0017: ldarg.1
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001d: ldstr "trim"
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0027: stloc.1
-			IL_0028: ldloc.0
+			IL_0010: ldarg.1
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0016: ldstr "trim"
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0020: stloc.1
+			IL_0021: ldloc.0
+			IL_0022: ldloc.1
+			IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0028: stloc.1
 			IL_0029: ldloc.1
-			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_002f: stloc.1
-			IL_0030: ldloc.1
-			IL_0031: ret
+			IL_002a: ret
 		} // end of method isPlaceholder::__js_call__
 
 	} // end of class isPlaceholder
@@ -1514,7 +1501,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3872
+					// Method begins at RVA 0x3852
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1539,7 +1526,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36dc
+				// Method begins at RVA 0x36bc
 				// Header size: 12
 				// Code size: 126 (0x7e)
 				.maxstack 8
@@ -1619,7 +1606,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3869
+				// Method begins at RVA 0x3849
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1647,7 +1634,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2d48
+			// Method begins at RVA 0x2d28
 			// Header size: 12
 			// Code size: 338 (0x152)
 			.maxstack 8
@@ -1794,7 +1781,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x388d
+					// Method begins at RVA 0x386d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1819,7 +1806,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3768
+				// Method begins at RVA 0x3748
 				// Header size: 12
 				// Code size: 101 (0x65)
 				.maxstack 8
@@ -1895,7 +1882,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3884
+					// Method begins at RVA 0x3864
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1915,7 +1902,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3896
+					// Method begins at RVA 0x3876
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1933,7 +1920,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x387b
+				// Method begins at RVA 0x385b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1959,7 +1946,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2ea8
+			// Method begins at RVA 0x2e88
 			// Header size: 12
 			// Code size: 2030 (0x7ee)
 			.maxstack 8
@@ -2796,7 +2783,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x389f
+				// Method begins at RVA 0x387f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2816,7 +2803,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38a8
+				// Method begins at RVA 0x3888
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2854,7 +2841,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x37d9
+			// Method begins at RVA 0x37b9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3298,7 +3285,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x38b1
+		// Method begins at RVA 0x3891
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3161
+				// Method begins at RVA 0x314d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x317c
+						// Method begins at RVA 0x3168
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3185
+						// Method begins at RVA 0x3171
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x318e
+						// Method begins at RVA 0x317a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3197
+						// Method begins at RVA 0x3183
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -124,7 +124,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3173
+					// Method begins at RVA 0x315f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -142,7 +142,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x316a
+				// Method begins at RVA 0x3156
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -445,7 +445,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31a9
+					// Method begins at RVA 0x3195
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -472,7 +472,7 @@
 				)
 				// Method begins at RVA 0x2bb4
 				// Header size: 12
-				// Code size: 409 (0x199)
+				// Code size: 400 (0x190)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -566,64 +566,61 @@
 				IL_00d2: stelem.ref
 				IL_00d3: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::min(object[])
 				IL_00d8: stloc.s 4
-				IL_00da: ldstr "#"
-				IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-				IL_00e4: stloc.s 11
-				IL_00e6: ldloc.s 4
-				IL_00e8: box [System.Runtime]System.Double
-				IL_00ed: stloc.s 12
-				IL_00ef: ldloc.s 11
-				IL_00f1: ldstr "repeat"
-				IL_00f6: ldloc.s 12
-				IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00fd: stloc.s 5
-				IL_00ff: ldarg.1
-				IL_0100: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0105: stloc.s 8
-				IL_0107: ldloc.s 8
-				IL_0109: brtrue IL_011a
+				IL_00da: ldloc.s 4
+				IL_00dc: box [System.Runtime]System.Double
+				IL_00e1: stloc.s 12
+				IL_00e3: ldstr "#"
+				IL_00e8: ldstr "repeat"
+				IL_00ed: ldloc.s 12
+				IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00f4: stloc.s 5
+				IL_00f6: ldarg.1
+				IL_00f7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00fc: stloc.s 8
+				IL_00fe: ldloc.s 8
+				IL_0100: brtrue IL_0111
 
-				IL_010e: ldstr ""
-				IL_0113: stloc.s 13
-				IL_0115: br IL_011d
+				IL_0105: ldstr ""
+				IL_010a: stloc.s 13
+				IL_010c: br IL_0114
 
-				IL_011a: ldarg.1
-				IL_011b: stloc.s 13
+				IL_0111: ldarg.1
+				IL_0112: stloc.s 13
 
-				IL_011d: ldloc.s 13
-				IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0124: stloc.s 7
-				IL_0126: ldstr "\\s+"
-				IL_012b: ldstr "g"
-				IL_0130: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0135: stloc.s 14
-				IL_0137: ldloc.s 7
-				IL_0139: ldstr "replace"
-				IL_013e: ldloc.s 14
-				IL_0140: ldstr " "
-				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_014a: stloc.s 7
-				IL_014c: ldloc.s 7
-				IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0153: ldstr "trim"
-				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_015d: stloc.s 6
-				IL_015f: ldloc.s 5
-				IL_0161: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0166: stloc.s 11
-				IL_0168: ldstr "\n\n"
-				IL_016d: ldloc.s 11
-				IL_016f: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0174: ldstr " "
-				IL_0179: call string [System.Runtime]System.String::Concat(string, string)
-				IL_017e: ldloc.s 6
-				IL_0180: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0185: stloc.s 11
-				IL_0187: ldloc.s 11
-				IL_0189: call string [System.Runtime]System.String::Concat(string, string)
-				IL_018e: ldstr "\n\n"
-				IL_0193: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0198: ret
+				IL_0114: ldloc.s 13
+				IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_011b: stloc.s 7
+				IL_011d: ldstr "\\s+"
+				IL_0122: ldstr "g"
+				IL_0127: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_012c: stloc.s 14
+				IL_012e: ldloc.s 7
+				IL_0130: ldstr "replace"
+				IL_0135: ldloc.s 14
+				IL_0137: ldstr " "
+				IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0141: stloc.s 7
+				IL_0143: ldloc.s 7
+				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_014a: ldstr "trim"
+				IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0154: stloc.s 6
+				IL_0156: ldloc.s 5
+				IL_0158: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_015d: stloc.s 11
+				IL_015f: ldstr "\n\n"
+				IL_0164: ldloc.s 11
+				IL_0166: call string [System.Runtime]System.String::Concat(string, string)
+				IL_016b: ldstr " "
+				IL_0170: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0175: ldloc.s 6
+				IL_0177: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_017c: stloc.s 11
+				IL_017e: ldloc.s 11
+				IL_0180: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0185: ldstr "\n\n"
+				IL_018a: call string [System.Runtime]System.String::Concat(string, string)
+				IL_018f: ret
 			} // end of method FunctionExpression_L61C15::__js_call__
 
 		} // end of class FunctionExpression_L61C15
@@ -639,7 +636,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31b2
+					// Method begins at RVA 0x319e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -663,7 +660,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d5c
+				// Method begins at RVA 0x2d50
 				// Header size: 12
 				// Code size: 140 (0x8c)
 				.maxstack 8
@@ -741,7 +738,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31bb
+					// Method begins at RVA 0x31a7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -765,7 +762,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2df4
+				// Method begins at RVA 0x2de8
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -811,7 +808,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31cd
+						// Method begins at RVA 0x31b9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -835,9 +832,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3014
+					// Method begins at RVA 0x3008
 					// Header size: 12
-					// Code size: 225 (0xe1)
+					// Code size: 216 (0xd8)
 					.maxstack 8
 					.locals init (
 						[0] object,
@@ -894,57 +891,54 @@
 					IL_005c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_0061: stloc.3
 					IL_0062: ldloc.3
-					IL_0063: brfalse IL_009a
+					IL_0063: brfalse IL_0091
 
 					IL_0068: ldstr "(?:^|\\s)language-([^\\s]+)"
 					IL_006d: ldstr "i"
 					IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 					IL_0077: stloc.s 7
 					IL_0079: ldloc.s 7
-					IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-					IL_0080: stloc.s 7
-					IL_0082: ldloc.s 7
-					IL_0084: ldstr "exec"
-					IL_0089: ldloc.1
-					IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_008f: stloc.s 4
-					IL_0091: ldloc.s 4
-					IL_0093: stloc.s 8
-					IL_0095: br IL_009d
+					IL_007b: ldstr "exec"
+					IL_0080: ldloc.1
+					IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_0086: stloc.s 4
+					IL_0088: ldloc.s 4
+					IL_008a: stloc.s 8
+					IL_008c: br IL_0094
 
-					IL_009a: ldloc.1
-					IL_009b: stloc.s 8
+					IL_0091: ldloc.1
+					IL_0092: stloc.s 8
 
-					IL_009d: ldloc.s 8
-					IL_009f: stloc.2
-					IL_00a0: ldloc.2
-					IL_00a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00a6: stloc.3
-					IL_00a7: ldloc.3
-					IL_00a8: brfalse IL_00c7
+					IL_0094: ldloc.s 8
+					IL_0096: stloc.2
+					IL_0097: ldloc.2
+					IL_0098: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_009d: stloc.3
+					IL_009e: ldloc.3
+					IL_009f: brfalse IL_00be
 
-					IL_00ad: ldloc.2
-					IL_00ae: ldc.r8 1
-					IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-					IL_00bc: stloc.s 4
-					IL_00be: ldloc.s 4
-					IL_00c0: stloc.s 9
-					IL_00c2: br IL_00ca
+					IL_00a4: ldloc.2
+					IL_00a5: ldc.r8 1
+					IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_00b3: stloc.s 4
+					IL_00b5: ldloc.s 4
+					IL_00b7: stloc.s 9
+					IL_00b9: br IL_00c1
 
-					IL_00c7: ldloc.2
-					IL_00c8: stloc.s 9
+					IL_00be: ldloc.2
+					IL_00bf: stloc.s 9
 
-					IL_00ca: ldloc.s 9
-					IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00d1: stloc.3
-					IL_00d2: ldloc.3
-					IL_00d3: brtrue IL_00de
+					IL_00c1: ldloc.s 9
+					IL_00c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00c8: stloc.3
+					IL_00c9: ldloc.3
+					IL_00ca: brtrue IL_00d5
 
-					IL_00d8: ldstr ""
-					IL_00dd: ret
+					IL_00cf: ldstr ""
+					IL_00d4: ret
 
-					IL_00de: ldloc.s 9
-					IL_00e0: ret
+					IL_00d5: ldloc.s 9
+					IL_00d7: ret
 				} // end of method ArrowFunction_L90C29::__js_call__
 
 			} // end of class ArrowFunction_L90C29
@@ -960,7 +954,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31d6
+						// Method begins at RVA 0x31c2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -978,7 +972,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31c4
+					// Method begins at RVA 0x31b0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1004,7 +998,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e20
+				// Method begins at RVA 0x2e14
 				// Header size: 12
 				// Code size: 488 (0x1e8)
 				.maxstack 8
@@ -1207,7 +1201,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31a0
+				// Method begins at RVA 0x318c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1472,7 +1466,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31df
+				// Method begins at RVA 0x31cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1895,7 +1889,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31f1
+					// Method begins at RVA 0x31dd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1915,7 +1909,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31fa
+					// Method begins at RVA 0x31e6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1933,7 +1927,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e8
+				// Method begins at RVA 0x31d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1959,7 +1953,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3158
+			// Method begins at RVA 0x3144
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2193,7 +2187,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x320c
+				// Method begins at RVA 0x31f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2216,7 +2210,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3101
+			// Method begins at RVA 0x30ec
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2245,7 +2239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3215
+				// Method begins at RVA 0x3201
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2270,7 +2264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3104
+			// Method begins at RVA 0x30f0
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -2307,7 +2301,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x321e
+				// Method begins at RVA 0x320a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2331,7 +2325,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x311c
+			// Method begins at RVA 0x3108
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -2385,7 +2379,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3203
+			// Method begins at RVA 0x31ef
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2496,7 +2490,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3227
+		// Method begins at RVA 0x3213
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x453b
+				// Method begins at RVA 0x452b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4544
+				// Method begins at RVA 0x4534
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -355,7 +355,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4532
+			// Method begins at RVA 0x4522
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -470,7 +470,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x455f
+					// Method begins at RVA 0x454f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -488,7 +488,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4556
+				// Method begins at RVA 0x4546
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -633,7 +633,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4568
+				// Method begins at RVA 0x4558
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -661,7 +661,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4583
+						// Method begins at RVA 0x4573
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -681,7 +681,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x458c
+						// Method begins at RVA 0x457c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -701,7 +701,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4595
+						// Method begins at RVA 0x4585
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -721,7 +721,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x459e
+						// Method begins at RVA 0x458e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -741,7 +741,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45a7
+						// Method begins at RVA 0x4597
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -761,7 +761,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45b0
+						// Method begins at RVA 0x45a0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -779,7 +779,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x457a
+					// Method begins at RVA 0x456a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -797,7 +797,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4571
+				// Method begins at RVA 0x4561
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1156,7 +1156,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x460a
+							// Method begins at RVA 0x45fa
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1181,7 +1181,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44ac
+						// Method begins at RVA 0x449c
 						// Header size: 12
 						// Code size: 38 (0x26)
 						.maxstack 8
@@ -1223,7 +1223,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4613
+							// Method begins at RVA 0x4603
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1247,7 +1247,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44e0
+						// Method begins at RVA 0x44d0
 						// Header size: 12
 						// Code size: 70 (0x46)
 						.maxstack 8
@@ -1326,7 +1326,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x45f8
+								// Method begins at RVA 0x45e8
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1344,7 +1344,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x45ef
+							// Method begins at RVA 0x45df
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1364,7 +1364,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4601
+							// Method begins at RVA 0x45f1
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1386,7 +1386,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45e6
+						// Method begins at RVA 0x45d6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1411,7 +1411,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x4050
+					// Method begins at RVA 0x4040
 					// Header size: 12
 					// Code size: 1101 (0x44d)
 					.maxstack 8
@@ -1913,7 +1913,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45d4
+						// Method begins at RVA 0x45c4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1933,7 +1933,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45dd
+						// Method begins at RVA 0x45cd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1956,7 +1956,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45cb
+					// Method begins at RVA 0x45bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1982,7 +1982,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e34
+				// Method begins at RVA 0x3e24
 				// Header size: 12
 				// Code size: 511 (0x1ff)
 				.maxstack 8
@@ -2233,7 +2233,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45c2
+					// Method begins at RVA 0x45b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2255,7 +2255,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45b9
+				// Method begins at RVA 0x45a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2352,7 +2352,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x461c
+				// Method begins at RVA 0x460c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2419,7 +2419,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x462e
+					// Method begins at RVA 0x461e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2443,7 +2443,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4640
+						// Method begins at RVA 0x4630
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2461,7 +2461,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4637
+					// Method begins at RVA 0x4627
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2479,7 +2479,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4625
+				// Method begins at RVA 0x4615
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2744,7 +2744,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4652
+					// Method begins at RVA 0x4642
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2764,7 +2764,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x465b
+					// Method begins at RVA 0x464b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2784,7 +2784,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4664
+					// Method begins at RVA 0x4654
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2804,7 +2804,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x466d
+					// Method begins at RVA 0x465d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2828,7 +2828,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x467f
+						// Method begins at RVA 0x466f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2848,7 +2848,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4688
+						// Method begins at RVA 0x4678
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2872,7 +2872,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x469a
+							// Method begins at RVA 0x468a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2890,7 +2890,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4691
+						// Method begins at RVA 0x4681
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2910,7 +2910,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46a3
+						// Method begins at RVA 0x4693
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2928,7 +2928,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4676
+					// Method begins at RVA 0x4666
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2946,7 +2946,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4649
+				// Method begins at RVA 0x4639
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2976,7 +2976,7 @@
 			)
 			// Method begins at RVA 0x2c2c
 			// Header size: 12
-			// Code size: 944 (0x3b0)
+			// Code size: 935 (0x3a7)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -2998,10 +2998,9 @@
 				[16] object[],
 				[17] bool,
 				[18] float64,
-				[19] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[19] object,
 				[20] object,
-				[21] object,
-				[22] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.3
@@ -3200,137 +3199,134 @@
 			IL_022d: stloc.s 10
 			// loop start (head: IL_022f)
 				IL_022f: ldc.i4.1
-				IL_0230: brfalse IL_0354
+				IL_0230: brfalse IL_034b
 
 				IL_0235: ldloc.s 8
-				IL_0237: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-				IL_023c: stloc.s 19
-				IL_023e: ldloc.s 19
-				IL_0240: ldstr "exec"
-				IL_0245: ldarg.2
-				IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_024b: stloc.s 11
-				IL_024d: ldloc.s 11
-				IL_024f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0254: ldc.i4.0
-				IL_0255: ceq
-				IL_0257: stloc.s 17
-				IL_0259: ldloc.s 17
-				IL_025b: brfalse IL_0265
+				IL_0237: ldstr "exec"
+				IL_023c: ldarg.2
+				IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0242: stloc.s 11
+				IL_0244: ldloc.s 11
+				IL_0246: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_024b: ldc.i4.0
+				IL_024c: ceq
+				IL_024e: stloc.s 17
+				IL_0250: ldloc.s 17
+				IL_0252: brfalse IL_025c
 
-				IL_0260: br IL_0354
+				IL_0257: br IL_034b
 
-				IL_0265: ldloc.s 11
-				IL_0267: ldc.r8 0.0
-				IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0275: stloc.s 12
-				IL_0277: ldloc.s 10
-				IL_0279: stloc.s 20
-				IL_027b: ldloc.s 20
-				IL_027d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0282: ldc.r8 0.0
-				IL_028b: clt
-				IL_028d: brfalse IL_02a4
+				IL_025c: ldloc.s 11
+				IL_025e: ldc.r8 0.0
+				IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_026c: stloc.s 12
+				IL_026e: ldloc.s 10
+				IL_0270: stloc.s 19
+				IL_0272: ldloc.s 19
+				IL_0274: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0279: ldc.r8 0.0
+				IL_0282: clt
+				IL_0284: brfalse IL_029b
 
-				IL_0292: ldloc.s 11
-				IL_0294: ldstr "index"
-				IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_029e: stloc.s 15
-				IL_02a0: ldloc.s 15
-				IL_02a2: stloc.s 10
+				IL_0289: ldloc.s 11
+				IL_028b: ldstr "index"
+				IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0295: stloc.s 15
+				IL_0297: ldloc.s 15
+				IL_0299: stloc.s 10
 
-				IL_02a4: ldloc.s 12
-				IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02ab: ldstr "startsWith"
-				IL_02b0: ldstr "</"
-				IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02ba: stloc.s 15
-				IL_02bc: ldloc.s 15
-				IL_02be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02c3: stloc.s 17
-				IL_02c5: ldloc.s 17
-				IL_02c7: brfalse IL_0341
+				IL_029b: ldloc.s 12
+				IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02a2: ldstr "startsWith"
+				IL_02a7: ldstr "</"
+				IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02b1: stloc.s 15
+				IL_02b3: ldloc.s 15
+				IL_02b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02ba: stloc.s 17
+				IL_02bc: ldloc.s 17
+				IL_02be: brfalse IL_0338
 
-				IL_02cc: ldloc.s 9
-				IL_02ce: ldc.r8 1
-				IL_02d7: sub
-				IL_02d8: stloc.s 9
-				IL_02da: ldloc.s 9
-				IL_02dc: stloc.s 18
-				IL_02de: ldloc.s 18
-				IL_02e0: ldc.r8 0.0
-				IL_02e9: ceq
-				IL_02eb: brfalse IL_033c
+				IL_02c3: ldloc.s 9
+				IL_02c5: ldc.r8 1
+				IL_02ce: sub
+				IL_02cf: stloc.s 9
+				IL_02d1: ldloc.s 9
+				IL_02d3: stloc.s 18
+				IL_02d5: ldloc.s 18
+				IL_02d7: ldc.r8 0.0
+				IL_02e0: ceq
+				IL_02e2: brfalse IL_0333
 
-				IL_02f0: ldarg.2
-				IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02f6: stloc.s 15
-				IL_02f8: ldloc.s 8
-				IL_02fa: ldstr "lastIndex"
-				IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0304: stloc.s 21
-				IL_0306: ldloc.s 15
-				IL_0308: ldstr "substring"
-				IL_030d: ldloc.s 10
-				IL_030f: ldloc.s 21
-				IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0316: stloc.s 21
-				IL_0318: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_031d: dup
-				IL_031e: ldstr "tagName"
-				IL_0323: ldloc.s 6
-				IL_0325: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_032a: dup
-				IL_032b: ldstr "html"
+				IL_02e7: ldarg.2
+				IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02ed: stloc.s 15
+				IL_02ef: ldloc.s 8
+				IL_02f1: ldstr "lastIndex"
+				IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_02fb: stloc.s 20
+				IL_02fd: ldloc.s 15
+				IL_02ff: ldstr "substring"
+				IL_0304: ldloc.s 10
+				IL_0306: ldloc.s 20
+				IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_030d: stloc.s 20
+				IL_030f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0314: dup
+				IL_0315: ldstr "tagName"
+				IL_031a: ldloc.s 6
+				IL_031c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0321: dup
+				IL_0322: ldstr "html"
+				IL_0327: ldloc.s 20
+				IL_0329: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_032e: stloc.s 21
 				IL_0330: ldloc.s 21
-				IL_0332: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0337: stloc.s 22
-				IL_0339: ldloc.s 22
-				IL_033b: ret
+				IL_0332: ret
 
-				IL_033c: br IL_034f
+				IL_0333: br IL_0346
 
-				IL_0341: ldloc.s 9
-				IL_0343: ldc.r8 1
-				IL_034c: add
-				IL_034d: stloc.s 9
+				IL_0338: ldloc.s 9
+				IL_033a: ldc.r8 1
+				IL_0343: add
+				IL_0344: stloc.s 9
 
-				IL_034f: br IL_022f
+				IL_0346: br IL_022f
 			// end loop
 
-			IL_0354: ldloc.s 6
-			IL_0356: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_035b: stloc.s 14
-			IL_035d: ldstr "Could not find a matching closing </"
-			IL_0362: ldloc.s 14
-			IL_0364: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0369: ldstr "> for id '"
-			IL_036e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0373: ldarg.3
-			IL_0374: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0379: stloc.s 14
-			IL_037b: ldloc.s 14
-			IL_037d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0382: ldstr "'."
-			IL_0387: call string [System.Runtime]System.String::Concat(string, string)
-			IL_038c: stloc.s 14
-			IL_038e: ldloc.s 14
-			IL_0390: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0395: stloc.s 13
-			IL_0397: ldloc.s 13
-			IL_0399: isinst [System.Runtime]System.Exception
-			IL_039e: dup
-			IL_039f: brtrue IL_03ad
+			IL_034b: ldloc.s 6
+			IL_034d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0352: stloc.s 14
+			IL_0354: ldstr "Could not find a matching closing </"
+			IL_0359: ldloc.s 14
+			IL_035b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0360: ldstr "> for id '"
+			IL_0365: call string [System.Runtime]System.String::Concat(string, string)
+			IL_036a: ldarg.3
+			IL_036b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0370: stloc.s 14
+			IL_0372: ldloc.s 14
+			IL_0374: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0379: ldstr "'."
+			IL_037e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0383: stloc.s 14
+			IL_0385: ldloc.s 14
+			IL_0387: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_038c: stloc.s 13
+			IL_038e: ldloc.s 13
+			IL_0390: isinst [System.Runtime]System.Exception
+			IL_0395: dup
+			IL_0396: brtrue IL_03a4
 
-			IL_03a4: pop
-			IL_03a5: ldloc.s 13
-			IL_03a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03ac: throw
+			IL_039b: pop
+			IL_039c: ldloc.s 13
+			IL_039e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03a3: throw
 
-			IL_03ad: throw
+			IL_03a4: throw
 
-			IL_03ae: ldnull
-			IL_03af: ret
+			IL_03a5: ldnull
+			IL_03a6: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3350,7 +3346,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46b5
+					// Method begins at RVA 0x46a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3368,7 +3364,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46ac
+				// Method begins at RVA 0x469c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3396,9 +3392,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2fe8
+			// Method begins at RVA 0x2fe0
 			// Header size: 12
-			// Code size: 476 (0x1dc)
+			// Code size: 467 (0x1d3)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3410,16 +3406,15 @@
 				[6] object,
 				[7] object[],
 				[8] string,
-				[9] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[10] bool,
+				[9] bool,
+				[10] object,
 				[11] object,
 				[12] object,
 				[13] object,
 				[14] object,
 				[15] object,
-				[16] object,
-				[17] float64,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[16] float64,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.0
@@ -3449,146 +3444,143 @@
 			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_0047: stloc.1
 			IL_0048: ldloc.1
-			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_004e: stloc.s 9
-			IL_0050: ldloc.s 9
-			IL_0052: ldstr "exec"
-			IL_0057: ldarg.2
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_005d: stloc.2
-			IL_005e: ldloc.2
-			IL_005f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0064: stloc.s 10
-			IL_0066: ldloc.s 10
-			IL_0068: brfalse IL_00b5
+			IL_0049: ldstr "exec"
+			IL_004e: ldarg.2
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0054: stloc.2
+			IL_0055: ldloc.2
+			IL_0056: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_005b: stloc.s 9
+			IL_005d: ldloc.s 9
+			IL_005f: brfalse IL_00ac
 
-			IL_006d: ldloc.2
-			IL_006e: ldc.r8 1
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_007c: stloc.s 11
-			IL_007e: ldloc.s 11
-			IL_0080: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0085: stloc.s 10
-			IL_0087: ldloc.s 10
-			IL_0089: brtrue IL_00a8
+			IL_0064: ldloc.2
+			IL_0065: ldc.r8 1
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0073: stloc.s 10
+			IL_0075: ldloc.s 10
+			IL_0077: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_007c: stloc.s 9
+			IL_007e: ldloc.s 9
+			IL_0080: brtrue IL_009f
 
-			IL_008e: ldloc.2
-			IL_008f: ldc.r8 2
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_009d: stloc.s 12
-			IL_009f: ldloc.s 12
-			IL_00a1: stloc.s 14
-			IL_00a3: br IL_00ac
+			IL_0085: ldloc.2
+			IL_0086: ldc.r8 2
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0094: stloc.s 11
+			IL_0096: ldloc.s 11
+			IL_0098: stloc.s 13
+			IL_009a: br IL_00a3
 
-			IL_00a8: ldloc.s 11
-			IL_00aa: stloc.s 14
+			IL_009f: ldloc.s 10
+			IL_00a1: stloc.s 13
 
-			IL_00ac: ldloc.s 14
-			IL_00ae: stloc.s 15
-			IL_00b0: br IL_00b8
+			IL_00a3: ldloc.s 13
+			IL_00a5: stloc.s 14
+			IL_00a7: br IL_00af
 
-			IL_00b5: ldloc.2
-			IL_00b6: stloc.s 15
+			IL_00ac: ldloc.2
+			IL_00ad: stloc.s 14
 
-			IL_00b8: ldloc.s 15
-			IL_00ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00bf: stloc.s 10
-			IL_00c1: ldloc.s 10
-			IL_00c3: brtrue IL_00d4
+			IL_00af: ldloc.s 14
+			IL_00b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00b6: stloc.s 9
+			IL_00b8: ldloc.s 9
+			IL_00ba: brtrue IL_00cb
 
-			IL_00c8: ldstr ""
-			IL_00cd: stloc.s 15
-			IL_00cf: br IL_00d4
+			IL_00bf: ldstr ""
+			IL_00c4: stloc.s 14
+			IL_00c6: br IL_00cb
 
-			IL_00d4: ldloc.s 15
-			IL_00d6: stloc.3
-			IL_00d7: ldloc.3
-			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00dd: ldc.i4.0
-			IL_00de: ceq
-			IL_00e0: stloc.s 10
-			IL_00e2: ldloc.s 10
-			IL_00e4: brfalse IL_00f0
+			IL_00cb: ldloc.s 14
+			IL_00cd: stloc.3
+			IL_00ce: ldloc.3
+			IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00d4: ldc.i4.0
+			IL_00d5: ceq
+			IL_00d7: stloc.s 9
+			IL_00d9: ldloc.s 9
+			IL_00db: brfalse IL_00e7
 
-			IL_00e9: ldc.i4.0
-			IL_00ea: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00ef: ret
+			IL_00e0: ldc.i4.0
+			IL_00e1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00e6: ret
 
-			IL_00f0: ldloc.3
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f6: castclass [System.Runtime]System.String
-			IL_00fb: ldstr "#"
-			IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0105: stloc.s 17
-			IL_0107: ldloc.s 17
-			IL_0109: box [System.Runtime]System.Double
-			IL_010e: stloc.s 4
-			IL_0110: ldloc.s 4
-			IL_0112: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0117: ldc.r8 0.0
-			IL_0120: clt
-			IL_0122: ldc.i4.0
-			IL_0123: ceq
-			IL_0125: brfalse IL_0155
+			IL_00e7: ldloc.3
+			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ed: castclass [System.Runtime]System.String
+			IL_00f2: ldstr "#"
+			IL_00f7: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00fc: stloc.s 16
+			IL_00fe: ldloc.s 16
+			IL_0100: box [System.Runtime]System.Double
+			IL_0105: stloc.s 4
+			IL_0107: ldloc.s 4
+			IL_0109: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_010e: ldc.r8 0.0
+			IL_0117: clt
+			IL_0119: ldc.i4.0
+			IL_011a: ceq
+			IL_011c: brfalse IL_014c
 
-			IL_012a: ldloc.3
-			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0130: castclass [System.Runtime]System.String
-			IL_0135: ldc.r8 0.0
-			IL_013e: box [System.Runtime]System.Double
-			IL_0143: ldloc.s 4
-			IL_0145: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_014a: stloc.s 8
-			IL_014c: ldloc.s 8
-			IL_014e: stloc.s 5
-			IL_0150: br IL_0158
+			IL_0121: ldloc.3
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0127: castclass [System.Runtime]System.String
+			IL_012c: ldc.r8 0.0
+			IL_0135: box [System.Runtime]System.Double
+			IL_013a: ldloc.s 4
+			IL_013c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_0141: stloc.s 8
+			IL_0143: ldloc.s 8
+			IL_0145: stloc.s 5
+			IL_0147: br IL_014f
 
-			IL_0155: ldloc.3
-			IL_0156: stloc.s 5
+			IL_014c: ldloc.3
+			IL_014d: stloc.s 5
 
-			IL_0158: ldloc.s 4
-			IL_015a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_015f: ldc.r8 0.0
-			IL_0168: clt
-			IL_016a: ldc.i4.0
-			IL_016b: ceq
-			IL_016d: brfalse IL_01a5
+			IL_014f: ldloc.s 4
+			IL_0151: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0156: ldc.r8 0.0
+			IL_015f: clt
+			IL_0161: ldc.i4.0
+			IL_0162: ceq
+			IL_0164: brfalse IL_019c
 
-			IL_0172: ldloc.3
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0178: stloc.s 11
-			IL_017a: ldloc.s 4
-			IL_017c: ldc.r8 1
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_018a: stloc.s 15
-			IL_018c: ldloc.s 11
-			IL_018e: castclass [System.Runtime]System.String
-			IL_0193: ldloc.s 15
-			IL_0195: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_019a: stloc.s 8
-			IL_019c: ldloc.s 8
-			IL_019e: stloc.s 6
-			IL_01a0: br IL_01ac
+			IL_0169: ldloc.3
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016f: stloc.s 10
+			IL_0171: ldloc.s 4
+			IL_0173: ldc.r8 1
+			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0181: stloc.s 14
+			IL_0183: ldloc.s 10
+			IL_0185: castclass [System.Runtime]System.String
+			IL_018a: ldloc.s 14
+			IL_018c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_0191: stloc.s 8
+			IL_0193: ldloc.s 8
+			IL_0195: stloc.s 6
+			IL_0197: br IL_01a3
 
-			IL_01a5: ldstr ""
-			IL_01aa: stloc.s 6
+			IL_019c: ldstr ""
+			IL_01a1: stloc.s 6
 
-			IL_01ac: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01b1: dup
-			IL_01b2: ldstr "href"
-			IL_01b7: ldloc.3
-			IL_01b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01bd: dup
-			IL_01be: ldstr "filePart"
-			IL_01c3: ldloc.s 5
-			IL_01c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01ca: dup
-			IL_01cb: ldstr "fragment"
-			IL_01d0: ldloc.s 6
-			IL_01d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01d7: stloc.s 18
-			IL_01d9: ldloc.s 18
-			IL_01db: ret
+			IL_01a3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01a8: dup
+			IL_01a9: ldstr "href"
+			IL_01ae: ldloc.3
+			IL_01af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01b4: dup
+			IL_01b5: ldstr "filePart"
+			IL_01ba: ldloc.s 5
+			IL_01bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01c1: dup
+			IL_01c2: ldstr "fragment"
+			IL_01c7: ldloc.s 6
+			IL_01c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01ce: stloc.s 17
+			IL_01d0: ldloc.s 17
+			IL_01d2: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -3604,7 +3596,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46be
+				// Method begins at RVA 0x46ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3630,7 +3622,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31d0
+			// Method begins at RVA 0x31c0
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -3722,7 +3714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46d0
+					// Method begins at RVA 0x46c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3742,7 +3734,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46d9
+					// Method begins at RVA 0x46c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3762,7 +3754,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46e2
+					// Method begins at RVA 0x46d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3786,7 +3778,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46f4
+						// Method begins at RVA 0x46e4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3806,7 +3798,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46fd
+						// Method begins at RVA 0x46ed
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3824,7 +3816,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46eb
+					// Method begins at RVA 0x46db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3844,7 +3836,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4706
+					// Method begins at RVA 0x46f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3864,7 +3856,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x470f
+					// Method begins at RVA 0x46ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3904,7 +3896,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46c7
+				// Method begins at RVA 0x46b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3928,7 +3920,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3260
+			// Method begins at RVA 0x3250
 			// Header size: 12
 			// Code size: 3014 (0xbc6)
 			.maxstack 8
@@ -5366,7 +5358,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x454d
+			// Method begins at RVA 0x453d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5622,7 +5614,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4718
+		// Method begins at RVA 0x4708
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x453b
+				// Method begins at RVA 0x452b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4544
+				// Method begins at RVA 0x4534
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -355,7 +355,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4532
+			// Method begins at RVA 0x4522
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -470,7 +470,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x455f
+					// Method begins at RVA 0x454f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -488,7 +488,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4556
+				// Method begins at RVA 0x4546
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -633,7 +633,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4568
+				// Method begins at RVA 0x4558
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -661,7 +661,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4583
+						// Method begins at RVA 0x4573
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -681,7 +681,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x458c
+						// Method begins at RVA 0x457c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -701,7 +701,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4595
+						// Method begins at RVA 0x4585
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -721,7 +721,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x459e
+						// Method begins at RVA 0x458e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -741,7 +741,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45a7
+						// Method begins at RVA 0x4597
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -761,7 +761,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45b0
+						// Method begins at RVA 0x45a0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -779,7 +779,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x457a
+					// Method begins at RVA 0x456a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -797,7 +797,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4571
+				// Method begins at RVA 0x4561
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1156,7 +1156,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x460a
+							// Method begins at RVA 0x45fa
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1181,7 +1181,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44ac
+						// Method begins at RVA 0x449c
 						// Header size: 12
 						// Code size: 38 (0x26)
 						.maxstack 8
@@ -1223,7 +1223,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4613
+							// Method begins at RVA 0x4603
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1247,7 +1247,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44e0
+						// Method begins at RVA 0x44d0
 						// Header size: 12
 						// Code size: 70 (0x46)
 						.maxstack 8
@@ -1326,7 +1326,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x45f8
+								// Method begins at RVA 0x45e8
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1344,7 +1344,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x45ef
+							// Method begins at RVA 0x45df
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1364,7 +1364,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4601
+							// Method begins at RVA 0x45f1
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1386,7 +1386,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45e6
+						// Method begins at RVA 0x45d6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1411,7 +1411,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x4050
+					// Method begins at RVA 0x4040
 					// Header size: 12
 					// Code size: 1101 (0x44d)
 					.maxstack 8
@@ -1913,7 +1913,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45d4
+						// Method begins at RVA 0x45c4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1933,7 +1933,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45dd
+						// Method begins at RVA 0x45cd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1956,7 +1956,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45cb
+					// Method begins at RVA 0x45bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1982,7 +1982,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e34
+				// Method begins at RVA 0x3e24
 				// Header size: 12
 				// Code size: 511 (0x1ff)
 				.maxstack 8
@@ -2233,7 +2233,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45c2
+					// Method begins at RVA 0x45b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2255,7 +2255,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45b9
+				// Method begins at RVA 0x45a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2352,7 +2352,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x461c
+				// Method begins at RVA 0x460c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2419,7 +2419,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x462e
+					// Method begins at RVA 0x461e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2443,7 +2443,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4640
+						// Method begins at RVA 0x4630
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2461,7 +2461,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4637
+					// Method begins at RVA 0x4627
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2479,7 +2479,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4625
+				// Method begins at RVA 0x4615
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2744,7 +2744,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4652
+					// Method begins at RVA 0x4642
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2764,7 +2764,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x465b
+					// Method begins at RVA 0x464b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2784,7 +2784,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4664
+					// Method begins at RVA 0x4654
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2804,7 +2804,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x466d
+					// Method begins at RVA 0x465d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2828,7 +2828,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x467f
+						// Method begins at RVA 0x466f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2848,7 +2848,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4688
+						// Method begins at RVA 0x4678
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2872,7 +2872,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x469a
+							// Method begins at RVA 0x468a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2890,7 +2890,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4691
+						// Method begins at RVA 0x4681
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2910,7 +2910,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46a3
+						// Method begins at RVA 0x4693
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2928,7 +2928,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4676
+					// Method begins at RVA 0x4666
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2946,7 +2946,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4649
+				// Method begins at RVA 0x4639
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2976,7 +2976,7 @@
 			)
 			// Method begins at RVA 0x2c2c
 			// Header size: 12
-			// Code size: 944 (0x3b0)
+			// Code size: 935 (0x3a7)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -2998,10 +2998,9 @@
 				[16] object[],
 				[17] bool,
 				[18] float64,
-				[19] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[19] object,
 				[20] object,
-				[21] object,
-				[22] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.3
@@ -3200,137 +3199,134 @@
 			IL_022d: stloc.s 10
 			// loop start (head: IL_022f)
 				IL_022f: ldc.i4.1
-				IL_0230: brfalse IL_0354
+				IL_0230: brfalse IL_034b
 
 				IL_0235: ldloc.s 8
-				IL_0237: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-				IL_023c: stloc.s 19
-				IL_023e: ldloc.s 19
-				IL_0240: ldstr "exec"
-				IL_0245: ldarg.2
-				IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_024b: stloc.s 11
-				IL_024d: ldloc.s 11
-				IL_024f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0254: ldc.i4.0
-				IL_0255: ceq
-				IL_0257: stloc.s 17
-				IL_0259: ldloc.s 17
-				IL_025b: brfalse IL_0265
+				IL_0237: ldstr "exec"
+				IL_023c: ldarg.2
+				IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0242: stloc.s 11
+				IL_0244: ldloc.s 11
+				IL_0246: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_024b: ldc.i4.0
+				IL_024c: ceq
+				IL_024e: stloc.s 17
+				IL_0250: ldloc.s 17
+				IL_0252: brfalse IL_025c
 
-				IL_0260: br IL_0354
+				IL_0257: br IL_034b
 
-				IL_0265: ldloc.s 11
-				IL_0267: ldc.r8 0.0
-				IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0275: stloc.s 12
-				IL_0277: ldloc.s 10
-				IL_0279: stloc.s 20
-				IL_027b: ldloc.s 20
-				IL_027d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0282: ldc.r8 0.0
-				IL_028b: clt
-				IL_028d: brfalse IL_02a4
+				IL_025c: ldloc.s 11
+				IL_025e: ldc.r8 0.0
+				IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_026c: stloc.s 12
+				IL_026e: ldloc.s 10
+				IL_0270: stloc.s 19
+				IL_0272: ldloc.s 19
+				IL_0274: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0279: ldc.r8 0.0
+				IL_0282: clt
+				IL_0284: brfalse IL_029b
 
-				IL_0292: ldloc.s 11
-				IL_0294: ldstr "index"
-				IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_029e: stloc.s 15
-				IL_02a0: ldloc.s 15
-				IL_02a2: stloc.s 10
+				IL_0289: ldloc.s 11
+				IL_028b: ldstr "index"
+				IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0295: stloc.s 15
+				IL_0297: ldloc.s 15
+				IL_0299: stloc.s 10
 
-				IL_02a4: ldloc.s 12
-				IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02ab: ldstr "startsWith"
-				IL_02b0: ldstr "</"
-				IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02ba: stloc.s 15
-				IL_02bc: ldloc.s 15
-				IL_02be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02c3: stloc.s 17
-				IL_02c5: ldloc.s 17
-				IL_02c7: brfalse IL_0341
+				IL_029b: ldloc.s 12
+				IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02a2: ldstr "startsWith"
+				IL_02a7: ldstr "</"
+				IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02b1: stloc.s 15
+				IL_02b3: ldloc.s 15
+				IL_02b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02ba: stloc.s 17
+				IL_02bc: ldloc.s 17
+				IL_02be: brfalse IL_0338
 
-				IL_02cc: ldloc.s 9
-				IL_02ce: ldc.r8 1
-				IL_02d7: sub
-				IL_02d8: stloc.s 9
-				IL_02da: ldloc.s 9
-				IL_02dc: stloc.s 18
-				IL_02de: ldloc.s 18
-				IL_02e0: ldc.r8 0.0
-				IL_02e9: ceq
-				IL_02eb: brfalse IL_033c
+				IL_02c3: ldloc.s 9
+				IL_02c5: ldc.r8 1
+				IL_02ce: sub
+				IL_02cf: stloc.s 9
+				IL_02d1: ldloc.s 9
+				IL_02d3: stloc.s 18
+				IL_02d5: ldloc.s 18
+				IL_02d7: ldc.r8 0.0
+				IL_02e0: ceq
+				IL_02e2: brfalse IL_0333
 
-				IL_02f0: ldarg.2
-				IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02f6: stloc.s 15
-				IL_02f8: ldloc.s 8
-				IL_02fa: ldstr "lastIndex"
-				IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0304: stloc.s 21
-				IL_0306: ldloc.s 15
-				IL_0308: ldstr "substring"
-				IL_030d: ldloc.s 10
-				IL_030f: ldloc.s 21
-				IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0316: stloc.s 21
-				IL_0318: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_031d: dup
-				IL_031e: ldstr "tagName"
-				IL_0323: ldloc.s 6
-				IL_0325: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_032a: dup
-				IL_032b: ldstr "html"
+				IL_02e7: ldarg.2
+				IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02ed: stloc.s 15
+				IL_02ef: ldloc.s 8
+				IL_02f1: ldstr "lastIndex"
+				IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_02fb: stloc.s 20
+				IL_02fd: ldloc.s 15
+				IL_02ff: ldstr "substring"
+				IL_0304: ldloc.s 10
+				IL_0306: ldloc.s 20
+				IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_030d: stloc.s 20
+				IL_030f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0314: dup
+				IL_0315: ldstr "tagName"
+				IL_031a: ldloc.s 6
+				IL_031c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0321: dup
+				IL_0322: ldstr "html"
+				IL_0327: ldloc.s 20
+				IL_0329: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_032e: stloc.s 21
 				IL_0330: ldloc.s 21
-				IL_0332: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0337: stloc.s 22
-				IL_0339: ldloc.s 22
-				IL_033b: ret
+				IL_0332: ret
 
-				IL_033c: br IL_034f
+				IL_0333: br IL_0346
 
-				IL_0341: ldloc.s 9
-				IL_0343: ldc.r8 1
-				IL_034c: add
-				IL_034d: stloc.s 9
+				IL_0338: ldloc.s 9
+				IL_033a: ldc.r8 1
+				IL_0343: add
+				IL_0344: stloc.s 9
 
-				IL_034f: br IL_022f
+				IL_0346: br IL_022f
 			// end loop
 
-			IL_0354: ldloc.s 6
-			IL_0356: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_035b: stloc.s 14
-			IL_035d: ldstr "Could not find a matching closing </"
-			IL_0362: ldloc.s 14
-			IL_0364: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0369: ldstr "> for id '"
-			IL_036e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0373: ldarg.3
-			IL_0374: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0379: stloc.s 14
-			IL_037b: ldloc.s 14
-			IL_037d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0382: ldstr "'."
-			IL_0387: call string [System.Runtime]System.String::Concat(string, string)
-			IL_038c: stloc.s 14
-			IL_038e: ldloc.s 14
-			IL_0390: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0395: stloc.s 13
-			IL_0397: ldloc.s 13
-			IL_0399: isinst [System.Runtime]System.Exception
-			IL_039e: dup
-			IL_039f: brtrue IL_03ad
+			IL_034b: ldloc.s 6
+			IL_034d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0352: stloc.s 14
+			IL_0354: ldstr "Could not find a matching closing </"
+			IL_0359: ldloc.s 14
+			IL_035b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0360: ldstr "> for id '"
+			IL_0365: call string [System.Runtime]System.String::Concat(string, string)
+			IL_036a: ldarg.3
+			IL_036b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0370: stloc.s 14
+			IL_0372: ldloc.s 14
+			IL_0374: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0379: ldstr "'."
+			IL_037e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0383: stloc.s 14
+			IL_0385: ldloc.s 14
+			IL_0387: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_038c: stloc.s 13
+			IL_038e: ldloc.s 13
+			IL_0390: isinst [System.Runtime]System.Exception
+			IL_0395: dup
+			IL_0396: brtrue IL_03a4
 
-			IL_03a4: pop
-			IL_03a5: ldloc.s 13
-			IL_03a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03ac: throw
+			IL_039b: pop
+			IL_039c: ldloc.s 13
+			IL_039e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03a3: throw
 
-			IL_03ad: throw
+			IL_03a4: throw
 
-			IL_03ae: ldnull
-			IL_03af: ret
+			IL_03a5: ldnull
+			IL_03a6: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3350,7 +3346,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46b5
+					// Method begins at RVA 0x46a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3368,7 +3364,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46ac
+				// Method begins at RVA 0x469c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3396,9 +3392,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2fe8
+			// Method begins at RVA 0x2fe0
 			// Header size: 12
-			// Code size: 476 (0x1dc)
+			// Code size: 467 (0x1d3)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3410,16 +3406,15 @@
 				[6] object,
 				[7] object[],
 				[8] string,
-				[9] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[10] bool,
+				[9] bool,
+				[10] object,
 				[11] object,
 				[12] object,
 				[13] object,
 				[14] object,
 				[15] object,
-				[16] object,
-				[17] float64,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[16] float64,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.0
@@ -3449,146 +3444,143 @@
 			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_0047: stloc.1
 			IL_0048: ldloc.1
-			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_004e: stloc.s 9
-			IL_0050: ldloc.s 9
-			IL_0052: ldstr "exec"
-			IL_0057: ldarg.2
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_005d: stloc.2
-			IL_005e: ldloc.2
-			IL_005f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0064: stloc.s 10
-			IL_0066: ldloc.s 10
-			IL_0068: brfalse IL_00b5
+			IL_0049: ldstr "exec"
+			IL_004e: ldarg.2
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0054: stloc.2
+			IL_0055: ldloc.2
+			IL_0056: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_005b: stloc.s 9
+			IL_005d: ldloc.s 9
+			IL_005f: brfalse IL_00ac
 
-			IL_006d: ldloc.2
-			IL_006e: ldc.r8 1
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_007c: stloc.s 11
-			IL_007e: ldloc.s 11
-			IL_0080: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0085: stloc.s 10
-			IL_0087: ldloc.s 10
-			IL_0089: brtrue IL_00a8
+			IL_0064: ldloc.2
+			IL_0065: ldc.r8 1
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0073: stloc.s 10
+			IL_0075: ldloc.s 10
+			IL_0077: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_007c: stloc.s 9
+			IL_007e: ldloc.s 9
+			IL_0080: brtrue IL_009f
 
-			IL_008e: ldloc.2
-			IL_008f: ldc.r8 2
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_009d: stloc.s 12
-			IL_009f: ldloc.s 12
-			IL_00a1: stloc.s 14
-			IL_00a3: br IL_00ac
+			IL_0085: ldloc.2
+			IL_0086: ldc.r8 2
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0094: stloc.s 11
+			IL_0096: ldloc.s 11
+			IL_0098: stloc.s 13
+			IL_009a: br IL_00a3
 
-			IL_00a8: ldloc.s 11
-			IL_00aa: stloc.s 14
+			IL_009f: ldloc.s 10
+			IL_00a1: stloc.s 13
 
-			IL_00ac: ldloc.s 14
-			IL_00ae: stloc.s 15
-			IL_00b0: br IL_00b8
+			IL_00a3: ldloc.s 13
+			IL_00a5: stloc.s 14
+			IL_00a7: br IL_00af
 
-			IL_00b5: ldloc.2
-			IL_00b6: stloc.s 15
+			IL_00ac: ldloc.2
+			IL_00ad: stloc.s 14
 
-			IL_00b8: ldloc.s 15
-			IL_00ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00bf: stloc.s 10
-			IL_00c1: ldloc.s 10
-			IL_00c3: brtrue IL_00d4
+			IL_00af: ldloc.s 14
+			IL_00b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00b6: stloc.s 9
+			IL_00b8: ldloc.s 9
+			IL_00ba: brtrue IL_00cb
 
-			IL_00c8: ldstr ""
-			IL_00cd: stloc.s 15
-			IL_00cf: br IL_00d4
+			IL_00bf: ldstr ""
+			IL_00c4: stloc.s 14
+			IL_00c6: br IL_00cb
 
-			IL_00d4: ldloc.s 15
-			IL_00d6: stloc.3
-			IL_00d7: ldloc.3
-			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00dd: ldc.i4.0
-			IL_00de: ceq
-			IL_00e0: stloc.s 10
-			IL_00e2: ldloc.s 10
-			IL_00e4: brfalse IL_00f0
+			IL_00cb: ldloc.s 14
+			IL_00cd: stloc.3
+			IL_00ce: ldloc.3
+			IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00d4: ldc.i4.0
+			IL_00d5: ceq
+			IL_00d7: stloc.s 9
+			IL_00d9: ldloc.s 9
+			IL_00db: brfalse IL_00e7
 
-			IL_00e9: ldc.i4.0
-			IL_00ea: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00ef: ret
+			IL_00e0: ldc.i4.0
+			IL_00e1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00e6: ret
 
-			IL_00f0: ldloc.3
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f6: castclass [System.Runtime]System.String
-			IL_00fb: ldstr "#"
-			IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0105: stloc.s 17
-			IL_0107: ldloc.s 17
-			IL_0109: box [System.Runtime]System.Double
-			IL_010e: stloc.s 4
-			IL_0110: ldloc.s 4
-			IL_0112: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0117: ldc.r8 0.0
-			IL_0120: clt
-			IL_0122: ldc.i4.0
-			IL_0123: ceq
-			IL_0125: brfalse IL_0155
+			IL_00e7: ldloc.3
+			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ed: castclass [System.Runtime]System.String
+			IL_00f2: ldstr "#"
+			IL_00f7: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00fc: stloc.s 16
+			IL_00fe: ldloc.s 16
+			IL_0100: box [System.Runtime]System.Double
+			IL_0105: stloc.s 4
+			IL_0107: ldloc.s 4
+			IL_0109: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_010e: ldc.r8 0.0
+			IL_0117: clt
+			IL_0119: ldc.i4.0
+			IL_011a: ceq
+			IL_011c: brfalse IL_014c
 
-			IL_012a: ldloc.3
-			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0130: castclass [System.Runtime]System.String
-			IL_0135: ldc.r8 0.0
-			IL_013e: box [System.Runtime]System.Double
-			IL_0143: ldloc.s 4
-			IL_0145: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_014a: stloc.s 8
-			IL_014c: ldloc.s 8
-			IL_014e: stloc.s 5
-			IL_0150: br IL_0158
+			IL_0121: ldloc.3
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0127: castclass [System.Runtime]System.String
+			IL_012c: ldc.r8 0.0
+			IL_0135: box [System.Runtime]System.Double
+			IL_013a: ldloc.s 4
+			IL_013c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_0141: stloc.s 8
+			IL_0143: ldloc.s 8
+			IL_0145: stloc.s 5
+			IL_0147: br IL_014f
 
-			IL_0155: ldloc.3
-			IL_0156: stloc.s 5
+			IL_014c: ldloc.3
+			IL_014d: stloc.s 5
 
-			IL_0158: ldloc.s 4
-			IL_015a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_015f: ldc.r8 0.0
-			IL_0168: clt
-			IL_016a: ldc.i4.0
-			IL_016b: ceq
-			IL_016d: brfalse IL_01a5
+			IL_014f: ldloc.s 4
+			IL_0151: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0156: ldc.r8 0.0
+			IL_015f: clt
+			IL_0161: ldc.i4.0
+			IL_0162: ceq
+			IL_0164: brfalse IL_019c
 
-			IL_0172: ldloc.3
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0178: stloc.s 11
-			IL_017a: ldloc.s 4
-			IL_017c: ldc.r8 1
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_018a: stloc.s 15
-			IL_018c: ldloc.s 11
-			IL_018e: castclass [System.Runtime]System.String
-			IL_0193: ldloc.s 15
-			IL_0195: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_019a: stloc.s 8
-			IL_019c: ldloc.s 8
-			IL_019e: stloc.s 6
-			IL_01a0: br IL_01ac
+			IL_0169: ldloc.3
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016f: stloc.s 10
+			IL_0171: ldloc.s 4
+			IL_0173: ldc.r8 1
+			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0181: stloc.s 14
+			IL_0183: ldloc.s 10
+			IL_0185: castclass [System.Runtime]System.String
+			IL_018a: ldloc.s 14
+			IL_018c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_0191: stloc.s 8
+			IL_0193: ldloc.s 8
+			IL_0195: stloc.s 6
+			IL_0197: br IL_01a3
 
-			IL_01a5: ldstr ""
-			IL_01aa: stloc.s 6
+			IL_019c: ldstr ""
+			IL_01a1: stloc.s 6
 
-			IL_01ac: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01b1: dup
-			IL_01b2: ldstr "href"
-			IL_01b7: ldloc.3
-			IL_01b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01bd: dup
-			IL_01be: ldstr "filePart"
-			IL_01c3: ldloc.s 5
-			IL_01c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01ca: dup
-			IL_01cb: ldstr "fragment"
-			IL_01d0: ldloc.s 6
-			IL_01d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01d7: stloc.s 18
-			IL_01d9: ldloc.s 18
-			IL_01db: ret
+			IL_01a3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01a8: dup
+			IL_01a9: ldstr "href"
+			IL_01ae: ldloc.3
+			IL_01af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01b4: dup
+			IL_01b5: ldstr "filePart"
+			IL_01ba: ldloc.s 5
+			IL_01bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01c1: dup
+			IL_01c2: ldstr "fragment"
+			IL_01c7: ldloc.s 6
+			IL_01c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01ce: stloc.s 17
+			IL_01d0: ldloc.s 17
+			IL_01d2: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -3604,7 +3596,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46be
+				// Method begins at RVA 0x46ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3630,7 +3622,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31d0
+			// Method begins at RVA 0x31c0
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -3722,7 +3714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46d0
+					// Method begins at RVA 0x46c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3742,7 +3734,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46d9
+					// Method begins at RVA 0x46c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3762,7 +3754,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46e2
+					// Method begins at RVA 0x46d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3786,7 +3778,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46f4
+						// Method begins at RVA 0x46e4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3806,7 +3798,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46fd
+						// Method begins at RVA 0x46ed
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3824,7 +3816,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46eb
+					// Method begins at RVA 0x46db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3844,7 +3836,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4706
+					// Method begins at RVA 0x46f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3864,7 +3856,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x470f
+					// Method begins at RVA 0x46ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3904,7 +3896,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46c7
+				// Method begins at RVA 0x46b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3928,7 +3920,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3260
+			// Method begins at RVA 0x3250
 			// Header size: 12
 			// Code size: 3014 (0xbc6)
 			.maxstack 8
@@ -5366,7 +5358,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x454d
+			// Method begins at RVA 0x453d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5622,7 +5614,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4718
+		// Method begins at RVA 0x4708
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Indices_Exec.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Indices_Exec.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2367
+			// Method begins at RVA 0x2359
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 779 (0x30b)
+		// Code size: 765 (0x2fd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_Indices_Exec/Scope,
@@ -61,213 +61,207 @@
 		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_0016: stloc.3
 		IL_0017: ldloc.3
-		IL_0018: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_001d: stloc.3
-		IL_001e: ldloc.3
-		IL_001f: ldstr "exec"
-		IL_0024: ldstr "b"
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_002e: stloc.1
-		IL_002f: ldstr "console"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003e: stloc.s 4
-		IL_0040: ldloc.1
-		IL_0041: stloc.s 5
-		IL_0043: ldloc.s 5
-		IL_0045: ldc.i4.0
-		IL_0046: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_004b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0050: stloc.s 6
-		IL_0052: ldloc.s 6
-		IL_0054: box [System.Runtime]System.Boolean
-		IL_0059: stloc.s 7
-		IL_005b: ldloc.s 4
-		IL_005d: ldstr "log"
-		IL_0062: ldloc.s 7
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0069: pop
-		IL_006a: ldstr "console"
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0079: stloc.s 4
-		IL_007b: ldloc.1
-		IL_007c: ldstr "indices"
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0086: stloc.s 5
-		IL_0088: ldloc.s 5
-		IL_008a: ldstr "length"
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0094: stloc.s 5
-		IL_0096: ldloc.s 4
-		IL_0098: ldstr "log"
-		IL_009d: ldloc.s 5
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a4: pop
-		IL_00a5: ldstr "console"
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b4: stloc.s 5
-		IL_00b6: ldloc.1
-		IL_00b7: ldstr "indices"
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c1: stloc.s 4
-		IL_00c3: ldloc.s 4
-		IL_00c5: ldc.r8 0.0
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00d3: stloc.s 4
-		IL_00d5: ldloc.s 4
-		IL_00d7: ldc.r8 0.0
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00e5: stloc.s 4
-		IL_00e7: ldloc.s 5
-		IL_00e9: ldstr "log"
-		IL_00ee: ldloc.s 4
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f5: pop
-		IL_00f6: ldstr "console"
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0105: stloc.s 4
-		IL_0107: ldloc.1
-		IL_0108: ldstr "indices"
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0112: stloc.s 5
-		IL_0114: ldloc.s 5
-		IL_0116: ldc.r8 0.0
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0124: stloc.s 5
-		IL_0126: ldloc.s 5
-		IL_0128: ldc.r8 1
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0136: stloc.s 5
-		IL_0138: ldloc.s 4
-		IL_013a: ldstr "log"
-		IL_013f: ldloc.s 5
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0146: pop
-		IL_0147: ldstr "console"
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0156: stloc.s 5
-		IL_0158: ldloc.1
-		IL_0159: ldstr "indices"
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0163: stloc.s 4
-		IL_0165: ldloc.s 4
-		IL_0167: ldc.r8 1
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0175: stloc.s 4
-		IL_0177: ldloc.s 4
-		IL_0179: ldc.i4.0
-		IL_017a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_017f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0184: stloc.s 6
-		IL_0186: ldloc.s 6
-		IL_0188: box [System.Runtime]System.Boolean
-		IL_018d: stloc.s 7
-		IL_018f: ldloc.s 5
-		IL_0191: ldstr "log"
-		IL_0196: ldloc.s 7
-		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019d: pop
-		IL_019e: ldstr "a(d)?"
-		IL_01a3: ldstr "d"
-		IL_01a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_01ad: stloc.3
-		IL_01ae: ldloc.3
-		IL_01af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_01b4: stloc.3
-		IL_01b5: ldloc.3
-		IL_01b6: ldstr "exec"
-		IL_01bb: ldstr "bad"
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c5: stloc.2
-		IL_01c6: ldstr "console"
-		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d5: stloc.s 5
-		IL_01d7: ldloc.2
-		IL_01d8: ldstr "indices"
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e2: stloc.s 4
-		IL_01e4: ldloc.s 4
-		IL_01e6: ldc.r8 0.0
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01f4: stloc.s 4
-		IL_01f6: ldloc.s 4
-		IL_01f8: ldc.r8 0.0
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0206: stloc.s 4
-		IL_0208: ldloc.s 5
-		IL_020a: ldstr "log"
-		IL_020f: ldloc.s 4
-		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0216: pop
-		IL_0217: ldstr "console"
-		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0226: stloc.s 4
-		IL_0228: ldloc.2
-		IL_0229: ldstr "indices"
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0233: stloc.s 5
-		IL_0235: ldloc.s 5
-		IL_0237: ldc.r8 0.0
-		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0245: stloc.s 5
-		IL_0247: ldloc.s 5
-		IL_0249: ldc.r8 1
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0257: stloc.s 5
-		IL_0259: ldloc.s 4
-		IL_025b: ldstr "log"
-		IL_0260: ldloc.s 5
-		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0267: pop
-		IL_0268: ldstr "console"
-		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0277: stloc.s 5
-		IL_0279: ldloc.2
-		IL_027a: ldstr "indices"
-		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0284: stloc.s 4
-		IL_0286: ldloc.s 4
-		IL_0288: ldc.r8 1
-		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0296: stloc.s 4
-		IL_0298: ldloc.s 4
-		IL_029a: ldc.r8 0.0
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02a8: stloc.s 4
-		IL_02aa: ldloc.s 5
-		IL_02ac: ldstr "log"
-		IL_02b1: ldloc.s 4
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b8: pop
-		IL_02b9: ldstr "console"
-		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c8: stloc.s 4
-		IL_02ca: ldloc.2
-		IL_02cb: ldstr "indices"
-		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02d5: stloc.s 5
-		IL_02d7: ldloc.s 5
-		IL_02d9: ldc.r8 1
-		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02e7: stloc.s 5
-		IL_02e9: ldloc.s 5
-		IL_02eb: ldc.r8 1
-		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02f9: stloc.s 5
-		IL_02fb: ldloc.s 4
-		IL_02fd: ldstr "log"
-		IL_0302: ldloc.s 5
-		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0309: pop
-		IL_030a: ret
+		IL_0018: ldstr "exec"
+		IL_001d: ldstr "b"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0027: stloc.1
+		IL_0028: ldstr "console"
+		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0037: stloc.s 4
+		IL_0039: ldloc.1
+		IL_003a: stloc.s 5
+		IL_003c: ldloc.s 5
+		IL_003e: ldc.i4.0
+		IL_003f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0049: stloc.s 6
+		IL_004b: ldloc.s 6
+		IL_004d: box [System.Runtime]System.Boolean
+		IL_0052: stloc.s 7
+		IL_0054: ldloc.s 4
+		IL_0056: ldstr "log"
+		IL_005b: ldloc.s 7
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0062: pop
+		IL_0063: ldstr "console"
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0072: stloc.s 4
+		IL_0074: ldloc.1
+		IL_0075: ldstr "indices"
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_007f: stloc.s 5
+		IL_0081: ldloc.s 5
+		IL_0083: ldstr "length"
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_008d: stloc.s 5
+		IL_008f: ldloc.s 4
+		IL_0091: ldstr "log"
+		IL_0096: ldloc.s 5
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009d: pop
+		IL_009e: ldstr "console"
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ad: stloc.s 5
+		IL_00af: ldloc.1
+		IL_00b0: ldstr "indices"
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ba: stloc.s 4
+		IL_00bc: ldloc.s 4
+		IL_00be: ldc.r8 0.0
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00cc: stloc.s 4
+		IL_00ce: ldloc.s 4
+		IL_00d0: ldc.r8 0.0
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00de: stloc.s 4
+		IL_00e0: ldloc.s 5
+		IL_00e2: ldstr "log"
+		IL_00e7: ldloc.s 4
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ee: pop
+		IL_00ef: ldstr "console"
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fe: stloc.s 4
+		IL_0100: ldloc.1
+		IL_0101: ldstr "indices"
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010b: stloc.s 5
+		IL_010d: ldloc.s 5
+		IL_010f: ldc.r8 0.0
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_011d: stloc.s 5
+		IL_011f: ldloc.s 5
+		IL_0121: ldc.r8 1
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_012f: stloc.s 5
+		IL_0131: ldloc.s 4
+		IL_0133: ldstr "log"
+		IL_0138: ldloc.s 5
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013f: pop
+		IL_0140: ldstr "console"
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014f: stloc.s 5
+		IL_0151: ldloc.1
+		IL_0152: ldstr "indices"
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015c: stloc.s 4
+		IL_015e: ldloc.s 4
+		IL_0160: ldc.r8 1
+		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_016e: stloc.s 4
+		IL_0170: ldloc.s 4
+		IL_0172: ldc.i4.0
+		IL_0173: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0178: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_017d: stloc.s 6
+		IL_017f: ldloc.s 6
+		IL_0181: box [System.Runtime]System.Boolean
+		IL_0186: stloc.s 7
+		IL_0188: ldloc.s 5
+		IL_018a: ldstr "log"
+		IL_018f: ldloc.s 7
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0196: pop
+		IL_0197: ldstr "a(d)?"
+		IL_019c: ldstr "d"
+		IL_01a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_01a6: stloc.3
+		IL_01a7: ldloc.3
+		IL_01a8: ldstr "exec"
+		IL_01ad: ldstr "bad"
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b7: stloc.2
+		IL_01b8: ldstr "console"
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c7: stloc.s 5
+		IL_01c9: ldloc.2
+		IL_01ca: ldstr "indices"
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d4: stloc.s 4
+		IL_01d6: ldloc.s 4
+		IL_01d8: ldc.r8 0.0
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01e6: stloc.s 4
+		IL_01e8: ldloc.s 4
+		IL_01ea: ldc.r8 0.0
+		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01f8: stloc.s 4
+		IL_01fa: ldloc.s 5
+		IL_01fc: ldstr "log"
+		IL_0201: ldloc.s 4
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0208: pop
+		IL_0209: ldstr "console"
+		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0218: stloc.s 4
+		IL_021a: ldloc.2
+		IL_021b: ldstr "indices"
+		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0225: stloc.s 5
+		IL_0227: ldloc.s 5
+		IL_0229: ldc.r8 0.0
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0237: stloc.s 5
+		IL_0239: ldloc.s 5
+		IL_023b: ldc.r8 1
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0249: stloc.s 5
+		IL_024b: ldloc.s 4
+		IL_024d: ldstr "log"
+		IL_0252: ldloc.s 5
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0259: pop
+		IL_025a: ldstr "console"
+		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0269: stloc.s 5
+		IL_026b: ldloc.2
+		IL_026c: ldstr "indices"
+		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0276: stloc.s 4
+		IL_0278: ldloc.s 4
+		IL_027a: ldc.r8 1
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0288: stloc.s 4
+		IL_028a: ldloc.s 4
+		IL_028c: ldc.r8 0.0
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_029a: stloc.s 4
+		IL_029c: ldloc.s 5
+		IL_029e: ldstr "log"
+		IL_02a3: ldloc.s 4
+		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02aa: pop
+		IL_02ab: ldstr "console"
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ba: stloc.s 4
+		IL_02bc: ldloc.2
+		IL_02bd: ldstr "indices"
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02c7: stloc.s 5
+		IL_02c9: ldloc.s 5
+		IL_02cb: ldc.r8 1
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02d9: stloc.s 5
+		IL_02db: ldloc.s 5
+		IL_02dd: ldc.r8 1
+		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02eb: stloc.s 5
+		IL_02ed: ldloc.s 4
+		IL_02ef: ldstr "log"
+		IL_02f4: ldloc.s 5
+		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02fb: pop
+		IL_02fc: ret
 	} // end of method IntrinsicCallables_RegExp_Indices_Exec::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_Indices_Exec
@@ -279,7 +273,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2370
+		// Method begins at RVA 0x2362
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ModernFlags_Basic.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ModernFlags_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24c1
+				// Method begins at RVA 0x248d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ca
+				// Method begins at RVA 0x2496
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d3
+				// Method begins at RVA 0x249f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24dc
+				// Method begins at RVA 0x24a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24b8
+			// Method begins at RVA 0x2484
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1087 (0x43f)
+		// Code size: 1033 (0x409)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope,
@@ -223,263 +223,245 @@
 		IL_0113: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_0118: stloc.s 11
 		IL_011a: ldloc.s 11
-		IL_011c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0121: stloc.s 11
-		IL_0123: ldloc.s 11
-		IL_0125: ldstr "\ud83d\ude00"
-		IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_012f: stloc.s 9
-		IL_0131: ldloc.s 10
-		IL_0133: ldstr "log"
-		IL_0138: ldloc.s 9
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013f: pop
-		IL_0140: ldstr "console"
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014f: stloc.s 9
-		IL_0151: ldstr "\\u{1F600}"
-		IL_0156: ldstr "u"
-		IL_015b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0160: stloc.s 11
-		IL_0162: ldloc.s 11
-		IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0169: stloc.s 11
-		IL_016b: ldloc.s 11
-		IL_016d: ldstr "\ud83d\ude00"
-		IL_0172: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0177: stloc.s 10
-		IL_0179: ldloc.s 9
-		IL_017b: ldstr "log"
-		IL_0180: ldloc.s 10
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0187: pop
-		IL_0188: ldstr "console"
-		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0197: stloc.s 10
-		IL_0199: ldstr "^.$"
-		IL_019e: ldstr "s"
-		IL_01a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_01a8: stloc.s 11
-		IL_01aa: ldloc.s 11
-		IL_01ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_01b1: stloc.s 11
-		IL_01b3: ldloc.s 11
-		IL_01b5: ldstr "\n"
-		IL_01ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_01bf: stloc.s 9
-		IL_01c1: ldloc.s 10
-		IL_01c3: ldstr "log"
-		IL_01c8: ldloc.s 9
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01cf: pop
-		IL_01d0: ldstr "console"
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01df: stloc.s 9
-		IL_01e1: ldstr "^.$"
-		IL_01e6: ldstr ""
-		IL_01eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_01f0: stloc.s 11
-		IL_01f2: ldloc.s 11
-		IL_01f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_01f9: stloc.s 11
-		IL_01fb: ldloc.s 11
-		IL_01fd: ldstr "\r"
-		IL_0202: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0207: stloc.s 10
-		IL_0209: ldloc.s 9
-		IL_020b: ldstr "log"
-		IL_0210: ldloc.s 10
-		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0217: pop
-		IL_0218: ldstr "console"
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0227: stloc.s 10
-		IL_0229: ldstr "^.$"
-		IL_022e: ldstr ""
-		IL_0233: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0238: stloc.s 11
-		IL_023a: ldloc.s 11
-		IL_023c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0241: stloc.s 11
-		IL_0243: ldloc.s 11
-		IL_0245: ldstr "\u2028"
-		IL_024a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_024f: stloc.s 9
-		IL_0251: ldloc.s 10
-		IL_0253: ldstr "log"
-		IL_0258: ldloc.s 9
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025f: pop
-		IL_0260: ldstr "console"
-		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026f: stloc.s 9
-		IL_0271: ldstr "^.$"
-		IL_0276: ldstr ""
-		IL_027b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0280: stloc.s 11
-		IL_0282: ldloc.s 11
-		IL_0284: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0289: stloc.s 11
-		IL_028b: ldloc.s 11
-		IL_028d: ldstr "\u2029"
-		IL_0292: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0297: stloc.s 10
-		IL_0299: ldloc.s 9
-		IL_029b: ldstr "log"
-		IL_02a0: ldloc.s 10
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a7: pop
+		IL_011c: ldstr "\ud83d\ude00"
+		IL_0121: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0126: stloc.s 9
+		IL_0128: ldloc.s 10
+		IL_012a: ldstr "log"
+		IL_012f: ldloc.s 9
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0136: pop
+		IL_0137: ldstr "console"
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0146: stloc.s 9
+		IL_0148: ldstr "\\u{1F600}"
+		IL_014d: ldstr "u"
+		IL_0152: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0157: stloc.s 11
+		IL_0159: ldloc.s 11
+		IL_015b: ldstr "\ud83d\ude00"
+		IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0165: stloc.s 10
+		IL_0167: ldloc.s 9
+		IL_0169: ldstr "log"
+		IL_016e: ldloc.s 10
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0175: pop
+		IL_0176: ldstr "console"
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0185: stloc.s 10
+		IL_0187: ldstr "^.$"
+		IL_018c: ldstr "s"
+		IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0196: stloc.s 11
+		IL_0198: ldloc.s 11
+		IL_019a: ldstr "\n"
+		IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_01a4: stloc.s 9
+		IL_01a6: ldloc.s 10
+		IL_01a8: ldstr "log"
+		IL_01ad: ldloc.s 9
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b4: pop
+		IL_01b5: ldstr "console"
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c4: stloc.s 9
+		IL_01c6: ldstr "^.$"
+		IL_01cb: ldstr ""
+		IL_01d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_01d5: stloc.s 11
+		IL_01d7: ldloc.s 11
+		IL_01d9: ldstr "\r"
+		IL_01de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_01e3: stloc.s 10
+		IL_01e5: ldloc.s 9
+		IL_01e7: ldstr "log"
+		IL_01ec: ldloc.s 10
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f3: pop
+		IL_01f4: ldstr "console"
+		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0203: stloc.s 10
+		IL_0205: ldstr "^.$"
+		IL_020a: ldstr ""
+		IL_020f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0214: stloc.s 11
+		IL_0216: ldloc.s 11
+		IL_0218: ldstr "\u2028"
+		IL_021d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0222: stloc.s 9
+		IL_0224: ldloc.s 10
+		IL_0226: ldstr "log"
+		IL_022b: ldloc.s 9
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0232: pop
+		IL_0233: ldstr "console"
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0242: stloc.s 9
+		IL_0244: ldstr "^.$"
+		IL_0249: ldstr ""
+		IL_024e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0253: stloc.s 11
+		IL_0255: ldloc.s 11
+		IL_0257: ldstr "\u2029"
+		IL_025c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0261: stloc.s 10
+		IL_0263: ldloc.s 9
+		IL_0265: ldstr "log"
+		IL_026a: ldloc.s 10
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0271: pop
 		.try
 		{
-			IL_02a8: nop
-			IL_02a9: ldstr "a"
-			IL_02ae: ldstr "v"
-			IL_02b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_02b8: pop
-			IL_02b9: ldstr "console"
-			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02c8: ldstr "log"
-			IL_02cd: ldstr "no-error"
-			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02d7: pop
-			IL_02d8: leave IL_03a1
+			IL_0272: nop
+			IL_0273: ldstr "a"
+			IL_0278: ldstr "v"
+			IL_027d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0282: pop
+			IL_0283: ldstr "console"
+			IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0292: ldstr "log"
+			IL_0297: ldstr "no-error"
+			IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02a1: pop
+			IL_02a2: leave IL_036b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02dd: stloc.2
-			IL_02de: ldloc.2
-			IL_02df: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02e4: dup
-			IL_02e5: brtrue IL_02fa
+			IL_02a7: stloc.2
+			IL_02a8: ldloc.2
+			IL_02a9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02ae: dup
+			IL_02af: brtrue IL_02c4
 
-			IL_02ea: pop
-			IL_02eb: ldloc.2
-			IL_02ec: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02f1: dup
-			IL_02f2: brtrue IL_0305
+			IL_02b4: pop
+			IL_02b5: ldloc.2
+			IL_02b6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02bb: dup
+			IL_02bc: brtrue IL_02cf
 
-			IL_02f7: pop
-			IL_02f8: rethrow
+			IL_02c1: pop
+			IL_02c2: rethrow
 
-			IL_02fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02ff: stloc.3
-			IL_0300: br IL_0306
+			IL_02c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02c9: stloc.3
+			IL_02ca: br IL_02d0
 
-			IL_0305: stloc.3
+			IL_02cf: stloc.3
 
-			IL_0306: ldloc.3
-			IL_0307: stloc.s 4
-			IL_0309: ldstr "console"
-			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0318: stloc.s 10
-			IL_031a: ldloc.s 4
-			IL_031c: ldstr "name"
-			IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0326: stloc.s 9
-			IL_0328: ldloc.s 10
-			IL_032a: ldstr "log"
-			IL_032f: ldloc.s 9
-			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0336: pop
-			IL_0337: ldstr "console"
-			IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0346: stloc.s 9
-			IL_0348: ldloc.s 4
-			IL_034a: ldstr "message"
-			IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0354: stloc.s 10
-			IL_0356: ldloc.s 10
-			IL_0358: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_035d: stloc.s 12
-			IL_035f: ldloc.s 12
-			IL_0361: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_0366: stloc.s 12
-			IL_0368: ldloc.s 12
-			IL_036a: ldstr "v"
-			IL_036f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0374: ldc.r8 0.0
-			IL_037d: clt
-			IL_037f: ldc.i4.0
-			IL_0380: ceq
-			IL_0382: stloc.s 13
-			IL_0384: ldloc.s 13
-			IL_0386: box [System.Runtime]System.Boolean
-			IL_038b: stloc.s 14
-			IL_038d: ldloc.s 9
-			IL_038f: ldstr "log"
-			IL_0394: ldloc.s 14
-			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_039b: pop
-			IL_039c: leave IL_03a1
+			IL_02d0: ldloc.3
+			IL_02d1: stloc.s 4
+			IL_02d3: ldstr "console"
+			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02e2: stloc.s 10
+			IL_02e4: ldloc.s 4
+			IL_02e6: ldstr "name"
+			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02f0: stloc.s 9
+			IL_02f2: ldloc.s 10
+			IL_02f4: ldstr "log"
+			IL_02f9: ldloc.s 9
+			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0300: pop
+			IL_0301: ldstr "console"
+			IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0310: stloc.s 9
+			IL_0312: ldloc.s 4
+			IL_0314: ldstr "message"
+			IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_031e: stloc.s 10
+			IL_0320: ldloc.s 10
+			IL_0322: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0327: stloc.s 12
+			IL_0329: ldloc.s 12
+			IL_032b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0330: stloc.s 12
+			IL_0332: ldloc.s 12
+			IL_0334: ldstr "v"
+			IL_0339: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_033e: ldc.r8 0.0
+			IL_0347: clt
+			IL_0349: ldc.i4.0
+			IL_034a: ceq
+			IL_034c: stloc.s 13
+			IL_034e: ldloc.s 13
+			IL_0350: box [System.Runtime]System.Boolean
+			IL_0355: stloc.s 14
+			IL_0357: ldloc.s 9
+			IL_0359: ldstr "log"
+			IL_035e: ldloc.s 14
+			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0365: pop
+			IL_0366: leave IL_036b
 		} // end handler
 		.try
 		{
-			IL_03a1: nop
-			IL_03a2: ldstr "a"
-			IL_03a7: ldstr "gg"
-			IL_03ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_03b1: pop
-			IL_03b2: ldstr "console"
-			IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03c1: ldstr "log"
-			IL_03c6: ldstr "no-error"
-			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03d0: pop
-			IL_03d1: leave IL_043b
+			IL_036b: nop
+			IL_036c: ldstr "a"
+			IL_0371: ldstr "gg"
+			IL_0376: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_037b: pop
+			IL_037c: ldstr "console"
+			IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_038b: ldstr "log"
+			IL_0390: ldstr "no-error"
+			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_039a: pop
+			IL_039b: leave IL_0405
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03d6: stloc.s 5
-			IL_03d8: ldloc.s 5
-			IL_03da: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03df: dup
-			IL_03e0: brtrue IL_03f6
+			IL_03a0: stloc.s 5
+			IL_03a2: ldloc.s 5
+			IL_03a4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03a9: dup
+			IL_03aa: brtrue IL_03c0
 
-			IL_03e5: pop
-			IL_03e6: ldloc.s 5
-			IL_03e8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03ed: dup
-			IL_03ee: brtrue IL_0402
+			IL_03af: pop
+			IL_03b0: ldloc.s 5
+			IL_03b2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03b7: dup
+			IL_03b8: brtrue IL_03cc
 
-			IL_03f3: pop
-			IL_03f4: rethrow
+			IL_03bd: pop
+			IL_03be: rethrow
 
-			IL_03f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03fb: stloc.s 6
-			IL_03fd: br IL_0404
+			IL_03c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03c5: stloc.s 6
+			IL_03c7: br IL_03ce
 
-			IL_0402: stloc.s 6
+			IL_03cc: stloc.s 6
 
-			IL_0404: ldloc.s 6
-			IL_0406: stloc.s 7
-			IL_0408: ldstr "console"
-			IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0417: stloc.s 9
-			IL_0419: ldloc.s 7
-			IL_041b: ldstr "name"
-			IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0425: stloc.s 10
-			IL_0427: ldloc.s 9
-			IL_0429: ldstr "log"
-			IL_042e: ldloc.s 10
-			IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0435: pop
-			IL_0436: leave IL_043b
+			IL_03ce: ldloc.s 6
+			IL_03d0: stloc.s 7
+			IL_03d2: ldstr "console"
+			IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03e1: stloc.s 9
+			IL_03e3: ldloc.s 7
+			IL_03e5: ldstr "name"
+			IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03ef: stloc.s 10
+			IL_03f1: ldloc.s 9
+			IL_03f3: ldstr "log"
+			IL_03f8: ldloc.s 10
+			IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03ff: pop
+			IL_0400: leave IL_0405
 		} // end handler
 
-		IL_043b: ldnull
-		IL_043c: stloc.s 8
-		IL_043e: ret
+		IL_0405: ldnull
+		IL_0406: stloc.s 8
+		IL_0408: ret
 	} // end of method IntrinsicCallables_RegExp_ModernFlags_Basic::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_ModernFlags_Basic
@@ -491,7 +473,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24e5
+		// Method begins at RVA 0x24b1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Test_LastIndex_Global.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Test_LastIndex_Global.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2211
+			// Method begins at RVA 0x21ed
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 437 (0x1b5)
+		// Code size: 401 (0x191)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_Test_LastIndex_Global/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[2] string,
 			[3] object,
-			[4] object,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.IntrinsicCallables_RegExp_Test_LastIndex_Global/Scope::.ctor()
@@ -78,118 +77,106 @@
 		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0057: stloc.s 4
 		IL_0059: ldloc.1
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_005f: stloc.s 5
-		IL_0061: ldloc.s 5
-		IL_0063: ldloc.2
-		IL_0064: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0069: stloc.3
-		IL_006a: ldloc.s 4
-		IL_006c: ldstr "log"
-		IL_0071: ldloc.3
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0077: pop
-		IL_0078: ldstr "console"
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0087: stloc.3
-		IL_0088: ldloc.1
-		IL_0089: ldstr "lastIndex"
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0093: stloc.s 4
-		IL_0095: ldloc.3
-		IL_0096: ldstr "log"
-		IL_009b: ldloc.s 4
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a2: pop
-		IL_00a3: ldstr "console"
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b2: stloc.s 4
-		IL_00b4: ldloc.1
-		IL_00b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_00ba: stloc.s 5
-		IL_00bc: ldloc.s 5
-		IL_00be: ldloc.2
-		IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_00c4: stloc.3
-		IL_00c5: ldloc.s 4
-		IL_00c7: ldstr "log"
-		IL_00cc: ldloc.3
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d2: pop
-		IL_00d3: ldstr "console"
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e2: stloc.3
-		IL_00e3: ldloc.1
-		IL_00e4: ldstr "lastIndex"
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ee: stloc.s 4
-		IL_00f0: ldloc.3
-		IL_00f1: ldstr "log"
-		IL_00f6: ldloc.s 4
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fd: pop
-		IL_00fe: ldstr "console"
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010d: stloc.s 4
-		IL_010f: ldloc.1
-		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0115: stloc.s 5
-		IL_0117: ldloc.s 5
-		IL_0119: ldloc.2
-		IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_011f: stloc.3
-		IL_0120: ldloc.s 4
-		IL_0122: ldstr "log"
-		IL_0127: ldloc.3
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012d: pop
-		IL_012e: ldstr "console"
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013d: stloc.3
-		IL_013e: ldloc.1
-		IL_013f: ldstr "lastIndex"
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0149: stloc.s 4
-		IL_014b: ldloc.3
-		IL_014c: ldstr "log"
-		IL_0151: ldloc.s 4
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0158: pop
-		IL_0159: ldstr "console"
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0168: stloc.s 4
-		IL_016a: ldloc.1
-		IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0170: stloc.s 5
-		IL_0172: ldloc.s 5
-		IL_0174: ldloc.2
-		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_017a: stloc.3
-		IL_017b: ldloc.s 4
-		IL_017d: ldstr "log"
+		IL_005a: ldloc.2
+		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0060: stloc.3
+		IL_0061: ldloc.s 4
+		IL_0063: ldstr "log"
+		IL_0068: ldloc.3
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006e: pop
+		IL_006f: ldstr "console"
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007e: stloc.3
+		IL_007f: ldloc.1
+		IL_0080: ldstr "lastIndex"
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_008a: stloc.s 4
+		IL_008c: ldloc.3
+		IL_008d: ldstr "log"
+		IL_0092: ldloc.s 4
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0099: pop
+		IL_009a: ldstr "console"
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a9: stloc.s 4
+		IL_00ab: ldloc.1
+		IL_00ac: ldloc.2
+		IL_00ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_00b2: stloc.3
+		IL_00b3: ldloc.s 4
+		IL_00b5: ldstr "log"
+		IL_00ba: ldloc.3
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c0: pop
+		IL_00c1: ldstr "console"
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d0: stloc.3
+		IL_00d1: ldloc.1
+		IL_00d2: ldstr "lastIndex"
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00dc: stloc.s 4
+		IL_00de: ldloc.3
+		IL_00df: ldstr "log"
+		IL_00e4: ldloc.s 4
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00eb: pop
+		IL_00ec: ldstr "console"
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fb: stloc.s 4
+		IL_00fd: ldloc.1
+		IL_00fe: ldloc.2
+		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0104: stloc.3
+		IL_0105: ldloc.s 4
+		IL_0107: ldstr "log"
+		IL_010c: ldloc.3
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0112: pop
+		IL_0113: ldstr "console"
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0122: stloc.3
+		IL_0123: ldloc.1
+		IL_0124: ldstr "lastIndex"
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012e: stloc.s 4
+		IL_0130: ldloc.3
+		IL_0131: ldstr "log"
+		IL_0136: ldloc.s 4
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013d: pop
+		IL_013e: ldstr "console"
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014d: stloc.s 4
+		IL_014f: ldloc.1
+		IL_0150: ldloc.2
+		IL_0151: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0156: stloc.3
+		IL_0157: ldloc.s 4
+		IL_0159: ldstr "log"
+		IL_015e: ldloc.3
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0164: pop
+		IL_0165: ldstr "console"
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0174: stloc.3
+		IL_0175: ldloc.1
+		IL_0176: ldstr "lastIndex"
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0180: stloc.s 4
 		IL_0182: ldloc.3
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0188: pop
-		IL_0189: ldstr "console"
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0198: stloc.3
-		IL_0199: ldloc.1
-		IL_019a: ldstr "lastIndex"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a4: stloc.s 4
-		IL_01a6: ldloc.3
-		IL_01a7: ldstr "log"
-		IL_01ac: ldloc.s 4
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b3: pop
-		IL_01b4: ret
+		IL_0183: ldstr "log"
+		IL_0188: ldloc.s 4
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018f: pop
+		IL_0190: ret
 	} // end of method IntrinsicCallables_RegExp_Test_LastIndex_Global::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_Test_LastIndex_Global
@@ -201,7 +188,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x221a
+		// Method begins at RVA 0x21f6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Test_LastIndex_Sticky.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Test_LastIndex_Sticky.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22de
+			// Method begins at RVA 0x22a8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 642 (0x282)
+		// Code size: 588 (0x24c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_Test_LastIndex_Sticky/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[2] string,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[5] object
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.IntrinsicCallables_RegExp_Test_LastIndex_Sticky/Scope::.ctor()
@@ -71,188 +70,170 @@
 		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0042: stloc.3
 		IL_0043: ldloc.1
-		IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0049: stloc.s 4
-		IL_004b: ldloc.s 4
-		IL_004d: ldloc.2
-		IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0053: stloc.s 5
-		IL_0055: ldloc.3
-		IL_0056: ldstr "log"
-		IL_005b: ldloc.s 5
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0062: pop
-		IL_0063: ldstr "console"
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0072: stloc.s 5
-		IL_0074: ldloc.1
-		IL_0075: ldstr "lastIndex"
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_007f: stloc.3
-		IL_0080: ldloc.s 5
-		IL_0082: ldstr "log"
-		IL_0087: ldloc.3
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008d: pop
-		IL_008e: ldstr "console"
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009d: stloc.3
-		IL_009e: ldloc.1
-		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_00a4: stloc.s 4
-		IL_00a6: ldloc.s 4
-		IL_00a8: ldloc.2
-		IL_00a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_00ae: stloc.s 5
-		IL_00b0: ldloc.3
-		IL_00b1: ldstr "log"
-		IL_00b6: ldloc.s 5
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bd: pop
-		IL_00be: ldstr "console"
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cd: stloc.s 5
-		IL_00cf: ldloc.1
-		IL_00d0: ldstr "lastIndex"
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00da: stloc.3
-		IL_00db: ldloc.s 5
-		IL_00dd: ldstr "log"
-		IL_00e2: ldloc.3
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e8: pop
-		IL_00e9: ldstr "console"
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f8: stloc.3
-		IL_00f9: ldloc.1
-		IL_00fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_00ff: stloc.s 4
-		IL_0101: ldloc.s 4
-		IL_0103: ldloc.2
-		IL_0104: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0109: stloc.s 5
-		IL_010b: ldloc.3
-		IL_010c: ldstr "log"
-		IL_0111: ldloc.s 5
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0118: pop
-		IL_0119: ldstr "console"
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0128: stloc.s 5
-		IL_012a: ldloc.1
-		IL_012b: ldstr "lastIndex"
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0135: stloc.3
-		IL_0136: ldloc.s 5
-		IL_0138: ldstr "log"
-		IL_013d: ldloc.3
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0143: pop
-		IL_0144: ldstr "console"
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0153: stloc.3
-		IL_0154: ldloc.1
-		IL_0155: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_015a: stloc.s 4
-		IL_015c: ldloc.s 4
-		IL_015e: ldloc.2
-		IL_015f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0164: stloc.s 5
-		IL_0166: ldloc.3
-		IL_0167: ldstr "log"
-		IL_016c: ldloc.s 5
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0173: pop
-		IL_0174: ldstr "console"
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0183: stloc.s 5
-		IL_0185: ldloc.1
-		IL_0186: ldstr "lastIndex"
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0190: stloc.3
-		IL_0191: ldloc.s 5
-		IL_0193: ldstr "log"
-		IL_0198: ldloc.3
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019e: pop
-		IL_019f: ldloc.1
-		IL_01a0: ldstr "lastIndex"
-		IL_01a5: ldc.r8 0.0
-		IL_01ae: ldc.i4.1
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_01b4: pop
-		IL_01b5: ldstr "console"
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c4: stloc.3
-		IL_01c5: ldloc.1
-		IL_01c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_01cb: stloc.s 4
-		IL_01cd: ldloc.s 4
-		IL_01cf: ldloc.2
-		IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_01d5: stloc.s 5
-		IL_01d7: ldloc.3
-		IL_01d8: ldstr "log"
-		IL_01dd: ldloc.s 5
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e4: pop
-		IL_01e5: ldstr "console"
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f4: stloc.s 5
-		IL_01f6: ldloc.1
-		IL_01f7: ldstr "lastIndex"
-		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0201: stloc.3
-		IL_0202: ldloc.s 5
-		IL_0204: ldstr "log"
-		IL_0209: ldloc.3
-		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020f: pop
-		IL_0210: ldloc.1
-		IL_0211: ldstr "lastIndex"
-		IL_0216: ldc.r8 (00 00 00 00 00 00 F0 7F)
-		IL_021f: ldc.i4.1
-		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0225: pop
-		IL_0226: ldstr "console"
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0235: stloc.3
-		IL_0236: ldloc.1
-		IL_0237: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_023c: stloc.s 4
-		IL_023e: ldloc.s 4
-		IL_0240: ldloc.2
-		IL_0241: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0246: stloc.s 5
-		IL_0248: ldloc.3
-		IL_0249: ldstr "log"
-		IL_024e: ldloc.s 5
-		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0255: pop
-		IL_0256: ldstr "console"
-		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0265: stloc.s 5
-		IL_0267: ldloc.1
-		IL_0268: ldstr "lastIndex"
-		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0272: stloc.3
-		IL_0273: ldloc.s 5
-		IL_0275: ldstr "log"
-		IL_027a: ldloc.3
-		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0280: pop
-		IL_0281: ret
+		IL_0044: ldloc.2
+		IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_004a: stloc.s 4
+		IL_004c: ldloc.3
+		IL_004d: ldstr "log"
+		IL_0052: ldloc.s 4
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0059: pop
+		IL_005a: ldstr "console"
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0069: stloc.s 4
+		IL_006b: ldloc.1
+		IL_006c: ldstr "lastIndex"
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0076: stloc.3
+		IL_0077: ldloc.s 4
+		IL_0079: ldstr "log"
+		IL_007e: ldloc.3
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0084: pop
+		IL_0085: ldstr "console"
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0094: stloc.3
+		IL_0095: ldloc.1
+		IL_0096: ldloc.2
+		IL_0097: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_009c: stloc.s 4
+		IL_009e: ldloc.3
+		IL_009f: ldstr "log"
+		IL_00a4: ldloc.s 4
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ab: pop
+		IL_00ac: ldstr "console"
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00bb: stloc.s 4
+		IL_00bd: ldloc.1
+		IL_00be: ldstr "lastIndex"
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c8: stloc.3
+		IL_00c9: ldloc.s 4
+		IL_00cb: ldstr "log"
+		IL_00d0: ldloc.3
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d6: pop
+		IL_00d7: ldstr "console"
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e6: stloc.3
+		IL_00e7: ldloc.1
+		IL_00e8: ldloc.2
+		IL_00e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_00ee: stloc.s 4
+		IL_00f0: ldloc.3
+		IL_00f1: ldstr "log"
+		IL_00f6: ldloc.s 4
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fd: pop
+		IL_00fe: ldstr "console"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010d: stloc.s 4
+		IL_010f: ldloc.1
+		IL_0110: ldstr "lastIndex"
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011a: stloc.3
+		IL_011b: ldloc.s 4
+		IL_011d: ldstr "log"
+		IL_0122: ldloc.3
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0128: pop
+		IL_0129: ldstr "console"
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0138: stloc.3
+		IL_0139: ldloc.1
+		IL_013a: ldloc.2
+		IL_013b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0140: stloc.s 4
+		IL_0142: ldloc.3
+		IL_0143: ldstr "log"
+		IL_0148: ldloc.s 4
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014f: pop
+		IL_0150: ldstr "console"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015f: stloc.s 4
+		IL_0161: ldloc.1
+		IL_0162: ldstr "lastIndex"
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_016c: stloc.3
+		IL_016d: ldloc.s 4
+		IL_016f: ldstr "log"
+		IL_0174: ldloc.3
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017a: pop
+		IL_017b: ldloc.1
+		IL_017c: ldstr "lastIndex"
+		IL_0181: ldc.r8 0.0
+		IL_018a: ldc.i4.1
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0190: pop
+		IL_0191: ldstr "console"
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a0: stloc.3
+		IL_01a1: ldloc.1
+		IL_01a2: ldloc.2
+		IL_01a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_01a8: stloc.s 4
+		IL_01aa: ldloc.3
+		IL_01ab: ldstr "log"
+		IL_01b0: ldloc.s 4
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b7: pop
+		IL_01b8: ldstr "console"
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c7: stloc.s 4
+		IL_01c9: ldloc.1
+		IL_01ca: ldstr "lastIndex"
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d4: stloc.3
+		IL_01d5: ldloc.s 4
+		IL_01d7: ldstr "log"
+		IL_01dc: ldloc.3
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e2: pop
+		IL_01e3: ldloc.1
+		IL_01e4: ldstr "lastIndex"
+		IL_01e9: ldc.r8 (00 00 00 00 00 00 F0 7F)
+		IL_01f2: ldc.i4.1
+		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_01f8: pop
+		IL_01f9: ldstr "console"
+		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0208: stloc.3
+		IL_0209: ldloc.1
+		IL_020a: ldloc.2
+		IL_020b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0210: stloc.s 4
+		IL_0212: ldloc.3
+		IL_0213: ldstr "log"
+		IL_0218: ldloc.s 4
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_021f: pop
+		IL_0220: ldstr "console"
+		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_022f: stloc.s 4
+		IL_0231: ldloc.1
+		IL_0232: ldstr "lastIndex"
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023c: stloc.3
+		IL_023d: ldloc.s 4
+		IL_023f: ldstr "log"
+		IL_0244: ldloc.3
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024a: pop
+		IL_024b: ret
 	} // end of method IntrinsicCallables_RegExp_Test_LastIndex_Sticky::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_Test_LastIndex_Sticky
@@ -264,7 +245,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e7
+		// Method begins at RVA 0x22b1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ToString_Basic.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ToString_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2132
+			// Method begins at RVA 0x2120
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 214 (0xd6)
+		// Code size: 196 (0xc4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_ToString_Basic/Scope,
@@ -48,8 +48,7 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[3] object,
 			[4] object,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[6] object
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.IntrinsicCallables_RegExp_ToString_Basic/Scope::.ctor()
@@ -64,56 +63,50 @@
 		IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0026: stloc.s 4
 		IL_0028: ldloc.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_002e: stloc.s 5
-		IL_0030: ldloc.s 5
-		IL_0032: ldstr "toString"
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_003c: stloc.s 6
-		IL_003e: ldloc.s 4
-		IL_0040: ldstr "log"
-		IL_0045: ldloc.s 6
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004c: pop
-		IL_004d: ldstr "test"
-		IL_0052: ldstr ""
-		IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_005c: stloc.2
-		IL_005d: ldstr "console"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006c: stloc.s 6
-		IL_006e: ldloc.2
-		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0074: stloc.s 5
-		IL_0076: ldloc.s 5
-		IL_0078: ldstr "toString"
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0082: stloc.s 4
-		IL_0084: ldloc.s 6
-		IL_0086: ldstr "log"
-		IL_008b: ldloc.s 4
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0092: pop
-		IL_0093: ldstr "hello"
-		IL_0098: ldstr "i"
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.RegExp::Call(object, object)
-		IL_00a2: stloc.3
-		IL_00a3: ldstr "console"
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b2: stloc.s 4
-		IL_00b4: ldloc.3
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ba: ldstr "toString"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00c4: stloc.s 6
-		IL_00c6: ldloc.s 4
-		IL_00c8: ldstr "log"
-		IL_00cd: ldloc.s 6
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d4: pop
-		IL_00d5: ret
+		IL_0029: ldstr "toString"
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0033: stloc.s 5
+		IL_0035: ldloc.s 4
+		IL_0037: ldstr "log"
+		IL_003c: ldloc.s 5
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0043: pop
+		IL_0044: ldstr "test"
+		IL_0049: ldstr ""
+		IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0053: stloc.2
+		IL_0054: ldstr "console"
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0063: stloc.s 5
+		IL_0065: ldloc.2
+		IL_0066: ldstr "toString"
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0070: stloc.s 4
+		IL_0072: ldloc.s 5
+		IL_0074: ldstr "log"
+		IL_0079: ldloc.s 4
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0080: pop
+		IL_0081: ldstr "hello"
+		IL_0086: ldstr "i"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.RegExp::Call(object, object)
+		IL_0090: stloc.3
+		IL_0091: ldstr "console"
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a0: stloc.s 4
+		IL_00a2: ldloc.3
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a8: ldstr "toString"
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00b2: stloc.s 5
+		IL_00b4: ldloc.s 4
+		IL_00b6: ldstr "log"
+		IL_00bb: ldloc.s 5
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c2: pop
+		IL_00c3: ret
 	} // end of method IntrinsicCallables_RegExp_ToString_Basic::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_ToString_Basic
@@ -125,7 +118,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x213b
+		// Method begins at RVA 0x2129
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Literals/Snapshots/GeneratorTests.NewExpression_Boolean_Sugar.verified.txt
+++ b/tests/Jroc.Tests/Literals/Snapshots/GeneratorTests.NewExpression_Boolean_Sugar.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2316
+			// Method begins at RVA 0x22f8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 698 (0x2ba)
+		// Code size: 668 (0x29c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.NewExpression_Boolean_Sugar/Scope,
@@ -93,164 +93,158 @@
 		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_007c: stloc.s 6
 		IL_007e: ldloc.1
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0084: ldstr "valueOf"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_008e: stloc.s 8
-		IL_0090: ldloc.s 6
-		IL_0092: ldstr "log"
-		IL_0097: ldloc.s 8
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009e: pop
-		IL_009f: ldstr "console"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ae: stloc.s 8
-		IL_00b0: ldloc.2
-		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b6: ldstr "valueOf"
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00c0: stloc.s 6
-		IL_00c2: ldloc.s 8
-		IL_00c4: ldstr "log"
-		IL_00c9: ldloc.s 6
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d0: pop
-		IL_00d1: ldstr "console"
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e0: stloc.s 6
-		IL_00e2: ldloc.3
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e8: ldstr "valueOf"
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00f2: stloc.s 8
-		IL_00f4: ldloc.s 6
-		IL_00f6: ldstr "log"
-		IL_00fb: ldloc.s 8
-		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0102: pop
-		IL_0103: ldstr "console"
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0112: stloc.s 8
-		IL_0114: ldloc.s 4
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011b: ldstr "valueOf"
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0125: stloc.s 6
-		IL_0127: ldloc.s 8
-		IL_0129: ldstr "log"
-		IL_012e: ldloc.s 6
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0135: pop
-		IL_0136: ldstr "console"
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0145: stloc.s 6
-		IL_0147: ldloc.s 5
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014e: ldstr "valueOf"
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0158: stloc.s 8
-		IL_015a: ldloc.s 6
-		IL_015c: ldstr "log"
-		IL_0161: ldloc.s 8
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0168: pop
-		IL_0169: ldstr "console"
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0178: stloc.s 8
-		IL_017a: ldloc.1
-		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0180: ldstr "toString"
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_018a: stloc.s 6
-		IL_018c: ldloc.s 8
-		IL_018e: ldstr "log"
-		IL_0193: ldloc.s 6
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019a: pop
-		IL_019b: ldstr "console"
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01aa: stloc.s 6
-		IL_01ac: ldstr "Boolean"
-		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b6: ldstr "prototype"
-		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c0: stloc.s 8
-		IL_01c2: ldloc.s 8
-		IL_01c4: ldstr "constructor"
-		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ce: stloc.s 8
-		IL_01d0: ldstr "Boolean"
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01da: stloc.s 9
-		IL_01dc: ldloc.s 8
-		IL_01de: ldloc.s 9
-		IL_01e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01e5: stloc.s 10
-		IL_01e7: ldloc.s 10
-		IL_01e9: box [System.Runtime]System.Boolean
-		IL_01ee: stloc.s 11
-		IL_01f0: ldloc.s 6
-		IL_01f2: ldstr "log"
-		IL_01f7: ldloc.s 11
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fe: pop
-		IL_01ff: ldstr "console"
-		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020e: stloc.s 6
-		IL_0210: ldstr "Boolean"
-		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_021a: ldstr "prototype"
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0224: stloc.s 9
-		IL_0226: ldloc.s 9
-		IL_0228: ldstr "toString"
-		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0232: stloc.s 9
-		IL_0234: ldloc.s 9
-		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023b: ldstr "call"
-		IL_0240: ldc.i4.0
-		IL_0241: box [System.Runtime]System.Boolean
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024b: stloc.s 9
-		IL_024d: ldloc.s 6
-		IL_024f: ldstr "log"
-		IL_0254: ldloc.s 9
-		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025b: pop
-		IL_025c: ldstr "console"
-		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026b: stloc.s 9
-		IL_026d: ldstr "Boolean"
-		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0277: ldstr "prototype"
-		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0281: stloc.s 6
-		IL_0283: ldloc.s 6
-		IL_0285: ldstr "valueOf"
-		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_028f: stloc.s 6
-		IL_0291: ldloc.s 6
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0298: ldstr "call"
-		IL_029d: ldc.i4.1
-		IL_029e: box [System.Runtime]System.Boolean
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a8: stloc.s 6
-		IL_02aa: ldloc.s 9
-		IL_02ac: ldstr "log"
-		IL_02b1: ldloc.s 6
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b8: pop
-		IL_02b9: ret
+		IL_007f: ldstr "valueOf"
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0089: stloc.s 8
+		IL_008b: ldloc.s 6
+		IL_008d: ldstr "log"
+		IL_0092: ldloc.s 8
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0099: pop
+		IL_009a: ldstr "console"
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a9: stloc.s 8
+		IL_00ab: ldloc.2
+		IL_00ac: ldstr "valueOf"
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00b6: stloc.s 6
+		IL_00b8: ldloc.s 8
+		IL_00ba: ldstr "log"
+		IL_00bf: ldloc.s 6
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c6: pop
+		IL_00c7: ldstr "console"
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d6: stloc.s 6
+		IL_00d8: ldloc.3
+		IL_00d9: ldstr "valueOf"
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00e3: stloc.s 8
+		IL_00e5: ldloc.s 6
+		IL_00e7: ldstr "log"
+		IL_00ec: ldloc.s 8
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f3: pop
+		IL_00f4: ldstr "console"
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0103: stloc.s 8
+		IL_0105: ldloc.s 4
+		IL_0107: ldstr "valueOf"
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0111: stloc.s 6
+		IL_0113: ldloc.s 8
+		IL_0115: ldstr "log"
+		IL_011a: ldloc.s 6
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0121: pop
+		IL_0122: ldstr "console"
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0131: stloc.s 6
+		IL_0133: ldloc.s 5
+		IL_0135: ldstr "valueOf"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_013f: stloc.s 8
+		IL_0141: ldloc.s 6
+		IL_0143: ldstr "log"
+		IL_0148: ldloc.s 8
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014f: pop
+		IL_0150: ldstr "console"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015f: stloc.s 8
+		IL_0161: ldloc.1
+		IL_0162: ldstr "toString"
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_016c: stloc.s 6
+		IL_016e: ldloc.s 8
+		IL_0170: ldstr "log"
+		IL_0175: ldloc.s 6
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017c: pop
+		IL_017d: ldstr "console"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018c: stloc.s 6
+		IL_018e: ldstr "Boolean"
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0198: ldstr "prototype"
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a2: stloc.s 8
+		IL_01a4: ldloc.s 8
+		IL_01a6: ldstr "constructor"
+		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01b0: stloc.s 8
+		IL_01b2: ldstr "Boolean"
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01bc: stloc.s 9
+		IL_01be: ldloc.s 8
+		IL_01c0: ldloc.s 9
+		IL_01c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01c7: stloc.s 10
+		IL_01c9: ldloc.s 10
+		IL_01cb: box [System.Runtime]System.Boolean
+		IL_01d0: stloc.s 11
+		IL_01d2: ldloc.s 6
+		IL_01d4: ldstr "log"
+		IL_01d9: ldloc.s 11
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e0: pop
+		IL_01e1: ldstr "console"
+		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f0: stloc.s 6
+		IL_01f2: ldstr "Boolean"
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01fc: ldstr "prototype"
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0206: stloc.s 9
+		IL_0208: ldloc.s 9
+		IL_020a: ldstr "toString"
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0214: stloc.s 9
+		IL_0216: ldloc.s 9
+		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021d: ldstr "call"
+		IL_0222: ldc.i4.0
+		IL_0223: box [System.Runtime]System.Boolean
+		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_022d: stloc.s 9
+		IL_022f: ldloc.s 6
+		IL_0231: ldstr "log"
+		IL_0236: ldloc.s 9
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023d: pop
+		IL_023e: ldstr "console"
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024d: stloc.s 9
+		IL_024f: ldstr "Boolean"
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0259: ldstr "prototype"
+		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0263: stloc.s 6
+		IL_0265: ldloc.s 6
+		IL_0267: ldstr "valueOf"
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0271: stloc.s 6
+		IL_0273: ldloc.s 6
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_027a: ldstr "call"
+		IL_027f: ldc.i4.1
+		IL_0280: box [System.Runtime]System.Boolean
+		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028a: stloc.s 6
+		IL_028c: ldloc.s 9
+		IL_028e: ldstr "log"
+		IL_0293: ldloc.s 6
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029a: pop
+		IL_029b: ret
 	} // end of method NewExpression_Boolean_Sugar::__js_module_init__
 
 } // end of class Modules.NewExpression_Boolean_Sugar
@@ -262,7 +256,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x231f
+		// Method begins at RVA 0x2301
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Clear_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Clear_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x210d
+			// Method begins at RVA 0x20f4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 177 (0xb1)
+		// Code size: 152 (0x98)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Clear_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[3] object,
-			[4] object
+			[2] object,
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Clear_Basic/Scope::.ctor()
@@ -56,57 +55,48 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0013: stloc.2
-		IL_0014: ldloc.2
-		IL_0015: ldstr "set"
-		IL_001a: ldstr "key1"
-		IL_001f: ldstr "value1"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0029: pop
-		IL_002a: ldloc.1
-		IL_002b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0030: stloc.2
-		IL_0031: ldloc.2
-		IL_0032: ldstr "set"
-		IL_0037: ldstr "key2"
-		IL_003c: ldstr "value2"
-		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0046: pop
-		IL_0047: ldstr "console"
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0056: stloc.3
-		IL_0057: ldloc.1
-		IL_0058: ldstr "size"
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0062: stloc.s 4
-		IL_0064: ldloc.3
-		IL_0065: ldstr "log"
-		IL_006a: ldloc.s 4
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0071: pop
-		IL_0072: ldloc.1
-		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0078: stloc.2
-		IL_0079: ldloc.2
-		IL_007a: ldstr "clear"
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0084: pop
-		IL_0085: ldstr "console"
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0094: stloc.s 4
-		IL_0096: ldloc.1
-		IL_0097: ldstr "size"
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a1: stloc.3
-		IL_00a2: ldloc.s 4
-		IL_00a4: ldstr "log"
-		IL_00a9: ldloc.3
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00af: pop
-		IL_00b0: ret
+		IL_000e: ldstr "set"
+		IL_0013: ldstr "key1"
+		IL_0018: ldstr "value1"
+		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0022: pop
+		IL_0023: ldloc.1
+		IL_0024: ldstr "set"
+		IL_0029: ldstr "key2"
+		IL_002e: ldstr "value2"
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0038: pop
+		IL_0039: ldstr "console"
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0048: stloc.2
+		IL_0049: ldloc.1
+		IL_004a: ldstr "size"
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0054: stloc.3
+		IL_0055: ldloc.2
+		IL_0056: ldstr "log"
+		IL_005b: ldloc.3
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0061: pop
+		IL_0062: ldloc.1
+		IL_0063: ldstr "clear"
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_006d: pop
+		IL_006e: ldstr "console"
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007d: stloc.3
+		IL_007e: ldloc.1
+		IL_007f: ldstr "size"
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0089: stloc.2
+		IL_008a: ldloc.3
+		IL_008b: ldstr "log"
+		IL_0090: ldloc.2
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0096: pop
+		IL_0097: ret
 	} // end of method Map_Clear_Basic::__js_module_init__
 
 } // end of class Modules.Map_Clear_Basic
@@ -118,7 +108,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2116
+		// Method begins at RVA 0x20fd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x292a
+						// Method begins at RVA 0x2906
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2921
+					// Method begins at RVA 0x28fd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x269c
+				// Method begins at RVA 0x2678
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -178,7 +178,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2918
+				// Method begins at RVA 0x28f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -204,7 +204,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x23f8
+			// Method begins at RVA 0x23d4
 			// Header size: 12
 			// Code size: 226 (0xe2)
 			.maxstack 8
@@ -311,7 +311,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2945
+						// Method begins at RVA 0x2921
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -329,7 +329,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x293c
+					// Method begins at RVA 0x2918
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -353,7 +353,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2770
+				// Method begins at RVA 0x274c
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -458,7 +458,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x294e
+					// Method begins at RVA 0x292a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -482,7 +482,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2843
+				// Method begins at RVA 0x281f
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -520,7 +520,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2933
+				// Method begins at RVA 0x290f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -546,7 +546,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x24e8
+			// Method begins at RVA 0x24c4
 			// Header size: 12
 			// Code size: 254 (0xfe)
 			.maxstack 8
@@ -671,7 +671,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2969
+						// Method begins at RVA 0x2945
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -689,7 +689,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2960
+					// Method begins at RVA 0x293c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -713,7 +713,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x286c
+				// Method begins at RVA 0x2848
 				// Header size: 12
 				// Code size: 113 (0x71)
 				.maxstack 8
@@ -779,7 +779,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2972
+					// Method begins at RVA 0x294e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -803,7 +803,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x28e9
+				// Method begins at RVA 0x28c5
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -839,7 +839,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2957
+				// Method begins at RVA 0x2933
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -865,7 +865,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x25f4
+			// Method begins at RVA 0x25d0
 			// Header size: 12
 			// Code size: 154 (0x9a)
 			.maxstack 8
@@ -965,7 +965,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x297b
+				// Method begins at RVA 0x2957
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -985,7 +985,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2984
+				// Method begins at RVA 0x2960
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1007,7 +1007,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x290f
+			// Method begins at RVA 0x28eb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1033,7 +1033,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 908 (0x38c)
+		// Code size: 872 (0x368)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Constructor_Iterable/Scope,
@@ -1051,10 +1051,9 @@
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[14] object,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[16] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[17] bool,
-			[18] object
+			[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[16] bool,
+			[17] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Constructor_Iterable/Scope::.ctor()
@@ -1108,250 +1107,238 @@
 		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_009b: stloc.s 14
 		IL_009d: ldloc.2
-		IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_00a3: stloc.s 15
-		IL_00a5: ldloc.s 15
-		IL_00a7: ldstr "get"
-		IL_00ac: ldstr "alpha"
-		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b6: stloc.s 11
-		IL_00b8: ldloc.s 14
-		IL_00ba: ldstr "log"
-		IL_00bf: ldloc.s 11
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c6: pop
-		IL_00c7: ldstr "console"
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d6: stloc.s 11
-		IL_00d8: ldloc.2
-		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_00de: stloc.s 15
-		IL_00e0: ldloc.s 15
-		IL_00e2: ldstr "get"
-		IL_00e7: ldstr "beta"
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f1: stloc.s 14
-		IL_00f3: ldloc.s 11
-		IL_00f5: ldstr "log"
-		IL_00fa: ldloc.s 14
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0101: pop
-		IL_0102: ldloc.0
-		IL_0103: ldc.i4.0
-		IL_0104: box [System.Runtime]System.Boolean
-		IL_0109: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_010e: ldstr "iterator"
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0118: stloc.s 14
-		IL_011a: ldloc.0
-		IL_011b: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_0120: ldftn object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
-		IL_0126: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_012b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0130: ldc.i4.0
-		IL_0131: conv.r8
-		IL_0132: ldstr ""
-		IL_0137: ldc.i4.0
-		IL_0138: ldc.i4.1
-		IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_013e: stloc.s 12
-		IL_0140: ldloc.s 12
-		IL_0142: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0147: stloc.s 12
-		IL_0149: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_014e: stloc.s 13
-		IL_0150: ldloc.s 13
-		IL_0152: ldloc.s 14
-		IL_0154: ldloc.s 12
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_015b: pop
-		IL_015c: ldloc.s 13
-		IL_015e: stloc.3
-		IL_015f: ldloc.3
-		IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_0165: stloc.s 4
-		IL_0167: ldstr "console"
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0176: stloc.s 14
-		IL_0178: ldloc.0
-		IL_0179: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_017e: stloc.s 11
-		IL_0180: ldloc.s 14
-		IL_0182: ldstr "log"
-		IL_0187: ldloc.s 11
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018e: pop
-		IL_018f: ldstr "console"
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019e: stloc.s 11
-		IL_01a0: ldloc.s 4
-		IL_01a2: ldstr "size"
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ac: stloc.s 14
-		IL_01ae: ldloc.s 11
-		IL_01b0: ldstr "log"
-		IL_01b5: ldloc.s 14
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bc: pop
-		IL_01bd: ldc.i4.1
-		IL_01be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01c3: dup
-		IL_01c4: ldc.i4.1
-		IL_01c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01ca: dup
-		IL_01cb: ldstr "short"
-		IL_01d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_01d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_01da: stloc.s 16
-		IL_01dc: ldloc.s 16
-		IL_01de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_01e3: stloc.s 5
-		IL_01e5: ldstr "console"
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f4: stloc.s 14
-		IL_01f6: ldloc.s 5
-		IL_01f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_01fd: stloc.s 15
-		IL_01ff: ldloc.s 15
-		IL_0201: ldstr "has"
-		IL_0206: ldstr "short"
-		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0210: stloc.s 11
-		IL_0212: ldloc.s 14
-		IL_0214: ldstr "log"
-		IL_0219: ldloc.s 11
-		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0220: pop
-		IL_0221: ldstr "console"
-		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0230: stloc.s 11
-		IL_0232: ldloc.s 5
-		IL_0234: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0239: stloc.s 15
-		IL_023b: ldloc.s 15
-		IL_023d: ldstr "get"
-		IL_0242: ldstr "short"
-		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024c: stloc.s 14
-		IL_024e: ldloc.s 14
-		IL_0250: ldnull
-		IL_0251: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0256: stloc.s 17
-		IL_0258: ldloc.s 17
-		IL_025a: box [System.Runtime]System.Boolean
-		IL_025f: stloc.s 18
-		IL_0261: ldloc.s 11
-		IL_0263: ldstr "log"
-		IL_0268: ldloc.s 18
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026f: pop
-		IL_0270: ldloc.0
-		IL_0271: ldc.i4.0
-		IL_0272: box [System.Runtime]System.Boolean
-		IL_0277: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
-		IL_027c: ldstr "iterator"
-		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0286: stloc.s 11
-		IL_0288: ldloc.0
-		IL_0289: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_028e: ldftn object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
-		IL_0294: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0299: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_029e: ldc.i4.0
-		IL_029f: conv.r8
-		IL_02a0: ldstr ""
-		IL_02a5: ldc.i4.0
-		IL_02a6: ldc.i4.1
-		IL_02a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_02ac: stloc.s 12
-		IL_02ae: ldloc.s 12
-		IL_02b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_02b5: stloc.s 12
-		IL_02b7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02bc: stloc.s 13
-		IL_02be: ldloc.s 13
-		IL_02c0: ldloc.s 11
-		IL_02c2: ldloc.s 12
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_02c9: pop
-		IL_02ca: ldloc.s 13
-		IL_02cc: stloc.s 6
+		IL_009e: ldstr "get"
+		IL_00a3: ldstr "alpha"
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ad: stloc.s 11
+		IL_00af: ldloc.s 14
+		IL_00b1: ldstr "log"
+		IL_00b6: ldloc.s 11
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bd: pop
+		IL_00be: ldstr "console"
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cd: stloc.s 11
+		IL_00cf: ldloc.2
+		IL_00d0: ldstr "get"
+		IL_00d5: ldstr "beta"
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00df: stloc.s 14
+		IL_00e1: ldloc.s 11
+		IL_00e3: ldstr "log"
+		IL_00e8: ldloc.s 14
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ef: pop
+		IL_00f0: ldloc.0
+		IL_00f1: ldc.i4.0
+		IL_00f2: box [System.Runtime]System.Boolean
+		IL_00f7: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_00fc: ldstr "iterator"
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0106: stloc.s 14
+		IL_0108: ldloc.0
+		IL_0109: castclass Modules.Map_Constructor_Iterable/Scope
+		IL_010e: ldftn object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
+		IL_0114: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0119: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_011e: ldc.i4.0
+		IL_011f: conv.r8
+		IL_0120: ldstr ""
+		IL_0125: ldc.i4.0
+		IL_0126: ldc.i4.1
+		IL_0127: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_012c: stloc.s 12
+		IL_012e: ldloc.s 12
+		IL_0130: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0135: stloc.s 12
+		IL_0137: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_013c: stloc.s 13
+		IL_013e: ldloc.s 13
+		IL_0140: ldloc.s 14
+		IL_0142: ldloc.s 12
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0149: pop
+		IL_014a: ldloc.s 13
+		IL_014c: stloc.3
+		IL_014d: ldloc.3
+		IL_014e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+		IL_0153: stloc.s 4
+		IL_0155: ldstr "console"
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0164: stloc.s 14
+		IL_0166: ldloc.0
+		IL_0167: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_016c: stloc.s 11
+		IL_016e: ldloc.s 14
+		IL_0170: ldstr "log"
+		IL_0175: ldloc.s 11
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017c: pop
+		IL_017d: ldstr "console"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018c: stloc.s 11
+		IL_018e: ldloc.s 4
+		IL_0190: ldstr "size"
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_019a: stloc.s 14
+		IL_019c: ldloc.s 11
+		IL_019e: ldstr "log"
+		IL_01a3: ldloc.s 14
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01aa: pop
+		IL_01ab: ldc.i4.1
+		IL_01ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01b1: dup
+		IL_01b2: ldc.i4.1
+		IL_01b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01b8: dup
+		IL_01b9: ldstr "short"
+		IL_01be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01c8: stloc.s 15
+		IL_01ca: ldloc.s 15
+		IL_01cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+		IL_01d1: stloc.s 5
+		IL_01d3: ldstr "console"
+		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e2: stloc.s 14
+		IL_01e4: ldloc.s 5
+		IL_01e6: ldstr "has"
+		IL_01eb: ldstr "short"
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f5: stloc.s 11
+		IL_01f7: ldloc.s 14
+		IL_01f9: ldstr "log"
+		IL_01fe: ldloc.s 11
+		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0205: pop
+		IL_0206: ldstr "console"
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0215: stloc.s 11
+		IL_0217: ldloc.s 5
+		IL_0219: ldstr "get"
+		IL_021e: ldstr "short"
+		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0228: stloc.s 14
+		IL_022a: ldloc.s 14
+		IL_022c: ldnull
+		IL_022d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0232: stloc.s 16
+		IL_0234: ldloc.s 16
+		IL_0236: box [System.Runtime]System.Boolean
+		IL_023b: stloc.s 17
+		IL_023d: ldloc.s 11
+		IL_023f: ldstr "log"
+		IL_0244: ldloc.s 17
+		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024b: pop
+		IL_024c: ldloc.0
+		IL_024d: ldc.i4.0
+		IL_024e: box [System.Runtime]System.Boolean
+		IL_0253: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
+		IL_0258: ldstr "iterator"
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0262: stloc.s 11
+		IL_0264: ldloc.0
+		IL_0265: castclass Modules.Map_Constructor_Iterable/Scope
+		IL_026a: ldftn object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
+		IL_0270: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0275: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_027a: ldc.i4.0
+		IL_027b: conv.r8
+		IL_027c: ldstr ""
+		IL_0281: ldc.i4.0
+		IL_0282: ldc.i4.1
+		IL_0283: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0288: stloc.s 12
+		IL_028a: ldloc.s 12
+		IL_028c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0291: stloc.s 12
+		IL_0293: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0298: stloc.s 13
+		IL_029a: ldloc.s 13
+		IL_029c: ldloc.s 11
+		IL_029e: ldloc.s 12
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_02a5: pop
+		IL_02a6: ldloc.s 13
+		IL_02a8: stloc.s 6
 		.try
 		{
-			IL_02ce: nop
-			IL_02cf: ldloc.s 6
-			IL_02d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-			IL_02d6: pop
-			IL_02d7: ldstr "console"
-			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e6: ldstr "log"
-			IL_02eb: ldstr "no error"
-			IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02f5: pop
-			IL_02f6: leave IL_0360
+			IL_02aa: nop
+			IL_02ab: ldloc.s 6
+			IL_02ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+			IL_02b2: pop
+			IL_02b3: ldstr "console"
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c2: ldstr "log"
+			IL_02c7: ldstr "no error"
+			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02d1: pop
+			IL_02d2: leave IL_033c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02fb: stloc.s 7
-			IL_02fd: ldloc.s 7
-			IL_02ff: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0304: dup
-			IL_0305: brtrue IL_031b
+			IL_02d7: stloc.s 7
+			IL_02d9: ldloc.s 7
+			IL_02db: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02e0: dup
+			IL_02e1: brtrue IL_02f7
 
-			IL_030a: pop
-			IL_030b: ldloc.s 7
-			IL_030d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0312: dup
-			IL_0313: brtrue IL_0327
+			IL_02e6: pop
+			IL_02e7: ldloc.s 7
+			IL_02e9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02ee: dup
+			IL_02ef: brtrue IL_0303
 
-			IL_0318: pop
-			IL_0319: rethrow
+			IL_02f4: pop
+			IL_02f5: rethrow
 
-			IL_031b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0320: stloc.s 8
-			IL_0322: br IL_0329
+			IL_02f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02fc: stloc.s 8
+			IL_02fe: br IL_0305
 
-			IL_0327: stloc.s 8
+			IL_0303: stloc.s 8
 
-			IL_0329: ldloc.s 8
-			IL_032b: stloc.s 9
-			IL_032d: ldstr "console"
-			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_033c: stloc.s 11
-			IL_033e: ldloc.s 9
-			IL_0340: ldstr "name"
-			IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_034a: stloc.s 14
-			IL_034c: ldloc.s 11
-			IL_034e: ldstr "log"
-			IL_0353: ldloc.s 14
-			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_035a: pop
-			IL_035b: leave IL_0360
+			IL_0305: ldloc.s 8
+			IL_0307: stloc.s 9
+			IL_0309: ldstr "console"
+			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0318: stloc.s 11
+			IL_031a: ldloc.s 9
+			IL_031c: ldstr "name"
+			IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0326: stloc.s 14
+			IL_0328: ldloc.s 11
+			IL_032a: ldstr "log"
+			IL_032f: ldloc.s 14
+			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0336: pop
+			IL_0337: leave IL_033c
 		} // end handler
 
-		IL_0360: ldstr "console"
-		IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_036f: stloc.s 14
-		IL_0371: ldloc.0
-		IL_0372: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
-		IL_0377: stloc.s 11
-		IL_0379: ldloc.s 14
-		IL_037b: ldstr "log"
-		IL_0380: ldloc.s 11
-		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0387: pop
-		IL_0388: ldnull
-		IL_0389: stloc.s 10
-		IL_038b: ret
+		IL_033c: ldstr "console"
+		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_034b: stloc.s 14
+		IL_034d: ldloc.0
+		IL_034e: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
+		IL_0353: stloc.s 11
+		IL_0355: ldloc.s 14
+		IL_0357: ldstr "log"
+		IL_035c: ldloc.s 11
+		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0363: pop
+		IL_0364: ldnull
+		IL_0365: stloc.s 10
+		IL_0367: ret
 	} // end of method Map_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Map_Constructor_Iterable
@@ -1363,7 +1350,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x298d
+		// Method begins at RVA 0x2969
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Delete_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Delete_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x212c
+			// Method begins at RVA 0x210a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 208 (0xd0)
+		// Code size: 174 (0xae)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Delete_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[3] object,
-			[4] object
+			[2] object,
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Delete_Basic/Scope::.ctor()
@@ -56,66 +55,54 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0013: stloc.2
-		IL_0014: ldloc.2
-		IL_0015: ldstr "set"
-		IL_001a: ldstr "key1"
-		IL_001f: ldstr "value1"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0029: pop
-		IL_002a: ldstr "console"
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0039: stloc.3
-		IL_003a: ldloc.1
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0040: stloc.2
-		IL_0041: ldloc.2
-		IL_0042: ldstr "delete"
-		IL_0047: ldstr "key1"
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0051: stloc.s 4
-		IL_0053: ldloc.3
-		IL_0054: ldstr "log"
-		IL_0059: ldloc.s 4
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0060: pop
-		IL_0061: ldstr "console"
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0070: stloc.s 4
-		IL_0072: ldloc.1
-		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0078: stloc.2
-		IL_0079: ldloc.2
-		IL_007a: ldstr "has"
-		IL_007f: ldstr "key1"
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0089: stloc.3
-		IL_008a: ldloc.s 4
-		IL_008c: ldstr "log"
-		IL_0091: ldloc.3
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0097: pop
-		IL_0098: ldstr "console"
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a7: stloc.3
-		IL_00a8: ldloc.1
-		IL_00a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_00ae: stloc.2
-		IL_00af: ldloc.2
-		IL_00b0: ldstr "delete"
-		IL_00b5: ldstr "key2"
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bf: stloc.s 4
-		IL_00c1: ldloc.3
-		IL_00c2: ldstr "log"
-		IL_00c7: ldloc.s 4
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ce: pop
-		IL_00cf: ret
+		IL_000e: ldstr "set"
+		IL_0013: ldstr "key1"
+		IL_0018: ldstr "value1"
+		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0022: pop
+		IL_0023: ldstr "console"
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0032: stloc.2
+		IL_0033: ldloc.1
+		IL_0034: ldstr "delete"
+		IL_0039: ldstr "key1"
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0043: stloc.3
+		IL_0044: ldloc.2
+		IL_0045: ldstr "log"
+		IL_004a: ldloc.3
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0050: pop
+		IL_0051: ldstr "console"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0060: stloc.3
+		IL_0061: ldloc.1
+		IL_0062: ldstr "has"
+		IL_0067: ldstr "key1"
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0071: stloc.2
+		IL_0072: ldloc.3
+		IL_0073: ldstr "log"
+		IL_0078: ldloc.2
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: pop
+		IL_007f: ldstr "console"
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008e: stloc.2
+		IL_008f: ldloc.1
+		IL_0090: ldstr "delete"
+		IL_0095: ldstr "key2"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009f: stloc.3
+		IL_00a0: ldloc.2
+		IL_00a1: ldstr "log"
+		IL_00a6: ldloc.3
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ac: pop
+		IL_00ad: ret
 	} // end of method Map_Delete_Basic::__js_module_init__
 
 } // end of class Modules.Map_Delete_Basic
@@ -127,7 +114,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2135
+		// Method begins at RVA 0x2113
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Has_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Has_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f5
+			// Method begins at RVA 0x20dc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 153 (0x99)
+		// Code size: 128 (0x80)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Has_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[3] object,
-			[4] object
+			[2] object,
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Has_Basic/Scope::.ctor()
@@ -56,49 +55,40 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0013: stloc.2
-		IL_0014: ldloc.2
-		IL_0015: ldstr "set"
-		IL_001a: ldstr "key1"
-		IL_001f: ldstr "value1"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0029: pop
-		IL_002a: ldstr "console"
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0039: stloc.3
-		IL_003a: ldloc.1
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0040: stloc.2
-		IL_0041: ldloc.2
-		IL_0042: ldstr "has"
-		IL_0047: ldstr "key1"
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0051: stloc.s 4
-		IL_0053: ldloc.3
-		IL_0054: ldstr "log"
-		IL_0059: ldloc.s 4
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0060: pop
-		IL_0061: ldstr "console"
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0070: stloc.s 4
-		IL_0072: ldloc.1
-		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0078: stloc.2
-		IL_0079: ldloc.2
-		IL_007a: ldstr "has"
-		IL_007f: ldstr "key2"
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0089: stloc.3
-		IL_008a: ldloc.s 4
-		IL_008c: ldstr "log"
-		IL_0091: ldloc.3
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0097: pop
-		IL_0098: ret
+		IL_000e: ldstr "set"
+		IL_0013: ldstr "key1"
+		IL_0018: ldstr "value1"
+		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0022: pop
+		IL_0023: ldstr "console"
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0032: stloc.2
+		IL_0033: ldloc.1
+		IL_0034: ldstr "has"
+		IL_0039: ldstr "key1"
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0043: stloc.3
+		IL_0044: ldloc.2
+		IL_0045: ldstr "log"
+		IL_004a: ldloc.3
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0050: pop
+		IL_0051: ldstr "console"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0060: stloc.3
+		IL_0061: ldloc.1
+		IL_0062: ldstr "has"
+		IL_0067: ldstr "key2"
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0071: stloc.2
+		IL_0072: ldloc.3
+		IL_0073: ldstr "log"
+		IL_0078: ldloc.2
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: pop
+		IL_007f: ret
 	} // end of method Map_Has_Basic::__js_module_init__
 
 } // end of class Modules.Map_Has_Basic
@@ -110,7 +100,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20fe
+		// Method begins at RVA 0x20e5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Keys_Values_Entries.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Keys_Values_Entries.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x227e
+			// Method begins at RVA 0x2251
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 546 (0x222)
+		// Code size: 501 (0x1f5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Keys_Values_Entries/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[5] object,
-			[6] object
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Keys_Values_Entries/Scope::.ctor()
@@ -58,144 +57,129 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0013: stloc.s 4
-		IL_0015: ldloc.s 4
-		IL_0017: ldstr "set"
-		IL_001c: ldstr "a"
-		IL_0021: ldc.r8 1
-		IL_002a: box [System.Runtime]System.Double
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0034: pop
-		IL_0035: ldloc.1
-		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_003b: stloc.s 4
-		IL_003d: ldloc.s 4
-		IL_003f: ldstr "set"
-		IL_0044: ldstr "b"
-		IL_0049: ldc.r8 2
-		IL_0052: box [System.Runtime]System.Double
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_005c: pop
-		IL_005d: ldloc.1
-		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0063: stloc.s 4
-		IL_0065: ldloc.s 4
-		IL_0067: ldstr "set"
-		IL_006c: ldstr "c"
-		IL_0071: ldc.r8 3
-		IL_007a: box [System.Runtime]System.Double
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0084: pop
-		IL_0085: ldloc.1
-		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_008b: stloc.s 4
-		IL_008d: ldloc.s 4
-		IL_008f: ldstr "keys"
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_000e: ldstr "set"
+		IL_0013: ldstr "a"
+		IL_0018: ldc.r8 1
+		IL_0021: box [System.Runtime]System.Double
+		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_002b: pop
+		IL_002c: ldloc.1
+		IL_002d: ldstr "set"
+		IL_0032: ldstr "b"
+		IL_0037: ldc.r8 2
+		IL_0040: box [System.Runtime]System.Double
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_004a: pop
+		IL_004b: ldloc.1
+		IL_004c: ldstr "set"
+		IL_0051: ldstr "c"
+		IL_0056: ldc.r8 3
+		IL_005f: box [System.Runtime]System.Double
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0069: pop
+		IL_006a: ldloc.1
+		IL_006b: ldstr "keys"
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0075: stloc.s 4
+		IL_0077: ldloc.s 4
+		IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_007e: stloc.2
+		IL_007f: ldstr "console"
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008e: ldloc.2
+		IL_008f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0094: box [System.Runtime]System.Double
 		IL_0099: stloc.s 5
-		IL_009b: ldloc.s 5
-		IL_009d: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_00a2: stloc.2
-		IL_00a3: ldstr "console"
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b2: ldloc.2
-		IL_00b3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_00b8: box [System.Runtime]System.Double
-		IL_00bd: stloc.s 6
-		IL_00bf: ldstr "log"
-		IL_00c4: ldloc.s 6
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cb: pop
-		IL_00cc: ldstr "console"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00db: ldloc.2
-		IL_00dc: ldc.r8 0.0
-		IL_00e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_00ea: stloc.s 5
-		IL_00ec: ldstr "log"
-		IL_00f1: ldloc.s 5
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f8: pop
-		IL_00f9: ldstr "console"
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0108: ldloc.2
-		IL_0109: ldc.r8 1
-		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0117: stloc.s 5
-		IL_0119: ldstr "log"
-		IL_011e: ldloc.s 5
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0125: pop
-		IL_0126: ldstr "console"
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0135: ldloc.2
-		IL_0136: ldc.r8 2
-		IL_013f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0144: stloc.s 5
-		IL_0146: ldstr "log"
-		IL_014b: ldloc.s 5
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0152: pop
-		IL_0153: ldloc.1
-		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0159: stloc.s 4
-		IL_015b: ldloc.s 4
-		IL_015d: ldstr "values"
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0167: stloc.s 5
-		IL_0169: ldloc.s 5
-		IL_016b: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0170: stloc.3
-		IL_0171: ldstr "console"
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0180: ldloc.3
-		IL_0181: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0186: box [System.Runtime]System.Double
-		IL_018b: stloc.s 6
+		IL_009b: ldstr "log"
+		IL_00a0: ldloc.s 5
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a7: pop
+		IL_00a8: ldstr "console"
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b7: ldloc.2
+		IL_00b8: ldc.r8 0.0
+		IL_00c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_00c6: stloc.s 4
+		IL_00c8: ldstr "log"
+		IL_00cd: ldloc.s 4
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d4: pop
+		IL_00d5: ldstr "console"
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e4: ldloc.2
+		IL_00e5: ldc.r8 1
+		IL_00ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_00f3: stloc.s 4
+		IL_00f5: ldstr "log"
+		IL_00fa: ldloc.s 4
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0101: pop
+		IL_0102: ldstr "console"
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0111: ldloc.2
+		IL_0112: ldc.r8 2
+		IL_011b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0120: stloc.s 4
+		IL_0122: ldstr "log"
+		IL_0127: ldloc.s 4
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012e: pop
+		IL_012f: ldloc.1
+		IL_0130: ldstr "values"
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_013a: stloc.s 4
+		IL_013c: ldloc.s 4
+		IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0143: stloc.3
+		IL_0144: ldstr "console"
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0153: ldloc.3
+		IL_0154: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0159: box [System.Runtime]System.Double
+		IL_015e: stloc.s 5
+		IL_0160: ldstr "log"
+		IL_0165: ldloc.s 5
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016c: pop
+		IL_016d: ldstr "console"
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017c: ldloc.3
+		IL_017d: ldc.r8 0.0
+		IL_0186: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_018b: stloc.s 4
 		IL_018d: ldstr "log"
-		IL_0192: ldloc.s 6
+		IL_0192: ldloc.s 4
 		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0199: pop
 		IL_019a: ldstr "console"
 		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_01a9: ldloc.3
-		IL_01aa: ldc.r8 0.0
+		IL_01aa: ldc.r8 1
 		IL_01b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01b8: stloc.s 5
+		IL_01b8: stloc.s 4
 		IL_01ba: ldstr "log"
-		IL_01bf: ldloc.s 5
+		IL_01bf: ldloc.s 4
 		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_01c6: pop
 		IL_01c7: ldstr "console"
 		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_01d6: ldloc.3
-		IL_01d7: ldc.r8 1
+		IL_01d7: ldc.r8 2
 		IL_01e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01e5: stloc.s 5
+		IL_01e5: stloc.s 4
 		IL_01e7: ldstr "log"
-		IL_01ec: ldloc.s 5
+		IL_01ec: ldloc.s 4
 		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_01f3: pop
-		IL_01f4: ldstr "console"
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0203: ldloc.3
-		IL_0204: ldc.r8 2
-		IL_020d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0212: stloc.s 5
-		IL_0214: ldstr "log"
-		IL_0219: ldloc.s 5
-		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0220: pop
-		IL_0221: ret
+		IL_01f4: ret
 	} // end of method Map_Keys_Values_Entries::__js_module_init__
 
 } // end of class Modules.Map_Keys_Values_Entries
@@ -207,7 +191,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2287
+		// Method begins at RVA 0x225a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Multiple_Keys.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Multiple_Keys.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2191
+			// Method begins at RVA 0x215f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 309 (0x135)
+		// Code size: 259 (0x103)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Multiple_Keys/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[3] object,
-			[4] object
+			[2] object,
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Multiple_Keys/Scope::.ctor()
@@ -56,97 +55,79 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0013: stloc.2
-		IL_0014: ldloc.2
-		IL_0015: ldstr "set"
-		IL_001a: ldstr "key1"
-		IL_001f: ldstr "value1"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0029: pop
-		IL_002a: ldloc.1
-		IL_002b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0030: stloc.2
-		IL_0031: ldloc.2
-		IL_0032: ldstr "set"
-		IL_0037: ldstr "key2"
-		IL_003c: ldstr "value2"
-		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0046: pop
-		IL_0047: ldloc.1
-		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_004d: stloc.2
-		IL_004e: ldloc.2
-		IL_004f: ldstr "set"
-		IL_0054: ldstr "key3"
-		IL_0059: ldstr "value3"
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0063: pop
-		IL_0064: ldstr "console"
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0073: stloc.3
-		IL_0074: ldloc.1
-		IL_0075: ldstr "size"
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_007f: stloc.s 4
-		IL_0081: ldloc.3
-		IL_0082: ldstr "log"
-		IL_0087: ldloc.s 4
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008e: pop
-		IL_008f: ldstr "console"
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009e: stloc.s 4
-		IL_00a0: ldloc.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_00a6: stloc.2
-		IL_00a7: ldloc.2
-		IL_00a8: ldstr "get"
-		IL_00ad: ldstr "key1"
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b7: stloc.3
-		IL_00b8: ldloc.s 4
-		IL_00ba: ldstr "log"
-		IL_00bf: ldloc.3
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c5: pop
-		IL_00c6: ldstr "console"
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d5: stloc.3
-		IL_00d6: ldloc.1
-		IL_00d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_00dc: stloc.2
-		IL_00dd: ldloc.2
-		IL_00de: ldstr "get"
-		IL_00e3: ldstr "key2"
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ed: stloc.s 4
-		IL_00ef: ldloc.3
-		IL_00f0: ldstr "log"
-		IL_00f5: ldloc.s 4
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fc: pop
-		IL_00fd: ldstr "console"
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010c: stloc.s 4
-		IL_010e: ldloc.1
-		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0114: stloc.2
-		IL_0115: ldloc.2
-		IL_0116: ldstr "get"
-		IL_011b: ldstr "key3"
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0125: stloc.3
-		IL_0126: ldloc.s 4
-		IL_0128: ldstr "log"
-		IL_012d: ldloc.3
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0133: pop
-		IL_0134: ret
+		IL_000e: ldstr "set"
+		IL_0013: ldstr "key1"
+		IL_0018: ldstr "value1"
+		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0022: pop
+		IL_0023: ldloc.1
+		IL_0024: ldstr "set"
+		IL_0029: ldstr "key2"
+		IL_002e: ldstr "value2"
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0038: pop
+		IL_0039: ldloc.1
+		IL_003a: ldstr "set"
+		IL_003f: ldstr "key3"
+		IL_0044: ldstr "value3"
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_004e: pop
+		IL_004f: ldstr "console"
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005e: stloc.2
+		IL_005f: ldloc.1
+		IL_0060: ldstr "size"
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006a: stloc.3
+		IL_006b: ldloc.2
+		IL_006c: ldstr "log"
+		IL_0071: ldloc.3
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0077: pop
+		IL_0078: ldstr "console"
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0087: stloc.3
+		IL_0088: ldloc.1
+		IL_0089: ldstr "get"
+		IL_008e: ldstr "key1"
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0098: stloc.2
+		IL_0099: ldloc.3
+		IL_009a: ldstr "log"
+		IL_009f: ldloc.2
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a5: pop
+		IL_00a6: ldstr "console"
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b5: stloc.2
+		IL_00b6: ldloc.1
+		IL_00b7: ldstr "get"
+		IL_00bc: ldstr "key2"
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c6: stloc.3
+		IL_00c7: ldloc.2
+		IL_00c8: ldstr "log"
+		IL_00cd: ldloc.3
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d3: pop
+		IL_00d4: ldstr "console"
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e3: stloc.3
+		IL_00e4: ldloc.1
+		IL_00e5: ldstr "get"
+		IL_00ea: ldstr "key3"
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f4: stloc.2
+		IL_00f5: ldloc.3
+		IL_00f6: ldstr "log"
+		IL_00fb: ldloc.2
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0101: pop
+		IL_0102: ret
 	} // end of method Map_Multiple_Keys::__js_module_init__
 
 } // end of class Modules.Map_Multiple_Keys
@@ -158,7 +139,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x219a
+		// Method begins at RVA 0x2168
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Null_Key.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Null_Key.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f8
+			// Method begins at RVA 0x20df
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 156 (0x9c)
+		// Code size: 131 (0x83)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Null_Key/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[3] object,
-			[4] object
+			[2] object,
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Null_Key/Scope::.ctor()
@@ -56,52 +55,43 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0013: stloc.2
-		IL_0014: ldloc.2
-		IL_0015: ldstr "set"
-		IL_001a: ldc.i4.0
-		IL_001b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0020: ldstr "nullValue"
-		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_002a: pop
-		IL_002b: ldstr "console"
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003a: stloc.3
-		IL_003b: ldloc.1
-		IL_003c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0041: stloc.2
-		IL_0042: ldloc.2
-		IL_0043: ldstr "has"
-		IL_0048: ldc.i4.0
-		IL_0049: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0053: stloc.s 4
-		IL_0055: ldloc.3
-		IL_0056: ldstr "log"
-		IL_005b: ldloc.s 4
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0062: pop
-		IL_0063: ldstr "console"
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0072: stloc.s 4
-		IL_0074: ldloc.1
-		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_007a: stloc.2
+		IL_000e: ldstr "set"
+		IL_0013: ldc.i4.0
+		IL_0014: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0019: ldstr "nullValue"
+		IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0023: pop
+		IL_0024: ldstr "console"
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0033: stloc.2
+		IL_0034: ldloc.1
+		IL_0035: ldstr "has"
+		IL_003a: ldc.i4.0
+		IL_003b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0045: stloc.3
+		IL_0046: ldloc.2
+		IL_0047: ldstr "log"
+		IL_004c: ldloc.3
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0052: pop
+		IL_0053: ldstr "console"
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0062: stloc.3
+		IL_0063: ldloc.1
+		IL_0064: ldstr "get"
+		IL_0069: ldc.i4.0
+		IL_006a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0074: stloc.2
+		IL_0075: ldloc.3
+		IL_0076: ldstr "log"
 		IL_007b: ldloc.2
-		IL_007c: ldstr "get"
-		IL_0081: ldc.i4.0
-		IL_0082: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008c: stloc.3
-		IL_008d: ldloc.s 4
-		IL_008f: ldstr "log"
-		IL_0094: ldloc.3
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009a: pop
-		IL_009b: ret
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0081: pop
+		IL_0082: ret
 	} // end of method Map_Null_Key::__js_module_init__
 
 } // end of class Modules.Map_Null_Key
@@ -113,7 +103,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2101
+		// Method begins at RVA 0x20e8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Set_Get_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Set_Get_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20be
+			// Method begins at RVA 0x20ae
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 98 (0x62)
+		// Code size: 82 (0x52)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Set_Get_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[3] object,
-			[4] object
+			[2] object,
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Set_Get_Basic/Scope::.ctor()
@@ -56,32 +55,26 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0013: stloc.2
-		IL_0014: ldloc.2
-		IL_0015: ldstr "set"
-		IL_001a: ldstr "key1"
-		IL_001f: ldstr "value1"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0029: pop
-		IL_002a: ldstr "console"
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0039: stloc.3
-		IL_003a: ldloc.1
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0040: stloc.2
-		IL_0041: ldloc.2
-		IL_0042: ldstr "get"
-		IL_0047: ldstr "key1"
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0051: stloc.s 4
-		IL_0053: ldloc.3
-		IL_0054: ldstr "log"
-		IL_0059: ldloc.s 4
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0060: pop
-		IL_0061: ret
+		IL_000e: ldstr "set"
+		IL_0013: ldstr "key1"
+		IL_0018: ldstr "value1"
+		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0022: pop
+		IL_0023: ldstr "console"
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0032: stloc.2
+		IL_0033: ldloc.1
+		IL_0034: ldstr "get"
+		IL_0039: ldstr "key1"
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0043: stloc.3
+		IL_0044: ldloc.2
+		IL_0045: ldstr "log"
+		IL_004a: ldloc.3
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0050: pop
+		IL_0051: ret
 	} // end of method Map_Set_Get_Basic::__js_module_init__
 
 } // end of class Modules.Map_Set_Get_Basic
@@ -93,7 +86,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20c7
+		// Method begins at RVA 0x20b7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Set_Returns_This.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Set_Returns_This.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20bd
+			// Method begins at RVA 0x20b4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,17 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 88 (0x58)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Set_Returns_This/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
 			[2] object,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[3] object,
 			[4] object,
-			[5] object,
-			[6] bool,
-			[7] object
+			[5] bool,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Set_Returns_This/Scope::.ctor()
@@ -59,33 +58,30 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0013: stloc.3
-		IL_0014: ldloc.3
-		IL_0015: ldstr "set"
-		IL_001a: ldstr "key1"
-		IL_001f: ldstr "value1"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0029: stloc.2
-		IL_002a: ldstr "console"
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0039: stloc.s 4
-		IL_003b: ldloc.2
-		IL_003c: stloc.s 5
-		IL_003e: ldloc.s 5
-		IL_0040: ldloc.1
-		IL_0041: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0046: stloc.s 6
-		IL_0048: ldloc.s 6
-		IL_004a: box [System.Runtime]System.Boolean
-		IL_004f: stloc.s 7
-		IL_0051: ldloc.s 4
-		IL_0053: ldstr "log"
-		IL_0058: ldloc.s 7
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005f: pop
-		IL_0060: ret
+		IL_000e: ldstr "set"
+		IL_0013: ldstr "key1"
+		IL_0018: ldstr "value1"
+		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0022: stloc.2
+		IL_0023: ldstr "console"
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0032: stloc.3
+		IL_0033: ldloc.2
+		IL_0034: stloc.s 4
+		IL_0036: ldloc.s 4
+		IL_0038: ldloc.1
+		IL_0039: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_003e: stloc.s 5
+		IL_0040: ldloc.s 5
+		IL_0042: box [System.Runtime]System.Boolean
+		IL_0047: stloc.s 6
+		IL_0049: ldloc.3
+		IL_004a: ldstr "log"
+		IL_004f: ldloc.s 6
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0056: pop
+		IL_0057: ret
 	} // end of method Map_Set_Returns_This::__js_module_init__
 
 } // end of class Modules.Map_Set_Returns_This
@@ -97,7 +93,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20c6
+		// Method begins at RVA 0x20bd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Size_Property.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Size_Property.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2123
+			// Method begins at RVA 0x2111
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 199 (0xc7)
+		// Code size: 181 (0xb5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Size_Property/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
 			[2] object,
-			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Map
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Size_Property/Scope::.ctor()
@@ -69,50 +68,44 @@
 		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0035: pop
 		IL_0036: ldloc.1
-		IL_0037: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_003c: stloc.s 4
-		IL_003e: ldloc.s 4
-		IL_0040: ldstr "set"
-		IL_0045: ldstr "key1"
-		IL_004a: ldstr "value1"
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0054: pop
-		IL_0055: ldstr "console"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0064: stloc.3
-		IL_0065: ldloc.1
-		IL_0066: ldstr "size"
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0070: stloc.2
-		IL_0071: ldloc.3
-		IL_0072: ldstr "log"
-		IL_0077: ldloc.2
-		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007d: pop
-		IL_007e: ldloc.1
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0084: stloc.s 4
-		IL_0086: ldloc.s 4
-		IL_0088: ldstr "set"
-		IL_008d: ldstr "key2"
-		IL_0092: ldstr "value2"
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_009c: pop
-		IL_009d: ldstr "console"
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ac: stloc.2
-		IL_00ad: ldloc.1
-		IL_00ae: ldstr "size"
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b8: stloc.3
-		IL_00b9: ldloc.2
-		IL_00ba: ldstr "log"
-		IL_00bf: ldloc.3
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c5: pop
-		IL_00c6: ret
+		IL_0037: ldstr "set"
+		IL_003c: ldstr "key1"
+		IL_0041: ldstr "value1"
+		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_004b: pop
+		IL_004c: ldstr "console"
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005b: stloc.3
+		IL_005c: ldloc.1
+		IL_005d: ldstr "size"
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0067: stloc.2
+		IL_0068: ldloc.3
+		IL_0069: ldstr "log"
+		IL_006e: ldloc.2
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0074: pop
+		IL_0075: ldloc.1
+		IL_0076: ldstr "set"
+		IL_007b: ldstr "key2"
+		IL_0080: ldstr "value2"
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_008a: pop
+		IL_008b: ldstr "console"
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009a: stloc.2
+		IL_009b: ldloc.1
+		IL_009c: ldstr "size"
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a6: stloc.3
+		IL_00a7: ldloc.2
+		IL_00a8: ldstr "log"
+		IL_00ad: ldloc.3
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b3: pop
+		IL_00b4: ret
 	} // end of method Map_Size_Property::__js_module_init__
 
 } // end of class Modules.Map_Size_Property
@@ -124,7 +117,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212c
+		// Method begins at RVA 0x211a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Symbol_Iterator.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Symbol_Iterator.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22a4
+			// Method begins at RVA 0x2293
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 584 (0x248)
+		// Code size: 567 (0x237)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Symbol_Iterator/Scope,
@@ -50,10 +50,8 @@
 			[4] object,
 			[5] object,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[8] object,
-			[9] object[],
-			[10] object
+			[7] object,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Symbol_Iterator/Scope::.ctor()
@@ -86,142 +84,135 @@
 		IL_005d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
 		IL_0062: stloc.1
 		IL_0063: ldloc.1
-		IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0069: stloc.s 7
-		IL_006b: ldstr "iterator"
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0075: stloc.s 8
-		IL_0077: ldc.i4.0
-		IL_0078: newarr [System.Runtime]System.Object
-		IL_007d: stloc.s 9
-		IL_007f: ldloc.s 7
-		IL_0081: ldloc.s 8
-		IL_0083: ldloc.s 9
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_008a: stloc.2
+		IL_0064: ldstr "iterator"
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_006e: ldc.i4.0
+		IL_006f: newarr [System.Runtime]System.Object
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0079: stloc.2
+		IL_007a: ldloc.2
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0080: ldstr "next"
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_008a: stloc.3
 		IL_008b: ldloc.2
 		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0091: ldstr "next"
 		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_009b: stloc.3
-		IL_009c: ldloc.2
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a2: ldstr "next"
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00ac: stloc.s 4
-		IL_00ae: ldloc.2
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b4: ldstr "next"
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00be: stloc.s 5
-		IL_00c0: ldstr "console"
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cf: stloc.s 8
-		IL_00d1: ldloc.3
-		IL_00d2: ldstr "done"
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00dc: stloc.s 10
-		IL_00de: ldloc.s 8
-		IL_00e0: ldstr "log"
-		IL_00e5: ldloc.s 10
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ec: pop
-		IL_00ed: ldstr "console"
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fc: stloc.s 10
-		IL_00fe: ldloc.3
-		IL_00ff: ldstr "value"
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0109: stloc.s 8
-		IL_010b: ldloc.s 8
-		IL_010d: ldc.r8 0.0
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_011b: stloc.s 8
-		IL_011d: ldloc.s 10
-		IL_011f: ldstr "log"
-		IL_0124: ldloc.s 8
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012b: pop
-		IL_012c: ldstr "console"
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013b: stloc.s 8
-		IL_013d: ldloc.3
-		IL_013e: ldstr "value"
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0148: stloc.s 10
-		IL_014a: ldloc.s 10
-		IL_014c: ldc.r8 1
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_015a: stloc.s 10
-		IL_015c: ldloc.s 8
-		IL_015e: ldstr "log"
-		IL_0163: ldloc.s 10
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016a: pop
-		IL_016b: ldstr "console"
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017a: stloc.s 10
-		IL_017c: ldloc.s 4
-		IL_017e: ldstr "done"
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0188: stloc.s 8
-		IL_018a: ldloc.s 10
-		IL_018c: ldstr "log"
-		IL_0191: ldloc.s 8
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0198: pop
-		IL_0199: ldstr "console"
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a8: stloc.s 8
-		IL_01aa: ldloc.s 4
-		IL_01ac: ldstr "value"
-		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b6: stloc.s 10
-		IL_01b8: ldloc.s 10
-		IL_01ba: ldc.r8 0.0
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01c8: stloc.s 10
-		IL_01ca: ldloc.s 8
-		IL_01cc: ldstr "log"
-		IL_01d1: ldloc.s 10
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d8: pop
-		IL_01d9: ldstr "console"
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e8: stloc.s 10
-		IL_01ea: ldloc.s 4
-		IL_01ec: ldstr "value"
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01f6: stloc.s 8
-		IL_01f8: ldloc.s 8
-		IL_01fa: ldc.r8 1
-		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0208: stloc.s 8
-		IL_020a: ldloc.s 10
-		IL_020c: ldstr "log"
-		IL_0211: ldloc.s 8
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0218: pop
-		IL_0219: ldstr "console"
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0228: stloc.s 8
-		IL_022a: ldloc.s 5
-		IL_022c: ldstr "done"
-		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0236: stloc.s 10
-		IL_0238: ldloc.s 8
-		IL_023a: ldstr "log"
-		IL_023f: ldloc.s 10
-		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0246: pop
-		IL_0247: ret
+		IL_009b: stloc.s 4
+		IL_009d: ldloc.2
+		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a3: ldstr "next"
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00ad: stloc.s 5
+		IL_00af: ldstr "console"
+		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00be: stloc.s 7
+		IL_00c0: ldloc.3
+		IL_00c1: ldstr "done"
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00cb: stloc.s 8
+		IL_00cd: ldloc.s 7
+		IL_00cf: ldstr "log"
+		IL_00d4: ldloc.s 8
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00db: pop
+		IL_00dc: ldstr "console"
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00eb: stloc.s 8
+		IL_00ed: ldloc.3
+		IL_00ee: ldstr "value"
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f8: stloc.s 7
+		IL_00fa: ldloc.s 7
+		IL_00fc: ldc.r8 0.0
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_010a: stloc.s 7
+		IL_010c: ldloc.s 8
+		IL_010e: ldstr "log"
+		IL_0113: ldloc.s 7
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011a: pop
+		IL_011b: ldstr "console"
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012a: stloc.s 7
+		IL_012c: ldloc.3
+		IL_012d: ldstr "value"
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0137: stloc.s 8
+		IL_0139: ldloc.s 8
+		IL_013b: ldc.r8 1
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0149: stloc.s 8
+		IL_014b: ldloc.s 7
+		IL_014d: ldstr "log"
+		IL_0152: ldloc.s 8
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0159: pop
+		IL_015a: ldstr "console"
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0169: stloc.s 8
+		IL_016b: ldloc.s 4
+		IL_016d: ldstr "done"
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0177: stloc.s 7
+		IL_0179: ldloc.s 8
+		IL_017b: ldstr "log"
+		IL_0180: ldloc.s 7
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0187: pop
+		IL_0188: ldstr "console"
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0197: stloc.s 7
+		IL_0199: ldloc.s 4
+		IL_019b: ldstr "value"
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a5: stloc.s 8
+		IL_01a7: ldloc.s 8
+		IL_01a9: ldc.r8 0.0
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01b7: stloc.s 8
+		IL_01b9: ldloc.s 7
+		IL_01bb: ldstr "log"
+		IL_01c0: ldloc.s 8
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c7: pop
+		IL_01c8: ldstr "console"
+		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d7: stloc.s 8
+		IL_01d9: ldloc.s 4
+		IL_01db: ldstr "value"
+		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e5: stloc.s 7
+		IL_01e7: ldloc.s 7
+		IL_01e9: ldc.r8 1
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01f7: stloc.s 7
+		IL_01f9: ldloc.s 8
+		IL_01fb: ldstr "log"
+		IL_0200: ldloc.s 7
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0207: pop
+		IL_0208: ldstr "console"
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0217: stloc.s 7
+		IL_0219: ldloc.s 5
+		IL_021b: ldstr "done"
+		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0225: stloc.s 8
+		IL_0227: ldloc.s 7
+		IL_0229: ldstr "log"
+		IL_022e: ldloc.s 8
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0235: pop
+		IL_0236: ret
 	} // end of method Map_Symbol_Iterator::__js_module_init__
 
 } // end of class Modules.Map_Symbol_Iterator
@@ -233,7 +224,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22ad
+		// Method begins at RVA 0x229c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Update_Existing_Key.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Update_Existing_Key.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x213d
+			// Method begins at RVA 0x211b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 225 (0xe1)
+		// Code size: 191 (0xbf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Update_Existing_Key/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[3] object,
-			[4] object
+			[2] object,
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Update_Existing_Key/Scope::.ctor()
@@ -56,71 +55,59 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0013: stloc.2
-		IL_0014: ldloc.2
-		IL_0015: ldstr "set"
-		IL_001a: ldstr "key1"
-		IL_001f: ldstr "value1"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0029: pop
-		IL_002a: ldstr "console"
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0039: stloc.3
-		IL_003a: ldloc.1
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0040: stloc.2
-		IL_0041: ldloc.2
-		IL_0042: ldstr "get"
-		IL_0047: ldstr "key1"
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0051: stloc.s 4
-		IL_0053: ldloc.3
-		IL_0054: ldstr "log"
-		IL_0059: ldloc.s 4
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0060: pop
-		IL_0061: ldloc.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0067: stloc.2
-		IL_0068: ldloc.2
-		IL_0069: ldstr "set"
-		IL_006e: ldstr "key1"
-		IL_0073: ldstr "value2"
-		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_007d: pop
-		IL_007e: ldstr "console"
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008d: stloc.s 4
-		IL_008f: ldloc.1
-		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Map>(!!0)
-		IL_0095: stloc.2
-		IL_0096: ldloc.2
-		IL_0097: ldstr "get"
-		IL_009c: ldstr "key1"
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a6: stloc.3
-		IL_00a7: ldloc.s 4
-		IL_00a9: ldstr "log"
-		IL_00ae: ldloc.3
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b4: pop
-		IL_00b5: ldstr "console"
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c4: stloc.3
-		IL_00c5: ldloc.1
-		IL_00c6: ldstr "size"
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d0: stloc.s 4
-		IL_00d2: ldloc.3
-		IL_00d3: ldstr "log"
-		IL_00d8: ldloc.s 4
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00df: pop
-		IL_00e0: ret
+		IL_000e: ldstr "set"
+		IL_0013: ldstr "key1"
+		IL_0018: ldstr "value1"
+		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0022: pop
+		IL_0023: ldstr "console"
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0032: stloc.2
+		IL_0033: ldloc.1
+		IL_0034: ldstr "get"
+		IL_0039: ldstr "key1"
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0043: stloc.3
+		IL_0044: ldloc.2
+		IL_0045: ldstr "log"
+		IL_004a: ldloc.3
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0050: pop
+		IL_0051: ldloc.1
+		IL_0052: ldstr "set"
+		IL_0057: ldstr "key1"
+		IL_005c: ldstr "value2"
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0066: pop
+		IL_0067: ldstr "console"
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0076: stloc.3
+		IL_0077: ldloc.1
+		IL_0078: ldstr "get"
+		IL_007d: ldstr "key1"
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0087: stloc.2
+		IL_0088: ldloc.3
+		IL_0089: ldstr "log"
+		IL_008e: ldloc.2
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0094: pop
+		IL_0095: ldstr "console"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a4: stloc.2
+		IL_00a5: ldloc.1
+		IL_00a6: ldstr "size"
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b0: stloc.3
+		IL_00b1: ldloc.2
+		IL_00b2: ldstr "log"
+		IL_00b7: ldloc.3
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bd: pop
+		IL_00be: ret
 	} // end of method Map_Update_Existing_Key::__js_module_init__
 
 } // end of class Modules.Map_Update_Existing_Key
@@ -132,7 +119,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2146
+		// Method begins at RVA 0x2124
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_ShadowedAndReplaced_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_ShadowedAndReplaced_Dispatch.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2255
+					// Method begins at RVA 0x224b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x222d
+				// Method begins at RVA 0x2223
 				// Header size: 1
 				// Code size: 10 (0xa)
 				.maxstack 8
@@ -67,7 +67,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x225e
+					// Method begins at RVA 0x2254
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -90,7 +90,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2238
+				// Method begins at RVA 0x222e
 				// Header size: 1
 				// Code size: 10 (0xa)
 				.maxstack 8
@@ -108,7 +108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x224c
+				// Method begins at RVA 0x2242
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -136,7 +136,7 @@
 			)
 			// Method begins at RVA 0x2128
 			// Header size: 12
-			// Code size: 238 (0xee)
+			// Code size: 228 (0xe4)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/Scope,
@@ -189,41 +189,39 @@
 			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0078: stloc.s 4
-			IL_007a: ldloc.1
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0080: ldc.r8 1
-			IL_0089: neg
-			IL_008a: stloc.s 5
-			IL_008c: ldloc.s 5
-			IL_008e: box [System.Runtime]System.Double
-			IL_0093: stloc.s 6
-			IL_0095: ldstr "abs"
-			IL_009a: ldloc.s 6
-			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00a1: stloc.s 7
-			IL_00a3: ldloc.1
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a9: ldstr "round"
-			IL_00ae: ldc.r8 0.0
-			IL_00b7: box [System.Runtime]System.Double
-			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00c1: stloc.s 8
-			IL_00c3: ldloc.1
-			IL_00c4: castclass Modules.Math_ShadowedAndReplaced_Dispatch/ObjectLiterals/L2C16_Math
-			IL_00c9: callvirt instance float64 Modules.Math_ShadowedAndReplaced_Dispatch/ObjectLiterals/L2C16_Math::get_PI()
-			IL_00ce: stloc.s 5
-			IL_00d0: ldloc.s 5
-			IL_00d2: box [System.Runtime]System.Double
-			IL_00d7: stloc.s 6
-			IL_00d9: ldloc.s 4
-			IL_00db: ldstr "log"
-			IL_00e0: ldloc.s 7
-			IL_00e2: ldloc.s 8
-			IL_00e4: ldloc.s 6
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_00eb: pop
-			IL_00ec: ldnull
-			IL_00ed: ret
+			IL_007a: ldc.r8 1
+			IL_0083: neg
+			IL_0084: stloc.s 5
+			IL_0086: ldloc.s 5
+			IL_0088: box [System.Runtime]System.Double
+			IL_008d: stloc.s 6
+			IL_008f: ldloc.1
+			IL_0090: ldstr "abs"
+			IL_0095: ldloc.s 6
+			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_009c: stloc.s 7
+			IL_009e: ldloc.1
+			IL_009f: ldstr "round"
+			IL_00a4: ldc.r8 0.0
+			IL_00ad: box [System.Runtime]System.Double
+			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00b7: stloc.s 8
+			IL_00b9: ldloc.1
+			IL_00ba: castclass Modules.Math_ShadowedAndReplaced_Dispatch/ObjectLiterals/L2C16_Math
+			IL_00bf: callvirt instance float64 Modules.Math_ShadowedAndReplaced_Dispatch/ObjectLiterals/L2C16_Math::get_PI()
+			IL_00c4: stloc.s 5
+			IL_00c6: ldloc.s 5
+			IL_00c8: box [System.Runtime]System.Double
+			IL_00cd: stloc.s 6
+			IL_00cf: ldloc.s 4
+			IL_00d1: ldstr "log"
+			IL_00d6: ldloc.s 7
+			IL_00d8: ldloc.s 8
+			IL_00da: ldloc.s 6
+			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_00e1: pop
+			IL_00e2: ldnull
+			IL_00e3: ret
 		} // end of method FunctionExpression_L1C1::__js_call__
 
 	} // end of class FunctionExpression_L1C1
@@ -239,7 +237,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2267
+				// Method begins at RVA 0x225d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -262,7 +260,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2222
+			// Method begins at RVA 0x2218
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -280,7 +278,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2243
+			// Method begins at RVA 0x2239
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -309,7 +307,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2270
+				// Method begins at RVA 0x2266
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -322,7 +320,7 @@
 			.method public hidebysig 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0 get_abs () cil managed 
 			{
-				// Method begins at RVA 0x2278
+				// Method begins at RVA 0x226e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -337,7 +335,7 @@
 					class [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x2280
+				// Method begins at RVA 0x2276
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -355,7 +353,7 @@
 			.method public hidebysig 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0 get_round () cil managed 
 			{
-				// Method begins at RVA 0x2295
+				// Method begins at RVA 0x228b
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -370,7 +368,7 @@
 					class [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x229d
+				// Method begins at RVA 0x2293
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -388,7 +386,7 @@
 			.method public hidebysig 
 				instance float64 get_PI () cil managed 
 			{
-				// Method begins at RVA 0x22b2
+				// Method begins at RVA 0x22a8
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -403,7 +401,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x22ba
+				// Method begins at RVA 0x22b0
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -525,7 +523,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22cf
+		// Method begins at RVA 0x22c5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Constructor_Legacy.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Constructor_Legacy.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2166
+			// Method begins at RVA 0x2154
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 266 (0x10a)
+		// Code size: 248 (0xf8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Buffer_Constructor_Legacy/Scope,
@@ -49,10 +49,9 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-			[7] object,
-			[8] float64,
-			[9] object
+			[6] object,
+			[7] float64,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.Buffer_Constructor_Legacy/Scope::.ctor()
@@ -84,51 +83,45 @@
 		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0071: stloc.s 5
 		IL_0073: ldloc.1
-		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0079: stloc.s 6
-		IL_007b: ldloc.s 6
-		IL_007d: ldstr "toString"
-		IL_0082: ldstr "utf8"
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008c: stloc.s 7
-		IL_008e: ldloc.s 5
-		IL_0090: ldstr "log"
-		IL_0095: ldloc.s 7
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009c: pop
-		IL_009d: ldstr "console"
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ac: stloc.s 7
-		IL_00ae: ldloc.2
-		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_00b4: stloc.s 6
-		IL_00b6: ldloc.s 6
-		IL_00b8: ldstr "toString"
-		IL_00bd: ldstr "utf8"
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c7: stloc.s 5
-		IL_00c9: ldloc.s 7
-		IL_00cb: ldstr "log"
-		IL_00d0: ldloc.s 5
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d7: pop
-		IL_00d8: ldstr "console"
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e7: stloc.s 5
-		IL_00e9: ldloc.3
-		IL_00ea: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-		IL_00ef: stloc.s 8
-		IL_00f1: ldloc.s 8
-		IL_00f3: box [System.Runtime]System.Double
-		IL_00f8: stloc.s 9
-		IL_00fa: ldloc.s 5
-		IL_00fc: ldstr "log"
-		IL_0101: ldloc.s 9
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0108: pop
-		IL_0109: ret
+		IL_0074: ldstr "toString"
+		IL_0079: ldstr "utf8"
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0083: stloc.s 6
+		IL_0085: ldloc.s 5
+		IL_0087: ldstr "log"
+		IL_008c: ldloc.s 6
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0093: pop
+		IL_0094: ldstr "console"
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a3: stloc.s 6
+		IL_00a5: ldloc.2
+		IL_00a6: ldstr "toString"
+		IL_00ab: ldstr "utf8"
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b5: stloc.s 5
+		IL_00b7: ldloc.s 6
+		IL_00b9: ldstr "log"
+		IL_00be: ldloc.s 5
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c5: pop
+		IL_00c6: ldstr "console"
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d5: stloc.s 5
+		IL_00d7: ldloc.3
+		IL_00d8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+		IL_00dd: stloc.s 7
+		IL_00df: ldloc.s 7
+		IL_00e1: box [System.Runtime]System.Double
+		IL_00e6: stloc.s 8
+		IL_00e8: ldloc.s 5
+		IL_00ea: ldstr "log"
+		IL_00ef: ldloc.s 8
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f6: pop
+		IL_00f7: ret
 	} // end of method Buffer_Constructor_Legacy::__js_module_init__
 
 } // end of class Modules.Buffer_Constructor_Legacy
@@ -140,7 +133,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x216f
+		// Method begins at RVA 0x215d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Rename_ExistingDirectory_Rejects.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Rename_ExistingDirectory_Rejects.verified.txt
@@ -41,7 +41,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2811
+						// Method begins at RVA 0x2808
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -61,7 +61,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x281a
+						// Method begins at RVA 0x2811
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -79,7 +79,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2808
+					// Method begins at RVA 0x27ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -99,7 +99,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2823
+					// Method begins at RVA 0x281a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -127,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27ff
+				// Method begins at RVA 0x27f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -153,7 +153,7 @@
 			)
 			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 1786 (0x6fa)
+			// Code size: 1777 (0x6f1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope,
@@ -320,7 +320,7 @@
 
 			IL_0110: ldloc.0
 			IL_0111: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0116: switch (IL_012f, IL_05de, IL_062e, IL_046c, IL_0434)
+			IL_0116: switch (IL_012f, IL_05d5, IL_0625, IL_046c, IL_0434)
 
 			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_0134: stloc.s 9
@@ -667,7 +667,7 @@
 			IL_045c: ldstr "success"
 			IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 			IL_0466: pop
-			IL_0467: br IL_0502
+			IL_0467: br IL_04f9
 
 			IL_046c: ldloc.0
 			IL_046d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
@@ -688,220 +688,217 @@
 			IL_049e: ldstr ""
 			IL_04a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_04a8: stloc.s 17
-			IL_04aa: ldloc.s 17
-			IL_04ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_04b1: stloc.s 17
-			IL_04b3: ldloc.s 6
-			IL_04b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04ba: stloc.s 18
-			IL_04bc: ldloc.s 18
-			IL_04be: brfalse IL_04da
+			IL_04aa: ldloc.s 6
+			IL_04ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04b1: stloc.s 18
+			IL_04b3: ldloc.s 18
+			IL_04b5: brfalse IL_04d1
 
-			IL_04c3: ldloc.s 6
-			IL_04c5: ldstr "message"
-			IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04cf: stloc.s 19
-			IL_04d1: ldloc.s 19
+			IL_04ba: ldloc.s 6
+			IL_04bc: ldstr "message"
+			IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04c6: stloc.s 19
+			IL_04c8: ldloc.s 19
+			IL_04ca: stloc.s 21
+			IL_04cc: br IL_04d5
+
+			IL_04d1: ldloc.s 6
 			IL_04d3: stloc.s 21
-			IL_04d5: br IL_04de
 
-			IL_04da: ldloc.s 6
-			IL_04dc: stloc.s 21
+			IL_04d5: ldloc.s 17
+			IL_04d7: ldloc.s 21
+			IL_04d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_04de: stloc.s 19
+			IL_04e0: ldloc.s 9
+			IL_04e2: ldstr "log"
+			IL_04e7: ldstr "RenameStartsWithEPERM:"
+			IL_04ec: ldloc.s 19
+			IL_04ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_04f3: pop
+			IL_04f4: br IL_04f9
 
-			IL_04de: ldloc.s 17
-			IL_04e0: ldloc.s 21
-			IL_04e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_04e7: stloc.s 19
-			IL_04e9: ldloc.s 9
-			IL_04eb: ldstr "log"
-			IL_04f0: ldstr "RenameStartsWithEPERM:"
-			IL_04f5: ldloc.s 19
-			IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_04fc: pop
-			IL_04fd: br IL_0502
-
-			IL_0502: ldstr "console"
-			IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04f9: ldstr "console"
+			IL_04fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0503: stloc.s 19
+			IL_0505: ldloc.s 19
+			IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_050c: stloc.s 19
-			IL_050e: ldloc.s 19
-			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0515: stloc.s 19
-			IL_0517: ldarg.0
-			IL_0518: ldc.i4.1
-			IL_0519: ldelem.ref
-			IL_051a: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_051f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0524: stloc.s 15
-			IL_0526: ldloc.s 15
-			IL_0528: ldloc.3
-			IL_0529: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_052e: box [System.Runtime]System.Boolean
-			IL_0533: stloc.s 9
-			IL_0535: ldloc.s 19
-			IL_0537: ldstr "log"
-			IL_053c: ldstr "SourceExists:"
-			IL_0541: ldloc.s 9
-			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0548: pop
-			IL_0549: ldstr "console"
-			IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_050e: ldarg.0
+			IL_050f: ldc.i4.1
+			IL_0510: ldelem.ref
+			IL_0511: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0516: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_051b: stloc.s 15
+			IL_051d: ldloc.s 15
+			IL_051f: ldloc.3
+			IL_0520: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_0525: box [System.Runtime]System.Boolean
+			IL_052a: stloc.s 9
+			IL_052c: ldloc.s 19
+			IL_052e: ldstr "log"
+			IL_0533: ldstr "SourceExists:"
+			IL_0538: ldloc.s 9
+			IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_053f: pop
+			IL_0540: ldstr "console"
+			IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_054a: stloc.s 9
+			IL_054c: ldloc.s 9
+			IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0553: stloc.s 9
-			IL_0555: ldloc.s 9
-			IL_0557: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_055c: stloc.s 9
-			IL_055e: ldarg.0
-			IL_055f: ldc.i4.1
-			IL_0560: ldelem.ref
-			IL_0561: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0566: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_056b: stloc.s 15
-			IL_056d: ldloc.s 15
-			IL_056f: ldloc.s 4
-			IL_0571: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_0576: box [System.Runtime]System.Boolean
-			IL_057b: stloc.s 19
-			IL_057d: ldloc.s 9
-			IL_057f: ldstr "log"
-			IL_0584: ldstr "DestinationExists:"
-			IL_0589: ldloc.s 19
-			IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0590: pop
-			IL_0591: ldstr "console"
-			IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0555: ldarg.0
+			IL_0556: ldc.i4.1
+			IL_0557: ldelem.ref
+			IL_0558: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_055d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0562: stloc.s 15
+			IL_0564: ldloc.s 15
+			IL_0566: ldloc.s 4
+			IL_0568: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_056d: box [System.Runtime]System.Boolean
+			IL_0572: stloc.s 19
+			IL_0574: ldloc.s 9
+			IL_0576: ldstr "log"
+			IL_057b: ldstr "DestinationExists:"
+			IL_0580: ldloc.s 19
+			IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0587: pop
+			IL_0588: ldstr "console"
+			IL_058d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0592: stloc.s 19
+			IL_0594: ldloc.s 19
+			IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_059b: stloc.s 19
-			IL_059d: ldloc.s 19
-			IL_059f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05a4: stloc.s 19
-			IL_05a6: ldarg.0
-			IL_05a7: ldc.i4.1
-			IL_05a8: ldelem.ref
-			IL_05a9: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_05ae: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_05b3: stloc.s 15
-			IL_05b5: ldloc.s 15
-			IL_05b7: ldloc.s 5
-			IL_05b9: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_05be: box [System.Runtime]System.Boolean
-			IL_05c3: stloc.s 9
-			IL_05c5: ldloc.s 19
-			IL_05c7: ldstr "log"
-			IL_05cc: ldstr "SentinelExists:"
-			IL_05d1: ldloc.s 9
-			IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_05d8: pop
-			IL_05d9: br IL_05f1
+			IL_059d: ldarg.0
+			IL_059e: ldc.i4.1
+			IL_059f: ldelem.ref
+			IL_05a0: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_05a5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_05aa: stloc.s 15
+			IL_05ac: ldloc.s 15
+			IL_05ae: ldloc.s 5
+			IL_05b0: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_05b5: box [System.Runtime]System.Boolean
+			IL_05ba: stloc.s 9
+			IL_05bc: ldloc.s 19
+			IL_05be: ldstr "log"
+			IL_05c3: ldstr "SentinelExists:"
+			IL_05c8: ldloc.s 9
+			IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_05cf: pop
+			IL_05d0: br IL_05e8
 
-			IL_05de: ldloc.0
-			IL_05df: ldc.i4.1
-			IL_05e0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_05e5: ldloc.0
-			IL_05e6: ldc.i4.0
-			IL_05e7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_05ec: br IL_05f1
+			IL_05d5: ldloc.0
+			IL_05d6: ldc.i4.1
+			IL_05d7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_05dc: ldloc.0
+			IL_05dd: ldc.i4.0
+			IL_05de: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_05e3: br IL_05e8
 
-			IL_05f1: ldarg.0
-			IL_05f2: ldc.i4.1
-			IL_05f3: ldelem.ref
-			IL_05f4: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_05f9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_05fe: stloc.s 15
-			IL_0600: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0605: dup
-			IL_0606: ldstr "recursive"
-			IL_060b: ldc.i4.1
-			IL_060c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0611: dup
-			IL_0612: ldstr "force"
-			IL_0617: ldc.i4.1
-			IL_0618: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_061d: stloc.s 16
-			IL_061f: ldloc.s 15
-			IL_0621: ldloc.2
-			IL_0622: ldloc.s 16
-			IL_0624: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0629: br IL_0641
+			IL_05e8: ldarg.0
+			IL_05e9: ldc.i4.1
+			IL_05ea: ldelem.ref
+			IL_05eb: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_05f0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_05f5: stloc.s 15
+			IL_05f7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05fc: dup
+			IL_05fd: ldstr "recursive"
+			IL_0602: ldc.i4.1
+			IL_0603: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0608: dup
+			IL_0609: ldstr "force"
+			IL_060e: ldc.i4.1
+			IL_060f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0614: stloc.s 16
+			IL_0616: ldloc.s 15
+			IL_0618: ldloc.2
+			IL_0619: ldloc.s 16
+			IL_061b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0620: br IL_0638
 
-			IL_062e: ldloc.0
-			IL_062f: ldc.i4.1
-			IL_0630: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0635: ldloc.0
-			IL_0636: ldc.i4.0
-			IL_0637: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_063c: br IL_0641
+			IL_0625: ldloc.0
+			IL_0626: ldc.i4.1
+			IL_0627: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_062c: ldloc.0
+			IL_062d: ldc.i4.0
+			IL_062e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0633: br IL_0638
 
-			IL_0641: ldloc.0
-			IL_0642: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0647: stloc.s 7
-			IL_0649: ldloc.s 7
-			IL_064b: brfalse IL_0688
+			IL_0638: ldloc.0
+			IL_0639: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_063e: stloc.s 7
+			IL_0640: ldloc.s 7
+			IL_0642: brfalse IL_067f
 
-			IL_0650: ldloc.0
-			IL_0651: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0656: stloc.s 9
-			IL_0658: ldloc.0
-			IL_0659: ldc.i4.m1
-			IL_065a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_065f: ldloc.0
-			IL_0660: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0665: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_066a: ldarg.0
-			IL_066b: ldc.i4.1
-			IL_066c: newarr [System.Runtime]System.Object
-			IL_0671: dup
-			IL_0672: ldc.i4.0
-			IL_0673: ldloc.s 9
-			IL_0675: stelem.ref
-			IL_0676: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_067b: pop
-			IL_067c: ldloc.0
-			IL_067d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0682: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0687: ret
+			IL_0647: ldloc.0
+			IL_0648: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_064d: stloc.s 9
+			IL_064f: ldloc.0
+			IL_0650: ldc.i4.m1
+			IL_0651: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0656: ldloc.0
+			IL_0657: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_065c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0661: ldarg.0
+			IL_0662: ldc.i4.1
+			IL_0663: newarr [System.Runtime]System.Object
+			IL_0668: dup
+			IL_0669: ldc.i4.0
+			IL_066a: ldloc.s 9
+			IL_066c: stelem.ref
+			IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0672: pop
+			IL_0673: ldloc.0
+			IL_0674: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0679: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_067e: ret
 
-			IL_0688: ldloc.0
-			IL_0689: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_068e: stloc.s 8
-			IL_0690: ldloc.s 8
-			IL_0692: brfalse IL_06cf
+			IL_067f: ldloc.0
+			IL_0680: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0685: stloc.s 8
+			IL_0687: ldloc.s 8
+			IL_0689: brfalse IL_06c6
 
-			IL_0697: ldloc.0
-			IL_0698: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_069d: stloc.s 9
-			IL_069f: ldloc.0
-			IL_06a0: ldc.i4.m1
-			IL_06a1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06a6: ldloc.0
-			IL_06a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_06b1: ldarg.0
-			IL_06b2: ldc.i4.1
-			IL_06b3: newarr [System.Runtime]System.Object
-			IL_06b8: dup
-			IL_06b9: ldc.i4.0
-			IL_06ba: ldloc.s 9
-			IL_06bc: stelem.ref
-			IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_06c2: pop
-			IL_06c3: ldloc.0
-			IL_06c4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06c9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06ce: ret
+			IL_068e: ldloc.0
+			IL_068f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0694: stloc.s 9
+			IL_0696: ldloc.0
+			IL_0697: ldc.i4.m1
+			IL_0698: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_069d: ldloc.0
+			IL_069e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06a8: ldarg.0
+			IL_06a9: ldc.i4.1
+			IL_06aa: newarr [System.Runtime]System.Object
+			IL_06af: dup
+			IL_06b0: ldc.i4.0
+			IL_06b1: ldloc.s 9
+			IL_06b3: stelem.ref
+			IL_06b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06b9: pop
+			IL_06ba: ldloc.0
+			IL_06bb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06c0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06c5: ret
 
-			IL_06cf: ldloc.0
-			IL_06d0: ldc.i4.m1
-			IL_06d1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06d6: ldloc.0
-			IL_06d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_06e1: ldarg.0
-			IL_06e2: ldc.i4.1
-			IL_06e3: newarr [System.Runtime]System.Object
-			IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_06ed: pop
-			IL_06ee: ldloc.0
-			IL_06ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06f4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06f9: ret
+			IL_06c6: ldloc.0
+			IL_06c7: ldc.i4.m1
+			IL_06c8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06cd: ldloc.0
+			IL_06ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06d8: ldarg.0
+			IL_06d9: ldc.i4.1
+			IL_06da: newarr [System.Runtime]System.Object
+			IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06e4: pop
+			IL_06e5: ldloc.0
+			IL_06e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06eb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06f0: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -923,7 +920,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27f6
+			// Method begins at RVA 0x27ed
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1024,7 +1021,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x282c
+		// Method begins at RVA 0x2823
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateReadStream_Missing_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateReadStream_Missing_Error.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b5
+				// Method begins at RVA 0x22ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			)
 			// Method begins at RVA 0x2210
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 97 (0x61)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -70,38 +70,35 @@
 			IL_0015: ldstr ""
 			IL_001a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_001f: stloc.1
-			IL_0020: ldloc.1
-			IL_0021: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_0026: stloc.1
-			IL_0027: ldarg.1
-			IL_0028: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_002d: stloc.2
-			IL_002e: ldloc.2
-			IL_002f: brfalse IL_0048
+			IL_0020: ldarg.1
+			IL_0021: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0026: stloc.2
+			IL_0027: ldloc.2
+			IL_0028: brfalse IL_0041
 
-			IL_0034: ldarg.1
-			IL_0035: ldstr "message"
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003f: stloc.3
-			IL_0040: ldloc.3
-			IL_0041: stloc.s 5
-			IL_0043: br IL_004b
+			IL_002d: ldarg.1
+			IL_002e: ldstr "message"
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0038: stloc.3
+			IL_0039: ldloc.3
+			IL_003a: stloc.s 5
+			IL_003c: br IL_0044
 
-			IL_0048: ldarg.1
-			IL_0049: stloc.s 5
+			IL_0041: ldarg.1
+			IL_0042: stloc.s 5
 
-			IL_004b: ldloc.1
-			IL_004c: ldloc.s 5
-			IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0053: stloc.3
-			IL_0054: ldloc.0
-			IL_0055: ldstr "log"
-			IL_005a: ldstr "ErrorStartsWithENOENT:"
-			IL_005f: ldloc.3
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0065: pop
-			IL_0066: ldnull
-			IL_0067: ret
+			IL_0044: ldloc.1
+			IL_0045: ldloc.s 5
+			IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_004c: stloc.3
+			IL_004d: ldloc.0
+			IL_004e: ldstr "log"
+			IL_0053: ldstr "ErrorStartsWithENOENT:"
+			IL_0058: ldloc.3
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_005e: pop
+			IL_005f: ldnull
+			IL_0060: ret
 		} // end of method ArrowFunction_L13C20::__js_call__
 
 	} // end of class ArrowFunction_L13C20
@@ -117,7 +114,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22be
+				// Method begins at RVA 0x22b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +137,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2284
+			// Method begins at RVA 0x227d
 			// Header size: 1
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -167,7 +164,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22ac
+			// Method begins at RVA 0x22a5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -365,7 +362,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22c7
+		// Method begins at RVA 0x22c0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Missing_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Missing_Error.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2329
+				// Method begins at RVA 0x2322
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			)
 			// Method begins at RVA 0x2284
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 97 (0x61)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -70,38 +70,35 @@
 			IL_0015: ldstr ""
 			IL_001a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_001f: stloc.1
-			IL_0020: ldloc.1
-			IL_0021: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_0026: stloc.1
-			IL_0027: ldarg.1
-			IL_0028: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_002d: stloc.2
-			IL_002e: ldloc.2
-			IL_002f: brfalse IL_0048
+			IL_0020: ldarg.1
+			IL_0021: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0026: stloc.2
+			IL_0027: ldloc.2
+			IL_0028: brfalse IL_0041
 
-			IL_0034: ldarg.1
-			IL_0035: ldstr "message"
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003f: stloc.3
-			IL_0040: ldloc.3
-			IL_0041: stloc.s 5
-			IL_0043: br IL_004b
+			IL_002d: ldarg.1
+			IL_002e: ldstr "message"
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0038: stloc.3
+			IL_0039: ldloc.3
+			IL_003a: stloc.s 5
+			IL_003c: br IL_0044
 
-			IL_0048: ldarg.1
-			IL_0049: stloc.s 5
+			IL_0041: ldarg.1
+			IL_0042: stloc.s 5
 
-			IL_004b: ldloc.1
-			IL_004c: ldloc.s 5
-			IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0053: stloc.3
-			IL_0054: ldloc.0
-			IL_0055: ldstr "log"
-			IL_005a: ldstr "ErrorStartsWithENOENT:"
-			IL_005f: ldloc.3
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0065: pop
-			IL_0066: ldnull
-			IL_0067: ret
+			IL_0044: ldloc.1
+			IL_0045: ldloc.s 5
+			IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_004c: stloc.3
+			IL_004d: ldloc.0
+			IL_004e: ldstr "log"
+			IL_0053: ldstr "ErrorStartsWithENOENT:"
+			IL_0058: ldloc.3
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_005e: pop
+			IL_005f: ldnull
+			IL_0060: ret
 		} // end of method ArrowFunction_L14C20::__js_call__
 
 	} // end of class ArrowFunction_L14C20
@@ -117,7 +114,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2332
+				// Method begins at RVA 0x232b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +137,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22f8
+			// Method begins at RVA 0x22f1
 			// Header size: 1
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -167,7 +164,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2320
+			// Method begins at RVA 0x2319
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -414,7 +411,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x233b
+		// Method begins at RVA 0x2334
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Unsupported_Connect_Fails_Clearly.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Unsupported_Connect_Fails_Clearly.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ad
+				// Method begins at RVA 0x21a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b6
+				// Method begins at RVA 0x21ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a4
+			// Method begins at RVA 0x219c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 310 (0x136)
+		// Code size: 301 (0x12d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_Request_Unsupported_Connect_Fails_Clearly/Scope,
@@ -143,7 +143,7 @@
 			IL_008d: ldstr "unexpected"
 			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_0097: pop
-			IL_0098: leave IL_0132
+			IL_0098: leave IL_0129
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -178,32 +178,29 @@
 			IL_00e2: ldstr ""
 			IL_00e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_00ec: stloc.s 9
-			IL_00ee: ldloc.s 9
-			IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-			IL_00f5: stloc.s 9
-			IL_00f7: ldloc.s 5
-			IL_00f9: ldstr "message"
-			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0103: stloc.s 10
-			IL_0105: ldloc.s 9
-			IL_0107: ldloc.s 10
-			IL_0109: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_010e: stloc.s 10
-			IL_0110: ldstr "connect unsupported:"
-			IL_0115: ldloc.s 10
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_011c: stloc.s 11
-			IL_011e: ldloc.s 8
-			IL_0120: ldstr "log"
-			IL_0125: ldloc.s 11
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_012c: pop
-			IL_012d: leave IL_0132
+			IL_00ee: ldloc.s 5
+			IL_00f0: ldstr "message"
+			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00fa: stloc.s 10
+			IL_00fc: ldloc.s 9
+			IL_00fe: ldloc.s 10
+			IL_0100: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0105: stloc.s 10
+			IL_0107: ldstr "connect unsupported:"
+			IL_010c: ldloc.s 10
+			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0113: stloc.s 11
+			IL_0115: ldloc.s 8
+			IL_0117: ldstr "log"
+			IL_011c: ldloc.s 11
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0123: pop
+			IL_0124: leave IL_0129
 		} // end handler
 
-		IL_0132: ldnull
-		IL_0133: stloc.s 6
-		IL_0135: ret
+		IL_0129: ldnull
+		IL_012a: stloc.s 6
+		IL_012c: ret
 	} // end of method Http_Request_Unsupported_Connect_Fails_Clearly::__js_module_init__
 
 } // end of class Modules.Http_Request_Unsupported_Connect_Fails_Clearly
@@ -215,7 +212,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21bf
+		// Method begins at RVA 0x21b7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Versions_Expanded.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Versions_Expanded.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24f5
+			// Method begins at RVA 0x24ec
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1177 (0x499)
+		// Code size: 1168 (0x490)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Process_Versions_Expanded/Scope,
@@ -401,19 +401,16 @@
 		IL_0469: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_046e: stloc.s 18
 		IL_0470: ldloc.s 18
-		IL_0472: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0477: stloc.s 18
-		IL_0479: ldloc.s 18
-		IL_047b: ldloc.s 6
-		IL_047d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0482: stloc.s 19
-		IL_0484: ldloc.s 7
-		IL_0486: ldstr "log"
-		IL_048b: ldstr "node version format valid"
-		IL_0490: ldloc.s 19
-		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0497: pop
-		IL_0498: ret
+		IL_0472: ldloc.s 6
+		IL_0474: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+		IL_0479: stloc.s 19
+		IL_047b: ldloc.s 7
+		IL_047d: ldstr "log"
+		IL_0482: ldstr "node version format valid"
+		IL_0487: ldloc.s 19
+		IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_048e: pop
+		IL_048f: ret
 	} // end of method Process_Versions_Expanded::__js_module_init__
 
 } // end of class Modules.Process_Versions_Expanded
@@ -425,7 +422,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24fe
+		// Method begins at RVA 0x24f5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.GlobalTimers_AsValues_WindowLikeAssignment.verified.txt
+++ b/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.GlobalTimers_AsValues_WindowLikeAssignment.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2225
+				// Method begins at RVA 0x2213
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2219
+			// Method begins at RVA 0x2207
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -59,7 +59,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x221c
+			// Method begins at RVA 0x220a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -85,7 +85,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 445 (0x1bd)
+		// Code size: 427 (0x1ab)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.GlobalTimers_AsValues_WindowLikeAssignment/Scope,
@@ -94,8 +94,7 @@
 			[3] object,
 			[4] object,
 			[5] string,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
 		)
 
 		IL_0000: newobj instance void Modules.GlobalTimers_AsValues_WindowLikeAssignment/Scope::.ctor()
@@ -203,43 +202,37 @@
 		IL_0139: ldloc.s 5
 		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0140: pop
-		IL_0141: ldloc.1
-		IL_0142: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
-		IL_0147: stloc.s 6
-		IL_0149: ldnull
-		IL_014a: ldftn object Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id::__js_call__(object)
-		IL_0150: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0155: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_015a: ldc.i4.0
-		IL_015b: conv.r8
-		IL_015c: ldstr ""
-		IL_0161: ldc.i4.0
-		IL_0162: ldc.i4.1
-		IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0168: stloc.s 7
-		IL_016a: ldloc.s 6
-		IL_016c: ldstr "setTimeout"
-		IL_0171: ldloc.s 7
-		IL_0173: ldc.r8 100000
-		IL_017c: box [System.Runtime]System.Double
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0186: stloc.2
-		IL_0187: ldloc.1
-		IL_0188: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
-		IL_018d: stloc.s 6
-		IL_018f: ldloc.s 6
-		IL_0191: ldstr "clearTimeout"
-		IL_0196: ldloc.2
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019c: pop
-		IL_019d: ldstr "console"
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ac: ldstr "log"
-		IL_01b1: ldstr "ok"
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bb: pop
-		IL_01bc: ret
+		IL_0141: ldnull
+		IL_0142: ldftn object Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id::__js_call__(object)
+		IL_0148: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_014d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0152: ldc.i4.0
+		IL_0153: conv.r8
+		IL_0154: ldstr ""
+		IL_0159: ldc.i4.0
+		IL_015a: ldc.i4.1
+		IL_015b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0160: stloc.s 6
+		IL_0162: ldloc.1
+		IL_0163: ldstr "setTimeout"
+		IL_0168: ldloc.s 6
+		IL_016a: ldc.r8 100000
+		IL_0173: box [System.Runtime]System.Double
+		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_017d: stloc.2
+		IL_017e: ldloc.1
+		IL_017f: ldstr "clearTimeout"
+		IL_0184: ldloc.2
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018a: pop
+		IL_018b: ldstr "console"
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019a: ldstr "log"
+		IL_019f: ldstr "ok"
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a9: pop
+		IL_01aa: ret
 	} // end of method GlobalTimers_AsValues_WindowLikeAssignment::__js_module_init__
 
 } // end of class Modules.GlobalTimers_AsValues_WindowLikeAssignment
@@ -251,7 +244,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x222e
+		// Method begins at RVA 0x221c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_EarlyBoundAccess_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_EarlyBoundAccess_Parity.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28cc
+				// Method begins at RVA 0x28c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2868
+			// Method begins at RVA 0x2860
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28d5
+				// Method begins at RVA 0x28cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -87,7 +87,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2870
+			// Method begins at RVA 0x2868
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -138,7 +138,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x28c3
+			// Method begins at RVA 0x28bb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -168,7 +168,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28de
+				// Method begins at RVA 0x28d6
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -181,7 +181,7 @@
 			.method public hidebysig 
 				instance object get_text () cil managed 
 			{
-				// Method begins at RVA 0x28e6
+				// Method begins at RVA 0x28de
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -196,7 +196,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x28ee
+				// Method begins at RVA 0x28e6
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig 
 				instance float64 get_num () cil managed 
 			{
-				// Method begins at RVA 0x2903
+				// Method begins at RVA 0x28fb
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -229,7 +229,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x290b
+				// Method begins at RVA 0x2903
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -247,7 +247,7 @@
 			.method public hidebysig 
 				instance object get_flag () cil managed 
 			{
-				// Method begins at RVA 0x2920
+				// Method begins at RVA 0x2918
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -262,7 +262,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x2928
+				// Method begins at RVA 0x2920
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -280,7 +280,7 @@
 			.method public hidebysig 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0 get_fn () cil managed 
 			{
-				// Method begins at RVA 0x293d
+				// Method begins at RVA 0x2935
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -295,7 +295,7 @@
 					class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x2945
+				// Method begins at RVA 0x293d
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -322,7 +322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x295a
+				// Method begins at RVA 0x2952
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -335,7 +335,7 @@
 			.method public hidebysig 
 				instance float64 get_n () cil managed 
 			{
-				// Method begins at RVA 0x2962
+				// Method begins at RVA 0x295a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -350,7 +350,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x296a
+				// Method begins at RVA 0x2962
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -378,7 +378,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x297f
+				// Method begins at RVA 0x2977
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -391,7 +391,7 @@
 			.method public hidebysig 
 				instance object get_maybe () cil managed 
 			{
-				// Method begins at RVA 0x2987
+				// Method begins at RVA 0x297f
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -406,7 +406,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x298f
+				// Method begins at RVA 0x2987
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -424,7 +424,7 @@
 			.method public hidebysig 
 				instance object get_ready () cil managed 
 			{
-				// Method begins at RVA 0x29a4
+				// Method begins at RVA 0x299c
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -439,7 +439,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x29ac
+				// Method begins at RVA 0x29a4
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -467,7 +467,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29c1
+				// Method begins at RVA 0x29b9
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -480,7 +480,7 @@
 			.method public hidebysig 
 				instance float64 get_a () cil managed 
 			{
-				// Method begins at RVA 0x29c9
+				// Method begins at RVA 0x29c1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -495,7 +495,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x29d1
+				// Method begins at RVA 0x29c9
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -513,7 +513,7 @@
 			.method public hidebysig 
 				instance object get_b () cil managed 
 			{
-				// Method begins at RVA 0x29e6
+				// Method begins at RVA 0x29de
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -528,7 +528,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x29ee
+				// Method begins at RVA 0x29e6
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -561,7 +561,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2041 (0x7f9)
+		// Code size: 2036 (0x7f4)
 		.maxstack 12
 		.locals init (
 			[0] class Modules.ObjectLiteral_EarlyBoundAccess_Parity/Scope,
@@ -660,582 +660,581 @@
 		IL_00ce: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_flag()
 		IL_00d3: stloc.s 19
 		IL_00d5: ldloc.2
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00db: ldstr "fn"
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00e5: stloc.s 20
-		IL_00e7: ldloc.s 15
-		IL_00e9: ldstr "log"
-		IL_00ee: ldc.i4.4
-		IL_00ef: newarr [System.Runtime]System.Object
+		IL_00d6: ldstr "fn"
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00e0: stloc.s 20
+		IL_00e2: ldloc.s 15
+		IL_00e4: ldstr "log"
+		IL_00e9: ldc.i4.4
+		IL_00ea: newarr [System.Runtime]System.Object
+		IL_00ef: dup
+		IL_00f0: ldc.i4.0
+		IL_00f1: ldloc.s 16
+		IL_00f3: stelem.ref
 		IL_00f4: dup
-		IL_00f5: ldc.i4.0
-		IL_00f6: ldloc.s 16
+		IL_00f5: ldc.i4.1
+		IL_00f6: ldloc.s 18
 		IL_00f8: stelem.ref
 		IL_00f9: dup
-		IL_00fa: ldc.i4.1
-		IL_00fb: ldloc.s 18
+		IL_00fa: ldc.i4.2
+		IL_00fb: ldloc.s 19
 		IL_00fd: stelem.ref
 		IL_00fe: dup
-		IL_00ff: ldc.i4.2
-		IL_0100: ldloc.s 19
+		IL_00ff: ldc.i4.3
+		IL_0100: ldloc.s 20
 		IL_0102: stelem.ref
-		IL_0103: dup
-		IL_0104: ldc.i4.3
-		IL_0105: ldloc.s 20
-		IL_0107: stelem.ref
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_010d: pop
-		IL_010e: ldloc.2
-		IL_010f: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
-		IL_0114: ldc.r8 2
-		IL_011d: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::set_num(float64)
-		IL_0122: ldloc.2
-		IL_0123: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
-		IL_0128: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_num()
-		IL_012d: stloc.s 17
-		IL_012f: ldloc.s 17
-		IL_0131: ldc.r8 1
-		IL_013a: sub
-		IL_013b: stloc.s 17
-		IL_013d: ldloc.2
-		IL_013e: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
-		IL_0143: ldloc.s 17
-		IL_0145: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::set_num(float64)
-		IL_014a: ldloc.2
-		IL_014b: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
-		IL_0150: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_num()
-		IL_0155: stloc.s 17
-		IL_0157: ldloc.s 17
-		IL_0159: ldc.r8 10
-		IL_0162: mul
-		IL_0163: stloc.s 17
-		IL_0165: ldloc.2
-		IL_0166: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
-		IL_016b: ldloc.s 17
-		IL_016d: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::set_num(float64)
-		IL_0172: ldstr "console"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0181: stloc.s 15
-		IL_0183: ldloc.2
-		IL_0184: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
-		IL_0189: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_num()
-		IL_018e: stloc.s 17
-		IL_0190: ldloc.s 17
-		IL_0192: box [System.Runtime]System.Double
-		IL_0197: stloc.s 18
-		IL_0199: ldloc.s 15
-		IL_019b: ldstr "log"
-		IL_01a0: ldloc.s 18
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a7: pop
-		IL_01a8: ldloc.2
-		IL_01a9: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
-		IL_01ae: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_text()
-		IL_01b3: stloc.s 15
-		IL_01b5: ldloc.s 15
-		IL_01b7: ldstr "!"
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01c1: stloc.s 21
-		IL_01c3: ldloc.2
-		IL_01c4: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
-		IL_01c9: ldloc.s 21
-		IL_01cb: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::set_text(object)
-		IL_01d0: ldloc.2
-		IL_01d1: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
-		IL_01d6: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_flag()
-		IL_01db: stloc.s 15
-		IL_01dd: ldloc.s 15
-		IL_01df: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_01e4: ldc.i4.0
-		IL_01e5: ceq
-		IL_01e7: stloc.s 22
-		IL_01e9: ldloc.2
-		IL_01ea: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
-		IL_01ef: ldloc.s 22
-		IL_01f1: box [System.Runtime]System.Boolean
-		IL_01f6: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::set_flag(object)
-		IL_01fb: ldstr "console"
-		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020a: stloc.s 15
-		IL_020c: ldloc.2
-		IL_020d: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
-		IL_0212: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_text()
-		IL_0217: stloc.s 20
-		IL_0219: ldloc.2
-		IL_021a: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
-		IL_021f: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_flag()
-		IL_0224: stloc.s 19
-		IL_0226: ldloc.s 15
-		IL_0228: ldstr "log"
-		IL_022d: ldloc.s 20
-		IL_022f: ldloc.s 19
-		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0236: pop
-		IL_0237: newobj instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::.ctor()
-		IL_023c: stloc.3
-		IL_023d: ldloc.3
-		IL_023e: ldc.r8 0.0
-		IL_0247: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::set_n(float64)
-		IL_024c: ldstr "console"
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025b: stloc.s 19
-		IL_025d: ldloc.3
-		IL_025e: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
-		IL_0263: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::get_n()
-		IL_0268: stloc.s 17
-		IL_026a: ldloc.s 17
-		IL_026c: box [System.Runtime]System.Double
-		IL_0271: stloc.s 18
-		IL_0273: ldloc.s 18
-		IL_0275: stloc.s 20
-		IL_0277: ldloc.s 17
-		IL_0279: ldc.r8 1
-		IL_0282: add
-		IL_0283: stloc.s 17
-		IL_0285: ldloc.3
-		IL_0286: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
-		IL_028b: ldloc.s 17
-		IL_028d: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::set_n(float64)
-		IL_0292: ldloc.s 19
-		IL_0294: ldstr "log"
-		IL_0299: ldloc.s 20
-		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a0: pop
-		IL_02a1: ldstr "console"
-		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b0: stloc.s 20
-		IL_02b2: ldloc.3
-		IL_02b3: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
-		IL_02b8: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::get_n()
-		IL_02bd: stloc.s 17
-		IL_02bf: ldloc.s 17
-		IL_02c1: ldc.r8 1
-		IL_02ca: add
-		IL_02cb: stloc.s 17
-		IL_02cd: ldloc.3
-		IL_02ce: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
-		IL_02d3: ldloc.s 17
-		IL_02d5: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::set_n(float64)
-		IL_02da: ldloc.s 17
-		IL_02dc: box [System.Runtime]System.Double
-		IL_02e1: stloc.s 18
-		IL_02e3: ldloc.s 20
-		IL_02e5: ldstr "log"
-		IL_02ea: ldloc.s 18
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02f1: pop
-		IL_02f2: ldstr "console"
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0301: stloc.s 20
-		IL_0303: ldloc.3
-		IL_0304: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
-		IL_0309: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::get_n()
-		IL_030e: stloc.s 17
-		IL_0310: ldloc.s 17
-		IL_0312: box [System.Runtime]System.Double
-		IL_0317: stloc.s 18
-		IL_0319: ldloc.s 18
-		IL_031b: stloc.s 19
-		IL_031d: ldloc.s 17
-		IL_031f: ldc.r8 1
-		IL_0328: sub
-		IL_0329: stloc.s 17
-		IL_032b: ldloc.3
-		IL_032c: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
-		IL_0331: ldloc.s 17
-		IL_0333: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::set_n(float64)
-		IL_0338: ldloc.s 20
-		IL_033a: ldstr "log"
-		IL_033f: ldloc.s 19
-		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0346: pop
-		IL_0347: ldstr "console"
-		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0356: stloc.s 19
-		IL_0358: ldloc.3
-		IL_0359: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
-		IL_035e: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::get_n()
-		IL_0363: stloc.s 17
-		IL_0365: ldloc.s 17
-		IL_0367: ldc.r8 1
-		IL_0370: sub
-		IL_0371: stloc.s 17
-		IL_0373: ldloc.3
-		IL_0374: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
-		IL_0379: ldloc.s 17
-		IL_037b: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::set_n(float64)
-		IL_0380: ldloc.s 17
-		IL_0382: box [System.Runtime]System.Double
-		IL_0387: stloc.s 18
-		IL_0389: ldloc.s 19
-		IL_038b: ldstr "log"
-		IL_0390: ldloc.s 18
-		IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0397: pop
-		IL_0398: ldstr "console"
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03a7: stloc.s 19
-		IL_03a9: ldloc.3
-		IL_03aa: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
-		IL_03af: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::get_n()
-		IL_03b4: stloc.s 17
-		IL_03b6: ldloc.s 17
-		IL_03b8: box [System.Runtime]System.Double
-		IL_03bd: stloc.s 18
-		IL_03bf: ldloc.s 19
-		IL_03c1: ldstr "log"
-		IL_03c6: ldloc.s 18
-		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03cd: pop
-		IL_03ce: newobj instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::.ctor()
-		IL_03d3: stloc.s 4
-		IL_03d5: ldloc.s 4
-		IL_03d7: ldc.i4.0
-		IL_03d8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_03dd: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::set_maybe(object)
-		IL_03e2: ldloc.s 4
-		IL_03e4: ldstr "set"
-		IL_03e9: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::set_ready(object)
-		IL_03ee: ldloc.s 4
-		IL_03f0: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable
-		IL_03f5: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::get_maybe()
-		IL_03fa: stloc.s 19
-		IL_03fc: ldloc.s 19
-		IL_03fe: brfalse IL_0414
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0108: pop
+		IL_0109: ldloc.2
+		IL_010a: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
+		IL_010f: ldc.r8 2
+		IL_0118: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::set_num(float64)
+		IL_011d: ldloc.2
+		IL_011e: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
+		IL_0123: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_num()
+		IL_0128: stloc.s 17
+		IL_012a: ldloc.s 17
+		IL_012c: ldc.r8 1
+		IL_0135: sub
+		IL_0136: stloc.s 17
+		IL_0138: ldloc.2
+		IL_0139: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
+		IL_013e: ldloc.s 17
+		IL_0140: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::set_num(float64)
+		IL_0145: ldloc.2
+		IL_0146: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
+		IL_014b: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_num()
+		IL_0150: stloc.s 17
+		IL_0152: ldloc.s 17
+		IL_0154: ldc.r8 10
+		IL_015d: mul
+		IL_015e: stloc.s 17
+		IL_0160: ldloc.2
+		IL_0161: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
+		IL_0166: ldloc.s 17
+		IL_0168: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::set_num(float64)
+		IL_016d: ldstr "console"
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017c: stloc.s 15
+		IL_017e: ldloc.2
+		IL_017f: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
+		IL_0184: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_num()
+		IL_0189: stloc.s 17
+		IL_018b: ldloc.s 17
+		IL_018d: box [System.Runtime]System.Double
+		IL_0192: stloc.s 18
+		IL_0194: ldloc.s 15
+		IL_0196: ldstr "log"
+		IL_019b: ldloc.s 18
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a2: pop
+		IL_01a3: ldloc.2
+		IL_01a4: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
+		IL_01a9: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_text()
+		IL_01ae: stloc.s 15
+		IL_01b0: ldloc.s 15
+		IL_01b2: ldstr "!"
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01bc: stloc.s 21
+		IL_01be: ldloc.2
+		IL_01bf: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
+		IL_01c4: ldloc.s 21
+		IL_01c6: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::set_text(object)
+		IL_01cb: ldloc.2
+		IL_01cc: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
+		IL_01d1: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_flag()
+		IL_01d6: stloc.s 15
+		IL_01d8: ldloc.s 15
+		IL_01da: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+		IL_01df: ldc.i4.0
+		IL_01e0: ceq
+		IL_01e2: stloc.s 22
+		IL_01e4: ldloc.2
+		IL_01e5: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
+		IL_01ea: ldloc.s 22
+		IL_01ec: box [System.Runtime]System.Boolean
+		IL_01f1: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::set_flag(object)
+		IL_01f6: ldstr "console"
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0205: stloc.s 15
+		IL_0207: ldloc.2
+		IL_0208: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
+		IL_020d: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_text()
+		IL_0212: stloc.s 20
+		IL_0214: ldloc.2
+		IL_0215: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible
+		IL_021a: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible::get_flag()
+		IL_021f: stloc.s 19
+		IL_0221: ldloc.s 15
+		IL_0223: ldstr "log"
+		IL_0228: ldloc.s 20
+		IL_022a: ldloc.s 19
+		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0231: pop
+		IL_0232: newobj instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::.ctor()
+		IL_0237: stloc.3
+		IL_0238: ldloc.3
+		IL_0239: ldc.r8 0.0
+		IL_0242: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::set_n(float64)
+		IL_0247: ldstr "console"
+		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0256: stloc.s 19
+		IL_0258: ldloc.3
+		IL_0259: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
+		IL_025e: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::get_n()
+		IL_0263: stloc.s 17
+		IL_0265: ldloc.s 17
+		IL_0267: box [System.Runtime]System.Double
+		IL_026c: stloc.s 18
+		IL_026e: ldloc.s 18
+		IL_0270: stloc.s 20
+		IL_0272: ldloc.s 17
+		IL_0274: ldc.r8 1
+		IL_027d: add
+		IL_027e: stloc.s 17
+		IL_0280: ldloc.3
+		IL_0281: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
+		IL_0286: ldloc.s 17
+		IL_0288: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::set_n(float64)
+		IL_028d: ldloc.s 19
+		IL_028f: ldstr "log"
+		IL_0294: ldloc.s 20
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029b: pop
+		IL_029c: ldstr "console"
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ab: stloc.s 20
+		IL_02ad: ldloc.3
+		IL_02ae: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
+		IL_02b3: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::get_n()
+		IL_02b8: stloc.s 17
+		IL_02ba: ldloc.s 17
+		IL_02bc: ldc.r8 1
+		IL_02c5: add
+		IL_02c6: stloc.s 17
+		IL_02c8: ldloc.3
+		IL_02c9: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
+		IL_02ce: ldloc.s 17
+		IL_02d0: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::set_n(float64)
+		IL_02d5: ldloc.s 17
+		IL_02d7: box [System.Runtime]System.Double
+		IL_02dc: stloc.s 18
+		IL_02de: ldloc.s 20
+		IL_02e0: ldstr "log"
+		IL_02e5: ldloc.s 18
+		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ec: pop
+		IL_02ed: ldstr "console"
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fc: stloc.s 20
+		IL_02fe: ldloc.3
+		IL_02ff: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
+		IL_0304: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::get_n()
+		IL_0309: stloc.s 17
+		IL_030b: ldloc.s 17
+		IL_030d: box [System.Runtime]System.Double
+		IL_0312: stloc.s 18
+		IL_0314: ldloc.s 18
+		IL_0316: stloc.s 19
+		IL_0318: ldloc.s 17
+		IL_031a: ldc.r8 1
+		IL_0323: sub
+		IL_0324: stloc.s 17
+		IL_0326: ldloc.3
+		IL_0327: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
+		IL_032c: ldloc.s 17
+		IL_032e: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::set_n(float64)
+		IL_0333: ldloc.s 20
+		IL_0335: ldstr "log"
+		IL_033a: ldloc.s 19
+		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0341: pop
+		IL_0342: ldstr "console"
+		IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0351: stloc.s 19
+		IL_0353: ldloc.3
+		IL_0354: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
+		IL_0359: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::get_n()
+		IL_035e: stloc.s 17
+		IL_0360: ldloc.s 17
+		IL_0362: ldc.r8 1
+		IL_036b: sub
+		IL_036c: stloc.s 17
+		IL_036e: ldloc.3
+		IL_036f: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
+		IL_0374: ldloc.s 17
+		IL_0376: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::set_n(float64)
+		IL_037b: ldloc.s 17
+		IL_037d: box [System.Runtime]System.Double
+		IL_0382: stloc.s 18
+		IL_0384: ldloc.s 19
+		IL_0386: ldstr "log"
+		IL_038b: ldloc.s 18
+		IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0392: pop
+		IL_0393: ldstr "console"
+		IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03a2: stloc.s 19
+		IL_03a4: ldloc.3
+		IL_03a5: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter
+		IL_03aa: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter::get_n()
+		IL_03af: stloc.s 17
+		IL_03b1: ldloc.s 17
+		IL_03b3: box [System.Runtime]System.Double
+		IL_03b8: stloc.s 18
+		IL_03ba: ldloc.s 19
+		IL_03bc: ldstr "log"
+		IL_03c1: ldloc.s 18
+		IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03c8: pop
+		IL_03c9: newobj instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::.ctor()
+		IL_03ce: stloc.s 4
+		IL_03d0: ldloc.s 4
+		IL_03d2: ldc.i4.0
+		IL_03d3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_03d8: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::set_maybe(object)
+		IL_03dd: ldloc.s 4
+		IL_03df: ldstr "set"
+		IL_03e4: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::set_ready(object)
+		IL_03e9: ldloc.s 4
+		IL_03eb: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable
+		IL_03f0: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::get_maybe()
+		IL_03f5: stloc.s 19
+		IL_03f7: ldloc.s 19
+		IL_03f9: brfalse IL_040f
 
-		IL_0403: ldloc.s 19
-		IL_0405: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_040a: brtrue IL_0414
+		IL_03fe: ldloc.s 19
+		IL_0400: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0405: brtrue IL_040f
 
-		IL_040f: br IL_0425
+		IL_040a: br IL_0420
 
-		IL_0414: ldloc.s 4
-		IL_0416: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable
-		IL_041b: ldstr "filled"
-		IL_0420: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::set_maybe(object)
+		IL_040f: ldloc.s 4
+		IL_0411: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable
+		IL_0416: ldstr "filled"
+		IL_041b: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::set_maybe(object)
 
-		IL_0425: ldloc.s 4
-		IL_0427: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable
-		IL_042c: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::get_ready()
-		IL_0431: stloc.s 19
-		IL_0433: ldloc.s 19
-		IL_0435: brfalse IL_044b
+		IL_0420: ldloc.s 4
+		IL_0422: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable
+		IL_0427: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::get_ready()
+		IL_042c: stloc.s 19
+		IL_042e: ldloc.s 19
+		IL_0430: brfalse IL_0446
 
-		IL_043a: ldloc.s 19
-		IL_043c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0441: brtrue IL_044b
+		IL_0435: ldloc.s 19
+		IL_0437: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_043c: brtrue IL_0446
 
-		IL_0446: br IL_045c
+		IL_0441: br IL_0457
 
-		IL_044b: ldloc.s 4
-		IL_044d: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable
-		IL_0452: ldstr "ignored"
-		IL_0457: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::set_ready(object)
+		IL_0446: ldloc.s 4
+		IL_0448: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable
+		IL_044d: ldstr "ignored"
+		IL_0452: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::set_ready(object)
 
-		IL_045c: ldstr "console"
-		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_046b: stloc.s 19
-		IL_046d: ldloc.s 4
-		IL_046f: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable
-		IL_0474: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::get_maybe()
-		IL_0479: stloc.s 20
-		IL_047b: ldloc.s 4
-		IL_047d: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable
-		IL_0482: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::get_ready()
-		IL_0487: stloc.s 15
-		IL_0489: ldloc.s 19
-		IL_048b: ldstr "log"
-		IL_0490: ldloc.s 20
-		IL_0492: ldloc.s 15
-		IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0499: pop
-		IL_049a: newobj instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::.ctor()
-		IL_049f: stloc.s 5
-		IL_04a1: ldloc.s 5
-		IL_04a3: ldc.r8 1
-		IL_04ac: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::set_a(float64)
-		IL_04b1: ldloc.s 5
-		IL_04b3: ldc.r8 2
-		IL_04bc: box [System.Runtime]System.Double
-		IL_04c1: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::set_b(object)
-		IL_04c6: ldloc.s 5
-		IL_04c8: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values
-		IL_04cd: ldc.r8 41
-		IL_04d6: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::set_a(float64)
-		IL_04db: ldc.r8 41
-		IL_04e4: ldc.r8 1
-		IL_04ed: add
-		IL_04ee: stloc.s 6
-		IL_04f0: ldloc.s 5
-		IL_04f2: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values
-		IL_04f7: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::get_b()
-		IL_04fc: stloc.s 15
-		IL_04fe: ldloc.s 15
-		IL_0500: ldc.r8 3
-		IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-		IL_050e: stloc.s 21
-		IL_0510: ldloc.s 5
-		IL_0512: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values
-		IL_0517: ldloc.s 21
-		IL_0519: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::set_b(object)
-		IL_051e: ldloc.s 21
-		IL_0520: stloc.s 7
-		IL_0522: ldstr "console"
-		IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0531: stloc.s 15
-		IL_0533: ldloc.s 6
-		IL_0535: box [System.Runtime]System.Double
-		IL_053a: stloc.s 18
-		IL_053c: ldloc.s 5
-		IL_053e: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values
-		IL_0543: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::get_a()
-		IL_0548: stloc.s 17
-		IL_054a: ldloc.s 17
-		IL_054c: box [System.Runtime]System.Double
-		IL_0551: stloc.s 23
-		IL_0553: ldloc.s 5
-		IL_0555: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values
-		IL_055a: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::get_b()
-		IL_055f: stloc.s 20
-		IL_0561: ldloc.s 15
-		IL_0563: ldstr "log"
-		IL_0568: ldc.i4.4
-		IL_0569: newarr [System.Runtime]System.Object
+		IL_0457: ldstr "console"
+		IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0466: stloc.s 19
+		IL_0468: ldloc.s 4
+		IL_046a: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable
+		IL_046f: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::get_maybe()
+		IL_0474: stloc.s 20
+		IL_0476: ldloc.s 4
+		IL_0478: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable
+		IL_047d: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable::get_ready()
+		IL_0482: stloc.s 15
+		IL_0484: ldloc.s 19
+		IL_0486: ldstr "log"
+		IL_048b: ldloc.s 20
+		IL_048d: ldloc.s 15
+		IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0494: pop
+		IL_0495: newobj instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::.ctor()
+		IL_049a: stloc.s 5
+		IL_049c: ldloc.s 5
+		IL_049e: ldc.r8 1
+		IL_04a7: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::set_a(float64)
+		IL_04ac: ldloc.s 5
+		IL_04ae: ldc.r8 2
+		IL_04b7: box [System.Runtime]System.Double
+		IL_04bc: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::set_b(object)
+		IL_04c1: ldloc.s 5
+		IL_04c3: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values
+		IL_04c8: ldc.r8 41
+		IL_04d1: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::set_a(float64)
+		IL_04d6: ldc.r8 41
+		IL_04df: ldc.r8 1
+		IL_04e8: add
+		IL_04e9: stloc.s 6
+		IL_04eb: ldloc.s 5
+		IL_04ed: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values
+		IL_04f2: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::get_b()
+		IL_04f7: stloc.s 15
+		IL_04f9: ldloc.s 15
+		IL_04fb: ldc.r8 3
+		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+		IL_0509: stloc.s 21
+		IL_050b: ldloc.s 5
+		IL_050d: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values
+		IL_0512: ldloc.s 21
+		IL_0514: callvirt instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::set_b(object)
+		IL_0519: ldloc.s 21
+		IL_051b: stloc.s 7
+		IL_051d: ldstr "console"
+		IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_052c: stloc.s 15
+		IL_052e: ldloc.s 6
+		IL_0530: box [System.Runtime]System.Double
+		IL_0535: stloc.s 18
+		IL_0537: ldloc.s 5
+		IL_0539: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values
+		IL_053e: callvirt instance float64 Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::get_a()
+		IL_0543: stloc.s 17
+		IL_0545: ldloc.s 17
+		IL_0547: box [System.Runtime]System.Double
+		IL_054c: stloc.s 23
+		IL_054e: ldloc.s 5
+		IL_0550: castclass Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values
+		IL_0555: callvirt instance object Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L36C16_values::get_b()
+		IL_055a: stloc.s 20
+		IL_055c: ldloc.s 15
+		IL_055e: ldstr "log"
+		IL_0563: ldc.i4.4
+		IL_0564: newarr [System.Runtime]System.Object
+		IL_0569: dup
+		IL_056a: ldc.i4.0
+		IL_056b: ldloc.s 18
+		IL_056d: stelem.ref
 		IL_056e: dup
-		IL_056f: ldc.i4.0
-		IL_0570: ldloc.s 18
+		IL_056f: ldc.i4.1
+		IL_0570: ldloc.s 23
 		IL_0572: stelem.ref
 		IL_0573: dup
-		IL_0574: ldc.i4.1
-		IL_0575: ldloc.s 23
+		IL_0574: ldc.i4.2
+		IL_0575: ldloc.s 7
 		IL_0577: stelem.ref
 		IL_0578: dup
-		IL_0579: ldc.i4.2
-		IL_057a: ldloc.s 7
+		IL_0579: ldc.i4.3
+		IL_057a: ldloc.s 20
 		IL_057c: stelem.ref
-		IL_057d: dup
-		IL_057e: ldc.i4.3
-		IL_057f: ldloc.s 20
-		IL_0581: stelem.ref
-		IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0587: pop
-		IL_0588: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_058d: dup
-		IL_058e: ldstr "num"
-		IL_0593: ldc.r8 10
-		IL_059c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_05a1: dup
-		IL_05a2: ldstr "text"
-		IL_05a7: ldstr "x"
-		IL_05ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_05b1: stloc.s 8
-		IL_05b3: ldnull
-		IL_05b4: ldloc.s 8
-		IL_05b6: call object Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect::__js_call__(object, object)
-		IL_05bb: pop
-		IL_05bc: ldloc.s 8
-		IL_05be: ldstr "num"
-		IL_05c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05c8: stloc.s 15
-		IL_05ca: ldloc.s 15
-		IL_05cc: ldc.r8 5
-		IL_05d5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-		IL_05da: stloc.s 21
-		IL_05dc: ldloc.s 8
-		IL_05de: ldstr "num"
-		IL_05e3: ldloc.s 21
-		IL_05e5: ldc.i4.0
-		IL_05e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_05eb: pop
-		IL_05ec: ldloc.s 8
-		IL_05ee: ldstr "num"
-		IL_05f3: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-		IL_05f8: stloc.s 17
-		IL_05fa: ldloc.s 17
-		IL_05fc: ldc.r8 1
-		IL_0605: add
-		IL_0606: stloc.s 17
-		IL_0608: ldloc.s 8
-		IL_060a: ldstr "num"
-		IL_060f: ldloc.s 17
-		IL_0611: ldc.i4.0
-		IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0617: pop
-		IL_0618: ldstr "console"
-		IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0622: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0627: stloc.s 15
-		IL_0629: ldloc.s 8
-		IL_062b: ldstr "num"
-		IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0635: stloc.s 20
-		IL_0637: ldloc.s 8
-		IL_0639: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_063e: stloc.s 19
-		IL_0640: ldloc.s 15
-		IL_0642: ldstr "log"
-		IL_0647: ldloc.s 20
-		IL_0649: ldloc.s 19
-		IL_064b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0650: pop
-		IL_0651: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0656: dup
-		IL_0657: ldstr "val"
-		IL_065c: ldc.r8 1
-		IL_0665: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_066a: stloc.s 9
-		IL_066c: ldc.i4.1
-		IL_066d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0672: dup
-		IL_0673: ldc.r8 42
-		IL_067c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0681: stloc.s 24
-		IL_0683: ldloc.s 24
-		IL_0685: brfalse IL_0696
+		IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0582: pop
+		IL_0583: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0588: dup
+		IL_0589: ldstr "num"
+		IL_058e: ldc.r8 10
+		IL_0597: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_059c: dup
+		IL_059d: ldstr "text"
+		IL_05a2: ldstr "x"
+		IL_05a7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_05ac: stloc.s 8
+		IL_05ae: ldnull
+		IL_05af: ldloc.s 8
+		IL_05b1: call object Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect::__js_call__(object, object)
+		IL_05b6: pop
+		IL_05b7: ldloc.s 8
+		IL_05b9: ldstr "num"
+		IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05c3: stloc.s 15
+		IL_05c5: ldloc.s 15
+		IL_05c7: ldc.r8 5
+		IL_05d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+		IL_05d5: stloc.s 21
+		IL_05d7: ldloc.s 8
+		IL_05d9: ldstr "num"
+		IL_05de: ldloc.s 21
+		IL_05e0: ldc.i4.0
+		IL_05e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_05e6: pop
+		IL_05e7: ldloc.s 8
+		IL_05e9: ldstr "num"
+		IL_05ee: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+		IL_05f3: stloc.s 17
+		IL_05f5: ldloc.s 17
+		IL_05f7: ldc.r8 1
+		IL_0600: add
+		IL_0601: stloc.s 17
+		IL_0603: ldloc.s 8
+		IL_0605: ldstr "num"
+		IL_060a: ldloc.s 17
+		IL_060c: ldc.i4.0
+		IL_060d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0612: pop
+		IL_0613: ldstr "console"
+		IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0622: stloc.s 15
+		IL_0624: ldloc.s 8
+		IL_0626: ldstr "num"
+		IL_062b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0630: stloc.s 20
+		IL_0632: ldloc.s 8
+		IL_0634: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0639: stloc.s 19
+		IL_063b: ldloc.s 15
+		IL_063d: ldstr "log"
+		IL_0642: ldloc.s 20
+		IL_0644: ldloc.s 19
+		IL_0646: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_064b: pop
+		IL_064c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0651: dup
+		IL_0652: ldstr "val"
+		IL_0657: ldc.r8 1
+		IL_0660: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0665: stloc.s 9
+		IL_0667: ldc.i4.1
+		IL_0668: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_066d: dup
+		IL_066e: ldc.r8 42
+		IL_0677: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_067c: stloc.s 24
+		IL_067e: ldloc.s 24
+		IL_0680: brfalse IL_0691
 
-		IL_068a: ldloc.s 24
-		IL_068c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0691: brfalse IL_06a7
+		IL_0685: ldloc.s 24
+		IL_0687: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_068c: brfalse IL_06a2
 
-		IL_0696: ldloc.s 24
-		IL_0698: ldstr ""
-		IL_069d: ldstr "0"
-		IL_06a2: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_0691: ldloc.s 24
+		IL_0693: ldstr ""
+		IL_0698: ldstr "0"
+		IL_069d: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_06a7: ldloc.s 24
-		IL_06a9: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-		IL_06ae: stloc.s 10
-		IL_06b0: ldc.i4.0
-		IL_06b1: stloc.s 11
-		IL_06b3: ldc.i4.0
-		IL_06b4: stloc.s 12
+		IL_06a2: ldloc.s 24
+		IL_06a4: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+		IL_06a9: stloc.s 10
+		IL_06ab: ldc.i4.0
+		IL_06ac: stloc.s 11
+		IL_06ae: ldc.i4.0
+		IL_06af: stloc.s 12
 		.try
 		{
-			IL_06b6: ldloc.s 12
-			IL_06b8: brtrue IL_06e2
+			IL_06b1: ldloc.s 12
+			IL_06b3: brtrue IL_06dd
 
-			IL_06bd: ldloc.s 10
-			IL_06bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
-			IL_06c4: stloc.s 19
-			IL_06c6: ldloc.s 19
-			IL_06c8: brfalse IL_06df
+			IL_06b8: ldloc.s 10
+			IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
+			IL_06bf: stloc.s 19
+			IL_06c1: ldloc.s 19
+			IL_06c3: brfalse IL_06da
 
-			IL_06cd: ldloc.s 19
-			IL_06cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
-			IL_06d4: stloc.s 19
-			IL_06d6: ldloc.s 19
-			IL_06d8: stloc.s 20
-			IL_06da: br IL_06e5
+			IL_06c8: ldloc.s 19
+			IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
+			IL_06cf: stloc.s 19
+			IL_06d1: ldloc.s 19
+			IL_06d3: stloc.s 20
+			IL_06d5: br IL_06e0
 
-			IL_06df: ldc.i4.1
-			IL_06e0: stloc.s 12
+			IL_06da: ldc.i4.1
+			IL_06db: stloc.s 12
 
-			IL_06e2: ldnull
-			IL_06e3: stloc.s 20
+			IL_06dd: ldnull
+			IL_06de: stloc.s 20
 
-			IL_06e5: ldloc.s 9
-			IL_06e7: ldstr "val"
-			IL_06ec: ldloc.s 20
-			IL_06ee: ldc.i4.0
-			IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_06f4: pop
-			IL_06f5: ldloc.s 12
-			IL_06f7: brtrue IL_0706
+			IL_06e0: ldloc.s 9
+			IL_06e2: ldstr "val"
+			IL_06e7: ldloc.s 20
+			IL_06e9: ldc.i4.0
+			IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_06ef: pop
+			IL_06f0: ldloc.s 12
+			IL_06f2: brtrue IL_0701
 
-			IL_06fc: ldc.i4.1
-			IL_06fd: stloc.s 11
-			IL_06ff: ldloc.s 10
-			IL_0701: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+			IL_06f7: ldc.i4.1
+			IL_06f8: stloc.s 11
+			IL_06fa: ldloc.s 10
+			IL_06fc: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
 
-			IL_0706: ldc.i4.1
-			IL_0707: stloc.s 11
-			IL_0709: leave IL_0724
+			IL_0701: ldc.i4.1
+			IL_0702: stloc.s 11
+			IL_0704: leave IL_071f
 		} // end .try
 		finally
 		{
-			IL_070e: ldloc.s 11
-			IL_0710: brtrue IL_0723
+			IL_0709: ldloc.s 11
+			IL_070b: brtrue IL_071e
 
-			IL_0715: ldloc.s 12
-			IL_0717: brtrue IL_0723
+			IL_0710: ldloc.s 12
+			IL_0712: brtrue IL_071e
 
-			IL_071c: ldloc.s 10
-			IL_071e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+			IL_0717: ldloc.s 10
+			IL_0719: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-			IL_0723: endfinally
+			IL_071e: endfinally
 		} // end handler
 
-		IL_0724: ldstr "console"
-		IL_0729: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0733: stloc.s 20
-		IL_0735: ldloc.s 9
-		IL_0737: ldstr "val"
-		IL_073c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0741: stloc.s 15
-		IL_0743: ldloc.s 20
-		IL_0745: ldstr "log"
-		IL_074a: ldloc.s 15
-		IL_074c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0751: pop
-		IL_0752: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0757: dup
-		IL_0758: ldstr "val"
-		IL_075d: ldc.r8 1
-		IL_0766: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_076b: stloc.s 13
-		IL_076d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0772: dup
-		IL_0773: ldstr "v"
-		IL_0778: ldc.r8 43
-		IL_0781: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0786: stloc.s 25
-		IL_0788: ldloc.s 25
-		IL_078a: brfalse IL_079b
+		IL_071f: ldstr "console"
+		IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0729: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_072e: stloc.s 20
+		IL_0730: ldloc.s 9
+		IL_0732: ldstr "val"
+		IL_0737: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_073c: stloc.s 15
+		IL_073e: ldloc.s 20
+		IL_0740: ldstr "log"
+		IL_0745: ldloc.s 15
+		IL_0747: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_074c: pop
+		IL_074d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0752: dup
+		IL_0753: ldstr "val"
+		IL_0758: ldc.r8 1
+		IL_0761: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0766: stloc.s 13
+		IL_0768: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_076d: dup
+		IL_076e: ldstr "v"
+		IL_0773: ldc.r8 43
+		IL_077c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0781: stloc.s 25
+		IL_0783: ldloc.s 25
+		IL_0785: brfalse IL_0796
 
-		IL_078f: ldloc.s 25
-		IL_0791: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0796: brfalse IL_07ac
+		IL_078a: ldloc.s 25
+		IL_078c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0791: brfalse IL_07a7
 
-		IL_079b: ldloc.s 25
-		IL_079d: ldstr ""
-		IL_07a2: ldstr "v"
-		IL_07a7: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_0796: ldloc.s 25
+		IL_0798: ldstr ""
+		IL_079d: ldstr "v"
+		IL_07a2: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_07ac: ldloc.s 25
-		IL_07ae: ldstr "v"
-		IL_07b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07b8: stloc.s 15
-		IL_07ba: ldloc.s 13
-		IL_07bc: ldstr "val"
-		IL_07c1: ldloc.s 15
-		IL_07c3: ldc.i4.0
-		IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_07c9: pop
-		IL_07ca: ldstr "console"
-		IL_07cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07d9: stloc.s 15
-		IL_07db: ldloc.s 13
-		IL_07dd: ldstr "val"
-		IL_07e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07e7: stloc.s 20
-		IL_07e9: ldloc.s 15
-		IL_07eb: ldstr "log"
-		IL_07f0: ldloc.s 20
-		IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07f7: pop
-		IL_07f8: ret
+		IL_07a7: ldloc.s 25
+		IL_07a9: ldstr "v"
+		IL_07ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07b3: stloc.s 15
+		IL_07b5: ldloc.s 13
+		IL_07b7: ldstr "val"
+		IL_07bc: ldloc.s 15
+		IL_07be: ldc.i4.0
+		IL_07bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_07c4: pop
+		IL_07c5: ldstr "console"
+		IL_07ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07d4: stloc.s 15
+		IL_07d6: ldloc.s 13
+		IL_07d8: ldstr "val"
+		IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07e2: stloc.s 20
+		IL_07e4: ldloc.s 15
+		IL_07e6: ldstr "log"
+		IL_07eb: ldloc.s 20
+		IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07f2: pop
+		IL_07f3: ret
 	} // end of method ObjectLiteral_EarlyBoundAccess_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_EarlyBoundAccess_Parity
@@ -1247,7 +1246,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a03
+		// Method begins at RVA 0x29fb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InferredConstruction_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InferredConstruction_Parity.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x244b
+				// Method begins at RVA 0x2443
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23ee
+			// Method begins at RVA 0x23e5
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2454
+				// Method begins at RVA 0x244c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -86,7 +86,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f5
+			// Method begins at RVA 0x23ec
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -108,7 +108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245d
+				// Method begins at RVA 0x2455
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -132,7 +132,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23fc
+			// Method begins at RVA 0x23f4
 			// Header size: 12
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -177,7 +177,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2442
+			// Method begins at RVA 0x243a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -208,7 +208,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2466
+				// Method begins at RVA 0x245e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -221,7 +221,7 @@
 			.method public hidebysig 
 				instance string get_text () cil managed 
 			{
-				// Method begins at RVA 0x246e
+				// Method begins at RVA 0x2466
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -236,7 +236,7 @@
 					string ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x2476
+				// Method begins at RVA 0x246e
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -254,7 +254,7 @@
 			.method public hidebysig 
 				instance float64 get_n () cil managed 
 			{
-				// Method begins at RVA 0x248b
+				// Method begins at RVA 0x2483
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -269,7 +269,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x2493
+				// Method begins at RVA 0x248b
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -287,7 +287,7 @@
 			.method public hidebysig 
 				instance bool get_flag () cil managed 
 			{
-				// Method begins at RVA 0x24a8
+				// Method begins at RVA 0x24a0
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -302,7 +302,7 @@
 					bool ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x24b0
+				// Method begins at RVA 0x24a8
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -320,7 +320,7 @@
 			.method public hidebysig 
 				instance object get_boxed () cil managed 
 			{
-				// Method begins at RVA 0x24c5
+				// Method begins at RVA 0x24bd
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -335,7 +335,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x24cd
+				// Method begins at RVA 0x24c5
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -353,7 +353,7 @@
 			.method public hidebysig 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0 get_fn () cil managed 
 			{
-				// Method begins at RVA 0x24e2
+				// Method begins at RVA 0x24da
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -368,7 +368,7 @@
 					class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x24ea
+				// Method begins at RVA 0x24e2
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -401,7 +401,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 914 (0x392)
+		// Code size: 905 (0x389)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_InferredConstruction_Parity/Scope,
@@ -422,8 +422,7 @@
 			[15] string,
 			[16] object,
 			[17] object,
-			[18] object,
-			[19] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[18] object
 		)
 
 		IL_0000: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/Scope::.ctor()
@@ -624,113 +623,110 @@
 		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_023b: stloc.s 7
 		IL_023d: ldloc.3
-		IL_023e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
-		IL_0243: stloc.s 19
-		IL_0245: ldloc.s 19
-		IL_0247: ldstr "fn"
-		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0251: stloc.s 17
-		IL_0253: ldloc.s 7
-		IL_0255: ldstr "log"
-		IL_025a: ldloc.s 17
-		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0261: pop
-		IL_0262: ldstr "console"
-		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0271: stloc.s 17
-		IL_0273: ldloc.3
-		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027e: ldstr "join"
-		IL_0283: ldstr ","
-		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_028d: stloc.s 7
-		IL_028f: ldloc.s 17
-		IL_0291: ldstr "log"
-		IL_0296: ldloc.s 7
-		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_029d: pop
-		IL_029e: ldstr "console"
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ad: ldloc.3
-		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_02b3: stloc.s 7
-		IL_02b5: ldstr "log"
-		IL_02ba: ldloc.s 7
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c1: pop
-		IL_02c2: ldloc.3
-		IL_02c3: ldstr "n"
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_02cd: stloc.s 4
-		IL_02cf: ldstr "console"
-		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02de: stloc.s 7
-		IL_02e0: ldloc.s 4
-		IL_02e2: ldstr "value"
-		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ec: stloc.s 17
-		IL_02ee: ldloc.s 4
-		IL_02f0: ldstr "writable"
-		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02fa: stloc.s 16
-		IL_02fc: ldloc.s 4
-		IL_02fe: ldstr "enumerable"
-		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0308: stloc.s 13
-		IL_030a: ldloc.s 4
-		IL_030c: ldstr "configurable"
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0316: stloc.s 18
-		IL_0318: ldloc.s 7
-		IL_031a: ldstr "log"
-		IL_031f: ldc.i4.4
-		IL_0320: newarr [System.Runtime]System.Object
-		IL_0325: dup
-		IL_0326: ldc.i4.0
-		IL_0327: ldloc.s 17
-		IL_0329: stelem.ref
-		IL_032a: dup
-		IL_032b: ldc.i4.1
-		IL_032c: ldloc.s 16
-		IL_032e: stelem.ref
-		IL_032f: dup
-		IL_0330: ldc.i4.2
-		IL_0331: ldloc.s 13
-		IL_0333: stelem.ref
-		IL_0334: dup
-		IL_0335: ldc.i4.3
-		IL_0336: ldloc.s 18
-		IL_0338: stelem.ref
-		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_033e: pop
-		IL_033f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0344: dup
-		IL_0345: ldstr "x"
-		IL_034a: ldc.r8 1
-		IL_0353: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0358: stloc.s 5
-		IL_035a: ldnull
-		IL_035b: ldloc.s 5
-		IL_035d: call object Modules.ObjectLiteral_InferredConstruction_Parity/leak::__js_call__(object, object)
-		IL_0362: pop
-		IL_0363: ldstr "console"
-		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0372: stloc.s 7
-		IL_0374: ldloc.s 5
-		IL_0376: ldstr "x"
-		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0380: stloc.s 18
-		IL_0382: ldloc.s 7
-		IL_0384: ldstr "log"
-		IL_0389: ldloc.s 18
-		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0390: pop
-		IL_0391: ret
+		IL_023e: ldstr "fn"
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0248: stloc.s 17
+		IL_024a: ldloc.s 7
+		IL_024c: ldstr "log"
+		IL_0251: ldloc.s 17
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0258: pop
+		IL_0259: ldstr "console"
+		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0268: stloc.s 17
+		IL_026a: ldloc.3
+		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0275: ldstr "join"
+		IL_027a: ldstr ","
+		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0284: stloc.s 7
+		IL_0286: ldloc.s 17
+		IL_0288: ldstr "log"
+		IL_028d: ldloc.s 7
+		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0294: pop
+		IL_0295: ldstr "console"
+		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a4: ldloc.3
+		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_02aa: stloc.s 7
+		IL_02ac: ldstr "log"
+		IL_02b1: ldloc.s 7
+		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b8: pop
+		IL_02b9: ldloc.3
+		IL_02ba: ldstr "n"
+		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_02c4: stloc.s 4
+		IL_02c6: ldstr "console"
+		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d5: stloc.s 7
+		IL_02d7: ldloc.s 4
+		IL_02d9: ldstr "value"
+		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02e3: stloc.s 17
+		IL_02e5: ldloc.s 4
+		IL_02e7: ldstr "writable"
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02f1: stloc.s 16
+		IL_02f3: ldloc.s 4
+		IL_02f5: ldstr "enumerable"
+		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ff: stloc.s 13
+		IL_0301: ldloc.s 4
+		IL_0303: ldstr "configurable"
+		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_030d: stloc.s 18
+		IL_030f: ldloc.s 7
+		IL_0311: ldstr "log"
+		IL_0316: ldc.i4.4
+		IL_0317: newarr [System.Runtime]System.Object
+		IL_031c: dup
+		IL_031d: ldc.i4.0
+		IL_031e: ldloc.s 17
+		IL_0320: stelem.ref
+		IL_0321: dup
+		IL_0322: ldc.i4.1
+		IL_0323: ldloc.s 16
+		IL_0325: stelem.ref
+		IL_0326: dup
+		IL_0327: ldc.i4.2
+		IL_0328: ldloc.s 13
+		IL_032a: stelem.ref
+		IL_032b: dup
+		IL_032c: ldc.i4.3
+		IL_032d: ldloc.s 18
+		IL_032f: stelem.ref
+		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0335: pop
+		IL_0336: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_033b: dup
+		IL_033c: ldstr "x"
+		IL_0341: ldc.r8 1
+		IL_034a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_034f: stloc.s 5
+		IL_0351: ldnull
+		IL_0352: ldloc.s 5
+		IL_0354: call object Modules.ObjectLiteral_InferredConstruction_Parity/leak::__js_call__(object, object)
+		IL_0359: pop
+		IL_035a: ldstr "console"
+		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0369: stloc.s 7
+		IL_036b: ldloc.s 5
+		IL_036d: ldstr "x"
+		IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0377: stloc.s 18
+		IL_0379: ldloc.s 7
+		IL_037b: ldstr "log"
+		IL_0380: ldloc.s 18
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0387: pop
+		IL_0388: ret
 	} // end of method ObjectLiteral_InferredConstruction_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_InferredConstruction_Parity
@@ -742,7 +738,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24ff
+		// Method begins at RVA 0x24f7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ShorthandAndMethod.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ShorthandAndMethod.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x215b
+				// Method begins at RVA 0x2153
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2134
+			// Method begins at RVA 0x212c
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -66,7 +66,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2152
+			// Method begins at RVA 0x214a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -92,7 +92,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 214 (0xd6)
+		// Code size: 205 (0xcd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_ShorthandAndMethod/Scope,
@@ -157,18 +157,15 @@
 		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00b0: stloc.s 5
 		IL_00b2: ldloc.2
-		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.JsObject>(!!0)
-		IL_00b8: stloc.s 4
-		IL_00ba: ldloc.s 4
-		IL_00bc: ldstr "m"
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00c6: stloc.3
-		IL_00c7: ldloc.s 5
-		IL_00c9: ldstr "log"
-		IL_00ce: ldloc.3
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d4: pop
-		IL_00d5: ret
+		IL_00b3: ldstr "m"
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00bd: stloc.3
+		IL_00be: ldloc.s 5
+		IL_00c0: ldstr "log"
+		IL_00c5: ldloc.3
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cb: pop
+		IL_00cc: ret
 	} // end of method ObjectLiteral_ShorthandAndMethod::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_ShorthandAndMethod
@@ -180,7 +177,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2164
+		// Method begins at RVA 0x215c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Executor_Rejected.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Executor_Rejected.verified.txt
@@ -27,7 +27,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2149
+				// Method begins at RVA 0x213d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20fc
+			// Method begins at RVA 0x20f0
 			// Header size: 12
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2152
+				// Method begins at RVA 0x2146
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -115,7 +115,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x211d
+			// Method begins at RVA 0x2111
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -141,7 +141,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2140
+			// Method begins at RVA 0x2134
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -167,14 +167,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 157 (0x9d)
+		// Code size: 148 (0x94)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Executor_Rejected/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		)
 
 		IL_0000: newobj instance void Modules.Promise_Executor_Rejected/Scope::.ctor()
@@ -203,37 +202,34 @@
 		IL_0040: ldloc.2
 		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
 		IL_0046: stloc.1
-		IL_0047: ldloc.1
-		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
-		IL_004d: stloc.3
-		IL_004e: ldnull
-		IL_004f: ldftn object Modules.Promise_Executor_Rejected/ArrowFunction_L7C14::__js_call__(object, object)
-		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_005a: ldc.i4.1
-		IL_005b: newarr [System.Runtime]System.Object
-		IL_0060: dup
-		IL_0061: ldc.i4.0
-		IL_0062: ldloc.0
-		IL_0063: stelem.ref
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_006e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0073: ldc.i4.1
-		IL_0074: conv.r8
-		IL_0075: ldstr ""
-		IL_007a: ldc.i4.0
-		IL_007b: ldc.i4.0
-		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_0086: stloc.s 4
-		IL_0088: ldloc.3
-		IL_0089: ldstr "then"
-		IL_008e: ldc.i4.0
-		IL_008f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0094: ldloc.s 4
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_009b: pop
-		IL_009c: ret
+		IL_0047: ldnull
+		IL_0048: ldftn object Modules.Promise_Executor_Rejected/ArrowFunction_L7C14::__js_call__(object, object)
+		IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0053: ldc.i4.1
+		IL_0054: newarr [System.Runtime]System.Object
+		IL_0059: dup
+		IL_005a: ldc.i4.0
+		IL_005b: ldloc.0
+		IL_005c: stelem.ref
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0067: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_006c: ldc.i4.1
+		IL_006d: conv.r8
+		IL_006e: ldstr ""
+		IL_0073: ldc.i4.0
+		IL_0074: ldc.i4.0
+		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_007f: stloc.3
+		IL_0080: ldloc.1
+		IL_0081: ldstr "then"
+		IL_0086: ldc.i4.0
+		IL_0087: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_008c: ldloc.3
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0092: pop
+		IL_0093: ret
 	} // end of method Promise_Executor_Rejected::__js_module_init__
 
 } // end of class Modules.Promise_Executor_Rejected
@@ -245,7 +241,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x215b
+		// Method begins at RVA 0x214f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Executor_Resolved.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Executor_Resolved.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2141
+				// Method begins at RVA 0x2139
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20f4
+			// Method begins at RVA 0x20ec
 			// Header size: 12
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x214a
+				// Method begins at RVA 0x2142
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -112,7 +112,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2115
+			// Method begins at RVA 0x210d
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -138,7 +138,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2138
+			// Method begins at RVA 0x2130
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -164,13 +164,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 149 (0x95)
+		// Code size: 142 (0x8e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Executor_Resolved/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.Promise
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		)
 
 		IL_0000: newobj instance void Modules.Promise_Executor_Resolved/Scope::.ctor()
@@ -199,35 +198,32 @@
 		IL_0040: ldloc.2
 		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
 		IL_0046: stloc.1
-		IL_0047: ldloc.1
-		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
-		IL_004d: stloc.3
-		IL_004e: ldnull
-		IL_004f: ldftn object Modules.Promise_Executor_Resolved/ArrowFunction_L7C8::__js_call__(object, object)
-		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_005a: ldc.i4.1
-		IL_005b: newarr [System.Runtime]System.Object
-		IL_0060: dup
-		IL_0061: ldc.i4.0
-		IL_0062: ldloc.0
-		IL_0063: stelem.ref
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_006e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0073: ldc.i4.1
-		IL_0074: conv.r8
-		IL_0075: ldstr ""
-		IL_007a: ldc.i4.0
-		IL_007b: ldc.i4.0
-		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_0086: stloc.2
-		IL_0087: ldloc.3
-		IL_0088: ldstr "then"
-		IL_008d: ldloc.2
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0093: pop
-		IL_0094: ret
+		IL_0047: ldnull
+		IL_0048: ldftn object Modules.Promise_Executor_Resolved/ArrowFunction_L7C8::__js_call__(object, object)
+		IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0053: ldc.i4.1
+		IL_0054: newarr [System.Runtime]System.Object
+		IL_0059: dup
+		IL_005a: ldc.i4.0
+		IL_005b: ldloc.0
+		IL_005c: stelem.ref
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0067: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_006c: ldc.i4.1
+		IL_006d: conv.r8
+		IL_006e: ldstr ""
+		IL_0073: ldc.i4.0
+		IL_0074: ldc.i4.0
+		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_007f: stloc.2
+		IL_0080: ldloc.1
+		IL_0081: ldstr "then"
+		IL_0086: ldloc.2
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008c: pop
+		IL_008d: ret
 	} // end of method Promise_Executor_Resolved::__js_module_init__
 
 } // end of class Modules.Promise_Executor_Resolved
@@ -239,7 +235,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2153
+		// Method begins at RVA 0x214b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Algebra_Methods.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Algebra_Methods.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x273d
+				// Method begins at RVA 0x26e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2594
+			// Method begins at RVA 0x2538
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2746
+				// Method begins at RVA 0x26ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -115,7 +115,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25e8
+			// Method begins at RVA 0x258c
 			// Header size: 12
 			// Code size: 320 (0x140)
 			.maxstack 8
@@ -266,7 +266,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x274f
+				// Method begins at RVA 0x26f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +286,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2758
+				// Method begins at RVA 0x26fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -304,7 +304,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2734
+			// Method begins at RVA 0x26d8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -330,7 +330,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1318 (0x526)
+		// Code size: 1228 (0x4cc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Algebra_Methods/Scope,
@@ -343,9 +343,9 @@
 			[7] object,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[9] object,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.Set,
-			[11] object,
-			[12] string,
+			[10] object,
+			[11] string,
+			[12] class [JavaScriptRuntime]JavaScriptRuntime.Set,
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.Set,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
 			[15] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
@@ -389,379 +389,349 @@
 		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0081: stloc.s 9
 		IL_0083: ldloc.1
-		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_0089: stloc.s 10
-		IL_008b: ldloc.s 10
-		IL_008d: ldstr "difference"
-		IL_0092: ldloc.2
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0098: stloc.s 11
-		IL_009a: ldloc.s 11
-		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_00a1: ldc.i4.1
-		IL_00a2: newarr [System.Runtime]System.Object
-		IL_00a7: dup
-		IL_00a8: ldc.i4.0
-		IL_00a9: ldstr ","
-		IL_00ae: stelem.ref
-		IL_00af: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_00b4: stloc.s 12
-		IL_00b6: ldloc.s 9
-		IL_00b8: ldstr "log"
-		IL_00bd: ldloc.s 12
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c4: pop
-		IL_00c5: ldstr "console"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d4: stloc.s 9
-		IL_00d6: ldloc.1
-		IL_00d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_00dc: stloc.s 10
-		IL_00de: ldloc.s 10
-		IL_00e0: ldstr "intersection"
-		IL_00e5: ldloc.2
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00eb: stloc.s 11
-		IL_00ed: ldloc.s 11
-		IL_00ef: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_00f4: ldc.i4.1
-		IL_00f5: newarr [System.Runtime]System.Object
-		IL_00fa: dup
-		IL_00fb: ldc.i4.0
-		IL_00fc: ldstr ","
-		IL_0101: stelem.ref
-		IL_0102: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0107: stloc.s 12
-		IL_0109: ldloc.s 9
-		IL_010b: ldstr "log"
-		IL_0110: ldloc.s 12
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0117: pop
-		IL_0118: ldstr "console"
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0127: stloc.s 9
-		IL_0129: ldloc.1
-		IL_012a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_012f: stloc.s 10
-		IL_0131: ldloc.s 10
-		IL_0133: ldstr "union"
-		IL_0138: ldloc.2
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013e: stloc.s 11
-		IL_0140: ldloc.s 11
-		IL_0142: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0147: ldc.i4.1
-		IL_0148: newarr [System.Runtime]System.Object
-		IL_014d: dup
-		IL_014e: ldc.i4.0
-		IL_014f: ldstr ","
-		IL_0154: stelem.ref
-		IL_0155: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_015a: stloc.s 12
-		IL_015c: ldloc.s 9
-		IL_015e: ldstr "log"
-		IL_0163: ldloc.s 12
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016a: pop
-		IL_016b: ldstr "console"
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017a: stloc.s 9
-		IL_017c: ldloc.1
-		IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_0182: stloc.s 10
-		IL_0184: ldloc.s 10
-		IL_0186: ldstr "symmetricDifference"
-		IL_018b: ldloc.2
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0191: stloc.s 11
-		IL_0193: ldloc.s 11
-		IL_0195: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_019a: ldc.i4.1
-		IL_019b: newarr [System.Runtime]System.Object
-		IL_01a0: dup
-		IL_01a1: ldc.i4.0
-		IL_01a2: ldstr ","
-		IL_01a7: stelem.ref
-		IL_01a8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_01ad: stloc.s 12
-		IL_01af: ldloc.s 9
-		IL_01b1: ldstr "log"
-		IL_01b6: ldloc.s 12
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bd: pop
-		IL_01be: ldstr "console"
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01cd: stloc.s 9
-		IL_01cf: ldloc.1
-		IL_01d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_01d5: stloc.s 10
-		IL_01d7: ldc.i4.2
-		IL_01d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01dd: dup
-		IL_01de: ldc.r8 4
-		IL_01e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01ec: dup
-		IL_01ed: ldc.r8 5
-		IL_01f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01fb: stloc.s 8
-		IL_01fd: ldloc.s 8
-		IL_01ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_0204: stloc.s 13
-		IL_0206: ldloc.s 10
-		IL_0208: ldstr "isDisjointFrom"
-		IL_020d: ldloc.s 13
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0214: stloc.s 11
-		IL_0216: ldloc.s 9
-		IL_0218: ldstr "log"
-		IL_021d: ldloc.s 11
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0224: pop
-		IL_0225: ldstr "console"
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0234: stloc.s 11
-		IL_0236: ldloc.1
-		IL_0237: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_023c: stloc.s 13
-		IL_023e: ldloc.s 13
-		IL_0240: ldstr "isDisjointFrom"
-		IL_0245: ldloc.2
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024b: stloc.s 9
-		IL_024d: ldloc.s 11
-		IL_024f: ldstr "log"
-		IL_0254: ldloc.s 9
-		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025b: pop
-		IL_025c: ldstr "console"
-		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026b: stloc.s 9
-		IL_026d: ldc.i4.2
-		IL_026e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0273: dup
-		IL_0274: ldc.r8 1
-		IL_027d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0282: dup
-		IL_0283: ldc.r8 2
-		IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0291: stloc.s 8
-		IL_0293: ldloc.s 8
-		IL_0295: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_029a: stloc.s 13
-		IL_029c: ldloc.s 13
-		IL_029e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_02a3: stloc.s 13
-		IL_02a5: ldc.i4.3
-		IL_02a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02ab: dup
-		IL_02ac: ldc.r8 1
-		IL_02b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02ba: dup
-		IL_02bb: ldc.r8 2
-		IL_02c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02c9: dup
-		IL_02ca: ldc.r8 3
-		IL_02d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02d8: stloc.s 8
-		IL_02da: ldloc.s 8
-		IL_02dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_02e1: stloc.s 10
-		IL_02e3: ldloc.s 13
-		IL_02e5: ldstr "isSubsetOf"
-		IL_02ea: ldloc.s 10
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02f1: stloc.s 11
-		IL_02f3: ldloc.s 9
-		IL_02f5: ldstr "log"
-		IL_02fa: ldloc.s 11
-		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0301: pop
-		IL_0302: ldstr "console"
-		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0311: stloc.s 11
-		IL_0313: ldloc.1
-		IL_0314: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_0319: stloc.s 10
-		IL_031b: ldc.i4.2
-		IL_031c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0321: dup
-		IL_0322: ldc.r8 1
-		IL_032b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0330: dup
-		IL_0331: ldc.r8 3
-		IL_033a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_033f: stloc.s 8
-		IL_0341: ldloc.s 8
-		IL_0343: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_0348: stloc.s 13
-		IL_034a: ldloc.s 10
-		IL_034c: ldstr "isSupersetOf"
-		IL_0351: ldloc.s 13
-		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0358: stloc.s 9
-		IL_035a: ldloc.s 11
-		IL_035c: ldstr "log"
-		IL_0361: ldloc.s 9
-		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0368: pop
-		IL_0369: ldnull
-		IL_036a: ldftn object Modules.Set_Algebra_Methods/FunctionExpression_setLike::__js_call__(object, object)
-		IL_0370: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0375: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_037a: ldc.i4.1
-		IL_037b: conv.r8
-		IL_037c: ldstr ""
-		IL_0381: ldc.i4.0
-		IL_0382: ldc.i4.1
-		IL_0383: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0388: stloc.s 14
-		IL_038a: ldc.i4.1
-		IL_038b: newarr [System.Runtime]System.Object
-		IL_0390: dup
-		IL_0391: ldc.i4.0
-		IL_0392: ldloc.0
-		IL_0393: stelem.ref
-		IL_0394: ldftn object Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10::__js_call__(object[], object)
-		IL_039a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_039f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_03a4: ldc.i4.0
-		IL_03a5: conv.r8
-		IL_03a6: ldstr ""
-		IL_03ab: ldc.i4.0
-		IL_03ac: ldc.i4.1
-		IL_03ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_03b7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_03bc: stloc.s 15
-		IL_03be: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03c3: dup
-		IL_03c4: ldstr "size"
-		IL_03c9: ldc.r8 2
-		IL_03d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_03d7: dup
-		IL_03d8: ldstr "has"
-		IL_03dd: ldloc.s 14
-		IL_03df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03e4: dup
-		IL_03e5: ldstr "keys"
-		IL_03ea: ldloc.s 15
-		IL_03ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03f1: stloc.3
-		IL_03f2: ldstr "console"
-		IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0401: stloc.s 9
-		IL_0403: ldloc.1
-		IL_0404: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_0409: stloc.s 13
-		IL_040b: ldloc.s 13
-		IL_040d: ldstr "union"
-		IL_0412: ldloc.3
-		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0418: stloc.s 11
-		IL_041a: ldloc.s 11
-		IL_041c: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0421: ldc.i4.1
-		IL_0422: newarr [System.Runtime]System.Object
-		IL_0427: dup
-		IL_0428: ldc.i4.0
-		IL_0429: ldstr ","
-		IL_042e: stelem.ref
-		IL_042f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0434: stloc.s 12
-		IL_0436: ldloc.s 9
-		IL_0438: ldstr "log"
-		IL_043d: ldloc.s 12
-		IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0444: pop
+		IL_0084: ldstr "difference"
+		IL_0089: ldloc.2
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008f: stloc.s 10
+		IL_0091: ldloc.s 10
+		IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0098: ldc.i4.1
+		IL_0099: newarr [System.Runtime]System.Object
+		IL_009e: dup
+		IL_009f: ldc.i4.0
+		IL_00a0: ldstr ","
+		IL_00a5: stelem.ref
+		IL_00a6: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_00ab: stloc.s 11
+		IL_00ad: ldloc.s 9
+		IL_00af: ldstr "log"
+		IL_00b4: ldloc.s 11
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bb: pop
+		IL_00bc: ldstr "console"
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cb: stloc.s 9
+		IL_00cd: ldloc.1
+		IL_00ce: ldstr "intersection"
+		IL_00d3: ldloc.2
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d9: stloc.s 10
+		IL_00db: ldloc.s 10
+		IL_00dd: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_00e2: ldc.i4.1
+		IL_00e3: newarr [System.Runtime]System.Object
+		IL_00e8: dup
+		IL_00e9: ldc.i4.0
+		IL_00ea: ldstr ","
+		IL_00ef: stelem.ref
+		IL_00f0: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_00f5: stloc.s 11
+		IL_00f7: ldloc.s 9
+		IL_00f9: ldstr "log"
+		IL_00fe: ldloc.s 11
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0105: pop
+		IL_0106: ldstr "console"
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0115: stloc.s 9
+		IL_0117: ldloc.1
+		IL_0118: ldstr "union"
+		IL_011d: ldloc.2
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0123: stloc.s 10
+		IL_0125: ldloc.s 10
+		IL_0127: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_012c: ldc.i4.1
+		IL_012d: newarr [System.Runtime]System.Object
+		IL_0132: dup
+		IL_0133: ldc.i4.0
+		IL_0134: ldstr ","
+		IL_0139: stelem.ref
+		IL_013a: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_013f: stloc.s 11
+		IL_0141: ldloc.s 9
+		IL_0143: ldstr "log"
+		IL_0148: ldloc.s 11
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014f: pop
+		IL_0150: ldstr "console"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015f: stloc.s 9
+		IL_0161: ldloc.1
+		IL_0162: ldstr "symmetricDifference"
+		IL_0167: ldloc.2
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016d: stloc.s 10
+		IL_016f: ldloc.s 10
+		IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0176: ldc.i4.1
+		IL_0177: newarr [System.Runtime]System.Object
+		IL_017c: dup
+		IL_017d: ldc.i4.0
+		IL_017e: ldstr ","
+		IL_0183: stelem.ref
+		IL_0184: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0189: stloc.s 11
+		IL_018b: ldloc.s 9
+		IL_018d: ldstr "log"
+		IL_0192: ldloc.s 11
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0199: pop
+		IL_019a: ldstr "console"
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a9: stloc.s 9
+		IL_01ab: ldc.i4.2
+		IL_01ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01b1: dup
+		IL_01b2: ldc.r8 4
+		IL_01bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01c0: dup
+		IL_01c1: ldc.r8 5
+		IL_01ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01cf: stloc.s 8
+		IL_01d1: ldloc.s 8
+		IL_01d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_01d8: stloc.s 12
+		IL_01da: ldloc.1
+		IL_01db: ldstr "isDisjointFrom"
+		IL_01e0: ldloc.s 12
+		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e7: stloc.s 10
+		IL_01e9: ldloc.s 9
+		IL_01eb: ldstr "log"
+		IL_01f0: ldloc.s 10
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f7: pop
+		IL_01f8: ldstr "console"
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0207: stloc.s 10
+		IL_0209: ldloc.1
+		IL_020a: ldstr "isDisjointFrom"
+		IL_020f: ldloc.2
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0215: stloc.s 9
+		IL_0217: ldloc.s 10
+		IL_0219: ldstr "log"
+		IL_021e: ldloc.s 9
+		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0225: pop
+		IL_0226: ldstr "console"
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0235: stloc.s 9
+		IL_0237: ldc.i4.2
+		IL_0238: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_023d: dup
+		IL_023e: ldc.r8 1
+		IL_0247: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_024c: dup
+		IL_024d: ldc.r8 2
+		IL_0256: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_025b: stloc.s 8
+		IL_025d: ldloc.s 8
+		IL_025f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_0264: stloc.s 12
+		IL_0266: ldc.i4.3
+		IL_0267: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_026c: dup
+		IL_026d: ldc.r8 1
+		IL_0276: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_027b: dup
+		IL_027c: ldc.r8 2
+		IL_0285: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_028a: dup
+		IL_028b: ldc.r8 3
+		IL_0294: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0299: stloc.s 8
+		IL_029b: ldloc.s 8
+		IL_029d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_02a2: stloc.s 13
+		IL_02a4: ldloc.s 12
+		IL_02a6: ldstr "isSubsetOf"
+		IL_02ab: ldloc.s 13
+		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b2: stloc.s 10
+		IL_02b4: ldloc.s 9
+		IL_02b6: ldstr "log"
+		IL_02bb: ldloc.s 10
+		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c2: pop
+		IL_02c3: ldstr "console"
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d2: stloc.s 10
+		IL_02d4: ldc.i4.2
+		IL_02d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02da: dup
+		IL_02db: ldc.r8 1
+		IL_02e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02e9: dup
+		IL_02ea: ldc.r8 3
+		IL_02f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02f8: stloc.s 8
+		IL_02fa: ldloc.s 8
+		IL_02fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_0301: stloc.s 13
+		IL_0303: ldloc.1
+		IL_0304: ldstr "isSupersetOf"
+		IL_0309: ldloc.s 13
+		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0310: stloc.s 9
+		IL_0312: ldloc.s 10
+		IL_0314: ldstr "log"
+		IL_0319: ldloc.s 9
+		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0320: pop
+		IL_0321: ldnull
+		IL_0322: ldftn object Modules.Set_Algebra_Methods/FunctionExpression_setLike::__js_call__(object, object)
+		IL_0328: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_032d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0332: ldc.i4.1
+		IL_0333: conv.r8
+		IL_0334: ldstr ""
+		IL_0339: ldc.i4.0
+		IL_033a: ldc.i4.1
+		IL_033b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0340: stloc.s 14
+		IL_0342: ldc.i4.1
+		IL_0343: newarr [System.Runtime]System.Object
+		IL_0348: dup
+		IL_0349: ldc.i4.0
+		IL_034a: ldloc.0
+		IL_034b: stelem.ref
+		IL_034c: ldftn object Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10::__js_call__(object[], object)
+		IL_0352: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0357: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_035c: ldc.i4.0
+		IL_035d: conv.r8
+		IL_035e: ldstr ""
+		IL_0363: ldc.i4.0
+		IL_0364: ldc.i4.1
+		IL_0365: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
+		IL_036f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0374: stloc.s 15
+		IL_0376: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_037b: dup
+		IL_037c: ldstr "size"
+		IL_0381: ldc.r8 2
+		IL_038a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_038f: dup
+		IL_0390: ldstr "has"
+		IL_0395: ldloc.s 14
+		IL_0397: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_039c: dup
+		IL_039d: ldstr "keys"
+		IL_03a2: ldloc.s 15
+		IL_03a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03a9: stloc.3
+		IL_03aa: ldstr "console"
+		IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03b9: stloc.s 9
+		IL_03bb: ldloc.1
+		IL_03bc: ldstr "union"
+		IL_03c1: ldloc.3
+		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03c7: stloc.s 10
+		IL_03c9: ldloc.s 10
+		IL_03cb: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_03d0: ldc.i4.1
+		IL_03d1: newarr [System.Runtime]System.Object
+		IL_03d6: dup
+		IL_03d7: ldc.i4.0
+		IL_03d8: ldstr ","
+		IL_03dd: stelem.ref
+		IL_03de: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_03e3: stloc.s 11
+		IL_03e5: ldloc.s 9
+		IL_03e7: ldstr "log"
+		IL_03ec: ldloc.s 11
+		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03f3: pop
 		.try
 		{
-			IL_0445: nop
-			IL_0446: ldloc.1
-			IL_0447: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-			IL_044c: stloc.s 13
-			IL_044e: ldc.i4.2
-			IL_044f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0454: dup
-			IL_0455: ldc.r8 3
-			IL_045e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0463: dup
-			IL_0464: ldc.r8 4
-			IL_046d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0472: stloc.s 8
-			IL_0474: ldloc.s 13
-			IL_0476: ldstr "union"
-			IL_047b: ldloc.s 8
-			IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0482: pop
-			IL_0483: ldstr "console"
-			IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0492: ldstr "log"
-			IL_0497: ldstr "array did not throw"
-			IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_04a1: pop
-			IL_04a2: leave IL_0522
+			IL_03f4: nop
+			IL_03f5: ldc.i4.2
+			IL_03f6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_03fb: dup
+			IL_03fc: ldc.r8 3
+			IL_0405: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_040a: dup
+			IL_040b: ldc.r8 4
+			IL_0414: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_0419: stloc.s 8
+			IL_041b: ldloc.1
+			IL_041c: ldstr "union"
+			IL_0421: ldloc.s 8
+			IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0428: pop
+			IL_0429: ldstr "console"
+			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0438: ldstr "log"
+			IL_043d: ldstr "array did not throw"
+			IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0447: pop
+			IL_0448: leave IL_04c8
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_04a7: stloc.s 4
-			IL_04a9: ldloc.s 4
-			IL_04ab: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_04b0: dup
-			IL_04b1: brtrue IL_04c7
+			IL_044d: stloc.s 4
+			IL_044f: ldloc.s 4
+			IL_0451: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0456: dup
+			IL_0457: brtrue IL_046d
 
-			IL_04b6: pop
-			IL_04b7: ldloc.s 4
-			IL_04b9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_04be: dup
-			IL_04bf: brtrue IL_04d3
+			IL_045c: pop
+			IL_045d: ldloc.s 4
+			IL_045f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0464: dup
+			IL_0465: brtrue IL_0479
 
-			IL_04c4: pop
-			IL_04c5: rethrow
+			IL_046a: pop
+			IL_046b: rethrow
 
-			IL_04c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_04cc: stloc.s 5
-			IL_04ce: br IL_04d5
+			IL_046d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0472: stloc.s 5
+			IL_0474: br IL_047b
 
-			IL_04d3: stloc.s 5
+			IL_0479: stloc.s 5
 
-			IL_04d5: ldloc.s 5
-			IL_04d7: stloc.s 6
-			IL_04d9: ldstr "console"
-			IL_04de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04e8: stloc.s 9
-			IL_04ea: ldloc.s 6
-			IL_04ec: stloc.s 11
-			IL_04ee: ldstr "TypeError"
-			IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04f8: stloc.s 16
-			IL_04fa: ldloc.s 11
-			IL_04fc: ldloc.s 16
-			IL_04fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0503: stloc.s 17
-			IL_0505: ldloc.s 17
-			IL_0507: box [System.Runtime]System.Boolean
-			IL_050c: stloc.s 18
-			IL_050e: ldloc.s 9
-			IL_0510: ldstr "log"
-			IL_0515: ldloc.s 18
-			IL_0517: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_051c: pop
-			IL_051d: leave IL_0522
+			IL_047b: ldloc.s 5
+			IL_047d: stloc.s 6
+			IL_047f: ldstr "console"
+			IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_048e: stloc.s 9
+			IL_0490: ldloc.s 6
+			IL_0492: stloc.s 10
+			IL_0494: ldstr "TypeError"
+			IL_0499: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_049e: stloc.s 16
+			IL_04a0: ldloc.s 10
+			IL_04a2: ldloc.s 16
+			IL_04a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_04a9: stloc.s 17
+			IL_04ab: ldloc.s 17
+			IL_04ad: box [System.Runtime]System.Boolean
+			IL_04b2: stloc.s 18
+			IL_04b4: ldloc.s 9
+			IL_04b6: ldstr "log"
+			IL_04bb: ldloc.s 18
+			IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04c2: pop
+			IL_04c3: leave IL_04c8
 		} // end handler
 
-		IL_0522: ldnull
-		IL_0523: stloc.s 7
-		IL_0525: ret
+		IL_04c8: ldnull
+		IL_04c9: stloc.s 7
+		IL_04cb: ret
 	} // end of method Set_Algebra_Methods::__js_module_init__
 
 } // end of class Modules.Set_Algebra_Methods
@@ -773,7 +743,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2761
+		// Method begins at RVA 0x2705
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2978
+						// Method begins at RVA 0x2954
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x296f
+					// Method begins at RVA 0x294b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2694
+				// Method begins at RVA 0x2670
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -178,7 +178,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2966
+				// Method begins at RVA 0x2942
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -204,7 +204,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x23d0
+			// Method begins at RVA 0x23ac
 			// Header size: 12
 			// Code size: 172 (0xac)
 			.maxstack 8
@@ -293,7 +293,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2993
+						// Method begins at RVA 0x296f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -311,7 +311,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x298a
+					// Method begins at RVA 0x2966
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -335,7 +335,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2768
+				// Method begins at RVA 0x2744
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -440,7 +440,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x299c
+					// Method begins at RVA 0x2978
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -464,7 +464,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x283b
+				// Method begins at RVA 0x2817
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -502,7 +502,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2981
+				// Method begins at RVA 0x295d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -528,7 +528,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2488
+			// Method begins at RVA 0x2464
 			// Header size: 12
 			// Code size: 208 (0xd0)
 			.maxstack 8
@@ -631,7 +631,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29a5
+				// Method begins at RVA 0x2981
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -655,7 +655,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2564
+			// Method begins at RVA 0x2540
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -712,7 +712,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x29c0
+						// Method begins at RVA 0x299c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -730,7 +730,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29b7
+					// Method begins at RVA 0x2993
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -754,7 +754,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2864
+				// Method begins at RVA 0x2840
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -859,7 +859,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29c9
+					// Method begins at RVA 0x29a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -883,7 +883,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2937
+				// Method begins at RVA 0x2913
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -921,7 +921,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29ae
+				// Method begins at RVA 0x298a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -947,7 +947,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x25b8
+			// Method begins at RVA 0x2594
 			// Header size: 12
 			// Code size: 208 (0xd0)
 			.maxstack 8
@@ -1060,7 +1060,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x295d
+			// Method begins at RVA 0x2939
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1086,7 +1086,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 881 (0x371)
+		// Code size: 845 (0x34d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Constructor_Iterable/Scope,
@@ -1100,8 +1100,7 @@
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[10] object,
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.Set,
-			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		)
 
 		IL_0000: newobj instance void Modules.Set_Constructor_Iterable/Scope::.ctor()
@@ -1155,214 +1154,202 @@
 		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_009b: stloc.s 10
 		IL_009d: ldloc.2
-		IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_00a3: stloc.s 11
-		IL_00a5: ldloc.s 11
-		IL_00a7: ldstr "has"
-		IL_00ac: ldc.r8 1
-		IL_00b5: box [System.Runtime]System.Double
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bf: stloc.s 7
-		IL_00c1: ldloc.s 10
-		IL_00c3: ldstr "log"
-		IL_00c8: ldloc.s 7
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cf: pop
-		IL_00d0: ldstr "console"
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00df: stloc.s 7
-		IL_00e1: ldloc.2
-		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_00e7: stloc.s 11
-		IL_00e9: ldloc.s 11
-		IL_00eb: ldstr "has"
-		IL_00f0: ldc.r8 3
-		IL_00f9: box [System.Runtime]System.Double
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0103: stloc.s 10
-		IL_0105: ldloc.s 7
-		IL_0107: ldstr "log"
-		IL_010c: ldloc.s 10
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0113: pop
-		IL_0114: ldstr "console"
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0123: stloc.s 10
-		IL_0125: ldloc.2
-		IL_0126: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_012b: stloc.s 11
-		IL_012d: ldloc.s 11
-		IL_012f: ldstr "has"
-		IL_0134: ldc.r8 4
-		IL_013d: box [System.Runtime]System.Double
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0147: stloc.s 7
-		IL_0149: ldloc.s 10
-		IL_014b: ldstr "log"
-		IL_0150: ldloc.s 7
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0157: pop
-		IL_0158: ldloc.0
-		IL_0159: ldc.i4.0
-		IL_015a: box [System.Runtime]System.Boolean
-		IL_015f: stfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_0164: ldstr "iterator"
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_016e: stloc.s 7
-		IL_0170: ldloc.0
-		IL_0171: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_0176: ldftn object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
-		IL_017c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0181: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0186: ldc.i4.0
-		IL_0187: conv.r8
-		IL_0188: ldstr ""
-		IL_018d: ldc.i4.0
-		IL_018e: ldc.i4.1
-		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0194: stloc.s 8
-		IL_0196: ldloc.s 8
-		IL_0198: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_019d: stloc.s 8
-		IL_019f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01a4: stloc.s 9
-		IL_01a6: ldloc.s 9
-		IL_01a8: ldloc.s 7
-		IL_01aa: ldloc.s 8
-		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_01b1: pop
-		IL_01b2: ldloc.s 9
-		IL_01b4: stloc.3
-		IL_01b5: ldloc.3
-		IL_01b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_01bb: stloc.s 4
-		IL_01bd: ldstr "console"
-		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01cc: stloc.s 7
-		IL_01ce: ldloc.0
-		IL_01cf: ldfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_01d4: stloc.s 10
-		IL_01d6: ldloc.s 7
-		IL_01d8: ldstr "log"
-		IL_01dd: ldloc.s 10
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e4: pop
-		IL_01e5: ldstr "console"
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f4: stloc.s 10
-		IL_01f6: ldloc.s 4
-		IL_01f8: ldstr "size"
-		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0202: stloc.s 7
-		IL_0204: ldloc.s 10
-		IL_0206: ldstr "log"
-		IL_020b: ldloc.s 7
-		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0212: pop
-		IL_0213: ldloc.0
-		IL_0214: ldc.i4.0
-		IL_0215: box [System.Runtime]System.Boolean
-		IL_021a: stfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
-		IL_021f: ldnull
-		IL_0220: ldftn object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike::__js_call__(object, object)
-		IL_0226: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_022b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0230: ldc.i4.1
-		IL_0231: conv.r8
-		IL_0232: ldstr ""
-		IL_0237: ldc.i4.0
-		IL_0238: ldc.i4.1
-		IL_0239: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_023e: stloc.s 12
-		IL_0240: ldloc.s 12
-		IL_0242: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_0247: stloc.s 12
-		IL_0249: ldloc.0
-		IL_024a: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_024f: ldftn object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
-		IL_0255: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_025a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_025f: ldc.i4.0
-		IL_0260: conv.r8
-		IL_0261: ldstr ""
-		IL_0266: ldc.i4.0
-		IL_0267: ldc.i4.1
-		IL_0268: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_026d: stloc.s 8
-		IL_026f: ldloc.s 8
-		IL_0271: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0276: stloc.s 8
-		IL_0278: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_027d: dup
-		IL_027e: ldstr "size"
-		IL_0283: ldc.r8 2
-		IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0291: dup
-		IL_0292: ldstr "has"
-		IL_0297: ldloc.s 12
-		IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_029e: dup
-		IL_029f: ldstr "keys"
-		IL_02a4: ldloc.s 8
-		IL_02a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_02ab: stloc.s 5
-		IL_02ad: ldloc.s 4
-		IL_02af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_02b4: stloc.s 11
-		IL_02b6: ldloc.s 11
-		IL_02b8: ldstr "union"
-		IL_02bd: ldloc.s 5
-		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c4: stloc.s 6
-		IL_02c6: ldstr "console"
-		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d5: stloc.s 7
-		IL_02d7: ldloc.0
-		IL_02d8: ldfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
-		IL_02dd: stloc.s 10
-		IL_02df: ldloc.s 7
-		IL_02e1: ldstr "log"
-		IL_02e6: ldloc.s 10
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ed: pop
-		IL_02ee: ldstr "console"
-		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02fd: stloc.s 10
-		IL_02ff: ldloc.s 6
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0306: ldstr "has"
-		IL_030b: ldc.r8 4
-		IL_0314: box [System.Runtime]System.Double
-		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_031e: stloc.s 7
-		IL_0320: ldloc.s 10
-		IL_0322: ldstr "log"
-		IL_0327: ldloc.s 7
-		IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_032e: pop
-		IL_032f: ldstr "console"
-		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_033e: stloc.s 7
-		IL_0340: ldloc.s 6
-		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0347: ldstr "has"
-		IL_034c: ldc.r8 6
-		IL_0355: box [System.Runtime]System.Double
-		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_035f: stloc.s 10
-		IL_0361: ldloc.s 7
-		IL_0363: ldstr "log"
-		IL_0368: ldloc.s 10
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_036f: pop
-		IL_0370: ret
+		IL_009e: ldstr "has"
+		IL_00a3: ldc.r8 1
+		IL_00ac: box [System.Runtime]System.Double
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b6: stloc.s 7
+		IL_00b8: ldloc.s 10
+		IL_00ba: ldstr "log"
+		IL_00bf: ldloc.s 7
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c6: pop
+		IL_00c7: ldstr "console"
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d6: stloc.s 7
+		IL_00d8: ldloc.2
+		IL_00d9: ldstr "has"
+		IL_00de: ldc.r8 3
+		IL_00e7: box [System.Runtime]System.Double
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f1: stloc.s 10
+		IL_00f3: ldloc.s 7
+		IL_00f5: ldstr "log"
+		IL_00fa: ldloc.s 10
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0101: pop
+		IL_0102: ldstr "console"
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0111: stloc.s 10
+		IL_0113: ldloc.2
+		IL_0114: ldstr "has"
+		IL_0119: ldc.r8 4
+		IL_0122: box [System.Runtime]System.Double
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012c: stloc.s 7
+		IL_012e: ldloc.s 10
+		IL_0130: ldstr "log"
+		IL_0135: ldloc.s 7
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013c: pop
+		IL_013d: ldloc.0
+		IL_013e: ldc.i4.0
+		IL_013f: box [System.Runtime]System.Boolean
+		IL_0144: stfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_0149: ldstr "iterator"
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0153: stloc.s 7
+		IL_0155: ldloc.0
+		IL_0156: castclass Modules.Set_Constructor_Iterable/Scope
+		IL_015b: ldftn object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
+		IL_0161: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0166: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_016b: ldc.i4.0
+		IL_016c: conv.r8
+		IL_016d: ldstr ""
+		IL_0172: ldc.i4.0
+		IL_0173: ldc.i4.1
+		IL_0174: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0179: stloc.s 8
+		IL_017b: ldloc.s 8
+		IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0182: stloc.s 8
+		IL_0184: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0189: stloc.s 9
+		IL_018b: ldloc.s 9
+		IL_018d: ldloc.s 7
+		IL_018f: ldloc.s 8
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0196: pop
+		IL_0197: ldloc.s 9
+		IL_0199: stloc.3
+		IL_019a: ldloc.3
+		IL_019b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_01a0: stloc.s 4
+		IL_01a2: ldstr "console"
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b1: stloc.s 7
+		IL_01b3: ldloc.0
+		IL_01b4: ldfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_01b9: stloc.s 10
+		IL_01bb: ldloc.s 7
+		IL_01bd: ldstr "log"
+		IL_01c2: ldloc.s 10
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c9: pop
+		IL_01ca: ldstr "console"
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d9: stloc.s 10
+		IL_01db: ldloc.s 4
+		IL_01dd: ldstr "size"
+		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e7: stloc.s 7
+		IL_01e9: ldloc.s 10
+		IL_01eb: ldstr "log"
+		IL_01f0: ldloc.s 7
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f7: pop
+		IL_01f8: ldloc.0
+		IL_01f9: ldc.i4.0
+		IL_01fa: box [System.Runtime]System.Boolean
+		IL_01ff: stfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
+		IL_0204: ldnull
+		IL_0205: ldftn object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike::__js_call__(object, object)
+		IL_020b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0210: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0215: ldc.i4.1
+		IL_0216: conv.r8
+		IL_0217: ldstr ""
+		IL_021c: ldc.i4.0
+		IL_021d: ldc.i4.1
+		IL_021e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0223: stloc.s 11
+		IL_0225: ldloc.s 11
+		IL_0227: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_022c: stloc.s 11
+		IL_022e: ldloc.0
+		IL_022f: castclass Modules.Set_Constructor_Iterable/Scope
+		IL_0234: ldftn object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
+		IL_023a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_023f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0244: ldc.i4.0
+		IL_0245: conv.r8
+		IL_0246: ldstr ""
+		IL_024b: ldc.i4.0
+		IL_024c: ldc.i4.1
+		IL_024d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0252: stloc.s 8
+		IL_0254: ldloc.s 8
+		IL_0256: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_025b: stloc.s 8
+		IL_025d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0262: dup
+		IL_0263: ldstr "size"
+		IL_0268: ldc.r8 2
+		IL_0271: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0276: dup
+		IL_0277: ldstr "has"
+		IL_027c: ldloc.s 11
+		IL_027e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0283: dup
+		IL_0284: ldstr "keys"
+		IL_0289: ldloc.s 8
+		IL_028b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0290: stloc.s 5
+		IL_0292: ldloc.s 4
+		IL_0294: ldstr "union"
+		IL_0299: ldloc.s 5
+		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a0: stloc.s 6
+		IL_02a2: ldstr "console"
+		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b1: stloc.s 7
+		IL_02b3: ldloc.0
+		IL_02b4: ldfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
+		IL_02b9: stloc.s 10
+		IL_02bb: ldloc.s 7
+		IL_02bd: ldstr "log"
+		IL_02c2: ldloc.s 10
+		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c9: pop
+		IL_02ca: ldstr "console"
+		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d9: stloc.s 10
+		IL_02db: ldloc.s 6
+		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02e2: ldstr "has"
+		IL_02e7: ldc.r8 4
+		IL_02f0: box [System.Runtime]System.Double
+		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02fa: stloc.s 7
+		IL_02fc: ldloc.s 10
+		IL_02fe: ldstr "log"
+		IL_0303: ldloc.s 7
+		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_030a: pop
+		IL_030b: ldstr "console"
+		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_031a: stloc.s 7
+		IL_031c: ldloc.s 6
+		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0323: ldstr "has"
+		IL_0328: ldc.r8 6
+		IL_0331: box [System.Runtime]System.Double
+		IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_033b: stloc.s 10
+		IL_033d: ldloc.s 7
+		IL_033f: ldstr "log"
+		IL_0344: ldloc.s 10
+		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_034b: pop
+		IL_034c: ret
 	} // end of method Set_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Set_Constructor_Iterable
@@ -1374,7 +1361,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29d2
+		// Method begins at RVA 0x29ae
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Core_Methods.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Core_Methods.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e1
+			// Method begins at RVA 0x21ad
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 389 (0x185)
+		// Code size: 337 (0x151)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Core_Methods/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Set,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.Set,
-			[3] object,
-			[4] object
+			[2] object,
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Set_Core_Methods/Scope::.ctor()
@@ -56,115 +55,97 @@
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor()
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_0013: stloc.2
-		IL_0014: ldloc.2
-		IL_0015: ldstr "add"
-		IL_001a: ldc.r8 1
-		IL_0023: box [System.Runtime]System.Double
-		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_002d: pop
-		IL_002e: ldloc.1
-		IL_002f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_0034: stloc.2
-		IL_0035: ldloc.2
-		IL_0036: ldstr "add"
-		IL_003b: ldc.r8 2
-		IL_0044: box [System.Runtime]System.Double
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004e: pop
-		IL_004f: ldloc.1
-		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_0055: stloc.2
-		IL_0056: ldloc.2
-		IL_0057: ldstr "add"
-		IL_005c: ldc.r8 2
-		IL_0065: box [System.Runtime]System.Double
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006f: pop
-		IL_0070: ldstr "console"
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007f: stloc.3
-		IL_0080: ldloc.1
-		IL_0081: ldstr "size"
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_008b: stloc.s 4
-		IL_008d: ldloc.3
-		IL_008e: ldstr "log"
-		IL_0093: ldloc.s 4
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009a: pop
-		IL_009b: ldstr "console"
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00aa: stloc.s 4
-		IL_00ac: ldloc.1
-		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_00b2: stloc.2
-		IL_00b3: ldloc.2
-		IL_00b4: ldstr "delete"
-		IL_00b9: ldc.r8 2
-		IL_00c2: box [System.Runtime]System.Double
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cc: stloc.3
-		IL_00cd: ldloc.s 4
-		IL_00cf: ldstr "log"
-		IL_00d4: ldloc.3
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00da: pop
-		IL_00db: ldstr "console"
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ea: stloc.3
-		IL_00eb: ldloc.1
-		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_00f1: stloc.2
-		IL_00f2: ldloc.2
-		IL_00f3: ldstr "has"
-		IL_00f8: ldc.r8 2
-		IL_0101: box [System.Runtime]System.Double
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010b: stloc.s 4
-		IL_010d: ldloc.3
-		IL_010e: ldstr "log"
-		IL_0113: ldloc.s 4
+		IL_000e: ldstr "add"
+		IL_0013: ldc.r8 1
+		IL_001c: box [System.Runtime]System.Double
+		IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0026: pop
+		IL_0027: ldloc.1
+		IL_0028: ldstr "add"
+		IL_002d: ldc.r8 2
+		IL_0036: box [System.Runtime]System.Double
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0040: pop
+		IL_0041: ldloc.1
+		IL_0042: ldstr "add"
+		IL_0047: ldc.r8 2
+		IL_0050: box [System.Runtime]System.Double
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005a: pop
+		IL_005b: ldstr "console"
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006a: stloc.2
+		IL_006b: ldloc.1
+		IL_006c: ldstr "size"
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0076: stloc.3
+		IL_0077: ldloc.2
+		IL_0078: ldstr "log"
+		IL_007d: ldloc.3
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0083: pop
+		IL_0084: ldstr "console"
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0093: stloc.3
+		IL_0094: ldloc.1
+		IL_0095: ldstr "delete"
+		IL_009a: ldc.r8 2
+		IL_00a3: box [System.Runtime]System.Double
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ad: stloc.2
+		IL_00ae: ldloc.3
+		IL_00af: ldstr "log"
+		IL_00b4: ldloc.2
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ba: pop
+		IL_00bb: ldstr "console"
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ca: stloc.2
+		IL_00cb: ldloc.1
+		IL_00cc: ldstr "has"
+		IL_00d1: ldc.r8 2
+		IL_00da: box [System.Runtime]System.Double
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e4: stloc.3
+		IL_00e5: ldloc.2
+		IL_00e6: ldstr "log"
+		IL_00eb: ldloc.3
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f1: pop
+		IL_00f2: ldstr "console"
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0101: stloc.3
+		IL_0102: ldloc.1
+		IL_0103: ldstr "size"
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010d: stloc.2
+		IL_010e: ldloc.3
+		IL_010f: ldstr "log"
+		IL_0114: ldloc.2
 		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_011a: pop
-		IL_011b: ldstr "console"
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012a: stloc.s 4
-		IL_012c: ldloc.1
-		IL_012d: ldstr "size"
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0137: stloc.3
-		IL_0138: ldloc.s 4
-		IL_013a: ldstr "log"
-		IL_013f: ldloc.3
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0145: pop
-		IL_0146: ldloc.1
-		IL_0147: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_014c: stloc.2
-		IL_014d: ldloc.2
-		IL_014e: ldstr "clear"
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0158: pop
-		IL_0159: ldstr "console"
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0168: stloc.3
-		IL_0169: ldloc.1
-		IL_016a: ldstr "size"
-		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0174: stloc.s 4
-		IL_0176: ldloc.3
-		IL_0177: ldstr "log"
-		IL_017c: ldloc.s 4
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0183: pop
-		IL_0184: ret
+		IL_011b: ldloc.1
+		IL_011c: ldstr "clear"
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0126: pop
+		IL_0127: ldstr "console"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0136: stloc.2
+		IL_0137: ldloc.1
+		IL_0138: ldstr "size"
+		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0142: stloc.3
+		IL_0143: ldloc.2
+		IL_0144: ldstr "log"
+		IL_0149: ldloc.3
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014f: pop
+		IL_0150: ret
 	} // end of method Set_Core_Methods::__js_module_init__
 
 } // end of class Modules.Set_Core_Methods
@@ -176,7 +157,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ea
+		// Method begins at RVA 0x21b6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Entries_Keys_Values.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Entries_Keys_Values.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x231d
+			// Method begins at RVA 0x2302
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 705 (0x2c1)
+		// Code size: 678 (0x2a6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Entries_Keys_Values/Scope,
@@ -49,10 +49,9 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.Set,
+			[6] object,
 			[7] object,
-			[8] object,
-			[9] object
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.Set_Entries_Keys_Values/Scope::.ctor()
@@ -71,173 +70,164 @@
 		IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
 		IL_0034: stloc.1
 		IL_0035: ldloc.1
-		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_003b: stloc.s 6
-		IL_003d: ldloc.s 6
-		IL_003f: ldstr "keys"
-		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0049: stloc.s 7
-		IL_004b: ldloc.s 7
-		IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_0059: stloc.s 6
-		IL_005b: ldloc.s 6
-		IL_005d: ldstr "values"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0067: stloc.s 7
-		IL_0069: ldloc.s 7
-		IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0070: stloc.3
-		IL_0071: ldloc.1
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_0077: stloc.s 6
-		IL_0079: ldloc.s 6
-		IL_007b: ldstr "entries"
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0085: stloc.s 7
-		IL_0087: ldloc.s 7
-		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_008e: stloc.s 4
-		IL_0090: ldstr "console"
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009f: ldloc.2
-		IL_00a0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_00a5: box [System.Runtime]System.Double
-		IL_00aa: stloc.s 8
-		IL_00ac: ldstr "log"
-		IL_00b1: ldloc.s 8
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b8: pop
-		IL_00b9: ldstr "console"
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c8: ldloc.2
-		IL_00c9: ldc.r8 0.0
-		IL_00d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_00d7: stloc.s 7
-		IL_00d9: ldstr "log"
-		IL_00de: ldloc.s 7
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e5: pop
-		IL_00e6: ldstr "console"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f5: ldloc.2
-		IL_00f6: ldc.r8 1
-		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0104: stloc.s 7
-		IL_0106: ldstr "log"
-		IL_010b: ldloc.s 7
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0112: pop
-		IL_0113: ldstr "console"
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0122: ldloc.3
-		IL_0123: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0128: box [System.Runtime]System.Double
-		IL_012d: stloc.s 8
-		IL_012f: ldstr "log"
-		IL_0134: ldloc.s 8
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013b: pop
-		IL_013c: ldstr "console"
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014b: ldloc.3
-		IL_014c: ldc.r8 0.0
-		IL_0155: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_015a: stloc.s 7
-		IL_015c: ldstr "log"
-		IL_0161: ldloc.s 7
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0168: pop
-		IL_0169: ldstr "console"
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0178: ldloc.3
-		IL_0179: ldc.r8 1
-		IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0187: stloc.s 7
-		IL_0189: ldstr "log"
-		IL_018e: ldloc.s 7
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0195: pop
-		IL_0196: ldstr "console"
-		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a5: ldloc.s 4
-		IL_01a7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_01ac: box [System.Runtime]System.Double
-		IL_01b1: stloc.s 8
-		IL_01b3: ldstr "log"
-		IL_01b8: ldloc.s 8
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bf: pop
-		IL_01c0: ldstr "console"
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01cf: stloc.s 7
-		IL_01d1: ldloc.s 4
-		IL_01d3: ldc.r8 0.0
-		IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01e1: ldc.r8 0.0
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01ef: stloc.s 9
-		IL_01f1: ldloc.s 7
-		IL_01f3: ldstr "log"
-		IL_01f8: ldloc.s 9
-		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ff: pop
-		IL_0200: ldstr "console"
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020f: stloc.s 9
-		IL_0211: ldloc.s 4
-		IL_0213: ldc.r8 0.0
-		IL_021c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0221: ldc.r8 1
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_022f: stloc.s 7
-		IL_0231: ldloc.s 9
-		IL_0233: ldstr "log"
-		IL_0238: ldloc.s 7
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023f: pop
-		IL_0240: ldstr "console"
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024f: stloc.s 7
-		IL_0251: ldloc.s 4
-		IL_0253: ldc.r8 1
-		IL_025c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0261: ldc.r8 0.0
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_026f: stloc.s 9
-		IL_0271: ldloc.s 7
-		IL_0273: ldstr "log"
-		IL_0278: ldloc.s 9
-		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027f: pop
-		IL_0280: ldstr "console"
-		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028f: stloc.s 9
-		IL_0291: ldloc.s 4
-		IL_0293: ldc.r8 1
-		IL_029c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_02a1: ldc.r8 1
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02af: stloc.s 7
-		IL_02b1: ldloc.s 9
-		IL_02b3: ldstr "log"
-		IL_02b8: ldloc.s 7
-		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02bf: pop
-		IL_02c0: ret
+		IL_0036: ldstr "keys"
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0040: stloc.s 6
+		IL_0042: ldloc.s 6
+		IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0049: stloc.2
+		IL_004a: ldloc.1
+		IL_004b: ldstr "values"
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0055: stloc.s 6
+		IL_0057: ldloc.s 6
+		IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_005e: stloc.3
+		IL_005f: ldloc.1
+		IL_0060: ldstr "entries"
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_006a: stloc.s 6
+		IL_006c: ldloc.s 6
+		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0073: stloc.s 4
+		IL_0075: ldstr "console"
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0084: ldloc.2
+		IL_0085: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_008a: box [System.Runtime]System.Double
+		IL_008f: stloc.s 7
+		IL_0091: ldstr "log"
+		IL_0096: ldloc.s 7
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009d: pop
+		IL_009e: ldstr "console"
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ad: ldloc.2
+		IL_00ae: ldc.r8 0.0
+		IL_00b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_00bc: stloc.s 6
+		IL_00be: ldstr "log"
+		IL_00c3: ldloc.s 6
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ca: pop
+		IL_00cb: ldstr "console"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00da: ldloc.2
+		IL_00db: ldc.r8 1
+		IL_00e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_00e9: stloc.s 6
+		IL_00eb: ldstr "log"
+		IL_00f0: ldloc.s 6
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f7: pop
+		IL_00f8: ldstr "console"
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0107: ldloc.3
+		IL_0108: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_010d: box [System.Runtime]System.Double
+		IL_0112: stloc.s 7
+		IL_0114: ldstr "log"
+		IL_0119: ldloc.s 7
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0120: pop
+		IL_0121: ldstr "console"
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0130: ldloc.3
+		IL_0131: ldc.r8 0.0
+		IL_013a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_013f: stloc.s 6
+		IL_0141: ldstr "log"
+		IL_0146: ldloc.s 6
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014d: pop
+		IL_014e: ldstr "console"
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015d: ldloc.3
+		IL_015e: ldc.r8 1
+		IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_016c: stloc.s 6
+		IL_016e: ldstr "log"
+		IL_0173: ldloc.s 6
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017a: pop
+		IL_017b: ldstr "console"
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018a: ldloc.s 4
+		IL_018c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0191: box [System.Runtime]System.Double
+		IL_0196: stloc.s 7
+		IL_0198: ldstr "log"
+		IL_019d: ldloc.s 7
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a4: pop
+		IL_01a5: ldstr "console"
+		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b4: stloc.s 6
+		IL_01b6: ldloc.s 4
+		IL_01b8: ldc.r8 0.0
+		IL_01c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01c6: ldc.r8 0.0
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01d4: stloc.s 8
+		IL_01d6: ldloc.s 6
+		IL_01d8: ldstr "log"
+		IL_01dd: ldloc.s 8
+		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e4: pop
+		IL_01e5: ldstr "console"
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f4: stloc.s 8
+		IL_01f6: ldloc.s 4
+		IL_01f8: ldc.r8 0.0
+		IL_0201: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0206: ldc.r8 1
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0214: stloc.s 6
+		IL_0216: ldloc.s 8
+		IL_0218: ldstr "log"
+		IL_021d: ldloc.s 6
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0224: pop
+		IL_0225: ldstr "console"
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0234: stloc.s 6
+		IL_0236: ldloc.s 4
+		IL_0238: ldc.r8 1
+		IL_0241: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0246: ldc.r8 0.0
+		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0254: stloc.s 8
+		IL_0256: ldloc.s 6
+		IL_0258: ldstr "log"
+		IL_025d: ldloc.s 8
+		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0264: pop
+		IL_0265: ldstr "console"
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0274: stloc.s 8
+		IL_0276: ldloc.s 4
+		IL_0278: ldc.r8 1
+		IL_0281: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0286: ldc.r8 1
+		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0294: stloc.s 6
+		IL_0296: ldloc.s 8
+		IL_0298: ldstr "log"
+		IL_029d: ldloc.s 6
+		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a4: pop
+		IL_02a5: ret
 	} // end of method Set_Entries_Keys_Values::__js_module_init__
 
 } // end of class Modules.Set_Entries_Keys_Values
@@ -249,7 +239,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2326
+		// Method begins at RVA 0x230b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Symbol_Iterator.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Symbol_Iterator.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d3
+			// Method begins at RVA 0x21c2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 375 (0x177)
+		// Code size: 358 (0x166)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Symbol_Iterator/Scope,
@@ -50,10 +50,8 @@
 			[4] object,
 			[5] object,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.Set,
-			[8] object,
-			[9] object[],
-			[10] object
+			[7] object,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.Set_Symbol_Iterator/Scope::.ctor()
@@ -72,100 +70,93 @@
 		IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
 		IL_0034: stloc.1
 		IL_0035: ldloc.1
-		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Set>(!!0)
-		IL_003b: stloc.s 7
-		IL_003d: ldstr "iterator"
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0047: stloc.s 8
-		IL_0049: ldc.i4.0
-		IL_004a: newarr [System.Runtime]System.Object
-		IL_004f: stloc.s 9
-		IL_0051: ldloc.s 7
-		IL_0053: ldloc.s 8
-		IL_0055: ldloc.s 9
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_005c: stloc.2
+		IL_0036: ldstr "iterator"
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0040: ldc.i4.0
+		IL_0041: newarr [System.Runtime]System.Object
+		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_004b: stloc.2
+		IL_004c: ldloc.2
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0052: ldstr "next"
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_005c: stloc.3
 		IL_005d: ldloc.2
 		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0063: ldstr "next"
 		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_006d: stloc.3
-		IL_006e: ldloc.2
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0074: ldstr "next"
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_007e: stloc.s 4
-		IL_0080: ldloc.2
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0086: ldstr "next"
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0090: stloc.s 5
-		IL_0092: ldstr "console"
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a1: stloc.s 8
-		IL_00a3: ldloc.3
-		IL_00a4: ldstr "done"
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ae: stloc.s 10
-		IL_00b0: ldloc.s 8
-		IL_00b2: ldstr "log"
-		IL_00b7: ldloc.s 10
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00be: pop
-		IL_00bf: ldstr "console"
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ce: stloc.s 10
-		IL_00d0: ldloc.3
-		IL_00d1: ldstr "value"
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00db: stloc.s 8
-		IL_00dd: ldloc.s 10
-		IL_00df: ldstr "log"
-		IL_00e4: ldloc.s 8
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00eb: pop
-		IL_00ec: ldstr "console"
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fb: stloc.s 8
-		IL_00fd: ldloc.s 4
-		IL_00ff: ldstr "done"
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0109: stloc.s 10
-		IL_010b: ldloc.s 8
-		IL_010d: ldstr "log"
-		IL_0112: ldloc.s 10
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0119: pop
-		IL_011a: ldstr "console"
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0129: stloc.s 10
-		IL_012b: ldloc.s 4
-		IL_012d: ldstr "value"
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0137: stloc.s 8
-		IL_0139: ldloc.s 10
-		IL_013b: ldstr "log"
-		IL_0140: ldloc.s 8
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0147: pop
-		IL_0148: ldstr "console"
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0157: stloc.s 8
-		IL_0159: ldloc.s 5
-		IL_015b: ldstr "done"
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0165: stloc.s 10
-		IL_0167: ldloc.s 8
-		IL_0169: ldstr "log"
-		IL_016e: ldloc.s 10
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0175: pop
-		IL_0176: ret
+		IL_006d: stloc.s 4
+		IL_006f: ldloc.2
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0075: ldstr "next"
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_007f: stloc.s 5
+		IL_0081: ldstr "console"
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0090: stloc.s 7
+		IL_0092: ldloc.3
+		IL_0093: ldstr "done"
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009d: stloc.s 8
+		IL_009f: ldloc.s 7
+		IL_00a1: ldstr "log"
+		IL_00a6: ldloc.s 8
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ad: pop
+		IL_00ae: ldstr "console"
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00bd: stloc.s 8
+		IL_00bf: ldloc.3
+		IL_00c0: ldstr "value"
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ca: stloc.s 7
+		IL_00cc: ldloc.s 8
+		IL_00ce: ldstr "log"
+		IL_00d3: ldloc.s 7
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00da: pop
+		IL_00db: ldstr "console"
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ea: stloc.s 7
+		IL_00ec: ldloc.s 4
+		IL_00ee: ldstr "done"
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f8: stloc.s 8
+		IL_00fa: ldloc.s 7
+		IL_00fc: ldstr "log"
+		IL_0101: ldloc.s 8
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0108: pop
+		IL_0109: ldstr "console"
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0118: stloc.s 8
+		IL_011a: ldloc.s 4
+		IL_011c: ldstr "value"
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0126: stloc.s 7
+		IL_0128: ldloc.s 8
+		IL_012a: ldstr "log"
+		IL_012f: ldloc.s 7
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0136: pop
+		IL_0137: ldstr "console"
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0146: stloc.s 7
+		IL_0148: ldloc.s 5
+		IL_014a: ldstr "done"
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0154: stloc.s 8
+		IL_0156: ldloc.s 7
+		IL_0158: ldstr "log"
+		IL_015d: ldloc.s 8
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0164: pop
+		IL_0165: ret
 	} // end of method Set_Symbol_Iterator::__js_module_init__
 
 } // end of class Modules.Set_Symbol_Iterator
@@ -177,7 +168,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21dc
+		// Method begins at RVA 0x21cb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharAt_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharAt_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2399
+				// Method begins at RVA 0x2349
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a2
+				// Method begins at RVA 0x2352
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2390
+			// Method begins at RVA 0x2340
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 804 (0x324)
+		// Code size: 722 (0x2d2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_CharAt_Basic/Scope,
@@ -92,14 +92,11 @@
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] object,
-			[8] string,
+			[7] string,
+			[8] object,
 			[9] bool,
 			[10] object,
-			[11] float64,
-			[12] object,
-			[13] object,
-			[14] object
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.String_CharAt_Basic/Scope::.ctor()
@@ -110,242 +107,210 @@
 		IL_000d: ldstr "console"
 		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_001c: stloc.s 7
-		IL_001e: ldloc.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0024: stloc.s 8
-		IL_0026: ldloc.s 8
-		IL_0028: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string)
-		IL_002d: stloc.s 8
-		IL_002f: ldloc.s 7
-		IL_0031: ldstr "log"
-		IL_0036: ldloc.s 8
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_003d: pop
-		IL_003e: ldstr "console"
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004d: stloc.s 7
-		IL_004f: ldloc.1
-		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0055: stloc.s 8
-		IL_0057: ldloc.s 8
-		IL_0059: ldc.r8 1
-		IL_0062: box [System.Runtime]System.Double
-		IL_0067: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_006c: stloc.s 8
-		IL_006e: ldloc.s 7
-		IL_0070: ldstr "log"
-		IL_0075: ldloc.s 8
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007c: pop
-		IL_007d: ldstr "console"
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008c: stloc.s 7
-		IL_008e: ldloc.1
-		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0094: stloc.s 8
-		IL_0096: ldloc.s 8
-		IL_0098: ldc.r8 4
-		IL_00a1: box [System.Runtime]System.Double
-		IL_00a6: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_00ab: stloc.s 8
-		IL_00ad: ldloc.s 7
-		IL_00af: ldstr "log"
-		IL_00b4: ldloc.s 8
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bb: pop
-		IL_00bc: ldstr "console"
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cb: stloc.s 7
-		IL_00cd: ldloc.1
-		IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_00d3: stloc.s 8
-		IL_00d5: ldloc.s 8
-		IL_00d7: ldc.r8 5
-		IL_00e0: box [System.Runtime]System.Double
-		IL_00e5: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_00ea: stloc.s 8
-		IL_00ec: ldloc.s 8
-		IL_00ee: ldstr ""
-		IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f8: stloc.s 9
-		IL_00fa: ldloc.s 9
-		IL_00fc: box [System.Runtime]System.Boolean
-		IL_0101: stloc.s 10
-		IL_0103: ldloc.s 7
-		IL_0105: ldstr "log"
-		IL_010a: ldloc.s 10
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0111: pop
-		IL_0112: ldstr "console"
-		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0121: stloc.s 7
-		IL_0123: ldloc.1
-		IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0129: stloc.s 8
-		IL_012b: ldc.r8 1
-		IL_0134: neg
-		IL_0135: stloc.s 11
-		IL_0137: ldloc.s 11
-		IL_0139: box [System.Runtime]System.Double
-		IL_013e: stloc.s 12
-		IL_0140: ldloc.s 8
-		IL_0142: ldloc.s 12
-		IL_0144: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_0149: stloc.s 8
-		IL_014b: ldloc.s 8
-		IL_014d: ldstr ""
-		IL_0152: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0157: stloc.s 9
-		IL_0159: ldloc.s 9
-		IL_015b: box [System.Runtime]System.Boolean
-		IL_0160: stloc.s 10
-		IL_0162: ldloc.s 7
-		IL_0164: ldstr "log"
-		IL_0169: ldloc.s 10
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0170: pop
+		IL_001c: ldloc.1
+		IL_001d: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string)
+		IL_0022: stloc.s 7
+		IL_0024: ldstr "log"
+		IL_0029: ldloc.s 7
+		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0030: pop
+		IL_0031: ldstr "console"
+		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0040: ldloc.1
+		IL_0041: ldc.r8 1
+		IL_004a: box [System.Runtime]System.Double
+		IL_004f: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_0054: stloc.s 7
+		IL_0056: ldstr "log"
+		IL_005b: ldloc.s 7
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0062: pop
+		IL_0063: ldstr "console"
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0072: ldloc.1
+		IL_0073: ldc.r8 4
+		IL_007c: box [System.Runtime]System.Double
+		IL_0081: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_0086: stloc.s 7
+		IL_0088: ldstr "log"
+		IL_008d: ldloc.s 7
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0094: pop
+		IL_0095: ldstr "console"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a4: stloc.s 8
+		IL_00a6: ldloc.1
+		IL_00a7: ldc.r8 5
+		IL_00b0: box [System.Runtime]System.Double
+		IL_00b5: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_00ba: stloc.s 7
+		IL_00bc: ldloc.s 7
+		IL_00be: ldstr ""
+		IL_00c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00c8: stloc.s 9
+		IL_00ca: ldloc.s 9
+		IL_00cc: box [System.Runtime]System.Boolean
+		IL_00d1: stloc.s 10
+		IL_00d3: ldloc.s 8
+		IL_00d5: ldstr "log"
+		IL_00da: ldloc.s 10
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e1: pop
+		IL_00e2: ldstr "console"
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f1: stloc.s 8
+		IL_00f3: ldloc.1
+		IL_00f4: ldc.r8 1
+		IL_00fd: neg
+		IL_00fe: box [System.Runtime]System.Double
+		IL_0103: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_0108: stloc.s 7
+		IL_010a: ldloc.s 7
+		IL_010c: ldstr ""
+		IL_0111: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0116: stloc.s 9
+		IL_0118: ldloc.s 9
+		IL_011a: box [System.Runtime]System.Boolean
+		IL_011f: stloc.s 10
+		IL_0121: ldloc.s 8
+		IL_0123: ldstr "log"
+		IL_0128: ldloc.s 10
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012f: pop
 		.try
 		{
-			IL_0171: nop
-			IL_0172: ldstr "console"
-			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0181: stloc.s 7
-			IL_0183: ldloc.1
-			IL_0184: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_0189: stloc.s 8
-			IL_018b: ldc.r8 1
-			IL_0194: box [System.Runtime]System.Double
-			IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_019e: stloc.s 13
-			IL_01a0: ldloc.s 8
-			IL_01a2: ldloc.s 13
-			IL_01a4: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-			IL_01a9: stloc.s 8
-			IL_01ab: ldloc.s 7
-			IL_01ad: ldstr "log"
-			IL_01b2: ldloc.s 8
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01b9: pop
-			IL_01ba: leave IL_027b
+			IL_0130: nop
+			IL_0131: ldstr "console"
+			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0140: ldloc.1
+			IL_0141: ldc.r8 1
+			IL_014a: box [System.Runtime]System.Double
+			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+			IL_0154: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+			IL_0159: stloc.s 7
+			IL_015b: ldstr "log"
+			IL_0160: ldloc.s 7
+			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0167: pop
+			IL_0168: leave IL_0229
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01bf: stloc.2
-			IL_01c0: ldloc.2
-			IL_01c1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_01c6: dup
-			IL_01c7: brtrue IL_01dc
+			IL_016d: stloc.2
+			IL_016e: ldloc.2
+			IL_016f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0174: dup
+			IL_0175: brtrue IL_018a
 
-			IL_01cc: pop
-			IL_01cd: ldloc.2
-			IL_01ce: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_01d3: dup
-			IL_01d4: brtrue IL_01e7
+			IL_017a: pop
+			IL_017b: ldloc.2
+			IL_017c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0181: dup
+			IL_0182: brtrue IL_0195
 
-			IL_01d9: pop
-			IL_01da: rethrow
+			IL_0187: pop
+			IL_0188: rethrow
 
-			IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_01e1: stloc.3
-			IL_01e2: br IL_01e8
+			IL_018a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_018f: stloc.3
+			IL_0190: br IL_0196
 
-			IL_01e7: stloc.3
+			IL_0195: stloc.3
 
-			IL_01e8: ldloc.3
-			IL_01e9: stloc.s 4
-			IL_01eb: ldstr "console"
-			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01fa: ldstr "log"
-			IL_01ff: ldstr "bigint threw:"
-			IL_0204: ldc.i4.1
-			IL_0205: box [System.Runtime]System.Boolean
-			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_020f: pop
-			IL_0210: ldstr "console"
-			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_021f: stloc.s 7
-			IL_0221: ldloc.s 4
-			IL_0223: ldstr "name"
-			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_022d: stloc.s 14
-			IL_022f: ldloc.s 7
-			IL_0231: ldstr "log"
-			IL_0236: ldstr "bigint name:"
-			IL_023b: ldloc.s 14
-			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0242: pop
-			IL_0243: ldstr "console"
-			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0252: stloc.s 14
-			IL_0254: ldloc.s 4
-			IL_0256: ldstr "message"
-			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0260: stloc.s 7
-			IL_0262: ldloc.s 14
-			IL_0264: ldstr "log"
-			IL_0269: ldstr "bigint message:"
-			IL_026e: ldloc.s 7
-			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0275: pop
-			IL_0276: leave IL_027b
+			IL_0196: ldloc.3
+			IL_0197: stloc.s 4
+			IL_0199: ldstr "console"
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a8: ldstr "log"
+			IL_01ad: ldstr "bigint threw:"
+			IL_01b2: ldc.i4.1
+			IL_01b3: box [System.Runtime]System.Boolean
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01bd: pop
+			IL_01be: ldstr "console"
+			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01cd: stloc.s 8
+			IL_01cf: ldloc.s 4
+			IL_01d1: ldstr "name"
+			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01db: stloc.s 11
+			IL_01dd: ldloc.s 8
+			IL_01df: ldstr "log"
+			IL_01e4: ldstr "bigint name:"
+			IL_01e9: ldloc.s 11
+			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01f0: pop
+			IL_01f1: ldstr "console"
+			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0200: stloc.s 11
+			IL_0202: ldloc.s 4
+			IL_0204: ldstr "message"
+			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_020e: stloc.s 8
+			IL_0210: ldloc.s 11
+			IL_0212: ldstr "log"
+			IL_0217: ldstr "bigint message:"
+			IL_021c: ldloc.s 8
+			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0223: pop
+			IL_0224: leave IL_0229
 		} // end handler
 
-		IL_027b: ldstr "String"
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0285: stloc.s 7
-		IL_0287: ldloc.s 7
-		IL_0289: ldc.i4.1
-		IL_028a: newarr [System.Runtime]System.Object
-		IL_028f: dup
-		IL_0290: ldc.i4.0
-		IL_0291: ldstr "world"
-		IL_0296: stelem.ref
-		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_029c: stloc.s 5
-		IL_029e: ldstr "console"
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ad: stloc.s 7
-		IL_02af: ldloc.s 5
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b6: ldstr "charAt"
-		IL_02bb: ldc.r8 0.0
-		IL_02c4: box [System.Runtime]System.Double
-		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ce: stloc.s 14
-		IL_02d0: ldloc.s 7
-		IL_02d2: ldstr "log"
-		IL_02d7: ldloc.s 14
-		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02de: pop
-		IL_02df: ldstr "console"
-		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ee: stloc.s 14
-		IL_02f0: ldloc.s 5
-		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f7: ldstr "charAt"
-		IL_02fc: ldc.r8 2
-		IL_0305: box [System.Runtime]System.Double
-		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_030f: stloc.s 7
-		IL_0311: ldloc.s 14
-		IL_0313: ldstr "log"
-		IL_0318: ldloc.s 7
-		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_031f: pop
-		IL_0320: ldnull
-		IL_0321: stloc.s 6
-		IL_0323: ret
+		IL_0229: ldstr "String"
+		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0233: stloc.s 8
+		IL_0235: ldloc.s 8
+		IL_0237: ldc.i4.1
+		IL_0238: newarr [System.Runtime]System.Object
+		IL_023d: dup
+		IL_023e: ldc.i4.0
+		IL_023f: ldstr "world"
+		IL_0244: stelem.ref
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_024a: stloc.s 5
+		IL_024c: ldstr "console"
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025b: stloc.s 8
+		IL_025d: ldloc.s 5
+		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0264: ldstr "charAt"
+		IL_0269: ldc.r8 0.0
+		IL_0272: box [System.Runtime]System.Double
+		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027c: stloc.s 11
+		IL_027e: ldloc.s 8
+		IL_0280: ldstr "log"
+		IL_0285: ldloc.s 11
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028c: pop
+		IL_028d: ldstr "console"
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_029c: stloc.s 11
+		IL_029e: ldloc.s 5
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a5: ldstr "charAt"
+		IL_02aa: ldc.r8 2
+		IL_02b3: box [System.Runtime]System.Double
+		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02bd: stloc.s 8
+		IL_02bf: ldloc.s 11
+		IL_02c1: ldstr "log"
+		IL_02c6: ldloc.s 8
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02cd: pop
+		IL_02ce: ldnull
+		IL_02cf: stloc.s 6
+		IL_02d1: ret
 	} // end of method String_CharAt_Basic::__js_module_init__
 
 } // end of class Modules.String_CharAt_Basic
@@ -357,7 +322,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23ab
+		// Method begins at RVA 0x235b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharCodeAt_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharCodeAt_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20de
+			// Method begins at RVA 0x20cc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,11 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 130 (0x82)
+		// Code size: 112 (0x70)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_CharCodeAt_Basic/Scope,
-			[1] object,
-			[2] string,
-			[3] float64
+			[1] float64
 		)
 
 		IL_0000: newobj instance void Modules.String_CharCodeAt_Basic/Scope::.ctor()
@@ -55,38 +53,28 @@
 		IL_0007: ldstr "console"
 		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0016: stloc.1
-		IL_0017: ldstr "A"
-		IL_001c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0021: stloc.2
-		IL_0022: ldloc.2
-		IL_0023: ldc.r8 0.0
-		IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
-		IL_0031: stloc.3
-		IL_0032: ldloc.1
-		IL_0033: ldstr "log"
-		IL_0038: ldloc.3
-		IL_0039: box [System.Runtime]System.Double
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0043: pop
-		IL_0044: ldstr "console"
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0053: stloc.1
-		IL_0054: ldstr "ABC"
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_005e: stloc.2
-		IL_005f: ldloc.2
-		IL_0060: ldc.r8 2
-		IL_0069: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
-		IL_006e: stloc.3
-		IL_006f: ldloc.1
-		IL_0070: ldstr "log"
-		IL_0075: ldloc.3
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0080: pop
-		IL_0081: ret
+		IL_0016: ldstr "A"
+		IL_001b: ldc.r8 0.0
+		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
+		IL_0029: stloc.1
+		IL_002a: ldstr "log"
+		IL_002f: ldloc.1
+		IL_0030: box [System.Runtime]System.Double
+		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_003a: pop
+		IL_003b: ldstr "console"
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_004a: ldstr "ABC"
+		IL_004f: ldc.r8 2
+		IL_0058: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
+		IL_005d: stloc.1
+		IL_005e: ldstr "log"
+		IL_0063: ldloc.1
+		IL_0064: box [System.Runtime]System.Double
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006e: pop
+		IL_006f: ret
 	} // end of method String_CharCodeAt_Basic::__js_module_init__
 
 } // end of class Modules.String_CharCodeAt_Basic
@@ -98,7 +86,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20e7
+		// Method begins at RVA 0x20d5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_LastIndexOf_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_LastIndexOf_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2271
+			// Method begins at RVA 0x2211
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 533 (0x215)
+		// Code size: 437 (0x1b5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_LastIndexOf_Basic/Scope,
 			[1] string,
-			[2] object,
-			[3] string,
-			[4] float64,
-			[5] object
+			[2] float64
 		)
 
 		IL_0000: newobj instance void Modules.String_LastIndexOf_Basic/Scope::.ctor()
@@ -59,155 +56,111 @@
 		IL_000d: ldstr "console"
 		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_001c: stloc.2
-		IL_001d: ldloc.1
-		IL_001e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0023: stloc.3
-		IL_0024: ldloc.3
-		IL_0025: ldstr "a"
-		IL_002a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
-		IL_002f: stloc.s 4
-		IL_0031: ldloc.2
-		IL_0032: ldstr "log"
-		IL_0037: ldloc.s 4
-		IL_0039: box [System.Runtime]System.Double
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0043: pop
-		IL_0044: ldstr "console"
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0053: stloc.2
-		IL_0054: ldloc.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_005a: stloc.3
-		IL_005b: ldloc.3
-		IL_005c: ldstr "a"
-		IL_0061: ldc.r8 2
-		IL_006a: box [System.Runtime]System.Double
-		IL_006f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
-		IL_0074: stloc.s 4
-		IL_0076: ldloc.2
-		IL_0077: ldstr "log"
-		IL_007c: ldloc.s 4
-		IL_007e: box [System.Runtime]System.Double
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0088: pop
-		IL_0089: ldstr "console"
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0098: stloc.2
-		IL_0099: ldloc.1
-		IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_009f: stloc.3
-		IL_00a0: ldc.r8 1
-		IL_00a9: neg
-		IL_00aa: stloc.s 4
-		IL_00ac: ldloc.s 4
-		IL_00ae: box [System.Runtime]System.Double
-		IL_00b3: stloc.s 5
-		IL_00b5: ldloc.3
-		IL_00b6: ldstr "a"
-		IL_00bb: ldloc.s 5
-		IL_00bd: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
-		IL_00c2: stloc.s 4
-		IL_00c4: ldloc.2
-		IL_00c5: ldstr "log"
-		IL_00ca: ldloc.s 4
+		IL_001c: ldloc.1
+		IL_001d: ldstr "a"
+		IL_0022: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+		IL_0027: stloc.2
+		IL_0028: ldstr "log"
+		IL_002d: ldloc.2
+		IL_002e: box [System.Runtime]System.Double
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0038: pop
+		IL_0039: ldstr "console"
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0048: ldloc.1
+		IL_0049: ldstr "a"
+		IL_004e: ldc.r8 2
+		IL_0057: box [System.Runtime]System.Double
+		IL_005c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_0061: stloc.2
+		IL_0062: ldstr "log"
+		IL_0067: ldloc.2
+		IL_0068: box [System.Runtime]System.Double
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0072: pop
+		IL_0073: ldstr "console"
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0082: ldloc.1
+		IL_0083: ldstr "a"
+		IL_0088: ldc.r8 1
+		IL_0091: neg
+		IL_0092: box [System.Runtime]System.Double
+		IL_0097: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_009c: stloc.2
+		IL_009d: ldstr "log"
+		IL_00a2: ldloc.2
+		IL_00a3: box [System.Runtime]System.Double
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ad: pop
+		IL_00ae: ldstr "console"
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00bd: ldloc.1
+		IL_00be: ldstr "a"
+		IL_00c3: ldc.r8 99
 		IL_00cc: box [System.Runtime]System.Double
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d6: pop
-		IL_00d7: ldstr "console"
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e6: stloc.2
-		IL_00e7: ldloc.1
-		IL_00e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_00ed: stloc.3
-		IL_00ee: ldloc.3
-		IL_00ef: ldstr "a"
-		IL_00f4: ldc.r8 99
-		IL_00fd: box [System.Runtime]System.Double
-		IL_0102: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
-		IL_0107: stloc.s 4
-		IL_0109: ldloc.2
-		IL_010a: ldstr "log"
-		IL_010f: ldloc.s 4
-		IL_0111: box [System.Runtime]System.Double
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011b: pop
-		IL_011c: ldstr "console"
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012b: stloc.2
-		IL_012c: ldloc.1
-		IL_012d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0132: stloc.3
-		IL_0133: ldloc.3
-		IL_0134: ldstr ""
-		IL_0139: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
-		IL_013e: stloc.s 4
-		IL_0140: ldloc.2
-		IL_0141: ldstr "log"
-		IL_0146: ldloc.s 4
-		IL_0148: box [System.Runtime]System.Double
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0152: pop
-		IL_0153: ldstr "console"
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0162: stloc.2
-		IL_0163: ldloc.1
-		IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0169: stloc.3
-		IL_016a: ldloc.3
-		IL_016b: ldstr ""
-		IL_0170: ldc.r8 2
-		IL_0179: box [System.Runtime]System.Double
-		IL_017e: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
-		IL_0183: stloc.s 4
-		IL_0185: ldloc.2
-		IL_0186: ldstr "log"
-		IL_018b: ldloc.s 4
-		IL_018d: box [System.Runtime]System.Double
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0197: pop
-		IL_0198: ldstr "console"
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a7: stloc.2
-		IL_01a8: ldloc.1
-		IL_01a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_01ae: stloc.3
-		IL_01af: ldloc.3
-		IL_01b0: ldstr "ab"
-		IL_01b5: ldc.r8 1
-		IL_01be: box [System.Runtime]System.Double
-		IL_01c3: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
-		IL_01c8: stloc.s 4
-		IL_01ca: ldloc.2
-		IL_01cb: ldstr "log"
-		IL_01d0: ldloc.s 4
-		IL_01d2: box [System.Runtime]System.Double
-		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01dc: pop
-		IL_01dd: ldstr "console"
-		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ec: stloc.2
-		IL_01ed: ldloc.1
-		IL_01ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_01f3: stloc.3
-		IL_01f4: ldloc.3
-		IL_01f5: ldstr "z"
-		IL_01fa: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
-		IL_01ff: stloc.s 4
-		IL_0201: ldloc.2
-		IL_0202: ldstr "log"
-		IL_0207: ldloc.s 4
-		IL_0209: box [System.Runtime]System.Double
-		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0213: pop
-		IL_0214: ret
+		IL_00d1: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_00d6: stloc.2
+		IL_00d7: ldstr "log"
+		IL_00dc: ldloc.2
+		IL_00dd: box [System.Runtime]System.Double
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e7: pop
+		IL_00e8: ldstr "console"
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f7: ldloc.1
+		IL_00f8: ldstr ""
+		IL_00fd: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+		IL_0102: stloc.2
+		IL_0103: ldstr "log"
+		IL_0108: ldloc.2
+		IL_0109: box [System.Runtime]System.Double
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0113: pop
+		IL_0114: ldstr "console"
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0123: ldloc.1
+		IL_0124: ldstr ""
+		IL_0129: ldc.r8 2
+		IL_0132: box [System.Runtime]System.Double
+		IL_0137: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_013c: stloc.2
+		IL_013d: ldstr "log"
+		IL_0142: ldloc.2
+		IL_0143: box [System.Runtime]System.Double
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014d: pop
+		IL_014e: ldstr "console"
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015d: ldloc.1
+		IL_015e: ldstr "ab"
+		IL_0163: ldc.r8 1
+		IL_016c: box [System.Runtime]System.Double
+		IL_0171: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_0176: stloc.2
+		IL_0177: ldstr "log"
+		IL_017c: ldloc.2
+		IL_017d: box [System.Runtime]System.Double
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0187: pop
+		IL_0188: ldstr "console"
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0197: ldloc.1
+		IL_0198: ldstr "z"
+		IL_019d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+		IL_01a2: stloc.2
+		IL_01a3: ldstr "log"
+		IL_01a8: ldloc.2
+		IL_01a9: box [System.Runtime]System.Double
+		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b3: pop
+		IL_01b4: ret
 	} // end of method String_LastIndexOf_Basic::__js_module_init__
 
 } // end of class Modules.String_LastIndexOf_Basic
@@ -219,7 +172,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x227a
+		// Method begins at RVA 0x221a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MatchAll_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MatchAll_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2435
+				// Method begins at RVA 0x241d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243e
+				// Method begins at RVA 0x2426
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x242c
+			// Method begins at RVA 0x2414
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 960 (0x3c0)
+		// Code size: 933 (0x3a5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MatchAll_Basic/Scope,
@@ -92,278 +92,268 @@
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] string,
-			[8] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[8] object,
 			[9] object,
-			[10] object,
-			[11] object
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.String_MatchAll_Basic/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldstr "test1 test22"
-		IL_000c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0011: stloc.s 7
-		IL_0013: ldstr "t(e)(st\\d+)"
-		IL_0018: ldstr "g"
-		IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0022: stloc.s 8
-		IL_0024: ldloc.s 7
-		IL_0026: ldstr "matchAll"
+		IL_0007: ldstr "t(e)(st\\d+)"
+		IL_000c: ldstr "g"
+		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0016: stloc.s 7
+		IL_0018: ldstr "test1 test22"
+		IL_001d: ldstr "matchAll"
+		IL_0022: ldloc.s 7
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0029: stloc.s 8
 		IL_002b: ldloc.s 8
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0032: stloc.s 9
-		IL_0034: ldloc.s 9
-		IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_003b: stloc.1
-		IL_003c: ldstr "console"
-		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004b: ldloc.1
-		IL_004c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0051: box [System.Runtime]System.Double
-		IL_0056: stloc.s 10
-		IL_0058: ldstr "log"
-		IL_005d: ldloc.s 10
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0064: pop
-		IL_0065: ldstr "console"
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0074: stloc.s 9
-		IL_0076: ldloc.1
-		IL_0077: ldc.r8 0.0
-		IL_0080: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0085: ldc.r8 0.0
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0093: stloc.s 11
-		IL_0095: ldloc.s 9
-		IL_0097: ldstr "log"
-		IL_009c: ldloc.s 11
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a3: pop
-		IL_00a4: ldstr "console"
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b3: stloc.s 11
-		IL_00b5: ldloc.1
-		IL_00b6: ldc.r8 0.0
-		IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_00c4: ldc.r8 1
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00d2: stloc.s 9
-		IL_00d4: ldloc.s 11
-		IL_00d6: ldstr "log"
-		IL_00db: ldloc.s 9
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e2: pop
-		IL_00e3: ldstr "console"
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f2: stloc.s 9
-		IL_00f4: ldloc.1
-		IL_00f5: ldc.r8 0.0
-		IL_00fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0103: ldc.r8 2
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0111: stloc.s 11
-		IL_0113: ldloc.s 9
-		IL_0115: ldstr "log"
-		IL_011a: ldloc.s 11
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0121: pop
-		IL_0122: ldstr "console"
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0131: stloc.s 11
-		IL_0133: ldloc.1
-		IL_0134: ldc.r8 0.0
-		IL_013d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0142: ldstr "index"
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_014c: stloc.s 9
-		IL_014e: ldloc.s 11
-		IL_0150: ldstr "log"
-		IL_0155: ldloc.s 9
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015c: pop
-		IL_015d: ldstr "console"
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016c: stloc.s 9
-		IL_016e: ldloc.1
-		IL_016f: ldc.r8 1
-		IL_0178: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_017d: ldc.r8 0.0
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_018b: stloc.s 11
-		IL_018d: ldloc.s 9
-		IL_018f: ldstr "log"
-		IL_0194: ldloc.s 11
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019b: pop
-		IL_019c: ldstr "console"
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ab: stloc.s 11
-		IL_01ad: ldloc.1
-		IL_01ae: ldc.r8 1
-		IL_01b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01bc: ldc.r8 1
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01ca: stloc.s 9
-		IL_01cc: ldloc.s 11
-		IL_01ce: ldstr "log"
-		IL_01d3: ldloc.s 9
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01da: pop
-		IL_01db: ldstr "console"
-		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ea: stloc.s 9
-		IL_01ec: ldloc.1
-		IL_01ed: ldc.r8 1
-		IL_01f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01fb: ldc.r8 2
-		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0209: stloc.s 11
-		IL_020b: ldloc.s 9
-		IL_020d: ldstr "log"
-		IL_0212: ldloc.s 11
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0219: pop
-		IL_021a: ldstr "console"
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0229: stloc.s 11
-		IL_022b: ldloc.1
-		IL_022c: ldc.r8 1
-		IL_0235: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_023a: ldstr "index"
-		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0244: stloc.s 9
-		IL_0246: ldloc.s 11
-		IL_0248: ldstr "log"
-		IL_024d: ldloc.s 9
-		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0254: pop
-		IL_0255: ldstr "aba"
-		IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_025f: stloc.s 7
-		IL_0261: ldloc.s 7
-		IL_0263: ldstr "matchAll"
-		IL_0268: ldstr "a"
-		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0272: stloc.s 9
-		IL_0274: ldloc.s 9
-		IL_0276: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_027b: stloc.2
-		IL_027c: ldstr "console"
-		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028b: ldloc.2
-		IL_028c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0291: box [System.Runtime]System.Double
-		IL_0296: stloc.s 10
-		IL_0298: ldstr "log"
-		IL_029d: ldloc.s 10
-		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a4: pop
-		IL_02a5: ldstr "console"
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b4: stloc.s 9
-		IL_02b6: ldloc.2
-		IL_02b7: ldc.r8 0.0
-		IL_02c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_02c5: ldc.r8 0.0
-		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02d3: stloc.s 11
-		IL_02d5: ldloc.s 9
-		IL_02d7: ldstr "log"
-		IL_02dc: ldloc.s 11
-		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e3: pop
-		IL_02e4: ldstr "console"
-		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f3: stloc.s 11
-		IL_02f5: ldloc.2
-		IL_02f6: ldc.r8 1
-		IL_02ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0304: ldstr "index"
-		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_030e: stloc.s 9
-		IL_0310: ldloc.s 11
-		IL_0312: ldstr "log"
-		IL_0317: ldloc.s 9
-		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_031e: pop
+		IL_002d: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0032: stloc.1
+		IL_0033: ldstr "console"
+		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0042: ldloc.1
+		IL_0043: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0048: box [System.Runtime]System.Double
+		IL_004d: stloc.s 9
+		IL_004f: ldstr "log"
+		IL_0054: ldloc.s 9
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005b: pop
+		IL_005c: ldstr "console"
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006b: stloc.s 8
+		IL_006d: ldloc.1
+		IL_006e: ldc.r8 0.0
+		IL_0077: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_007c: ldc.r8 0.0
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_008a: stloc.s 10
+		IL_008c: ldloc.s 8
+		IL_008e: ldstr "log"
+		IL_0093: ldloc.s 10
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009a: pop
+		IL_009b: ldstr "console"
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00aa: stloc.s 10
+		IL_00ac: ldloc.1
+		IL_00ad: ldc.r8 0.0
+		IL_00b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_00bb: ldc.r8 1
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00c9: stloc.s 8
+		IL_00cb: ldloc.s 10
+		IL_00cd: ldstr "log"
+		IL_00d2: ldloc.s 8
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d9: pop
+		IL_00da: ldstr "console"
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e9: stloc.s 8
+		IL_00eb: ldloc.1
+		IL_00ec: ldc.r8 0.0
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_00fa: ldc.r8 2
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0108: stloc.s 10
+		IL_010a: ldloc.s 8
+		IL_010c: ldstr "log"
+		IL_0111: ldloc.s 10
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0118: pop
+		IL_0119: ldstr "console"
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0128: stloc.s 10
+		IL_012a: ldloc.1
+		IL_012b: ldc.r8 0.0
+		IL_0134: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0139: ldstr "index"
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0143: stloc.s 8
+		IL_0145: ldloc.s 10
+		IL_0147: ldstr "log"
+		IL_014c: ldloc.s 8
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0153: pop
+		IL_0154: ldstr "console"
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0163: stloc.s 8
+		IL_0165: ldloc.1
+		IL_0166: ldc.r8 1
+		IL_016f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0174: ldc.r8 0.0
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0182: stloc.s 10
+		IL_0184: ldloc.s 8
+		IL_0186: ldstr "log"
+		IL_018b: ldloc.s 10
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0192: pop
+		IL_0193: ldstr "console"
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a2: stloc.s 10
+		IL_01a4: ldloc.1
+		IL_01a5: ldc.r8 1
+		IL_01ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01b3: ldc.r8 1
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01c1: stloc.s 8
+		IL_01c3: ldloc.s 10
+		IL_01c5: ldstr "log"
+		IL_01ca: ldloc.s 8
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d1: pop
+		IL_01d2: ldstr "console"
+		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e1: stloc.s 8
+		IL_01e3: ldloc.1
+		IL_01e4: ldc.r8 1
+		IL_01ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01f2: ldc.r8 2
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0200: stloc.s 10
+		IL_0202: ldloc.s 8
+		IL_0204: ldstr "log"
+		IL_0209: ldloc.s 10
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0210: pop
+		IL_0211: ldstr "console"
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0220: stloc.s 10
+		IL_0222: ldloc.1
+		IL_0223: ldc.r8 1
+		IL_022c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0231: ldstr "index"
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023b: stloc.s 8
+		IL_023d: ldloc.s 10
+		IL_023f: ldstr "log"
+		IL_0244: ldloc.s 8
+		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024b: pop
+		IL_024c: ldstr "aba"
+		IL_0251: ldstr "matchAll"
+		IL_0256: ldstr "a"
+		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0260: stloc.s 8
+		IL_0262: ldloc.s 8
+		IL_0264: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0269: stloc.2
+		IL_026a: ldstr "console"
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0279: ldloc.2
+		IL_027a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_027f: box [System.Runtime]System.Double
+		IL_0284: stloc.s 9
+		IL_0286: ldstr "log"
+		IL_028b: ldloc.s 9
+		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0292: pop
+		IL_0293: ldstr "console"
+		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a2: stloc.s 8
+		IL_02a4: ldloc.2
+		IL_02a5: ldc.r8 0.0
+		IL_02ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_02b3: ldc.r8 0.0
+		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02c1: stloc.s 10
+		IL_02c3: ldloc.s 8
+		IL_02c5: ldstr "log"
+		IL_02ca: ldloc.s 10
+		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d1: pop
+		IL_02d2: ldstr "console"
+		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02e1: stloc.s 10
+		IL_02e3: ldloc.2
+		IL_02e4: ldc.r8 1
+		IL_02ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_02f2: ldstr "index"
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02fc: stloc.s 8
+		IL_02fe: ldloc.s 10
+		IL_0300: ldstr "log"
+		IL_0305: ldloc.s 8
+		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_030c: pop
 		.try
 		{
-			IL_031f: nop
-			IL_0320: ldstr "aba"
-			IL_0325: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_032a: stloc.s 7
-			IL_032c: ldstr "a"
-			IL_0331: ldstr ""
-			IL_0336: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_033b: stloc.s 8
-			IL_033d: ldloc.s 7
-			IL_033f: ldstr "matchAll"
-			IL_0344: ldloc.s 8
-			IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_034b: stloc.s 9
-			IL_034d: ldloc.s 9
-			IL_034f: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0354: pop
-			IL_0355: leave IL_03bc
+			IL_030d: nop
+			IL_030e: ldstr "a"
+			IL_0313: ldstr ""
+			IL_0318: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_031d: stloc.s 7
+			IL_031f: ldstr "aba"
+			IL_0324: ldstr "matchAll"
+			IL_0329: ldloc.s 7
+			IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0330: stloc.s 8
+			IL_0332: ldloc.s 8
+			IL_0334: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0339: pop
+			IL_033a: leave IL_03a1
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_035a: stloc.3
-			IL_035b: ldloc.3
-			IL_035c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0361: dup
-			IL_0362: brtrue IL_0377
+			IL_033f: stloc.3
+			IL_0340: ldloc.3
+			IL_0341: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0346: dup
+			IL_0347: brtrue IL_035c
 
-			IL_0367: pop
-			IL_0368: ldloc.3
-			IL_0369: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_036e: dup
-			IL_036f: brtrue IL_0383
+			IL_034c: pop
+			IL_034d: ldloc.3
+			IL_034e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0353: dup
+			IL_0354: brtrue IL_0368
 
-			IL_0374: pop
-			IL_0375: rethrow
+			IL_0359: pop
+			IL_035a: rethrow
 
-			IL_0377: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_037c: stloc.s 4
-			IL_037e: br IL_0385
+			IL_035c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0361: stloc.s 4
+			IL_0363: br IL_036a
 
-			IL_0383: stloc.s 4
+			IL_0368: stloc.s 4
 
-			IL_0385: ldloc.s 4
-			IL_0387: stloc.s 5
-			IL_0389: ldstr "console"
-			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0398: stloc.s 9
-			IL_039a: ldloc.s 5
-			IL_039c: ldstr "name"
-			IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03a6: stloc.s 11
-			IL_03a8: ldloc.s 9
-			IL_03aa: ldstr "log"
-			IL_03af: ldloc.s 11
-			IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03b6: pop
-			IL_03b7: leave IL_03bc
+			IL_036a: ldloc.s 4
+			IL_036c: stloc.s 5
+			IL_036e: ldstr "console"
+			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_037d: stloc.s 8
+			IL_037f: ldloc.s 5
+			IL_0381: ldstr "name"
+			IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_038b: stloc.s 10
+			IL_038d: ldloc.s 8
+			IL_038f: ldstr "log"
+			IL_0394: ldloc.s 10
+			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_039b: pop
+			IL_039c: leave IL_03a1
 		} // end handler
 
-		IL_03bc: ldnull
-		IL_03bd: stloc.s 6
-		IL_03bf: ret
+		IL_03a1: ldnull
+		IL_03a2: stloc.s 6
+		IL_03a4: ret
 	} // end of method String_MatchAll_Basic::__js_module_init__
 
 } // end of class Modules.String_MatchAll_Basic
@@ -375,7 +365,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2447
+		// Method begins at RVA 0x242f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Match_Global.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Match_Global.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2150
+			// Method begins at RVA 0x2147
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 244 (0xf4)
+		// Code size: 235 (0xeb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Match_Global/Scope,
 			[1] string,
 			[2] object,
-			[3] string,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[5] object,
-			[6] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Match_Global/Scope::.ctor()
@@ -57,71 +56,68 @@
 		IL_0006: nop
 		IL_0007: ldstr "baaa"
 		IL_000c: stloc.1
-		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0013: stloc.3
-		IL_0014: ldstr "a"
-		IL_0019: ldstr "g"
-		IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0023: stloc.s 4
-		IL_0025: ldloc.3
-		IL_0026: ldstr "match"
-		IL_002b: ldloc.s 4
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0032: stloc.2
-		IL_0033: ldstr "console"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0042: stloc.s 5
-		IL_0044: ldloc.2
-		IL_0045: ldstr "length"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_004f: stloc.s 6
-		IL_0051: ldloc.s 5
-		IL_0053: ldstr "log"
-		IL_0058: ldloc.s 6
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005f: pop
-		IL_0060: ldstr "console"
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: stloc.s 6
-		IL_0071: ldloc.2
-		IL_0072: ldc.r8 0.0
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0080: stloc.s 5
-		IL_0082: ldloc.s 6
-		IL_0084: ldstr "log"
-		IL_0089: ldloc.s 5
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0090: pop
-		IL_0091: ldstr "console"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a0: stloc.s 5
-		IL_00a2: ldloc.2
-		IL_00a3: ldc.r8 1
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00b1: stloc.s 6
-		IL_00b3: ldloc.s 5
-		IL_00b5: ldstr "log"
-		IL_00ba: ldloc.s 6
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c1: pop
-		IL_00c2: ldstr "console"
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d1: stloc.s 6
-		IL_00d3: ldloc.2
-		IL_00d4: ldc.r8 2
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00e2: stloc.s 5
-		IL_00e4: ldloc.s 6
-		IL_00e6: ldstr "log"
-		IL_00eb: ldloc.s 5
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f2: pop
-		IL_00f3: ret
+		IL_000d: ldstr "a"
+		IL_0012: ldstr "g"
+		IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_001c: stloc.3
+		IL_001d: ldloc.1
+		IL_001e: ldstr "match"
+		IL_0023: ldloc.3
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0029: stloc.2
+		IL_002a: ldstr "console"
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0039: stloc.s 4
+		IL_003b: ldloc.2
+		IL_003c: ldstr "length"
+		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0046: stloc.s 5
+		IL_0048: ldloc.s 4
+		IL_004a: ldstr "log"
+		IL_004f: ldloc.s 5
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0056: pop
+		IL_0057: ldstr "console"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0066: stloc.s 5
+		IL_0068: ldloc.2
+		IL_0069: ldc.r8 0.0
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.s 5
+		IL_007b: ldstr "log"
+		IL_0080: ldloc.s 4
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0087: pop
+		IL_0088: ldstr "console"
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0097: stloc.s 4
+		IL_0099: ldloc.2
+		IL_009a: ldc.r8 1
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00a8: stloc.s 5
+		IL_00aa: ldloc.s 4
+		IL_00ac: ldstr "log"
+		IL_00b1: ldloc.s 5
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b8: pop
+		IL_00b9: ldstr "console"
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c8: stloc.s 5
+		IL_00ca: ldloc.2
+		IL_00cb: ldc.r8 2
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00d9: stloc.s 4
+		IL_00db: ldloc.s 5
+		IL_00dd: ldstr "log"
+		IL_00e2: ldloc.s 4
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e9: pop
+		IL_00ea: ret
 	} // end of method String_Match_Global::__js_module_init__
 
 } // end of class Modules.String_Match_Global
@@ -133,7 +129,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2159
+		// Method begins at RVA 0x2150
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Match_NonGlobal.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Match_NonGlobal.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217d
+			// Method begins at RVA 0x2174
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 289 (0x121)
+		// Code size: 280 (0x118)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Match_NonGlobal/Scope,
 			[1] string,
 			[2] object,
-			[3] string,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[5] object,
-			[6] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Match_NonGlobal/Scope::.ctor()
@@ -57,84 +56,81 @@
 		IL_0006: nop
 		IL_0007: ldstr "  abc"
 		IL_000c: stloc.1
-		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0013: stloc.3
-		IL_0014: ldstr "\\s+(a)(b)c"
-		IL_0019: ldstr ""
-		IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0023: stloc.s 4
-		IL_0025: ldloc.3
-		IL_0026: ldstr "match"
-		IL_002b: ldloc.s 4
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0032: stloc.2
-		IL_0033: ldstr "console"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0042: stloc.s 5
-		IL_0044: ldloc.2
-		IL_0045: ldc.r8 0.0
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0053: stloc.s 6
-		IL_0055: ldloc.s 5
-		IL_0057: ldstr "log"
-		IL_005c: ldloc.s 6
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0063: pop
-		IL_0064: ldstr "console"
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0073: stloc.s 6
-		IL_0075: ldloc.2
-		IL_0076: ldc.r8 1
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0084: stloc.s 5
-		IL_0086: ldloc.s 6
-		IL_0088: ldstr "log"
-		IL_008d: ldloc.s 5
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0094: pop
-		IL_0095: ldstr "console"
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a4: stloc.s 5
-		IL_00a6: ldloc.2
-		IL_00a7: ldc.r8 2
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00b5: stloc.s 6
-		IL_00b7: ldloc.s 5
-		IL_00b9: ldstr "log"
-		IL_00be: ldloc.s 6
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c5: pop
-		IL_00c6: ldstr "console"
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d5: stloc.s 6
-		IL_00d7: ldloc.2
-		IL_00d8: ldstr "index"
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e2: stloc.s 5
-		IL_00e4: ldloc.s 6
-		IL_00e6: ldstr "log"
-		IL_00eb: ldloc.s 5
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f2: pop
-		IL_00f3: ldstr "console"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0102: stloc.s 5
-		IL_0104: ldloc.2
-		IL_0105: ldstr "input"
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010f: stloc.s 6
-		IL_0111: ldloc.s 5
-		IL_0113: ldstr "log"
-		IL_0118: ldloc.s 6
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011f: pop
-		IL_0120: ret
+		IL_000d: ldstr "\\s+(a)(b)c"
+		IL_0012: ldstr ""
+		IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_001c: stloc.3
+		IL_001d: ldloc.1
+		IL_001e: ldstr "match"
+		IL_0023: ldloc.3
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0029: stloc.2
+		IL_002a: ldstr "console"
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0039: stloc.s 4
+		IL_003b: ldloc.2
+		IL_003c: ldc.r8 0.0
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_004a: stloc.s 5
+		IL_004c: ldloc.s 4
+		IL_004e: ldstr "log"
+		IL_0053: ldloc.s 5
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005a: pop
+		IL_005b: ldstr "console"
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006a: stloc.s 5
+		IL_006c: ldloc.2
+		IL_006d: ldc.r8 1
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_007b: stloc.s 4
+		IL_007d: ldloc.s 5
+		IL_007f: ldstr "log"
+		IL_0084: ldloc.s 4
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008b: pop
+		IL_008c: ldstr "console"
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009b: stloc.s 4
+		IL_009d: ldloc.2
+		IL_009e: ldc.r8 2
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00ac: stloc.s 5
+		IL_00ae: ldloc.s 4
+		IL_00b0: ldstr "log"
+		IL_00b5: ldloc.s 5
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bc: pop
+		IL_00bd: ldstr "console"
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cc: stloc.s 5
+		IL_00ce: ldloc.2
+		IL_00cf: ldstr "index"
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d9: stloc.s 4
+		IL_00db: ldloc.s 5
+		IL_00dd: ldstr "log"
+		IL_00e2: ldloc.s 4
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e9: pop
+		IL_00ea: ldstr "console"
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f9: stloc.s 4
+		IL_00fb: ldloc.2
+		IL_00fc: ldstr "input"
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0106: stloc.s 5
+		IL_0108: ldloc.s 4
+		IL_010a: ldstr "log"
+		IL_010f: ldloc.s 5
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0116: pop
+		IL_0117: ret
 	} // end of method String_Match_NonGlobal::__js_module_init__
 
 } // end of class Modules.String_Match_NonGlobal
@@ -146,7 +142,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2186
+		// Method begins at RVA 0x217d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_Arity3_Replace.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_Arity3_Replace.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20a7
+			// Method begins at RVA 0x20a0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 75 (0x4b)
+		// Code size: 68 (0x44)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MemberCall_Arity3_Replace/Scope,
 			[1] string,
-			[2] object,
-			[3] string
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.String_MemberCall_Arity3_Replace/Scope::.ctor()
@@ -55,23 +54,20 @@
 		IL_0007: ldstr "hello world"
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0013: stloc.3
-		IL_0014: ldloc.3
-		IL_0015: ldstr "replace"
-		IL_001a: ldstr "world"
-		IL_001f: ldstr "JS"
-		IL_0024: ldstr "unused"
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_002e: stloc.2
-		IL_002f: ldstr "console"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003e: ldstr "log"
-		IL_0043: ldloc.2
-		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0049: pop
-		IL_004a: ret
+		IL_000e: ldstr "replace"
+		IL_0013: ldstr "world"
+		IL_0018: ldstr "JS"
+		IL_001d: ldstr "unused"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0027: stloc.2
+		IL_0028: ldstr "console"
+		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0037: ldstr "log"
+		IL_003c: ldloc.2
+		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0042: pop
+		IL_0043: ret
 	} // end of method String_MemberCall_Arity3_Replace::__js_module_init__
 
 } // end of class Modules.String_MemberCall_Arity3_Replace
@@ -83,7 +79,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20b0
+		// Method begins at RVA 0x20a9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2501
+				// Method begins at RVA 0x24a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2200
+			// Method begins at RVA 0x21a4
 			// Header size: 12
 			// Code size: 748 (0x2ec)
 			.maxstack 8
@@ -303,7 +303,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24f8
+			// Method begins at RVA 0x249c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -329,14 +329,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 417 (0x1a1)
+		// Code size: 326 (0x146)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MemberCall_FastPath_CommonMethods/Scope,
 			[1] class [System.Runtime]System.Func`3<object, string, object>,
 			[2] object[],
-			[3] object,
-			[4] string
+			[3] string
 		)
 
 		IL_0000: newobj instance void Modules.String_MemberCall_FastPath_CommonMethods/Scope::.ctor()
@@ -364,109 +363,74 @@
 		IL_003b: ldstr "console"
 		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004a: stloc.3
-		IL_004b: ldstr "  x  "
-		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0055: stloc.s 4
-		IL_0057: ldloc.s 4
-		IL_0059: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-		IL_005e: stloc.s 4
-		IL_0060: ldloc.3
-		IL_0061: ldstr "log"
-		IL_0066: ldloc.s 4
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006d: pop
-		IL_006e: ldstr "console"
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007d: stloc.3
-		IL_007e: ldstr "  x  "
-		IL_0083: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0088: stloc.s 4
-		IL_008a: ldloc.s 4
-		IL_008c: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimStart(string)
-		IL_0091: stloc.s 4
-		IL_0093: ldloc.3
-		IL_0094: ldstr "log"
-		IL_0099: ldloc.s 4
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a0: pop
-		IL_00a1: ldstr "console"
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b0: stloc.3
-		IL_00b1: ldstr "x  "
-		IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_00bb: stloc.s 4
-		IL_00bd: ldloc.s 4
-		IL_00bf: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimEnd(string)
-		IL_00c4: stloc.s 4
-		IL_00c6: ldloc.3
+		IL_004a: ldstr "  x  "
+		IL_004f: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+		IL_0054: stloc.3
+		IL_0055: ldstr "log"
+		IL_005a: ldloc.3
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0060: pop
+		IL_0061: ldstr "console"
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0070: ldstr "  x  "
+		IL_0075: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimStart(string)
+		IL_007a: stloc.3
+		IL_007b: ldstr "log"
+		IL_0080: ldloc.3
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0086: pop
+		IL_0087: ldstr "console"
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0096: ldstr "x  "
+		IL_009b: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimEnd(string)
+		IL_00a0: stloc.3
+		IL_00a1: ldstr "log"
+		IL_00a6: ldloc.3
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ac: pop
+		IL_00ad: ldstr "console"
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00bc: ldstr "  x  "
+		IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimLeft(string)
+		IL_00c6: stloc.3
 		IL_00c7: ldstr "log"
-		IL_00cc: ldloc.s 4
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ldstr "console"
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e3: stloc.3
-		IL_00e4: ldstr "  x  "
-		IL_00e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_00ee: stloc.s 4
-		IL_00f0: ldloc.s 4
-		IL_00f2: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimLeft(string)
-		IL_00f7: stloc.s 4
-		IL_00f9: ldloc.3
-		IL_00fa: ldstr "log"
-		IL_00ff: ldloc.s 4
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0106: pop
-		IL_0107: ldstr "console"
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0116: stloc.3
-		IL_0117: ldstr "x  "
-		IL_011c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0121: stloc.s 4
-		IL_0123: ldloc.s 4
-		IL_0125: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimRight(string)
-		IL_012a: stloc.s 4
-		IL_012c: ldloc.3
-		IL_012d: ldstr "log"
-		IL_0132: ldloc.s 4
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0139: pop
-		IL_013a: ldstr "console"
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0149: stloc.3
-		IL_014a: ldstr "A"
-		IL_014f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0154: stloc.s 4
-		IL_0156: ldloc.s 4
-		IL_0158: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
-		IL_015d: stloc.s 4
-		IL_015f: ldloc.3
-		IL_0160: ldstr "log"
-		IL_0165: ldloc.s 4
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016c: pop
-		IL_016d: ldstr "console"
-		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017c: stloc.3
-		IL_017d: ldstr "a"
-		IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0187: stloc.s 4
-		IL_0189: ldloc.s 4
-		IL_018b: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-		IL_0190: stloc.s 4
-		IL_0192: ldloc.3
-		IL_0193: ldstr "log"
-		IL_0198: ldloc.s 4
-		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019f: pop
-		IL_01a0: ret
+		IL_00cc: ldloc.3
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d2: pop
+		IL_00d3: ldstr "console"
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e2: ldstr "x  "
+		IL_00e7: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimRight(string)
+		IL_00ec: stloc.3
+		IL_00ed: ldstr "log"
+		IL_00f2: ldloc.3
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f8: pop
+		IL_00f9: ldstr "console"
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0108: ldstr "A"
+		IL_010d: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
+		IL_0112: stloc.3
+		IL_0113: ldstr "log"
+		IL_0118: ldloc.3
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011e: pop
+		IL_011f: ldstr "console"
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012e: ldstr "a"
+		IL_0133: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+		IL_0138: stloc.3
+		IL_0139: ldstr "log"
+		IL_013e: ldloc.3
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0144: pop
+		IL_0145: ret
 	} // end of method String_MemberCall_FastPath_CommonMethods::__js_module_init__
 
 } // end of class Modules.String_MemberCall_FastPath_CommonMethods
@@ -478,7 +442,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x250a
+		// Method begins at RVA 0x24ae
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_NewApis_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_NewApis_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24fc
+			// Method begins at RVA 0x24a8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1184 (0x4a0)
+		// Code size: 1100 (0x44c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_NewApis_Basic/Scope,
@@ -150,232 +150,196 @@
 		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0170: stloc.2
 		IL_0171: ldstr "abc"
-		IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_017b: stloc.1
-		IL_017c: ldloc.1
-		IL_017d: ldstr "at"
-		IL_0182: ldc.r8 0.0
-		IL_018b: box [System.Runtime]System.Double
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0195: stloc.s 4
-		IL_0197: ldloc.2
-		IL_0198: ldstr "log"
-		IL_019d: ldloc.s 4
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a4: pop
-		IL_01a5: ldstr "console"
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b4: stloc.s 4
-		IL_01b6: ldstr "abc"
-		IL_01bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_01c0: stloc.1
-		IL_01c1: ldc.r8 1
-		IL_01ca: neg
-		IL_01cb: stloc.s 5
-		IL_01cd: ldloc.s 5
-		IL_01cf: box [System.Runtime]System.Double
-		IL_01d4: stloc.s 6
-		IL_01d6: ldloc.1
-		IL_01d7: ldstr "at"
-		IL_01dc: ldloc.s 6
+		IL_0176: ldstr "at"
+		IL_017b: ldc.r8 0.0
+		IL_0184: box [System.Runtime]System.Double
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018e: stloc.s 4
+		IL_0190: ldloc.2
+		IL_0191: ldstr "log"
+		IL_0196: ldloc.s 4
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019d: pop
+		IL_019e: ldstr "console"
+		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ad: stloc.s 4
+		IL_01af: ldc.r8 1
+		IL_01b8: neg
+		IL_01b9: stloc.s 5
+		IL_01bb: ldloc.s 5
+		IL_01bd: box [System.Runtime]System.Double
+		IL_01c2: stloc.s 6
+		IL_01c4: ldstr "abc"
+		IL_01c9: ldstr "at"
+		IL_01ce: ldloc.s 6
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d5: stloc.2
+		IL_01d6: ldloc.s 4
+		IL_01d8: ldstr "log"
+		IL_01dd: ldloc.2
 		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e3: stloc.2
-		IL_01e4: ldloc.s 4
-		IL_01e6: ldstr "log"
-		IL_01eb: ldloc.2
-		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f1: pop
-		IL_01f2: ldstr "console"
-		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0201: stloc.2
-		IL_0202: ldstr "abc"
-		IL_0207: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_020c: stloc.1
-		IL_020d: ldloc.1
-		IL_020e: ldstr "at"
-		IL_0213: ldc.r8 99
-		IL_021c: box [System.Runtime]System.Double
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0226: stloc.s 4
-		IL_0228: ldloc.s 4
-		IL_022a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_022f: stloc.1
-		IL_0230: ldloc.2
-		IL_0231: ldstr "log"
-		IL_0236: ldloc.1
-		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023c: pop
-		IL_023d: ldstr "console"
-		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024c: stloc.2
-		IL_024d: ldstr "A\ud83d\ude00B"
-		IL_0252: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0257: stloc.1
-		IL_0258: ldloc.1
-		IL_0259: ldstr "codePointAt"
-		IL_025e: ldc.r8 1
-		IL_0267: box [System.Runtime]System.Double
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0271: stloc.s 4
-		IL_0273: ldloc.2
-		IL_0274: ldstr "log"
-		IL_0279: ldloc.s 4
-		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0280: pop
-		IL_0281: ldstr "console"
-		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0290: stloc.s 4
-		IL_0292: ldstr "A\ud83d\ude00B"
-		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_029c: stloc.1
-		IL_029d: ldloc.1
-		IL_029e: ldstr "codePointAt"
-		IL_02a3: ldc.r8 20
-		IL_02ac: box [System.Runtime]System.Double
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b6: stloc.2
-		IL_02b7: ldloc.2
-		IL_02b8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_02bd: stloc.1
-		IL_02be: ldloc.s 4
-		IL_02c0: ldstr "log"
-		IL_02c5: ldloc.1
-		IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02cb: pop
-		IL_02cc: ldstr "console"
-		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02db: stloc.s 4
-		IL_02dd: ldstr "5"
-		IL_02e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_02e7: stloc.1
-		IL_02e8: ldloc.1
-		IL_02e9: ldstr "padStart"
-		IL_02ee: ldc.r8 3
-		IL_02f7: box [System.Runtime]System.Double
-		IL_02fc: ldstr "0"
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0306: stloc.2
-		IL_0307: ldloc.s 4
-		IL_0309: ldstr "log"
-		IL_030e: ldloc.2
-		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0314: pop
-		IL_0315: ldstr "console"
-		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0324: stloc.2
-		IL_0325: ldstr "5"
-		IL_032a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_032f: stloc.1
-		IL_0330: ldloc.1
-		IL_0331: ldstr "padEnd"
-		IL_0336: ldc.r8 4
-		IL_033f: box [System.Runtime]System.Double
-		IL_0344: ldstr "xy"
-		IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_034e: stloc.s 4
-		IL_0350: ldloc.2
-		IL_0351: ldstr "log"
-		IL_0356: ldloc.s 4
-		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_035d: pop
-		IL_035e: ldstr "console"
-		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_036d: stloc.s 4
-		IL_036f: ldstr "foofoo"
-		IL_0374: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0379: stloc.1
-		IL_037a: ldloc.1
+		IL_01e3: pop
+		IL_01e4: ldstr "console"
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f3: stloc.2
+		IL_01f4: ldstr "abc"
+		IL_01f9: ldstr "at"
+		IL_01fe: ldc.r8 99
+		IL_0207: box [System.Runtime]System.Double
+		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0211: stloc.s 4
+		IL_0213: ldloc.s 4
+		IL_0215: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_021a: stloc.1
+		IL_021b: ldloc.2
+		IL_021c: ldstr "log"
+		IL_0221: ldloc.1
+		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0227: pop
+		IL_0228: ldstr "console"
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0237: stloc.2
+		IL_0238: ldstr "A\ud83d\ude00B"
+		IL_023d: ldstr "codePointAt"
+		IL_0242: ldc.r8 1
+		IL_024b: box [System.Runtime]System.Double
+		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0255: stloc.s 4
+		IL_0257: ldloc.2
+		IL_0258: ldstr "log"
+		IL_025d: ldloc.s 4
+		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0264: pop
+		IL_0265: ldstr "console"
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0274: stloc.s 4
+		IL_0276: ldstr "A\ud83d\ude00B"
+		IL_027b: ldstr "codePointAt"
+		IL_0280: ldc.r8 20
+		IL_0289: box [System.Runtime]System.Double
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0293: stloc.2
+		IL_0294: ldloc.2
+		IL_0295: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_029a: stloc.1
+		IL_029b: ldloc.s 4
+		IL_029d: ldstr "log"
+		IL_02a2: ldloc.1
+		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a8: pop
+		IL_02a9: ldstr "console"
+		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b8: stloc.s 4
+		IL_02ba: ldstr "5"
+		IL_02bf: ldstr "padStart"
+		IL_02c4: ldc.r8 3
+		IL_02cd: box [System.Runtime]System.Double
+		IL_02d2: ldstr "0"
+		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02dc: stloc.2
+		IL_02dd: ldloc.s 4
+		IL_02df: ldstr "log"
+		IL_02e4: ldloc.2
+		IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ea: pop
+		IL_02eb: ldstr "console"
+		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fa: stloc.2
+		IL_02fb: ldstr "5"
+		IL_0300: ldstr "padEnd"
+		IL_0305: ldc.r8 4
+		IL_030e: box [System.Runtime]System.Double
+		IL_0313: ldstr "xy"
+		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_031d: stloc.s 4
+		IL_031f: ldloc.2
+		IL_0320: ldstr "log"
+		IL_0325: ldloc.s 4
+		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_032c: pop
+		IL_032d: ldstr "console"
+		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_033c: stloc.s 4
+		IL_033e: ldstr "foofoo"
+		IL_0343: ldstr "replaceAll"
+		IL_0348: ldstr "oo"
+		IL_034d: ldstr "ar"
+		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0357: stloc.2
+		IL_0358: ldloc.s 4
+		IL_035a: ldstr "log"
+		IL_035f: ldloc.2
+		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0365: pop
+		IL_0366: ldstr "console"
+		IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0375: stloc.2
+		IL_0376: ldstr "aba"
 		IL_037b: ldstr "replaceAll"
-		IL_0380: ldstr "oo"
-		IL_0385: ldstr "ar"
+		IL_0380: ldstr ""
+		IL_0385: ldstr "-"
 		IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_038f: stloc.2
-		IL_0390: ldloc.s 4
+		IL_038f: stloc.s 4
+		IL_0391: ldloc.2
 		IL_0392: ldstr "log"
-		IL_0397: ldloc.2
-		IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_039d: pop
-		IL_039e: ldstr "console"
-		IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03ad: stloc.2
-		IL_03ae: ldstr "aba"
-		IL_03b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_03b8: stloc.1
-		IL_03b9: ldloc.1
-		IL_03ba: ldstr "replaceAll"
-		IL_03bf: ldstr ""
-		IL_03c4: ldstr "-"
-		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03ce: stloc.s 4
-		IL_03d0: ldloc.2
-		IL_03d1: ldstr "log"
-		IL_03d6: ldloc.s 4
-		IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03dd: pop
-		IL_03de: ldstr "console"
-		IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0397: ldloc.s 4
+		IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_039e: pop
+		IL_039f: ldstr "console"
+		IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03ae: stloc.s 4
+		IL_03b0: ldstr "\ud83d\ude00"
+		IL_03b5: ldstr "isWellFormed"
+		IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_03bf: stloc.2
+		IL_03c0: ldloc.s 4
+		IL_03c2: ldstr "log"
+		IL_03c7: ldloc.2
+		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03cd: pop
+		IL_03ce: ldstr "console"
+		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03dd: stloc.2
+		IL_03de: ldstr "\ud83d"
+		IL_03e3: ldstr "isWellFormed"
+		IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 		IL_03ed: stloc.s 4
-		IL_03ef: ldstr "\ud83d\ude00"
-		IL_03f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_03f9: stloc.1
-		IL_03fa: ldloc.1
-		IL_03fb: ldstr "isWellFormed"
-		IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0405: stloc.2
-		IL_0406: ldloc.s 4
-		IL_0408: ldstr "log"
-		IL_040d: ldloc.2
-		IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0413: pop
-		IL_0414: ldstr "console"
-		IL_0419: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0423: stloc.2
-		IL_0424: ldstr "\ud83d"
-		IL_0429: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_042e: stloc.1
-		IL_042f: ldloc.1
-		IL_0430: ldstr "isWellFormed"
-		IL_0435: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_043a: stloc.s 4
-		IL_043c: ldloc.2
-		IL_043d: ldstr "log"
-		IL_0442: ldloc.s 4
-		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0449: pop
-		IL_044a: ldstr "console"
-		IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0459: stloc.s 4
-		IL_045b: ldstr "A\ud83d"
-		IL_0460: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0465: stloc.1
-		IL_0466: ldloc.1
-		IL_0467: ldstr "toWellFormed"
-		IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0471: stloc.2
-		IL_0472: ldloc.2
-		IL_0473: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0478: ldstr "charCodeAt"
-		IL_047d: ldc.r8 1
-		IL_0486: box [System.Runtime]System.Double
-		IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0490: stloc.2
-		IL_0491: ldloc.s 4
-		IL_0493: ldstr "log"
-		IL_0498: ldloc.2
-		IL_0499: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_049e: pop
-		IL_049f: ret
+		IL_03ef: ldloc.2
+		IL_03f0: ldstr "log"
+		IL_03f5: ldloc.s 4
+		IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03fc: pop
+		IL_03fd: ldstr "console"
+		IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_040c: stloc.s 4
+		IL_040e: ldstr "A\ud83d"
+		IL_0413: ldstr "toWellFormed"
+		IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_041d: stloc.2
+		IL_041e: ldloc.2
+		IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0424: ldstr "charCodeAt"
+		IL_0429: ldc.r8 1
+		IL_0432: box [System.Runtime]System.Double
+		IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_043c: stloc.2
+		IL_043d: ldloc.s 4
+		IL_043f: ldstr "log"
+		IL_0444: ldloc.2
+		IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_044a: pop
+		IL_044b: ret
 	} // end of method String_NewApis_Basic::__js_module_init__
 
 } // end of class Modules.String_NewApis_Basic
@@ -387,7 +351,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2505
+		// Method begins at RVA 0x24b1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_EmptyMatch_Global.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_EmptyMatch_Global.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x222d
+			// Method begins at RVA 0x2212
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 465 (0x1d1)
+		// Code size: 438 (0x1b6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global/Scope,
@@ -51,9 +51,8 @@
 			[5] object,
 			[6] object,
 			[7] object,
-			[8] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[9] bool,
-			[10] object
+			[8] bool,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global/Scope::.ctor()
@@ -79,122 +78,113 @@
 		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0049: pop
 		IL_004a: ldloc.1
-		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0050: stloc.s 8
-		IL_0052: ldloc.s 8
-		IL_0054: ldstr "exec"
-		IL_0059: ldloc.2
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005f: stloc.3
-		IL_0060: ldstr "console"
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: stloc.s 7
-		IL_0071: ldloc.3
-		IL_0072: ldc.r8 0.0
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0080: stloc.s 6
-		IL_0082: ldloc.s 6
-		IL_0084: ldstr "length"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_008e: stloc.s 6
-		IL_0090: ldloc.s 7
-		IL_0092: ldstr "log"
-		IL_0097: ldloc.s 6
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009e: pop
-		IL_009f: ldstr "console"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ae: stloc.s 6
-		IL_00b0: ldloc.1
-		IL_00b1: ldstr "lastIndex"
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00bb: stloc.s 7
-		IL_00bd: ldloc.s 6
-		IL_00bf: ldstr "log"
-		IL_00c4: ldloc.s 7
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cb: pop
-		IL_00cc: ldloc.1
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_00d2: stloc.s 8
-		IL_00d4: ldloc.s 8
-		IL_00d6: ldstr "exec"
-		IL_00db: ldloc.2
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e1: stloc.s 4
-		IL_00e3: ldstr "console"
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f2: stloc.s 7
-		IL_00f4: ldloc.s 4
-		IL_00f6: ldc.r8 0.0
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0104: stloc.s 6
-		IL_0106: ldloc.s 6
-		IL_0108: ldstr "length"
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0112: stloc.s 6
-		IL_0114: ldloc.s 7
-		IL_0116: ldstr "log"
-		IL_011b: ldloc.s 6
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0122: pop
-		IL_0123: ldstr "console"
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0132: stloc.s 6
-		IL_0134: ldloc.1
-		IL_0135: ldstr "lastIndex"
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013f: stloc.s 7
-		IL_0141: ldloc.s 6
-		IL_0143: ldstr "log"
-		IL_0148: ldloc.s 7
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014f: pop
-		IL_0150: ldloc.1
-		IL_0151: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0156: stloc.s 8
-		IL_0158: ldloc.s 8
-		IL_015a: ldstr "exec"
-		IL_015f: ldloc.2
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0165: stloc.s 5
-		IL_0167: ldstr "console"
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0176: stloc.s 7
-		IL_0178: ldloc.s 5
-		IL_017a: stloc.s 6
-		IL_017c: ldloc.s 6
-		IL_017e: ldc.i4.0
-		IL_017f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0189: stloc.s 9
-		IL_018b: ldloc.s 9
-		IL_018d: box [System.Runtime]System.Boolean
-		IL_0192: stloc.s 10
-		IL_0194: ldloc.s 7
-		IL_0196: ldstr "log"
-		IL_019b: ldloc.s 10
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a2: pop
-		IL_01a3: ldstr "console"
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b2: stloc.s 7
-		IL_01b4: ldloc.1
-		IL_01b5: ldstr "lastIndex"
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01bf: stloc.s 6
-		IL_01c1: ldloc.s 7
-		IL_01c3: ldstr "log"
-		IL_01c8: ldloc.s 6
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01cf: pop
-		IL_01d0: ret
+		IL_004b: ldstr "exec"
+		IL_0050: ldloc.2
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0056: stloc.3
+		IL_0057: ldstr "console"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0066: stloc.s 7
+		IL_0068: ldloc.3
+		IL_0069: ldc.r8 0.0
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0077: stloc.s 6
+		IL_0079: ldloc.s 6
+		IL_007b: ldstr "length"
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0085: stloc.s 6
+		IL_0087: ldloc.s 7
+		IL_0089: ldstr "log"
+		IL_008e: ldloc.s 6
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0095: pop
+		IL_0096: ldstr "console"
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a5: stloc.s 6
+		IL_00a7: ldloc.1
+		IL_00a8: ldstr "lastIndex"
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b2: stloc.s 7
+		IL_00b4: ldloc.s 6
+		IL_00b6: ldstr "log"
+		IL_00bb: ldloc.s 7
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c2: pop
+		IL_00c3: ldloc.1
+		IL_00c4: ldstr "exec"
+		IL_00c9: ldloc.2
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cf: stloc.s 4
+		IL_00d1: ldstr "console"
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e0: stloc.s 7
+		IL_00e2: ldloc.s 4
+		IL_00e4: ldc.r8 0.0
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00f2: stloc.s 6
+		IL_00f4: ldloc.s 6
+		IL_00f6: ldstr "length"
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0100: stloc.s 6
+		IL_0102: ldloc.s 7
+		IL_0104: ldstr "log"
+		IL_0109: ldloc.s 6
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0110: pop
+		IL_0111: ldstr "console"
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0120: stloc.s 6
+		IL_0122: ldloc.1
+		IL_0123: ldstr "lastIndex"
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012d: stloc.s 7
+		IL_012f: ldloc.s 6
+		IL_0131: ldstr "log"
+		IL_0136: ldloc.s 7
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013d: pop
+		IL_013e: ldloc.1
+		IL_013f: ldstr "exec"
+		IL_0144: ldloc.2
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014a: stloc.s 5
+		IL_014c: ldstr "console"
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015b: stloc.s 7
+		IL_015d: ldloc.s 5
+		IL_015f: stloc.s 6
+		IL_0161: ldloc.s 6
+		IL_0163: ldc.i4.0
+		IL_0164: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0169: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_016e: stloc.s 8
+		IL_0170: ldloc.s 8
+		IL_0172: box [System.Runtime]System.Boolean
+		IL_0177: stloc.s 9
+		IL_0179: ldloc.s 7
+		IL_017b: ldstr "log"
+		IL_0180: ldloc.s 9
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0187: pop
+		IL_0188: ldstr "console"
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0197: stloc.s 7
+		IL_0199: ldloc.1
+		IL_019a: ldstr "lastIndex"
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a4: stloc.s 6
+		IL_01a6: ldloc.s 7
+		IL_01a8: ldstr "log"
+		IL_01ad: ldloc.s 6
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b4: pop
+		IL_01b5: ret
 	} // end of method String_RegExp_Exec_LastIndex_EmptyMatch_Global::__js_module_init__
 
 } // end of class Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global
@@ -206,7 +196,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2236
+		// Method begins at RVA 0x221b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_Global.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_Global.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2219
+			// Method begins at RVA 0x2207
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 445 (0x1bd)
+		// Code size: 427 (0x1ab)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_Exec_LastIndex_Global/Scope,
@@ -49,8 +49,7 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] object,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.String_RegExp_Exec_LastIndex_Global/Scope::.ctor()
@@ -76,113 +75,107 @@
 		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0049: pop
 		IL_004a: ldloc.1
-		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0050: stloc.s 7
-		IL_0052: ldloc.s 7
-		IL_0054: ldstr "exec"
-		IL_0059: ldloc.2
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005f: stloc.3
-		IL_0060: ldstr "console"
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: stloc.s 6
-		IL_0071: ldloc.3
-		IL_0072: ldc.r8 0.0
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0080: stloc.s 5
-		IL_0082: ldloc.s 6
-		IL_0084: ldstr "log"
-		IL_0089: ldloc.s 5
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0090: pop
-		IL_0091: ldstr "console"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a0: stloc.s 5
-		IL_00a2: ldloc.3
-		IL_00a3: ldstr "index"
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ad: stloc.s 6
-		IL_00af: ldloc.s 5
-		IL_00b1: ldstr "log"
-		IL_00b6: ldloc.s 6
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bd: pop
-		IL_00be: ldstr "console"
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cd: stloc.s 6
-		IL_00cf: ldloc.3
-		IL_00d0: ldstr "input"
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00da: stloc.s 5
-		IL_00dc: ldloc.s 6
-		IL_00de: ldstr "log"
-		IL_00e3: ldloc.s 5
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ea: pop
-		IL_00eb: ldstr "console"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fa: stloc.s 5
-		IL_00fc: ldloc.1
-		IL_00fd: ldstr "lastIndex"
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0107: stloc.s 6
-		IL_0109: ldloc.s 5
-		IL_010b: ldstr "log"
-		IL_0110: ldloc.s 6
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0117: pop
-		IL_0118: ldloc.1
-		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_011e: stloc.s 7
-		IL_0120: ldloc.s 7
-		IL_0122: ldstr "exec"
-		IL_0127: ldloc.2
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012d: stloc.s 4
-		IL_012f: ldstr "console"
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013e: stloc.s 6
-		IL_0140: ldloc.s 4
-		IL_0142: ldc.r8 0.0
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0150: stloc.s 5
-		IL_0152: ldloc.s 6
-		IL_0154: ldstr "log"
-		IL_0159: ldloc.s 5
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0160: pop
-		IL_0161: ldstr "console"
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0170: stloc.s 5
-		IL_0172: ldloc.s 4
-		IL_0174: ldstr "index"
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017e: stloc.s 6
-		IL_0180: ldloc.s 5
-		IL_0182: ldstr "log"
-		IL_0187: ldloc.s 6
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018e: pop
-		IL_018f: ldstr "console"
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019e: stloc.s 6
-		IL_01a0: ldloc.1
-		IL_01a1: ldstr "lastIndex"
-		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ab: stloc.s 5
-		IL_01ad: ldloc.s 6
-		IL_01af: ldstr "log"
-		IL_01b4: ldloc.s 5
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bb: pop
-		IL_01bc: ret
+		IL_004b: ldstr "exec"
+		IL_0050: ldloc.2
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0056: stloc.3
+		IL_0057: ldstr "console"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0066: stloc.s 6
+		IL_0068: ldloc.3
+		IL_0069: ldc.r8 0.0
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0077: stloc.s 5
+		IL_0079: ldloc.s 6
+		IL_007b: ldstr "log"
+		IL_0080: ldloc.s 5
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0087: pop
+		IL_0088: ldstr "console"
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0097: stloc.s 5
+		IL_0099: ldloc.3
+		IL_009a: ldstr "index"
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a4: stloc.s 6
+		IL_00a6: ldloc.s 5
+		IL_00a8: ldstr "log"
+		IL_00ad: ldloc.s 6
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b4: pop
+		IL_00b5: ldstr "console"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c4: stloc.s 6
+		IL_00c6: ldloc.3
+		IL_00c7: ldstr "input"
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d1: stloc.s 5
+		IL_00d3: ldloc.s 6
+		IL_00d5: ldstr "log"
+		IL_00da: ldloc.s 5
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e1: pop
+		IL_00e2: ldstr "console"
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f1: stloc.s 5
+		IL_00f3: ldloc.1
+		IL_00f4: ldstr "lastIndex"
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00fe: stloc.s 6
+		IL_0100: ldloc.s 5
+		IL_0102: ldstr "log"
+		IL_0107: ldloc.s 6
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010e: pop
+		IL_010f: ldloc.1
+		IL_0110: ldstr "exec"
+		IL_0115: ldloc.2
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011b: stloc.s 4
+		IL_011d: ldstr "console"
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012c: stloc.s 6
+		IL_012e: ldloc.s 4
+		IL_0130: ldc.r8 0.0
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_013e: stloc.s 5
+		IL_0140: ldloc.s 6
+		IL_0142: ldstr "log"
+		IL_0147: ldloc.s 5
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014e: pop
+		IL_014f: ldstr "console"
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015e: stloc.s 5
+		IL_0160: ldloc.s 4
+		IL_0162: ldstr "index"
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_016c: stloc.s 6
+		IL_016e: ldloc.s 5
+		IL_0170: ldstr "log"
+		IL_0175: ldloc.s 6
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017c: pop
+		IL_017d: ldstr "console"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018c: stloc.s 6
+		IL_018e: ldloc.1
+		IL_018f: ldstr "lastIndex"
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0199: stloc.s 5
+		IL_019b: ldloc.s 6
+		IL_019d: ldstr "log"
+		IL_01a2: ldloc.s 5
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a9: pop
+		IL_01aa: ret
 	} // end of method String_RegExp_Exec_LastIndex_Global::__js_module_init__
 
 } // end of class Modules.String_RegExp_Exec_LastIndex_Global
@@ -194,7 +187,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2222
+		// Method begins at RVA 0x2210
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_Sticky.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_Sticky.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x236a
+			// Method begins at RVA 0x2346
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 782 (0x30e)
+		// Code size: 746 (0x2ea)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_Exec_LastIndex_Sticky/Scope,
@@ -50,9 +50,8 @@
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[8] bool,
-			[9] object
+			[7] bool,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.String_RegExp_Exec_LastIndex_Sticky/Scope::.ctor()
@@ -95,197 +94,185 @@
 		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0086: stloc.s 5
 		IL_0088: ldloc.1
-		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_008e: stloc.s 7
-		IL_0090: ldloc.s 7
-		IL_0092: ldstr "exec"
-		IL_0097: ldloc.2
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009d: stloc.s 6
-		IL_009f: ldloc.s 6
-		IL_00a1: ldc.i4.0
-		IL_00a2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_00a7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0089: ldstr "exec"
+		IL_008e: ldloc.2
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0094: stloc.s 6
+		IL_0096: ldloc.s 6
+		IL_0098: ldc.i4.0
+		IL_0099: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00a3: stloc.s 7
+		IL_00a5: ldloc.s 7
+		IL_00a7: box [System.Runtime]System.Boolean
 		IL_00ac: stloc.s 8
-		IL_00ae: ldloc.s 8
-		IL_00b0: box [System.Runtime]System.Boolean
-		IL_00b5: stloc.s 9
-		IL_00b7: ldloc.s 5
-		IL_00b9: ldstr "log"
-		IL_00be: ldloc.s 9
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c5: pop
-		IL_00c6: ldstr "console"
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d5: stloc.s 5
-		IL_00d7: ldloc.1
-		IL_00d8: ldstr "lastIndex"
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e2: stloc.s 6
-		IL_00e4: ldloc.s 5
-		IL_00e6: ldstr "log"
-		IL_00eb: ldloc.s 6
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f2: pop
-		IL_00f3: ldloc.1
-		IL_00f4: ldstr "lastIndex"
-		IL_00f9: ldc.r8 1
-		IL_0102: ldc.i4.1
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0108: pop
-		IL_0109: ldloc.1
-		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_010f: stloc.s 7
-		IL_0111: ldloc.s 7
-		IL_0113: ldstr "exec"
-		IL_0118: ldloc.2
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011e: stloc.3
-		IL_011f: ldstr "console"
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012e: stloc.s 6
-		IL_0130: ldloc.3
-		IL_0131: ldc.r8 0.0
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_013f: stloc.s 5
-		IL_0141: ldloc.s 6
-		IL_0143: ldstr "log"
-		IL_0148: ldloc.s 5
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014f: pop
-		IL_0150: ldstr "console"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015f: stloc.s 5
-		IL_0161: ldloc.3
-		IL_0162: ldstr "index"
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_016c: stloc.s 6
-		IL_016e: ldloc.s 5
-		IL_0170: ldstr "log"
-		IL_0175: ldloc.s 6
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017c: pop
-		IL_017d: ldstr "console"
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018c: stloc.s 6
-		IL_018e: ldloc.3
-		IL_018f: ldstr "input"
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0199: stloc.s 5
-		IL_019b: ldloc.s 6
-		IL_019d: ldstr "log"
-		IL_01a2: ldloc.s 5
-		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a9: pop
-		IL_01aa: ldstr "console"
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b9: stloc.s 5
-		IL_01bb: ldloc.1
-		IL_01bc: ldstr "lastIndex"
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c6: stloc.s 6
-		IL_01c8: ldloc.s 5
-		IL_01ca: ldstr "log"
-		IL_01cf: ldloc.s 6
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d6: pop
-		IL_01d7: ldloc.1
-		IL_01d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_01dd: stloc.s 7
-		IL_01df: ldloc.s 7
-		IL_01e1: ldstr "exec"
-		IL_01e6: ldloc.2
-		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ec: stloc.s 4
-		IL_01ee: ldstr "console"
-		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01fd: stloc.s 6
-		IL_01ff: ldloc.s 4
-		IL_0201: ldc.r8 0.0
-		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_020f: stloc.s 5
-		IL_0211: ldloc.s 6
-		IL_0213: ldstr "log"
-		IL_0218: ldloc.s 5
-		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_021f: pop
-		IL_0220: ldstr "console"
-		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022f: stloc.s 5
-		IL_0231: ldloc.s 4
-		IL_0233: ldstr "index"
-		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_023d: stloc.s 6
-		IL_023f: ldloc.s 5
-		IL_0241: ldstr "log"
-		IL_0246: ldloc.s 6
-		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024d: pop
-		IL_024e: ldstr "console"
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025d: stloc.s 6
-		IL_025f: ldloc.1
-		IL_0260: ldstr "lastIndex"
-		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_026a: stloc.s 5
-		IL_026c: ldloc.s 6
-		IL_026e: ldstr "log"
-		IL_0273: ldloc.s 5
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027a: pop
-		IL_027b: ldloc.1
-		IL_027c: ldstr "lastIndex"
-		IL_0281: ldc.r8 10
-		IL_028a: ldc.i4.1
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0290: pop
-		IL_0291: ldstr "console"
-		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a0: stloc.s 5
-		IL_02a2: ldloc.1
-		IL_02a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_02a8: stloc.s 7
-		IL_02aa: ldloc.s 7
-		IL_02ac: ldstr "exec"
-		IL_02b1: ldloc.2
-		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b7: stloc.s 6
-		IL_02b9: ldloc.s 6
-		IL_02bb: ldc.i4.0
-		IL_02bc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_02c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02c6: stloc.s 8
-		IL_02c8: ldloc.s 8
-		IL_02ca: box [System.Runtime]System.Boolean
-		IL_02cf: stloc.s 9
-		IL_02d1: ldloc.s 5
-		IL_02d3: ldstr "log"
-		IL_02d8: ldloc.s 9
-		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02df: pop
-		IL_02e0: ldstr "console"
-		IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ef: stloc.s 5
-		IL_02f1: ldloc.1
-		IL_02f2: ldstr "lastIndex"
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02fc: stloc.s 6
-		IL_02fe: ldloc.s 5
-		IL_0300: ldstr "log"
-		IL_0305: ldloc.s 6
-		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_030c: pop
-		IL_030d: ret
+		IL_00ae: ldloc.s 5
+		IL_00b0: ldstr "log"
+		IL_00b5: ldloc.s 8
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bc: pop
+		IL_00bd: ldstr "console"
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cc: stloc.s 5
+		IL_00ce: ldloc.1
+		IL_00cf: ldstr "lastIndex"
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d9: stloc.s 6
+		IL_00db: ldloc.s 5
+		IL_00dd: ldstr "log"
+		IL_00e2: ldloc.s 6
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e9: pop
+		IL_00ea: ldloc.1
+		IL_00eb: ldstr "lastIndex"
+		IL_00f0: ldc.r8 1
+		IL_00f9: ldc.i4.1
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_00ff: pop
+		IL_0100: ldloc.1
+		IL_0101: ldstr "exec"
+		IL_0106: ldloc.2
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010c: stloc.3
+		IL_010d: ldstr "console"
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011c: stloc.s 6
+		IL_011e: ldloc.3
+		IL_011f: ldc.r8 0.0
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_012d: stloc.s 5
+		IL_012f: ldloc.s 6
+		IL_0131: ldstr "log"
+		IL_0136: ldloc.s 5
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013d: pop
+		IL_013e: ldstr "console"
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014d: stloc.s 5
+		IL_014f: ldloc.3
+		IL_0150: ldstr "index"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015a: stloc.s 6
+		IL_015c: ldloc.s 5
+		IL_015e: ldstr "log"
+		IL_0163: ldloc.s 6
+		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016a: pop
+		IL_016b: ldstr "console"
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017a: stloc.s 6
+		IL_017c: ldloc.3
+		IL_017d: ldstr "input"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0187: stloc.s 5
+		IL_0189: ldloc.s 6
+		IL_018b: ldstr "log"
+		IL_0190: ldloc.s 5
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0197: pop
+		IL_0198: ldstr "console"
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a7: stloc.s 5
+		IL_01a9: ldloc.1
+		IL_01aa: ldstr "lastIndex"
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01b4: stloc.s 6
+		IL_01b6: ldloc.s 5
+		IL_01b8: ldstr "log"
+		IL_01bd: ldloc.s 6
+		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c4: pop
+		IL_01c5: ldloc.1
+		IL_01c6: ldstr "exec"
+		IL_01cb: ldloc.2
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d1: stloc.s 4
+		IL_01d3: ldstr "console"
+		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e2: stloc.s 6
+		IL_01e4: ldloc.s 4
+		IL_01e6: ldc.r8 0.0
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01f4: stloc.s 5
+		IL_01f6: ldloc.s 6
+		IL_01f8: ldstr "log"
+		IL_01fd: ldloc.s 5
+		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0204: pop
+		IL_0205: ldstr "console"
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0214: stloc.s 5
+		IL_0216: ldloc.s 4
+		IL_0218: ldstr "index"
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0222: stloc.s 6
+		IL_0224: ldloc.s 5
+		IL_0226: ldstr "log"
+		IL_022b: ldloc.s 6
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0232: pop
+		IL_0233: ldstr "console"
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0242: stloc.s 6
+		IL_0244: ldloc.1
+		IL_0245: ldstr "lastIndex"
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_024f: stloc.s 5
+		IL_0251: ldloc.s 6
+		IL_0253: ldstr "log"
+		IL_0258: ldloc.s 5
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025f: pop
+		IL_0260: ldloc.1
+		IL_0261: ldstr "lastIndex"
+		IL_0266: ldc.r8 10
+		IL_026f: ldc.i4.1
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0275: pop
+		IL_0276: ldstr "console"
+		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0285: stloc.s 5
+		IL_0287: ldloc.1
+		IL_0288: ldstr "exec"
+		IL_028d: ldloc.2
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0293: stloc.s 6
+		IL_0295: ldloc.s 6
+		IL_0297: ldc.i4.0
+		IL_0298: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_029d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02a2: stloc.s 7
+		IL_02a4: ldloc.s 7
+		IL_02a6: box [System.Runtime]System.Boolean
+		IL_02ab: stloc.s 8
+		IL_02ad: ldloc.s 5
+		IL_02af: ldstr "log"
+		IL_02b4: ldloc.s 8
+		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02bb: pop
+		IL_02bc: ldstr "console"
+		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02cb: stloc.s 5
+		IL_02cd: ldloc.1
+		IL_02ce: ldstr "lastIndex"
+		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02d8: stloc.s 6
+		IL_02da: ldloc.s 5
+		IL_02dc: ldstr "log"
+		IL_02e1: ldloc.s 6
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02e8: pop
+		IL_02e9: ret
 	} // end of method String_RegExp_Exec_LastIndex_Sticky::__js_module_init__
 
 } // end of class Modules.String_RegExp_Exec_LastIndex_Sticky
@@ -297,7 +284,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2373
+		// Method begins at RVA 0x234f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_NamedGroups_Indices.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_NamedGroups_Indices.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2890
+			// Method begins at RVA 0x286c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2100 (0x834)
+		// Code size: 2064 (0x810)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_NamedGroups_Indices/Scope,
@@ -54,8 +54,7 @@
 			[8] bool,
 			[9] object,
 			[10] object,
-			[11] string,
-			[12] object
+			[11] object
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -67,606 +66,594 @@
 		IL_0016: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_001b: stloc.s 5
 		IL_001d: ldloc.s 5
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_0024: stloc.s 5
-		IL_0026: ldloc.s 5
-		IL_0028: ldstr "exec"
-		IL_002d: ldstr "a"
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0037: stloc.1
-		IL_0038: ldstr "console"
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0047: stloc.s 6
-		IL_0049: ldloc.1
-		IL_004a: ldstr "groups"
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_001f: ldstr "exec"
+		IL_0024: ldstr "a"
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_002e: stloc.1
+		IL_002f: ldstr "console"
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003e: stloc.s 6
+		IL_0040: ldloc.1
+		IL_0041: ldstr "groups"
+		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_004b: stloc.s 7
+		IL_004d: ldloc.s 7
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
 		IL_0054: stloc.s 7
 		IL_0056: ldloc.s 7
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_005d: stloc.s 7
-		IL_005f: ldloc.s 7
-		IL_0061: ldc.i4.0
-		IL_0062: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0067: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_006c: stloc.s 8
-		IL_006e: ldloc.s 8
-		IL_0070: box [System.Runtime]System.Boolean
-		IL_0075: stloc.s 9
-		IL_0077: ldloc.s 6
-		IL_0079: ldstr "log"
-		IL_007e: ldloc.s 9
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0085: pop
-		IL_0086: ldstr "console"
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0095: ldloc.1
-		IL_0096: ldstr "groups"
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_00a5: stloc.s 6
-		IL_00a7: ldstr "log"
-		IL_00ac: ldloc.s 6
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b3: pop
-		IL_00b4: ldstr "console"
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c3: stloc.s 6
-		IL_00c5: ldloc.1
-		IL_00c6: ldstr "groups"
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0058: ldc.i4.0
+		IL_0059: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_005e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0063: stloc.s 8
+		IL_0065: ldloc.s 8
+		IL_0067: box [System.Runtime]System.Boolean
+		IL_006c: stloc.s 9
+		IL_006e: ldloc.s 6
+		IL_0070: ldstr "log"
+		IL_0075: ldloc.s 9
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007c: pop
+		IL_007d: ldstr "console"
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008c: ldloc.1
+		IL_008d: ldstr "groups"
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_009c: stloc.s 6
+		IL_009e: ldstr "log"
+		IL_00a3: ldloc.s 6
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00aa: pop
+		IL_00ab: ldstr "console"
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ba: stloc.s 6
+		IL_00bc: ldloc.1
+		IL_00bd: ldstr "groups"
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c7: stloc.s 7
+		IL_00c9: ldloc.s 7
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 		IL_00d0: stloc.s 7
 		IL_00d2: ldloc.s 7
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
 		IL_00d9: stloc.s 7
-		IL_00db: ldloc.s 7
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_00e2: stloc.s 7
-		IL_00e4: ldloc.s 6
-		IL_00e6: ldstr "log"
-		IL_00eb: ldloc.s 7
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f2: pop
-		IL_00f3: ldstr "console"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0102: stloc.s 7
-		IL_0104: ldloc.1
-		IL_0105: ldstr "groups"
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010f: stloc.s 6
-		IL_0111: ldloc.s 6
-		IL_0113: ldstr "word"
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_011d: stloc.s 6
-		IL_011f: ldloc.s 7
-		IL_0121: ldstr "log"
-		IL_0126: ldloc.s 6
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012d: pop
-		IL_012e: ldstr "console"
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013d: stloc.s 6
-		IL_013f: ldloc.1
-		IL_0140: ldstr "groups"
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_014a: stloc.s 7
-		IL_014c: ldloc.s 7
-		IL_014e: ldstr "optional"
-		IL_0153: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0158: box [System.Runtime]System.Boolean
-		IL_015d: stloc.s 9
-		IL_015f: ldloc.s 6
-		IL_0161: ldstr "log"
-		IL_0166: ldloc.s 9
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016d: pop
-		IL_016e: ldstr "console"
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017d: stloc.s 6
-		IL_017f: ldloc.1
-		IL_0180: ldstr "groups"
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018a: stloc.s 7
-		IL_018c: ldloc.s 7
-		IL_018e: ldstr "optional"
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0198: stloc.s 7
-		IL_019a: ldloc.s 7
-		IL_019c: ldnull
-		IL_019d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01a2: stloc.s 8
-		IL_01a4: ldloc.s 8
-		IL_01a6: box [System.Runtime]System.Boolean
-		IL_01ab: stloc.s 9
-		IL_01ad: ldloc.s 6
-		IL_01af: ldstr "log"
-		IL_01b4: ldloc.s 9
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bb: pop
-		IL_01bc: ldstr "console"
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01cb: stloc.s 6
-		IL_01cd: ldloc.1
-		IL_01ce: ldstr "groups"
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01d8: stloc.s 7
-		IL_01da: ldloc.s 7
-		IL_01dc: ldstr "word"
-		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_00db: ldloc.s 6
+		IL_00dd: ldstr "log"
+		IL_00e2: ldloc.s 7
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e9: pop
+		IL_00ea: ldstr "console"
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f9: stloc.s 7
+		IL_00fb: ldloc.1
+		IL_00fc: ldstr "groups"
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0106: stloc.s 6
+		IL_0108: ldloc.s 6
+		IL_010a: ldstr "word"
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0114: stloc.s 6
+		IL_0116: ldloc.s 7
+		IL_0118: ldstr "log"
+		IL_011d: ldloc.s 6
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0124: pop
+		IL_0125: ldstr "console"
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0134: stloc.s 6
+		IL_0136: ldloc.1
+		IL_0137: ldstr "groups"
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0141: stloc.s 7
+		IL_0143: ldloc.s 7
+		IL_0145: ldstr "optional"
+		IL_014a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_014f: box [System.Runtime]System.Boolean
+		IL_0154: stloc.s 9
+		IL_0156: ldloc.s 6
+		IL_0158: ldstr "log"
+		IL_015d: ldloc.s 9
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0164: pop
+		IL_0165: ldstr "console"
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0174: stloc.s 6
+		IL_0176: ldloc.1
+		IL_0177: ldstr "groups"
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0181: stloc.s 7
+		IL_0183: ldloc.s 7
+		IL_0185: ldstr "optional"
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018f: stloc.s 7
+		IL_0191: ldloc.s 7
+		IL_0193: ldnull
+		IL_0194: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0199: stloc.s 8
+		IL_019b: ldloc.s 8
+		IL_019d: box [System.Runtime]System.Boolean
+		IL_01a2: stloc.s 9
+		IL_01a4: ldloc.s 6
+		IL_01a6: ldstr "log"
+		IL_01ab: ldloc.s 9
+		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b2: pop
+		IL_01b3: ldstr "console"
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c2: stloc.s 6
+		IL_01c4: ldloc.1
+		IL_01c5: ldstr "groups"
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01cf: stloc.s 7
+		IL_01d1: ldloc.s 7
+		IL_01d3: ldstr "word"
+		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_01dd: stloc.s 7
+		IL_01df: ldloc.s 7
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
 		IL_01e6: stloc.s 7
-		IL_01e8: ldloc.s 7
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_01ef: stloc.s 7
-		IL_01f1: ldloc.s 6
-		IL_01f3: ldstr "log"
-		IL_01f8: ldloc.s 7
-		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ff: pop
-		IL_0200: ldstr "console"
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020f: stloc.s 7
-		IL_0211: ldloc.1
-		IL_0212: ldstr "groups"
-		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e8: ldloc.s 6
+		IL_01ea: ldstr "log"
+		IL_01ef: ldloc.s 7
+		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f6: pop
+		IL_01f7: ldstr "console"
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0206: stloc.s 7
+		IL_0208: ldloc.1
+		IL_0209: ldstr "groups"
+		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0213: stloc.s 6
+		IL_0215: ldloc.s 6
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
 		IL_021c: stloc.s 6
-		IL_021e: ldloc.s 6
-		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0225: stloc.s 6
-		IL_0227: ldloc.s 7
-		IL_0229: ldstr "log"
-		IL_022e: ldloc.s 6
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0235: pop
-		IL_0236: ldstr "console"
-		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0245: stloc.s 6
-		IL_0247: ldloc.1
-		IL_0248: ldstr "indices"
-		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0252: stloc.s 7
-		IL_0254: ldloc.s 7
-		IL_0256: ldc.r8 0.0
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_021e: ldloc.s 7
+		IL_0220: ldstr "log"
+		IL_0225: ldloc.s 6
+		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_022c: pop
+		IL_022d: ldstr "console"
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_023c: stloc.s 6
+		IL_023e: ldloc.1
+		IL_023f: ldstr "indices"
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0249: stloc.s 7
+		IL_024b: ldloc.s 7
+		IL_024d: ldc.r8 0.0
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_025b: stloc.s 7
+		IL_025d: ldloc.s 7
+		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
 		IL_0264: stloc.s 7
-		IL_0266: ldloc.s 7
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_026d: stloc.s 7
-		IL_026f: ldloc.s 6
-		IL_0271: ldstr "log"
-		IL_0276: ldloc.s 7
-		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027d: pop
-		IL_027e: ldstr "console"
-		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028d: stloc.s 7
-		IL_028f: ldloc.1
-		IL_0290: ldstr "indices"
-		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_029a: stloc.s 6
-		IL_029c: ldloc.s 6
-		IL_029e: ldc.r8 1
-		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0266: ldloc.s 6
+		IL_0268: ldstr "log"
+		IL_026d: ldloc.s 7
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0274: pop
+		IL_0275: ldstr "console"
+		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0284: stloc.s 7
+		IL_0286: ldloc.1
+		IL_0287: ldstr "indices"
+		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0291: stloc.s 6
+		IL_0293: ldloc.s 6
+		IL_0295: ldc.r8 1
+		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02a3: stloc.s 6
+		IL_02a5: ldloc.s 6
+		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
 		IL_02ac: stloc.s 6
-		IL_02ae: ldloc.s 6
-		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_02b5: stloc.s 6
-		IL_02b7: ldloc.s 7
-		IL_02b9: ldstr "log"
-		IL_02be: ldloc.s 6
-		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c5: pop
-		IL_02c6: ldstr "console"
-		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d5: stloc.s 6
-		IL_02d7: ldloc.1
-		IL_02d8: ldstr "indices"
-		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e2: stloc.s 7
-		IL_02e4: ldloc.s 7
-		IL_02e6: ldc.r8 2
-		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02f4: stloc.s 7
-		IL_02f6: ldloc.s 7
-		IL_02f8: ldnull
-		IL_02f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02fe: stloc.s 8
-		IL_0300: ldloc.s 8
-		IL_0302: box [System.Runtime]System.Boolean
-		IL_0307: stloc.s 9
-		IL_0309: ldloc.s 6
-		IL_030b: ldstr "log"
-		IL_0310: ldloc.s 9
-		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0317: pop
-		IL_0318: ldstr "console"
-		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0327: stloc.s 6
-		IL_0329: ldloc.1
-		IL_032a: ldstr "indices"
-		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0334: stloc.s 7
-		IL_0336: ldloc.s 7
-		IL_0338: ldstr "groups"
-		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ae: ldloc.s 7
+		IL_02b0: ldstr "log"
+		IL_02b5: ldloc.s 6
+		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02bc: pop
+		IL_02bd: ldstr "console"
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02cc: stloc.s 6
+		IL_02ce: ldloc.1
+		IL_02cf: ldstr "indices"
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02d9: stloc.s 7
+		IL_02db: ldloc.s 7
+		IL_02dd: ldc.r8 2
+		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02eb: stloc.s 7
+		IL_02ed: ldloc.s 7
+		IL_02ef: ldnull
+		IL_02f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02f5: stloc.s 8
+		IL_02f7: ldloc.s 8
+		IL_02f9: box [System.Runtime]System.Boolean
+		IL_02fe: stloc.s 9
+		IL_0300: ldloc.s 6
+		IL_0302: ldstr "log"
+		IL_0307: ldloc.s 9
+		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_030e: pop
+		IL_030f: ldstr "console"
+		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_031e: stloc.s 6
+		IL_0320: ldloc.1
+		IL_0321: ldstr "indices"
+		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_032b: stloc.s 7
+		IL_032d: ldloc.s 7
+		IL_032f: ldstr "groups"
+		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0339: stloc.s 7
+		IL_033b: ldloc.s 7
+		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
 		IL_0342: stloc.s 7
 		IL_0344: ldloc.s 7
-		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_034b: stloc.s 7
-		IL_034d: ldloc.s 7
-		IL_034f: ldc.i4.0
-		IL_0350: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0355: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_035a: stloc.s 8
-		IL_035c: ldloc.s 8
-		IL_035e: box [System.Runtime]System.Boolean
-		IL_0363: stloc.s 9
-		IL_0365: ldloc.s 6
-		IL_0367: ldstr "log"
-		IL_036c: ldloc.s 9
-		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0373: pop
-		IL_0374: ldstr "console"
-		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0383: stloc.s 6
-		IL_0385: ldloc.1
-		IL_0386: ldstr "indices"
-		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0390: stloc.s 7
-		IL_0392: ldloc.s 7
-		IL_0394: ldstr "groups"
-		IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0346: ldc.i4.0
+		IL_0347: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_034c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0351: stloc.s 8
+		IL_0353: ldloc.s 8
+		IL_0355: box [System.Runtime]System.Boolean
+		IL_035a: stloc.s 9
+		IL_035c: ldloc.s 6
+		IL_035e: ldstr "log"
+		IL_0363: ldloc.s 9
+		IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_036a: pop
+		IL_036b: ldstr "console"
+		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_037a: stloc.s 6
+		IL_037c: ldloc.1
+		IL_037d: ldstr "indices"
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0387: stloc.s 7
+		IL_0389: ldloc.s 7
+		IL_038b: ldstr "groups"
+		IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0395: stloc.s 7
+		IL_0397: ldloc.s 7
+		IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
 		IL_039e: stloc.s 7
-		IL_03a0: ldloc.s 7
-		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_03a7: stloc.s 7
-		IL_03a9: ldloc.s 6
-		IL_03ab: ldstr "log"
-		IL_03b0: ldloc.s 7
-		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03b7: pop
-		IL_03b8: ldstr "console"
-		IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03c7: stloc.s 7
-		IL_03c9: ldloc.1
-		IL_03ca: ldstr "indices"
-		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03d4: stloc.s 6
-		IL_03d6: ldloc.s 6
-		IL_03d8: ldstr "groups"
-		IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03a0: ldloc.s 6
+		IL_03a2: ldstr "log"
+		IL_03a7: ldloc.s 7
+		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03ae: pop
+		IL_03af: ldstr "console"
+		IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03be: stloc.s 7
+		IL_03c0: ldloc.1
+		IL_03c1: ldstr "indices"
+		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03cb: stloc.s 6
+		IL_03cd: ldloc.s 6
+		IL_03cf: ldstr "groups"
+		IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03d9: stloc.s 6
+		IL_03db: ldloc.s 6
+		IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 		IL_03e2: stloc.s 6
 		IL_03e4: ldloc.s 6
-		IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
 		IL_03eb: stloc.s 6
-		IL_03ed: ldloc.s 6
-		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_03f4: stloc.s 6
-		IL_03f6: ldloc.s 7
-		IL_03f8: ldstr "log"
-		IL_03fd: ldloc.s 6
-		IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0404: pop
-		IL_0405: ldstr "console"
-		IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0414: stloc.s 6
-		IL_0416: ldloc.1
-		IL_0417: ldstr "indices"
-		IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0421: stloc.s 7
-		IL_0423: ldloc.s 7
-		IL_0425: ldstr "groups"
-		IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_042f: stloc.s 7
-		IL_0431: ldloc.s 7
-		IL_0433: ldstr "word"
-		IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03ed: ldloc.s 7
+		IL_03ef: ldstr "log"
+		IL_03f4: ldloc.s 6
+		IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03fb: pop
+		IL_03fc: ldstr "console"
+		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_040b: stloc.s 6
+		IL_040d: ldloc.1
+		IL_040e: ldstr "indices"
+		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0418: stloc.s 7
+		IL_041a: ldloc.s 7
+		IL_041c: ldstr "groups"
+		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0426: stloc.s 7
+		IL_0428: ldloc.s 7
+		IL_042a: ldstr "word"
+		IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0434: stloc.s 7
+		IL_0436: ldloc.s 7
+		IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
 		IL_043d: stloc.s 7
-		IL_043f: ldloc.s 7
-		IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0446: stloc.s 7
-		IL_0448: ldloc.s 6
-		IL_044a: ldstr "log"
-		IL_044f: ldloc.s 7
-		IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0456: pop
-		IL_0457: ldstr "console"
-		IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0466: stloc.s 7
-		IL_0468: ldloc.1
-		IL_0469: ldstr "indices"
-		IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0473: stloc.s 6
-		IL_0475: ldloc.s 6
-		IL_0477: ldstr "groups"
-		IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0481: stloc.s 6
-		IL_0483: ldloc.s 6
-		IL_0485: ldstr "optional"
-		IL_048a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_048f: box [System.Runtime]System.Boolean
-		IL_0494: stloc.s 9
-		IL_0496: ldloc.s 7
-		IL_0498: ldstr "log"
-		IL_049d: ldloc.s 9
-		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04a4: pop
-		IL_04a5: ldstr "console"
-		IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b4: stloc.s 7
-		IL_04b6: ldloc.1
-		IL_04b7: ldstr "indices"
-		IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04c1: stloc.s 6
-		IL_04c3: ldloc.s 6
-		IL_04c5: ldstr "groups"
-		IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04cf: stloc.s 6
-		IL_04d1: ldloc.s 6
-		IL_04d3: ldstr "optional"
-		IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04dd: stloc.s 6
-		IL_04df: ldloc.s 6
-		IL_04e1: ldnull
-		IL_04e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04e7: stloc.s 8
-		IL_04e9: ldloc.s 8
-		IL_04eb: box [System.Runtime]System.Boolean
-		IL_04f0: stloc.s 9
-		IL_04f2: ldloc.s 7
-		IL_04f4: ldstr "log"
-		IL_04f9: ldloc.s 9
-		IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0500: pop
-		IL_0501: ldstr "console"
-		IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0510: stloc.s 7
-		IL_0512: ldloc.1
-		IL_0513: ldstr "groups"
-		IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_051d: stloc.s 6
-		IL_051f: ldloc.1
-		IL_0520: ldstr "indices"
-		IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_052a: stloc.s 10
-		IL_052c: ldloc.s 10
-		IL_052e: ldstr "groups"
-		IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0538: stloc.s 10
-		IL_053a: ldloc.s 6
-		IL_053c: ldloc.s 10
-		IL_053e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0543: stloc.s 8
-		IL_0545: ldloc.s 8
-		IL_0547: box [System.Runtime]System.Boolean
-		IL_054c: stloc.s 9
-		IL_054e: ldloc.s 7
-		IL_0550: ldstr "log"
-		IL_0555: ldloc.s 9
-		IL_0557: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_055c: pop
-		IL_055d: ldstr "a"
-		IL_0562: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0567: stloc.s 11
-		IL_0569: ldstr "(?<letter>a)"
-		IL_056e: ldstr ""
-		IL_0573: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0578: stloc.s 5
-		IL_057a: ldloc.s 11
-		IL_057c: ldstr "match"
-		IL_0581: ldloc.s 5
-		IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0588: stloc.2
-		IL_0589: ldstr "console"
-		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0598: stloc.s 7
-		IL_059a: ldloc.2
-		IL_059b: ldstr "groups"
-		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05a5: stloc.s 10
-		IL_05a7: ldloc.s 10
-		IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_05ae: stloc.s 10
-		IL_05b0: ldloc.s 10
-		IL_05b2: ldc.i4.0
-		IL_05b3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_05b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_05bd: stloc.s 8
-		IL_05bf: ldloc.s 8
-		IL_05c1: box [System.Runtime]System.Boolean
-		IL_05c6: stloc.s 9
-		IL_05c8: ldloc.s 7
-		IL_05ca: ldstr "log"
-		IL_05cf: ldloc.s 9
-		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05d6: pop
-		IL_05d7: ldstr "console"
-		IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05e6: stloc.s 7
-		IL_05e8: ldloc.2
-		IL_05e9: ldstr "groups"
-		IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05f3: stloc.s 10
-		IL_05f5: ldloc.s 10
-		IL_05f7: ldstr "letter"
-		IL_05fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0601: stloc.s 10
-		IL_0603: ldloc.s 7
-		IL_0605: ldstr "log"
-		IL_060a: ldloc.s 10
-		IL_060c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0611: pop
-		IL_0612: ldstr "a a"
-		IL_0617: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_061c: stloc.s 11
-		IL_061e: ldstr "(?<letter>a)"
-		IL_0623: ldstr "g"
-		IL_0628: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_062d: stloc.s 5
-		IL_062f: ldloc.s 11
-		IL_0631: ldstr "matchAll"
-		IL_0636: ldloc.s 5
-		IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_063d: stloc.s 10
-		IL_063f: ldloc.s 10
-		IL_0641: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0646: stloc.3
-		IL_0647: ldstr "console"
-		IL_064c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0656: ldloc.3
-		IL_0657: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_065c: box [System.Runtime]System.Double
-		IL_0661: stloc.s 12
-		IL_0663: ldstr "log"
-		IL_0668: ldloc.s 12
-		IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_066f: pop
-		IL_0670: ldstr "console"
-		IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_067f: stloc.s 10
-		IL_0681: ldloc.3
-		IL_0682: ldc.r8 0.0
-		IL_068b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0690: ldstr "groups"
-		IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_069a: stloc.s 7
-		IL_069c: ldloc.s 7
-		IL_069e: ldstr "letter"
-		IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06a8: stloc.s 7
-		IL_06aa: ldloc.s 10
-		IL_06ac: ldstr "log"
-		IL_06b1: ldloc.s 7
-		IL_06b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06b8: pop
-		IL_06b9: ldstr "console"
-		IL_06be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06c8: stloc.s 7
-		IL_06ca: ldloc.3
-		IL_06cb: ldc.r8 1
-		IL_06d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_06d9: ldstr "groups"
-		IL_06de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06e3: stloc.s 10
-		IL_06e5: ldloc.s 10
-		IL_06e7: ldstr "letter"
-		IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06f1: stloc.s 10
-		IL_06f3: ldloc.s 7
-		IL_06f5: ldstr "log"
-		IL_06fa: ldloc.s 10
-		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0701: pop
-		IL_0702: ldstr "a"
-		IL_0707: ldstr "d"
-		IL_070c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0711: stloc.s 5
-		IL_0713: ldloc.s 5
-		IL_0715: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.RegExp>(!!0)
-		IL_071a: stloc.s 5
-		IL_071c: ldloc.s 5
-		IL_071e: ldstr "exec"
-		IL_0723: ldstr "a"
-		IL_0728: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_072d: stloc.s 4
-		IL_072f: ldstr "console"
-		IL_0734: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_073e: stloc.s 10
-		IL_0740: ldloc.s 4
-		IL_0742: ldstr "groups"
-		IL_0747: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_074c: stloc.s 7
-		IL_074e: ldloc.s 7
-		IL_0750: ldnull
-		IL_0751: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0756: stloc.s 8
-		IL_0758: ldloc.s 8
-		IL_075a: box [System.Runtime]System.Boolean
-		IL_075f: stloc.s 9
-		IL_0761: ldloc.s 10
-		IL_0763: ldstr "log"
-		IL_0768: ldloc.s 9
-		IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_076f: pop
-		IL_0770: ldstr "console"
-		IL_0775: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_077a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_077f: stloc.s 10
-		IL_0781: ldloc.s 4
-		IL_0783: ldstr "indices"
-		IL_0788: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_078d: stloc.s 7
-		IL_078f: ldloc.s 7
-		IL_0791: ldstr "groups"
-		IL_0796: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_079b: stloc.s 7
-		IL_079d: ldloc.s 7
-		IL_079f: ldnull
-		IL_07a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_07a5: stloc.s 8
-		IL_07a7: ldloc.s 8
-		IL_07a9: box [System.Runtime]System.Boolean
-		IL_07ae: stloc.s 9
-		IL_07b0: ldloc.s 10
-		IL_07b2: ldstr "log"
-		IL_07b7: ldloc.s 9
-		IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07be: pop
-		IL_07bf: ldstr "console"
-		IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07ce: ldloc.s 4
-		IL_07d0: ldstr "groups"
-		IL_07d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_07da: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_07df: stloc.s 10
-		IL_07e1: ldstr "log"
-		IL_07e6: ldloc.s 10
-		IL_07e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07ed: pop
-		IL_07ee: ldstr "console"
-		IL_07f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07fd: stloc.s 10
-		IL_07ff: ldloc.s 4
-		IL_0801: ldstr "indices"
-		IL_0806: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_080b: stloc.s 7
-		IL_080d: ldloc.s 7
-		IL_080f: ldstr "groups"
-		IL_0814: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0819: stloc.s 7
-		IL_081b: ldloc.s 7
-		IL_081d: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0822: stloc.s 7
-		IL_0824: ldloc.s 10
-		IL_0826: ldstr "log"
-		IL_082b: ldloc.s 7
-		IL_082d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0832: pop
-		IL_0833: ret
+		IL_043f: ldloc.s 6
+		IL_0441: ldstr "log"
+		IL_0446: ldloc.s 7
+		IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_044d: pop
+		IL_044e: ldstr "console"
+		IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_045d: stloc.s 7
+		IL_045f: ldloc.1
+		IL_0460: ldstr "indices"
+		IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_046a: stloc.s 6
+		IL_046c: ldloc.s 6
+		IL_046e: ldstr "groups"
+		IL_0473: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0478: stloc.s 6
+		IL_047a: ldloc.s 6
+		IL_047c: ldstr "optional"
+		IL_0481: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0486: box [System.Runtime]System.Boolean
+		IL_048b: stloc.s 9
+		IL_048d: ldloc.s 7
+		IL_048f: ldstr "log"
+		IL_0494: ldloc.s 9
+		IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_049b: pop
+		IL_049c: ldstr "console"
+		IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04ab: stloc.s 7
+		IL_04ad: ldloc.1
+		IL_04ae: ldstr "indices"
+		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04b8: stloc.s 6
+		IL_04ba: ldloc.s 6
+		IL_04bc: ldstr "groups"
+		IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04c6: stloc.s 6
+		IL_04c8: ldloc.s 6
+		IL_04ca: ldstr "optional"
+		IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04d4: stloc.s 6
+		IL_04d6: ldloc.s 6
+		IL_04d8: ldnull
+		IL_04d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04de: stloc.s 8
+		IL_04e0: ldloc.s 8
+		IL_04e2: box [System.Runtime]System.Boolean
+		IL_04e7: stloc.s 9
+		IL_04e9: ldloc.s 7
+		IL_04eb: ldstr "log"
+		IL_04f0: ldloc.s 9
+		IL_04f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04f7: pop
+		IL_04f8: ldstr "console"
+		IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0507: stloc.s 7
+		IL_0509: ldloc.1
+		IL_050a: ldstr "groups"
+		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0514: stloc.s 6
+		IL_0516: ldloc.1
+		IL_0517: ldstr "indices"
+		IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0521: stloc.s 10
+		IL_0523: ldloc.s 10
+		IL_0525: ldstr "groups"
+		IL_052a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_052f: stloc.s 10
+		IL_0531: ldloc.s 6
+		IL_0533: ldloc.s 10
+		IL_0535: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_053a: stloc.s 8
+		IL_053c: ldloc.s 8
+		IL_053e: box [System.Runtime]System.Boolean
+		IL_0543: stloc.s 9
+		IL_0545: ldloc.s 7
+		IL_0547: ldstr "log"
+		IL_054c: ldloc.s 9
+		IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0553: pop
+		IL_0554: ldstr "(?<letter>a)"
+		IL_0559: ldstr ""
+		IL_055e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0563: stloc.s 5
+		IL_0565: ldstr "a"
+		IL_056a: ldstr "match"
+		IL_056f: ldloc.s 5
+		IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0576: stloc.2
+		IL_0577: ldstr "console"
+		IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0581: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0586: stloc.s 7
+		IL_0588: ldloc.2
+		IL_0589: ldstr "groups"
+		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0593: stloc.s 10
+		IL_0595: ldloc.s 10
+		IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_059c: stloc.s 10
+		IL_059e: ldloc.s 10
+		IL_05a0: ldc.i4.0
+		IL_05a1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_05a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05ab: stloc.s 8
+		IL_05ad: ldloc.s 8
+		IL_05af: box [System.Runtime]System.Boolean
+		IL_05b4: stloc.s 9
+		IL_05b6: ldloc.s 7
+		IL_05b8: ldstr "log"
+		IL_05bd: ldloc.s 9
+		IL_05bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05c4: pop
+		IL_05c5: ldstr "console"
+		IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05d4: stloc.s 7
+		IL_05d6: ldloc.2
+		IL_05d7: ldstr "groups"
+		IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05e1: stloc.s 10
+		IL_05e3: ldloc.s 10
+		IL_05e5: ldstr "letter"
+		IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ef: stloc.s 10
+		IL_05f1: ldloc.s 7
+		IL_05f3: ldstr "log"
+		IL_05f8: ldloc.s 10
+		IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05ff: pop
+		IL_0600: ldstr "(?<letter>a)"
+		IL_0605: ldstr "g"
+		IL_060a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_060f: stloc.s 5
+		IL_0611: ldstr "a a"
+		IL_0616: ldstr "matchAll"
+		IL_061b: ldloc.s 5
+		IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0622: stloc.s 10
+		IL_0624: ldloc.s 10
+		IL_0626: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_062b: stloc.3
+		IL_062c: ldstr "console"
+		IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0636: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_063b: ldloc.3
+		IL_063c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0641: box [System.Runtime]System.Double
+		IL_0646: stloc.s 11
+		IL_0648: ldstr "log"
+		IL_064d: ldloc.s 11
+		IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0654: pop
+		IL_0655: ldstr "console"
+		IL_065a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_065f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0664: stloc.s 10
+		IL_0666: ldloc.3
+		IL_0667: ldc.r8 0.0
+		IL_0670: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0675: ldstr "groups"
+		IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_067f: stloc.s 7
+		IL_0681: ldloc.s 7
+		IL_0683: ldstr "letter"
+		IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_068d: stloc.s 7
+		IL_068f: ldloc.s 10
+		IL_0691: ldstr "log"
+		IL_0696: ldloc.s 7
+		IL_0698: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_069d: pop
+		IL_069e: ldstr "console"
+		IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06ad: stloc.s 7
+		IL_06af: ldloc.3
+		IL_06b0: ldc.r8 1
+		IL_06b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_06be: ldstr "groups"
+		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06c8: stloc.s 10
+		IL_06ca: ldloc.s 10
+		IL_06cc: ldstr "letter"
+		IL_06d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06d6: stloc.s 10
+		IL_06d8: ldloc.s 7
+		IL_06da: ldstr "log"
+		IL_06df: ldloc.s 10
+		IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06e6: pop
+		IL_06e7: ldstr "a"
+		IL_06ec: ldstr "d"
+		IL_06f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_06f6: stloc.s 5
+		IL_06f8: ldloc.s 5
+		IL_06fa: ldstr "exec"
+		IL_06ff: ldstr "a"
+		IL_0704: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0709: stloc.s 4
+		IL_070b: ldstr "console"
+		IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0715: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_071a: stloc.s 10
+		IL_071c: ldloc.s 4
+		IL_071e: ldstr "groups"
+		IL_0723: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0728: stloc.s 7
+		IL_072a: ldloc.s 7
+		IL_072c: ldnull
+		IL_072d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0732: stloc.s 8
+		IL_0734: ldloc.s 8
+		IL_0736: box [System.Runtime]System.Boolean
+		IL_073b: stloc.s 9
+		IL_073d: ldloc.s 10
+		IL_073f: ldstr "log"
+		IL_0744: ldloc.s 9
+		IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_074b: pop
+		IL_074c: ldstr "console"
+		IL_0751: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_075b: stloc.s 10
+		IL_075d: ldloc.s 4
+		IL_075f: ldstr "indices"
+		IL_0764: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0769: stloc.s 7
+		IL_076b: ldloc.s 7
+		IL_076d: ldstr "groups"
+		IL_0772: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0777: stloc.s 7
+		IL_0779: ldloc.s 7
+		IL_077b: ldnull
+		IL_077c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0781: stloc.s 8
+		IL_0783: ldloc.s 8
+		IL_0785: box [System.Runtime]System.Boolean
+		IL_078a: stloc.s 9
+		IL_078c: ldloc.s 10
+		IL_078e: ldstr "log"
+		IL_0793: ldloc.s 9
+		IL_0795: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_079a: pop
+		IL_079b: ldstr "console"
+		IL_07a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07aa: ldloc.s 4
+		IL_07ac: ldstr "groups"
+		IL_07b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_07b6: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_07bb: stloc.s 10
+		IL_07bd: ldstr "log"
+		IL_07c2: ldloc.s 10
+		IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07c9: pop
+		IL_07ca: ldstr "console"
+		IL_07cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07d9: stloc.s 10
+		IL_07db: ldloc.s 4
+		IL_07dd: ldstr "indices"
+		IL_07e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07e7: stloc.s 7
+		IL_07e9: ldloc.s 7
+		IL_07eb: ldstr "groups"
+		IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_07f5: stloc.s 7
+		IL_07f7: ldloc.s 7
+		IL_07f9: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_07fe: stloc.s 7
+		IL_0800: ldloc.s 10
+		IL_0802: ldstr "log"
+		IL_0807: ldloc.s 7
+		IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_080e: pop
+		IL_080f: ret
 	} // end of method String_RegExp_NamedGroups_Indices::__js_module_init__
 
 } // end of class Modules.String_RegExp_NamedGroups_Indices
@@ -678,7 +665,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2899
+		// Method begins at RVA 0x2875
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2624
+				// Method begins at RVA 0x25f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2430
+			// Method begins at RVA 0x2404
 			// Header size: 12
 			// Code size: 100 (0x64)
 			.maxstack 8
@@ -103,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x262d
+				// Method begins at RVA 0x2601
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,7 +131,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x24a0
+			// Method begins at RVA 0x2474
 			// Header size: 12
 			// Code size: 124 (0x7c)
 			.maxstack 8
@@ -193,7 +193,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2636
+				// Method begins at RVA 0x260a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -220,7 +220,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2528
+			// Method begins at RVA 0x24fc
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -274,7 +274,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x263f
+				// Method begins at RVA 0x2613
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -302,7 +302,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x258c
+			// Method begins at RVA 0x2560
 			// Header size: 12
 			// Code size: 131 (0x83)
 			.maxstack 8
@@ -371,7 +371,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2648
+				// Method begins at RVA 0x261c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -391,7 +391,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2651
+				// Method begins at RVA 0x2625
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -412,7 +412,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x261b
+			// Method begins at RVA 0x25ef
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -438,7 +438,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 964 (0x3c4)
+		// Code size: 919 (0x397)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_SymbolDispatch_Custom/Scope,
@@ -563,211 +563,196 @@
 		IL_012b: ldc.i4.1
 		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
 		IL_0131: pop
-		IL_0132: ldstr "abc"
-		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_013c: stloc.s 15
-		IL_013e: ldloc.0
-		IL_013f: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0144: stloc.s 11
-		IL_0146: ldloc.s 15
-		IL_0148: ldstr "match"
-		IL_014d: ldloc.s 11
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0154: stloc.1
-		IL_0155: ldstr "console"
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0164: stloc.s 11
-		IL_0166: ldloc.1
-		IL_0167: ldc.r8 0.0
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0175: stloc.s 12
-		IL_0177: ldloc.s 11
-		IL_0179: ldstr "log"
-		IL_017e: ldloc.s 12
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0185: pop
-		IL_0186: ldstr "abc"
-		IL_018b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0190: stloc.s 15
-		IL_0192: ldloc.0
-		IL_0193: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0198: stloc.s 12
-		IL_019a: ldloc.s 15
-		IL_019c: ldstr "replace"
-		IL_01a1: ldloc.s 12
-		IL_01a3: ldstr "x"
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01ad: stloc.2
-		IL_01ae: ldstr "console"
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bd: stloc.s 12
-		IL_01bf: ldloc.2
-		IL_01c0: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_01c5: stloc.s 15
-		IL_01c7: ldloc.s 12
-		IL_01c9: ldstr "log"
-		IL_01ce: ldloc.s 15
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d5: pop
-		IL_01d6: ldstr "console"
-		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e5: ldstr "log"
-		IL_01ea: ldloc.2
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f0: pop
-		IL_01f1: ldstr "abc"
-		IL_01f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_01fb: stloc.s 15
-		IL_01fd: ldloc.0
-		IL_01fe: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0203: stloc.s 12
-		IL_0205: ldloc.s 15
-		IL_0207: ldstr "search"
-		IL_020c: ldloc.s 12
-		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0213: stloc.3
-		IL_0214: ldstr "console"
-		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0223: stloc.s 12
-		IL_0225: ldloc.3
-		IL_0226: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_022b: stloc.s 15
-		IL_022d: ldloc.s 12
-		IL_022f: ldstr "log"
-		IL_0234: ldloc.s 15
+		IL_0132: ldloc.0
+		IL_0133: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_0138: stloc.s 11
+		IL_013a: ldstr "abc"
+		IL_013f: ldstr "match"
+		IL_0144: ldloc.s 11
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014b: stloc.1
+		IL_014c: ldstr "console"
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015b: stloc.s 11
+		IL_015d: ldloc.1
+		IL_015e: ldc.r8 0.0
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_016c: stloc.s 12
+		IL_016e: ldloc.s 11
+		IL_0170: ldstr "log"
+		IL_0175: ldloc.s 12
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017c: pop
+		IL_017d: ldloc.0
+		IL_017e: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_0183: stloc.s 12
+		IL_0185: ldstr "abc"
+		IL_018a: ldstr "replace"
+		IL_018f: ldloc.s 12
+		IL_0191: ldstr "x"
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_019b: stloc.2
+		IL_019c: ldstr "console"
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ab: stloc.s 12
+		IL_01ad: ldloc.2
+		IL_01ae: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_01b3: stloc.s 15
+		IL_01b5: ldloc.s 12
+		IL_01b7: ldstr "log"
+		IL_01bc: ldloc.s 15
+		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c3: pop
+		IL_01c4: ldstr "console"
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d3: ldstr "log"
+		IL_01d8: ldloc.2
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01de: pop
+		IL_01df: ldloc.0
+		IL_01e0: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_01e5: stloc.s 12
+		IL_01e7: ldstr "abc"
+		IL_01ec: ldstr "search"
+		IL_01f1: ldloc.s 12
+		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f8: stloc.3
+		IL_01f9: ldstr "console"
+		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0208: stloc.s 12
+		IL_020a: ldloc.3
+		IL_020b: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0210: stloc.s 15
+		IL_0212: ldloc.s 12
+		IL_0214: ldstr "log"
+		IL_0219: ldloc.s 15
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0220: pop
+		IL_0221: ldstr "console"
+		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0230: ldstr "log"
+		IL_0235: ldloc.3
 		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_023b: pop
-		IL_023c: ldstr "console"
-		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024b: ldstr "log"
-		IL_0250: ldloc.3
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0256: pop
-		IL_0257: ldstr "abc"
-		IL_025c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0261: stloc.s 15
-		IL_0263: ldloc.0
-		IL_0264: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0269: stloc.s 12
-		IL_026b: ldloc.s 15
-		IL_026d: ldstr "split"
-		IL_0272: ldloc.s 12
-		IL_0274: ldc.r8 5
-		IL_027d: box [System.Runtime]System.Double
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0287: stloc.s 4
-		IL_0289: ldstr "console"
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0298: stloc.s 12
-		IL_029a: ldloc.s 4
-		IL_029c: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_02a1: stloc.s 15
-		IL_02a3: ldloc.s 12
-		IL_02a5: ldstr "log"
-		IL_02aa: ldloc.s 15
-		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b1: pop
-		IL_02b2: ldstr "console"
-		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c1: stloc.s 12
-		IL_02c3: ldloc.s 4
-		IL_02c5: ldstr "marker"
-		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02cf: stloc.s 11
-		IL_02d1: ldloc.s 12
-		IL_02d3: ldstr "log"
-		IL_02d8: ldloc.s 11
-		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02df: pop
-		IL_02e0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02e5: stloc.s 5
-		IL_02e7: ldstr "match"
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_02f1: stloc.s 11
-		IL_02f3: ldloc.s 5
-		IL_02f5: ldloc.s 11
-		IL_02f7: ldc.r8 1
-		IL_0300: box [System.Runtime]System.Double
-		IL_0305: ldc.i4.1
-		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_030b: pop
+		IL_023c: ldloc.0
+		IL_023d: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_0242: stloc.s 12
+		IL_0244: ldstr "abc"
+		IL_0249: ldstr "split"
+		IL_024e: ldloc.s 12
+		IL_0250: ldc.r8 5
+		IL_0259: box [System.Runtime]System.Double
+		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0263: stloc.s 4
+		IL_0265: ldstr "console"
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0274: stloc.s 12
+		IL_0276: ldloc.s 4
+		IL_0278: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_027d: stloc.s 15
+		IL_027f: ldloc.s 12
+		IL_0281: ldstr "log"
+		IL_0286: ldloc.s 15
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028d: pop
+		IL_028e: ldstr "console"
+		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_029d: stloc.s 12
+		IL_029f: ldloc.s 4
+		IL_02a1: ldstr "marker"
+		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ab: stloc.s 11
+		IL_02ad: ldloc.s 12
+		IL_02af: ldstr "log"
+		IL_02b4: ldloc.s 11
+		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02bb: pop
+		IL_02bc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02c1: stloc.s 5
+		IL_02c3: ldstr "match"
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_02cd: stloc.s 11
+		IL_02cf: ldloc.s 5
+		IL_02d1: ldloc.s 11
+		IL_02d3: ldc.r8 1
+		IL_02dc: box [System.Runtime]System.Double
+		IL_02e1: ldc.i4.1
+		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_02e7: pop
 		.try
 		{
-			IL_030c: nop
-			IL_030d: ldstr "abc"
-			IL_0312: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_0317: stloc.s 15
-			IL_0319: ldloc.s 15
-			IL_031b: ldstr "match"
-			IL_0320: ldloc.s 5
-			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0327: pop
-			IL_0328: leave IL_03c0
+			IL_02e8: nop
+			IL_02e9: ldstr "abc"
+			IL_02ee: ldstr "match"
+			IL_02f3: ldloc.s 5
+			IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02fa: pop
+			IL_02fb: leave IL_0393
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_032d: stloc.s 6
-			IL_032f: ldloc.s 6
-			IL_0331: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0336: dup
-			IL_0337: brtrue IL_034d
+			IL_0300: stloc.s 6
+			IL_0302: ldloc.s 6
+			IL_0304: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0309: dup
+			IL_030a: brtrue IL_0320
 
-			IL_033c: pop
-			IL_033d: ldloc.s 6
-			IL_033f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0344: dup
-			IL_0345: brtrue IL_0359
+			IL_030f: pop
+			IL_0310: ldloc.s 6
+			IL_0312: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0317: dup
+			IL_0318: brtrue IL_032c
 
-			IL_034a: pop
-			IL_034b: rethrow
+			IL_031d: pop
+			IL_031e: rethrow
 
-			IL_034d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0352: stloc.s 7
-			IL_0354: br IL_035b
+			IL_0320: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0325: stloc.s 7
+			IL_0327: br IL_032e
 
-			IL_0359: stloc.s 7
+			IL_032c: stloc.s 7
 
-			IL_035b: ldloc.s 7
-			IL_035d: stloc.s 8
-			IL_035f: ldstr "console"
-			IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_036e: stloc.s 11
-			IL_0370: ldloc.s 8
-			IL_0372: ldstr "name"
-			IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_037c: stloc.s 12
-			IL_037e: ldloc.s 11
-			IL_0380: ldstr "log"
-			IL_0385: ldloc.s 12
-			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_038c: pop
-			IL_038d: ldstr "console"
-			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_039c: stloc.s 12
-			IL_039e: ldloc.s 8
-			IL_03a0: ldstr "message"
-			IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03aa: stloc.s 11
-			IL_03ac: ldloc.s 12
-			IL_03ae: ldstr "log"
-			IL_03b3: ldloc.s 11
-			IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03ba: pop
-			IL_03bb: leave IL_03c0
+			IL_032e: ldloc.s 7
+			IL_0330: stloc.s 8
+			IL_0332: ldstr "console"
+			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0341: stloc.s 11
+			IL_0343: ldloc.s 8
+			IL_0345: ldstr "name"
+			IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_034f: stloc.s 12
+			IL_0351: ldloc.s 11
+			IL_0353: ldstr "log"
+			IL_0358: ldloc.s 12
+			IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_035f: pop
+			IL_0360: ldstr "console"
+			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_036f: stloc.s 12
+			IL_0371: ldloc.s 8
+			IL_0373: ldstr "message"
+			IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_037d: stloc.s 11
+			IL_037f: ldloc.s 12
+			IL_0381: ldstr "log"
+			IL_0386: ldloc.s 11
+			IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_038d: pop
+			IL_038e: leave IL_0393
 		} // end handler
 
-		IL_03c0: ldnull
-		IL_03c1: stloc.s 9
-		IL_03c3: ret
+		IL_0393: ldnull
+		IL_0394: stloc.s 9
+		IL_0396: ret
 	} // end of method String_RegExp_SymbolDispatch_Custom::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_Custom
@@ -779,7 +764,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x265a
+		// Method begins at RVA 0x262e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpOverride.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpOverride.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2572
+				// Method begins at RVA 0x254e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x22fc
+			// Method begins at RVA 0x22d8
 			// Header size: 12
 			// Code size: 131 (0x83)
 			.maxstack 8
@@ -110,7 +110,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x257b
+				// Method begins at RVA 0x2557
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x238c
+			// Method begins at RVA 0x2368
 			// Header size: 12
 			// Code size: 146 (0x92)
 			.maxstack 8
@@ -206,7 +206,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2584
+				// Method begins at RVA 0x2560
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -233,7 +233,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x242c
+			// Method begins at RVA 0x2408
 			// Header size: 12
 			// Code size: 128 (0x80)
 			.maxstack 8
@@ -295,7 +295,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x258d
+				// Method begins at RVA 0x2569
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -323,7 +323,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x24b8
+			// Method begins at RVA 0x2494
 			// Header size: 12
 			// Code size: 165 (0xa5)
 			.maxstack 8
@@ -401,7 +401,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2569
+			// Method begins at RVA 0x2545
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -427,7 +427,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 669 (0x29d)
+		// Code size: 633 (0x279)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope,
@@ -436,8 +436,7 @@
 			[3] object,
 			[4] object,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[7] string
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
 		)
 
 		IL_0000: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::.ctor()
@@ -550,107 +549,95 @@
 		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0141: stloc.3
-		IL_0142: ldstr "aba"
-		IL_0147: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_014c: stloc.s 7
-		IL_014e: ldloc.0
-		IL_014f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-		IL_0154: stloc.s 4
-		IL_0156: ldloc.s 7
-		IL_0158: ldstr "match"
+		IL_0142: ldloc.0
+		IL_0143: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+		IL_0148: stloc.s 4
+		IL_014a: ldstr "aba"
+		IL_014f: ldstr "match"
+		IL_0154: ldloc.s 4
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015b: stloc.s 4
 		IL_015d: ldloc.s 4
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0164: stloc.s 4
-		IL_0166: ldloc.s 4
-		IL_0168: ldc.r8 0.0
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0176: stloc.s 4
-		IL_0178: ldloc.3
-		IL_0179: ldstr "log"
-		IL_017e: ldloc.s 4
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0185: pop
-		IL_0186: ldstr "console"
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0195: stloc.s 4
-		IL_0197: ldstr "aba"
-		IL_019c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_01a1: stloc.s 7
-		IL_01a3: ldloc.0
-		IL_01a4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-		IL_01a9: stloc.3
-		IL_01aa: ldloc.s 7
-		IL_01ac: ldstr "replace"
-		IL_01b1: ldloc.3
-		IL_01b2: ldstr "x"
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01bc: stloc.3
-		IL_01bd: ldloc.s 4
-		IL_01bf: ldstr "log"
-		IL_01c4: ldloc.3
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ca: pop
-		IL_01cb: ldstr "console"
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01da: stloc.3
-		IL_01db: ldstr "aba"
-		IL_01e0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_01e5: stloc.s 7
-		IL_01e7: ldloc.0
-		IL_01e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-		IL_01ed: stloc.s 4
-		IL_01ef: ldloc.s 7
-		IL_01f1: ldstr "search"
-		IL_01f6: ldloc.s 4
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fd: stloc.s 4
-		IL_01ff: ldloc.3
-		IL_0200: ldstr "log"
-		IL_0205: ldloc.s 4
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020c: pop
-		IL_020d: ldstr "aba"
-		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0217: stloc.s 7
-		IL_0219: ldloc.0
-		IL_021a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-		IL_021f: stloc.s 4
-		IL_0221: ldloc.s 7
-		IL_0223: ldstr "split"
-		IL_0228: ldloc.s 4
-		IL_022a: ldc.r8 3
-		IL_0233: box [System.Runtime]System.Double
-		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_023d: stloc.1
-		IL_023e: ldstr "console"
-		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024d: stloc.s 4
-		IL_024f: ldloc.1
-		IL_0250: ldc.r8 0.0
-		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_025e: stloc.3
-		IL_025f: ldloc.s 4
-		IL_0261: ldstr "log"
-		IL_0266: ldloc.3
-		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026c: pop
-		IL_026d: ldstr "console"
-		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027c: stloc.3
-		IL_027d: ldloc.1
-		IL_027e: ldc.r8 1
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_028c: stloc.s 4
-		IL_028e: ldloc.3
-		IL_028f: ldstr "log"
-		IL_0294: ldloc.s 4
-		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_029b: pop
-		IL_029c: ret
+		IL_015f: ldc.r8 0.0
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_016d: stloc.s 4
+		IL_016f: ldloc.3
+		IL_0170: ldstr "log"
+		IL_0175: ldloc.s 4
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017c: pop
+		IL_017d: ldstr "console"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018c: stloc.s 4
+		IL_018e: ldloc.0
+		IL_018f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+		IL_0194: stloc.3
+		IL_0195: ldstr "aba"
+		IL_019a: ldstr "replace"
+		IL_019f: ldloc.3
+		IL_01a0: ldstr "x"
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01aa: stloc.3
+		IL_01ab: ldloc.s 4
+		IL_01ad: ldstr "log"
+		IL_01b2: ldloc.3
+		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b8: pop
+		IL_01b9: ldstr "console"
+		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c8: stloc.3
+		IL_01c9: ldloc.0
+		IL_01ca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+		IL_01cf: stloc.s 4
+		IL_01d1: ldstr "aba"
+		IL_01d6: ldstr "search"
+		IL_01db: ldloc.s 4
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e2: stloc.s 4
+		IL_01e4: ldloc.3
+		IL_01e5: ldstr "log"
+		IL_01ea: ldloc.s 4
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f1: pop
+		IL_01f2: ldloc.0
+		IL_01f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+		IL_01f8: stloc.s 4
+		IL_01fa: ldstr "aba"
+		IL_01ff: ldstr "split"
+		IL_0204: ldloc.s 4
+		IL_0206: ldc.r8 3
+		IL_020f: box [System.Runtime]System.Double
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0219: stloc.1
+		IL_021a: ldstr "console"
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0229: stloc.s 4
+		IL_022b: ldloc.1
+		IL_022c: ldc.r8 0.0
+		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_023a: stloc.3
+		IL_023b: ldloc.s 4
+		IL_023d: ldstr "log"
+		IL_0242: ldloc.3
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0248: pop
+		IL_0249: ldstr "console"
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0258: stloc.3
+		IL_0259: ldloc.1
+		IL_025a: ldc.r8 1
+		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0268: stloc.s 4
+		IL_026a: ldloc.3
+		IL_026b: ldstr "log"
+		IL_0270: ldloc.s 4
+		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0277: pop
+		IL_0278: ret
 	} // end of method String_RegExp_SymbolDispatch_RegExpOverride::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_RegExpOverride
@@ -662,7 +649,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2596
+		// Method begins at RVA 0x2572
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpPrototypeOverride.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpPrototypeOverride.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x262e
+				// Method begins at RVA 0x260a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x23b8
+			// Method begins at RVA 0x2394
 			// Header size: 12
 			// Code size: 131 (0x83)
 			.maxstack 8
@@ -110,7 +110,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2637
+				// Method begins at RVA 0x2613
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2448
+			// Method begins at RVA 0x2424
 			// Header size: 12
 			// Code size: 146 (0x92)
 			.maxstack 8
@@ -206,7 +206,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2640
+				// Method begins at RVA 0x261c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -233,7 +233,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x24e8
+			// Method begins at RVA 0x24c4
 			// Header size: 12
 			// Code size: 128 (0x80)
 			.maxstack 8
@@ -295,7 +295,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2649
+				// Method begins at RVA 0x2625
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -323,7 +323,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2574
+			// Method begins at RVA 0x2550
 			// Header size: 12
 			// Code size: 165 (0xa5)
 			.maxstack 8
@@ -401,7 +401,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2625
+			// Method begins at RVA 0x2601
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -427,7 +427,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 859 (0x35b)
+		// Code size: 823 (0x337)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope,
@@ -441,8 +441,7 @@
 			[8] object,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[11] string,
-			[12] object
+			[11] object
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -578,143 +577,131 @@
 		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0192: stloc.s 8
-		IL_0194: ldstr "aba"
-		IL_0199: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_019e: stloc.s 11
-		IL_01a0: ldloc.0
-		IL_01a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-		IL_01a6: stloc.s 12
-		IL_01a8: ldloc.s 11
-		IL_01aa: ldstr "match"
-		IL_01af: ldloc.s 12
-		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b6: stloc.s 12
-		IL_01b8: ldloc.s 12
-		IL_01ba: ldc.r8 0.0
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01c8: stloc.s 12
-		IL_01ca: ldloc.s 8
-		IL_01cc: ldstr "log"
-		IL_01d1: ldloc.s 12
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d8: pop
-		IL_01d9: ldstr "console"
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e8: stloc.s 12
-		IL_01ea: ldstr "aba"
-		IL_01ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_01f4: stloc.s 11
-		IL_01f6: ldloc.0
-		IL_01f7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-		IL_01fc: stloc.s 8
-		IL_01fe: ldloc.s 11
-		IL_0200: ldstr "replace"
-		IL_0205: ldloc.s 8
-		IL_0207: ldstr "x"
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0211: stloc.s 8
-		IL_0213: ldloc.s 12
-		IL_0215: ldstr "log"
-		IL_021a: ldloc.s 8
-		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0221: pop
-		IL_0222: ldstr "console"
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0231: stloc.s 8
-		IL_0233: ldstr "aba"
-		IL_0238: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_023d: stloc.s 11
-		IL_023f: ldloc.0
-		IL_0240: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-		IL_0245: stloc.s 12
-		IL_0247: ldloc.s 11
-		IL_0249: ldstr "search"
-		IL_024e: ldloc.s 12
-		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0255: stloc.s 12
-		IL_0257: ldloc.s 8
-		IL_0259: ldstr "log"
-		IL_025e: ldloc.s 12
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0265: pop
-		IL_0266: ldstr "aba"
-		IL_026b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0270: stloc.s 11
-		IL_0272: ldloc.0
-		IL_0273: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-		IL_0278: stloc.s 12
-		IL_027a: ldloc.s 11
-		IL_027c: ldstr "split"
-		IL_0281: ldloc.s 12
-		IL_0283: ldc.r8 3
-		IL_028c: box [System.Runtime]System.Double
-		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0296: stloc.s 6
-		IL_0298: ldstr "console"
-		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a7: stloc.s 12
-		IL_02a9: ldloc.s 6
-		IL_02ab: ldc.r8 0.0
-		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02b9: stloc.s 8
-		IL_02bb: ldloc.s 12
-		IL_02bd: ldstr "log"
-		IL_02c2: ldloc.s 8
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c9: pop
-		IL_02ca: ldstr "console"
-		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d9: stloc.s 8
-		IL_02db: ldloc.s 6
-		IL_02dd: ldc.r8 1
-		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02eb: stloc.s 12
-		IL_02ed: ldloc.s 8
-		IL_02ef: ldstr "log"
-		IL_02f4: ldloc.s 12
-		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02fb: pop
-		IL_02fc: ldstr "match"
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0306: stloc.s 12
-		IL_0308: ldloc.1
-		IL_0309: ldloc.s 12
-		IL_030b: ldloc.2
-		IL_030c: ldc.i4.1
-		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_0312: pop
-		IL_0313: ldstr "replace"
-		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_031d: stloc.s 12
-		IL_031f: ldloc.1
-		IL_0320: ldloc.s 12
-		IL_0322: ldloc.3
-		IL_0323: ldc.i4.1
-		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_0329: pop
-		IL_032a: ldstr "search"
-		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0334: stloc.s 12
-		IL_0336: ldloc.1
-		IL_0337: ldloc.s 12
-		IL_0339: ldloc.s 4
-		IL_033b: ldc.i4.1
-		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_0341: pop
-		IL_0342: ldstr "split"
-		IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_034c: stloc.s 12
-		IL_034e: ldloc.1
-		IL_034f: ldloc.s 12
-		IL_0351: ldloc.s 5
-		IL_0353: ldc.i4.1
-		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_0359: pop
-		IL_035a: ret
+		IL_0194: ldloc.0
+		IL_0195: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
+		IL_019a: stloc.s 11
+		IL_019c: ldstr "aba"
+		IL_01a1: ldstr "match"
+		IL_01a6: ldloc.s 11
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ad: stloc.s 11
+		IL_01af: ldloc.s 11
+		IL_01b1: ldc.r8 0.0
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01bf: stloc.s 11
+		IL_01c1: ldloc.s 8
+		IL_01c3: ldstr "log"
+		IL_01c8: ldloc.s 11
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01cf: pop
+		IL_01d0: ldstr "console"
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01df: stloc.s 11
+		IL_01e1: ldloc.0
+		IL_01e2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
+		IL_01e7: stloc.s 8
+		IL_01e9: ldstr "aba"
+		IL_01ee: ldstr "replace"
+		IL_01f3: ldloc.s 8
+		IL_01f5: ldstr "x"
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01ff: stloc.s 8
+		IL_0201: ldloc.s 11
+		IL_0203: ldstr "log"
+		IL_0208: ldloc.s 8
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_020f: pop
+		IL_0210: ldstr "console"
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021f: stloc.s 8
+		IL_0221: ldloc.0
+		IL_0222: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
+		IL_0227: stloc.s 11
+		IL_0229: ldstr "aba"
+		IL_022e: ldstr "search"
+		IL_0233: ldloc.s 11
+		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023a: stloc.s 11
+		IL_023c: ldloc.s 8
+		IL_023e: ldstr "log"
+		IL_0243: ldloc.s 11
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024a: pop
+		IL_024b: ldloc.0
+		IL_024c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
+		IL_0251: stloc.s 11
+		IL_0253: ldstr "aba"
+		IL_0258: ldstr "split"
+		IL_025d: ldloc.s 11
+		IL_025f: ldc.r8 3
+		IL_0268: box [System.Runtime]System.Double
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0272: stloc.s 6
+		IL_0274: ldstr "console"
+		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0283: stloc.s 11
+		IL_0285: ldloc.s 6
+		IL_0287: ldc.r8 0.0
+		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0295: stloc.s 8
+		IL_0297: ldloc.s 11
+		IL_0299: ldstr "log"
+		IL_029e: ldloc.s 8
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a5: pop
+		IL_02a6: ldstr "console"
+		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b5: stloc.s 8
+		IL_02b7: ldloc.s 6
+		IL_02b9: ldc.r8 1
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02c7: stloc.s 11
+		IL_02c9: ldloc.s 8
+		IL_02cb: ldstr "log"
+		IL_02d0: ldloc.s 11
+		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d7: pop
+		IL_02d8: ldstr "match"
+		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_02e2: stloc.s 11
+		IL_02e4: ldloc.1
+		IL_02e5: ldloc.s 11
+		IL_02e7: ldloc.2
+		IL_02e8: ldc.i4.1
+		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_02ee: pop
+		IL_02ef: ldstr "replace"
+		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_02f9: stloc.s 11
+		IL_02fb: ldloc.1
+		IL_02fc: ldloc.s 11
+		IL_02fe: ldloc.3
+		IL_02ff: ldc.i4.1
+		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_0305: pop
+		IL_0306: ldstr "search"
+		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0310: stloc.s 11
+		IL_0312: ldloc.1
+		IL_0313: ldloc.s 11
+		IL_0315: ldloc.s 4
+		IL_0317: ldc.i4.1
+		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_031d: pop
+		IL_031e: ldstr "split"
+		IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0328: stloc.s 11
+		IL_032a: ldloc.1
+		IL_032b: ldloc.s 11
+		IL_032d: ldloc.s 5
+		IL_032f: ldc.i4.1
+		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_0335: pop
+		IL_0336: ret
 	} // end of method String_RegExp_SymbolDispatch_RegExpPrototypeOverride::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride
@@ -726,7 +713,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2652
+		// Method begins at RVA 0x262e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Replace_CallOnExpression.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Replace_CallOnExpression.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20ee
+			// Method begins at RVA 0x20de
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 146 (0x92)
+		// Code size: 130 (0x82)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Replace_CallOnExpression/Scope,
 			[1] object,
-			[2] string,
-			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			[2] object,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		)
 
 		IL_0000: newobj instance void Modules.String_Replace_CallOnExpression/Scope::.ctor()
@@ -58,42 +57,36 @@
 		IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0016: stloc.1
 		IL_0017: ldstr "abc"
-		IL_001c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0021: stloc.2
-		IL_0022: ldloc.2
-		IL_0023: ldstr "replace"
-		IL_0028: ldstr "b"
-		IL_002d: ldstr "x"
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0037: stloc.3
-		IL_0038: ldloc.1
-		IL_0039: ldstr "log"
-		IL_003e: ldloc.3
-		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0044: pop
-		IL_0045: ldstr "console"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0054: stloc.3
-		IL_0055: ldstr "abc"
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_005f: stloc.2
-		IL_0060: ldstr "b"
-		IL_0065: ldstr "g"
-		IL_006a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_006f: stloc.s 4
-		IL_0071: ldloc.2
-		IL_0072: ldstr "replace"
-		IL_0077: ldloc.s 4
-		IL_0079: ldstr "x"
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0083: stloc.1
-		IL_0084: ldloc.3
-		IL_0085: ldstr "log"
-		IL_008a: ldloc.1
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0090: pop
-		IL_0091: ret
+		IL_001c: ldstr "replace"
+		IL_0021: ldstr "b"
+		IL_0026: ldstr "x"
+		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0030: stloc.2
+		IL_0031: ldloc.1
+		IL_0032: ldstr "log"
+		IL_0037: ldloc.2
+		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_003d: pop
+		IL_003e: ldstr "console"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_004d: stloc.2
+		IL_004e: ldstr "b"
+		IL_0053: ldstr "g"
+		IL_0058: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_005d: stloc.3
+		IL_005e: ldstr "abc"
+		IL_0063: ldstr "replace"
+		IL_0068: ldloc.3
+		IL_0069: ldstr "x"
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0073: stloc.1
+		IL_0074: ldloc.2
+		IL_0075: ldstr "log"
+		IL_007a: ldloc.1
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0080: pop
+		IL_0081: ret
 	} // end of method String_Replace_CallOnExpression::__js_module_init__
 
 } // end of class Modules.String_Replace_CallOnExpression
@@ -105,7 +98,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f7
+		// Method begins at RVA 0x20e7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Replace_Regex_Global.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Replace_Regex_Global.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20b4
+			// Method begins at RVA 0x20ab
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 88 (0x58)
+		// Code size: 79 (0x4f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Replace_Regex_Global/Scope,
 			[1] string,
 			[2] object,
-			[3] string,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[5] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Replace_Regex_Global/Scope::.ctor()
@@ -60,25 +59,22 @@
 		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_001c: stloc.2
-		IL_001d: ldloc.1
-		IL_001e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0023: stloc.3
-		IL_0024: ldstr "b"
-		IL_0029: ldstr "g"
-		IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0033: stloc.s 4
-		IL_0035: ldloc.3
-		IL_0036: ldstr "replace"
-		IL_003b: ldloc.s 4
-		IL_003d: ldstr "x"
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0047: stloc.s 5
-		IL_0049: ldloc.2
-		IL_004a: ldstr "log"
-		IL_004f: ldloc.s 5
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0056: pop
-		IL_0057: ret
+		IL_001d: ldstr "b"
+		IL_0022: ldstr "g"
+		IL_0027: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_002c: stloc.3
+		IL_002d: ldloc.1
+		IL_002e: ldstr "replace"
+		IL_0033: ldloc.3
+		IL_0034: ldstr "x"
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_003e: stloc.s 4
+		IL_0040: ldloc.2
+		IL_0041: ldstr "log"
+		IL_0046: ldloc.s 4
+		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004d: pop
+		IL_004e: ret
 	} // end of method String_Replace_Regex_Global::__js_module_init__
 
 } // end of class Modules.String_Replace_Regex_Global
@@ -90,7 +86,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20bd
+		// Method begins at RVA 0x20b4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Search_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Search_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21f3
+			// Method begins at RVA 0x21c6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 407 (0x197)
+		// Code size: 362 (0x16a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Search_Basic/Scope,
 			[1] string,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[3] object,
-			[4] string,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[6] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Search_Basic/Scope::.ctor()
@@ -61,118 +60,103 @@
 		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_001c: stloc.3
-		IL_001d: ldloc.1
-		IL_001e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0023: stloc.s 4
-		IL_0025: ldstr "\\d+"
-		IL_002a: ldstr ""
-		IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0034: stloc.s 5
-		IL_0036: ldloc.s 4
-		IL_0038: ldstr "search"
-		IL_003d: ldloc.s 5
-		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0044: stloc.s 6
-		IL_0046: ldloc.3
-		IL_0047: ldstr "log"
-		IL_004c: ldloc.s 6
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0053: pop
-		IL_0054: ldstr "console"
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0063: stloc.s 6
-		IL_0065: ldloc.1
-		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_006b: stloc.s 4
-		IL_006d: ldloc.s 4
-		IL_006f: ldstr "search"
-		IL_0074: ldstr "123"
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007e: stloc.3
-		IL_007f: ldloc.s 6
-		IL_0081: ldstr "log"
-		IL_0086: ldloc.3
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008c: pop
-		IL_008d: ldstr "console"
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009c: stloc.3
-		IL_009d: ldloc.1
-		IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_00a3: stloc.s 4
-		IL_00a5: ldstr "xyz"
-		IL_00aa: ldstr ""
-		IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00b4: stloc.s 5
-		IL_00b6: ldloc.s 4
-		IL_00b8: ldstr "search"
-		IL_00bd: ldloc.s 5
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c4: stloc.s 6
-		IL_00c6: ldloc.3
-		IL_00c7: ldstr "log"
-		IL_00cc: ldloc.s 6
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ldstr "console"
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e3: stloc.s 6
-		IL_00e5: ldstr "undefined-value"
-		IL_00ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_00ef: stloc.s 4
-		IL_00f1: ldloc.s 4
-		IL_00f3: ldstr "search"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00fd: stloc.3
-		IL_00fe: ldloc.s 6
-		IL_0100: ldstr "log"
-		IL_0105: ldloc.3
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010b: pop
-		IL_010c: ldstr "a"
-		IL_0111: ldstr "g"
-		IL_0116: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_011b: stloc.2
-		IL_011c: ldloc.2
-		IL_011d: ldstr "lastIndex"
-		IL_0122: ldc.r8 2
-		IL_012b: ldc.i4.1
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0131: pop
-		IL_0132: ldstr "console"
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0141: stloc.3
-		IL_0142: ldstr "baaa"
-		IL_0147: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_014c: stloc.s 4
-		IL_014e: ldloc.s 4
-		IL_0150: ldstr "search"
-		IL_0155: ldloc.2
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015b: stloc.s 6
-		IL_015d: ldloc.3
-		IL_015e: ldstr "log"
-		IL_0163: ldloc.s 6
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016a: pop
-		IL_016b: ldstr "console"
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017a: stloc.s 6
-		IL_017c: ldloc.2
-		IL_017d: ldstr "lastIndex"
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0187: stloc.3
-		IL_0188: ldloc.s 6
-		IL_018a: ldstr "log"
-		IL_018f: ldloc.3
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0195: pop
-		IL_0196: ret
+		IL_001d: ldstr "\\d+"
+		IL_0022: ldstr ""
+		IL_0027: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_002c: stloc.s 4
+		IL_002e: ldloc.1
+		IL_002f: ldstr "search"
+		IL_0034: ldloc.s 4
+		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_003b: stloc.s 5
+		IL_003d: ldloc.3
+		IL_003e: ldstr "log"
+		IL_0043: ldloc.s 5
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004a: pop
+		IL_004b: ldstr "console"
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005a: stloc.s 5
+		IL_005c: ldloc.1
+		IL_005d: ldstr "search"
+		IL_0062: ldstr "123"
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006c: stloc.3
+		IL_006d: ldloc.s 5
+		IL_006f: ldstr "log"
+		IL_0074: ldloc.3
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007a: pop
+		IL_007b: ldstr "console"
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008a: stloc.3
+		IL_008b: ldstr "xyz"
+		IL_0090: ldstr ""
+		IL_0095: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_009a: stloc.s 4
+		IL_009c: ldloc.1
+		IL_009d: ldstr "search"
+		IL_00a2: ldloc.s 4
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a9: stloc.s 5
+		IL_00ab: ldloc.3
+		IL_00ac: ldstr "log"
+		IL_00b1: ldloc.s 5
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b8: pop
+		IL_00b9: ldstr "console"
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c8: stloc.s 5
+		IL_00ca: ldstr "undefined-value"
+		IL_00cf: ldstr "search"
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00d9: stloc.3
+		IL_00da: ldloc.s 5
+		IL_00dc: ldstr "log"
+		IL_00e1: ldloc.3
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e7: pop
+		IL_00e8: ldstr "a"
+		IL_00ed: ldstr "g"
+		IL_00f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00f7: stloc.2
+		IL_00f8: ldloc.2
+		IL_00f9: ldstr "lastIndex"
+		IL_00fe: ldc.r8 2
+		IL_0107: ldc.i4.1
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_010d: pop
+		IL_010e: ldstr "console"
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011d: stloc.3
+		IL_011e: ldstr "baaa"
+		IL_0123: ldstr "search"
+		IL_0128: ldloc.2
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012e: stloc.s 5
+		IL_0130: ldloc.3
+		IL_0131: ldstr "log"
+		IL_0136: ldloc.s 5
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013d: pop
+		IL_013e: ldstr "console"
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014d: stloc.s 5
+		IL_014f: ldloc.2
+		IL_0150: ldstr "lastIndex"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015a: stloc.3
+		IL_015b: ldloc.s 5
+		IL_015d: ldstr "log"
+		IL_0162: ldloc.3
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0168: pop
+		IL_0169: ret
 	} // end of method String_Search_Basic::__js_module_init__
 
 } // end of class Modules.String_Search_Basic
@@ -184,7 +168,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21fc
+		// Method begins at RVA 0x21cf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2142
+			// Method begins at RVA 0x2133
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 230 (0xe6)
+		// Code size: 215 (0xd7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Split_Basic/Scope,
 			[1] string,
 			[2] object,
-			[3] string,
-			[4] object,
-			[5] object
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Split_Basic/Scope::.ctor()
@@ -57,66 +56,63 @@
 		IL_0007: ldstr "a,b,c"
 		IL_000c: stloc.1
 		IL_000d: ldloc.1
-		IL_000e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0013: stloc.3
-		IL_0014: ldloc.3
-		IL_0015: ldstr "split"
-		IL_001a: ldstr ","
-		IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0024: stloc.2
-		IL_0025: ldstr "console"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0034: stloc.s 4
-		IL_0036: ldloc.2
-		IL_0037: ldstr "length"
-		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0041: stloc.s 5
-		IL_0043: ldloc.s 4
-		IL_0045: ldstr "log"
-		IL_004a: ldloc.s 5
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0051: pop
-		IL_0052: ldstr "console"
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0061: stloc.s 5
-		IL_0063: ldloc.2
-		IL_0064: ldc.r8 0.0
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0072: stloc.s 4
-		IL_0074: ldloc.s 5
-		IL_0076: ldstr "log"
-		IL_007b: ldloc.s 4
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0082: pop
-		IL_0083: ldstr "console"
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0092: stloc.s 4
-		IL_0094: ldloc.2
-		IL_0095: ldc.r8 1
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00a3: stloc.s 5
-		IL_00a5: ldloc.s 4
-		IL_00a7: ldstr "log"
-		IL_00ac: ldloc.s 5
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b3: pop
-		IL_00b4: ldstr "console"
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c3: stloc.s 5
-		IL_00c5: ldloc.2
-		IL_00c6: ldc.r8 2
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00d4: stloc.s 4
-		IL_00d6: ldloc.s 5
-		IL_00d8: ldstr "log"
-		IL_00dd: ldloc.s 4
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e4: pop
-		IL_00e5: ret
+		IL_000e: ldstr "split"
+		IL_0013: ldstr ","
+		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_001d: stloc.2
+		IL_001e: ldstr "console"
+		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_002d: stloc.3
+		IL_002e: ldloc.2
+		IL_002f: ldstr "length"
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0039: stloc.s 4
+		IL_003b: ldloc.3
+		IL_003c: ldstr "log"
+		IL_0041: ldloc.s 4
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0048: pop
+		IL_0049: ldstr "console"
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0058: stloc.s 4
+		IL_005a: ldloc.2
+		IL_005b: ldc.r8 0.0
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0069: stloc.3
+		IL_006a: ldloc.s 4
+		IL_006c: ldstr "log"
+		IL_0071: ldloc.3
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0077: pop
+		IL_0078: ldstr "console"
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0087: stloc.3
+		IL_0088: ldloc.2
+		IL_0089: ldc.r8 1
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0097: stloc.s 4
+		IL_0099: ldloc.3
+		IL_009a: ldstr "log"
+		IL_009f: ldloc.s 4
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a6: pop
+		IL_00a7: ldstr "console"
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b6: stloc.s 4
+		IL_00b8: ldloc.2
+		IL_00b9: ldc.r8 2
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00c7: stloc.3
+		IL_00c8: ldloc.s 4
+		IL_00ca: ldstr "log"
+		IL_00cf: ldloc.3
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d5: pop
+		IL_00d6: ret
 	} // end of method String_Split_Basic::__js_module_init__
 
 } // end of class Modules.String_Split_Basic
@@ -128,7 +124,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x214b
+		// Method begins at RVA 0x213c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2215
+			// Method begins at RVA 0x2203
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,139 +40,132 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 441 (0x1b9)
+		// Code size: 423 (0x1a7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Split_Regex_Basic/Scope,
 			[1] object,
 			[2] object,
-			[3] string,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[5] object,
-			[6] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Split_Regex_Basic/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldstr "a,b,c"
-		IL_000c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0011: stloc.3
-		IL_0012: ldstr ","
-		IL_0017: ldstr ""
-		IL_001c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0021: stloc.s 4
-		IL_0023: ldloc.3
-		IL_0024: ldstr "split"
-		IL_0029: ldloc.s 4
-		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0030: stloc.1
-		IL_0031: ldstr "console"
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0040: stloc.s 5
-		IL_0042: ldloc.1
-		IL_0043: ldstr "length"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_004d: stloc.s 6
-		IL_004f: ldloc.s 5
-		IL_0051: ldstr "log"
-		IL_0056: ldloc.s 6
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005d: pop
-		IL_005e: ldstr "console"
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006d: stloc.s 6
-		IL_006f: ldloc.1
-		IL_0070: ldc.r8 0.0
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_007e: stloc.s 5
-		IL_0080: ldloc.s 6
-		IL_0082: ldstr "log"
-		IL_0087: ldloc.s 5
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008e: pop
-		IL_008f: ldstr "console"
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009e: stloc.s 5
-		IL_00a0: ldloc.1
-		IL_00a1: ldc.r8 1
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00af: stloc.s 6
-		IL_00b1: ldloc.s 5
-		IL_00b3: ldstr "log"
-		IL_00b8: ldloc.s 6
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bf: pop
-		IL_00c0: ldstr "console"
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cf: stloc.s 6
-		IL_00d1: ldloc.1
-		IL_00d2: ldc.r8 2
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00e0: stloc.s 5
-		IL_00e2: ldloc.s 6
-		IL_00e4: ldstr "log"
-		IL_00e9: ldloc.s 5
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f0: pop
-		IL_00f1: ldstr "a,b,c"
-		IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_00fb: stloc.3
-		IL_00fc: ldstr ","
-		IL_0101: ldstr ""
-		IL_0106: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_010b: stloc.s 4
-		IL_010d: ldloc.3
-		IL_010e: ldstr "split"
-		IL_0113: ldloc.s 4
-		IL_0115: ldc.r8 2
-		IL_011e: box [System.Runtime]System.Double
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0128: stloc.2
-		IL_0129: ldstr "console"
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0138: stloc.s 5
-		IL_013a: ldloc.2
-		IL_013b: ldstr "length"
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0145: stloc.s 6
-		IL_0147: ldloc.s 5
-		IL_0149: ldstr "log"
-		IL_014e: ldloc.s 6
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0155: pop
-		IL_0156: ldstr "console"
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0165: stloc.s 6
-		IL_0167: ldloc.2
-		IL_0168: ldc.r8 0.0
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0176: stloc.s 5
-		IL_0178: ldloc.s 6
-		IL_017a: ldstr "log"
-		IL_017f: ldloc.s 5
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0186: pop
-		IL_0187: ldstr "console"
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0196: stloc.s 5
-		IL_0198: ldloc.2
-		IL_0199: ldc.r8 1
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01a7: stloc.s 6
-		IL_01a9: ldloc.s 5
-		IL_01ab: ldstr "log"
-		IL_01b0: ldloc.s 6
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b7: pop
-		IL_01b8: ret
+		IL_0007: ldstr ","
+		IL_000c: ldstr ""
+		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0016: stloc.3
+		IL_0017: ldstr "a,b,c"
+		IL_001c: ldstr "split"
+		IL_0021: ldloc.3
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0027: stloc.1
+		IL_0028: ldstr "console"
+		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0037: stloc.s 4
+		IL_0039: ldloc.1
+		IL_003a: ldstr "length"
+		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0044: stloc.s 5
+		IL_0046: ldloc.s 4
+		IL_0048: ldstr "log"
+		IL_004d: ldloc.s 5
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0054: pop
+		IL_0055: ldstr "console"
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0064: stloc.s 5
+		IL_0066: ldloc.1
+		IL_0067: ldc.r8 0.0
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0075: stloc.s 4
+		IL_0077: ldloc.s 5
+		IL_0079: ldstr "log"
+		IL_007e: ldloc.s 4
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0085: pop
+		IL_0086: ldstr "console"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0095: stloc.s 4
+		IL_0097: ldloc.1
+		IL_0098: ldc.r8 1
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00a6: stloc.s 5
+		IL_00a8: ldloc.s 4
+		IL_00aa: ldstr "log"
+		IL_00af: ldloc.s 5
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b6: pop
+		IL_00b7: ldstr "console"
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c6: stloc.s 5
+		IL_00c8: ldloc.1
+		IL_00c9: ldc.r8 2
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00d7: stloc.s 4
+		IL_00d9: ldloc.s 5
+		IL_00db: ldstr "log"
+		IL_00e0: ldloc.s 4
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e7: pop
+		IL_00e8: ldstr ","
+		IL_00ed: ldstr ""
+		IL_00f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00f7: stloc.3
+		IL_00f8: ldstr "a,b,c"
+		IL_00fd: ldstr "split"
+		IL_0102: ldloc.3
+		IL_0103: ldc.r8 2
+		IL_010c: box [System.Runtime]System.Double
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0116: stloc.2
+		IL_0117: ldstr "console"
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0126: stloc.s 4
+		IL_0128: ldloc.2
+		IL_0129: ldstr "length"
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0133: stloc.s 5
+		IL_0135: ldloc.s 4
+		IL_0137: ldstr "log"
+		IL_013c: ldloc.s 5
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0143: pop
+		IL_0144: ldstr "console"
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0153: stloc.s 5
+		IL_0155: ldloc.2
+		IL_0156: ldc.r8 0.0
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0164: stloc.s 4
+		IL_0166: ldloc.s 5
+		IL_0168: ldstr "log"
+		IL_016d: ldloc.s 4
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0174: pop
+		IL_0175: ldstr "console"
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0184: stloc.s 4
+		IL_0186: ldloc.2
+		IL_0187: ldc.r8 1
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0195: stloc.s 5
+		IL_0197: ldloc.s 4
+		IL_0199: ldstr "log"
+		IL_019e: ldloc.s 5
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a5: pop
+		IL_01a6: ret
 	} // end of method String_Split_Regex_Basic::__js_module_init__
 
 } // end of class Modules.String_Split_Regex_Basic
@@ -184,7 +177,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x221e
+		// Method begins at RVA 0x220c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Empty.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Empty.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2464
+			// Method begins at RVA 0x2437
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1032 (0x408)
+		// Code size: 987 (0x3db)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Split_Regex_Empty/Scope,
@@ -49,287 +49,271 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] string,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[8] object,
-			[9] object
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[7] object,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Split_Regex_Empty/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldstr "abc"
-		IL_000c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0011: stloc.s 6
-		IL_0013: ldstr "(?:)"
-		IL_0018: ldstr ""
-		IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0022: stloc.s 7
-		IL_0024: ldloc.s 6
-		IL_0026: ldstr "split"
-		IL_002b: ldloc.s 7
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0032: stloc.1
-		IL_0033: ldstr "console"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0042: stloc.s 8
-		IL_0044: ldloc.1
-		IL_0045: ldstr "length"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_004f: stloc.s 9
-		IL_0051: ldloc.s 8
-		IL_0053: ldstr "log"
-		IL_0058: ldloc.s 9
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005f: pop
-		IL_0060: ldstr "console"
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: stloc.s 9
-		IL_0071: ldloc.1
-		IL_0072: ldc.r8 0.0
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0080: stloc.s 8
-		IL_0082: ldloc.s 9
-		IL_0084: ldstr "log"
-		IL_0089: ldloc.s 8
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0090: pop
-		IL_0091: ldstr "console"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a0: stloc.s 8
-		IL_00a2: ldloc.1
-		IL_00a3: ldc.r8 1
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00b1: stloc.s 9
-		IL_00b3: ldloc.s 8
-		IL_00b5: ldstr "log"
-		IL_00ba: ldloc.s 9
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c1: pop
-		IL_00c2: ldstr "console"
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d1: stloc.s 9
-		IL_00d3: ldloc.1
-		IL_00d4: ldc.r8 2
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00e2: stloc.s 8
-		IL_00e4: ldloc.s 9
-		IL_00e6: ldstr "log"
-		IL_00eb: ldloc.s 8
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f2: pop
-		IL_00f3: ldstr "abc"
-		IL_00f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_00fd: stloc.s 6
-		IL_00ff: ldstr "(?:)"
-		IL_0104: ldstr ""
-		IL_0109: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_010e: stloc.s 7
-		IL_0110: ldloc.s 6
-		IL_0112: ldstr "split"
-		IL_0117: ldloc.s 7
-		IL_0119: ldc.r8 2
-		IL_0122: box [System.Runtime]System.Double
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_012c: stloc.2
-		IL_012d: ldstr "console"
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013c: stloc.s 8
-		IL_013e: ldloc.2
-		IL_013f: ldstr "length"
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0149: stloc.s 9
-		IL_014b: ldloc.s 8
-		IL_014d: ldstr "log"
-		IL_0152: ldloc.s 9
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0159: pop
-		IL_015a: ldstr "console"
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0169: stloc.s 9
-		IL_016b: ldloc.2
-		IL_016c: ldc.r8 0.0
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_017a: stloc.s 8
-		IL_017c: ldloc.s 9
-		IL_017e: ldstr "log"
-		IL_0183: ldloc.s 8
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018a: pop
-		IL_018b: ldstr "console"
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019a: stloc.s 8
-		IL_019c: ldloc.2
-		IL_019d: ldc.r8 1
-		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01ab: stloc.s 9
-		IL_01ad: ldloc.s 8
-		IL_01af: ldstr "log"
-		IL_01b4: ldloc.s 9
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bb: pop
-		IL_01bc: ldstr ""
-		IL_01c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_01c6: stloc.s 6
-		IL_01c8: ldstr "(?:)"
-		IL_01cd: ldstr ""
-		IL_01d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_01d7: stloc.s 7
-		IL_01d9: ldloc.s 6
-		IL_01db: ldstr "split"
-		IL_01e0: ldloc.s 7
-		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e7: stloc.3
-		IL_01e8: ldstr "console"
-		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f7: stloc.s 9
-		IL_01f9: ldloc.3
-		IL_01fa: ldstr "length"
-		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0204: stloc.s 8
-		IL_0206: ldloc.s 9
-		IL_0208: ldstr "log"
-		IL_020d: ldloc.s 8
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0214: pop
-		IL_0215: ldstr "\ud83d\ude00a"
-		IL_021a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_021f: stloc.s 6
-		IL_0221: ldstr "(?:)"
-		IL_0226: ldstr ""
-		IL_022b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0230: stloc.s 7
-		IL_0232: ldloc.s 6
-		IL_0234: ldstr "split"
-		IL_0239: ldloc.s 7
-		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0240: stloc.s 4
-		IL_0242: ldstr "console"
-		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0251: stloc.s 8
-		IL_0253: ldloc.s 4
-		IL_0255: ldstr "length"
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_025f: stloc.s 9
-		IL_0261: ldloc.s 8
-		IL_0263: ldstr "log"
-		IL_0268: ldloc.s 9
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026f: pop
-		IL_0270: ldstr "console"
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027f: stloc.s 9
-		IL_0281: ldloc.s 4
-		IL_0283: ldc.r8 0.0
-		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0291: stloc.s 8
-		IL_0293: ldloc.s 8
-		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_029a: ldstr "charCodeAt"
-		IL_029f: ldc.r8 0.0
-		IL_02a8: box [System.Runtime]System.Double
-		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b2: stloc.s 8
-		IL_02b4: ldloc.s 9
-		IL_02b6: ldstr "log"
-		IL_02bb: ldloc.s 8
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c2: pop
-		IL_02c3: ldstr "console"
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d2: stloc.s 8
-		IL_02d4: ldloc.s 4
-		IL_02d6: ldc.r8 1
-		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02e4: stloc.s 9
-		IL_02e6: ldloc.s 9
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ed: ldstr "charCodeAt"
-		IL_02f2: ldc.r8 0.0
-		IL_02fb: box [System.Runtime]System.Double
-		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0305: stloc.s 9
-		IL_0307: ldloc.s 8
-		IL_0309: ldstr "log"
-		IL_030e: ldloc.s 9
-		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0315: pop
-		IL_0316: ldstr "console"
-		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0325: stloc.s 9
-		IL_0327: ldloc.s 4
-		IL_0329: ldc.r8 2
-		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0337: stloc.s 8
-		IL_0339: ldloc.s 9
-		IL_033b: ldstr "log"
-		IL_0340: ldloc.s 8
-		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0347: pop
-		IL_0348: ldstr "\ud83d\ude00a"
-		IL_034d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0352: stloc.s 6
-		IL_0354: ldstr "(?:)"
-		IL_0359: ldstr "u"
-		IL_035e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0363: stloc.s 7
-		IL_0365: ldloc.s 6
-		IL_0367: ldstr "split"
-		IL_036c: ldloc.s 7
-		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0373: stloc.s 5
-		IL_0375: ldstr "console"
-		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0384: stloc.s 8
-		IL_0386: ldloc.s 5
-		IL_0388: ldstr "length"
-		IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0392: stloc.s 9
-		IL_0394: ldloc.s 8
-		IL_0396: ldstr "log"
-		IL_039b: ldloc.s 9
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03a2: pop
-		IL_03a3: ldstr "console"
-		IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b2: stloc.s 9
-		IL_03b4: ldloc.s 5
-		IL_03b6: ldc.r8 0.0
-		IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03c4: stloc.s 8
-		IL_03c6: ldloc.s 9
-		IL_03c8: ldstr "log"
-		IL_03cd: ldloc.s 8
-		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03d4: pop
-		IL_03d5: ldstr "console"
-		IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03e4: stloc.s 8
-		IL_03e6: ldloc.s 5
-		IL_03e8: ldc.r8 1
-		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03f6: stloc.s 9
-		IL_03f8: ldloc.s 8
-		IL_03fa: ldstr "log"
-		IL_03ff: ldloc.s 9
-		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0406: pop
-		IL_0407: ret
+		IL_0007: ldstr "(?:)"
+		IL_000c: ldstr ""
+		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0016: stloc.s 6
+		IL_0018: ldstr "abc"
+		IL_001d: ldstr "split"
+		IL_0022: ldloc.s 6
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0029: stloc.1
+		IL_002a: ldstr "console"
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0039: stloc.s 7
+		IL_003b: ldloc.1
+		IL_003c: ldstr "length"
+		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0046: stloc.s 8
+		IL_0048: ldloc.s 7
+		IL_004a: ldstr "log"
+		IL_004f: ldloc.s 8
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0056: pop
+		IL_0057: ldstr "console"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0066: stloc.s 8
+		IL_0068: ldloc.1
+		IL_0069: ldc.r8 0.0
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0077: stloc.s 7
+		IL_0079: ldloc.s 8
+		IL_007b: ldstr "log"
+		IL_0080: ldloc.s 7
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0087: pop
+		IL_0088: ldstr "console"
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0097: stloc.s 7
+		IL_0099: ldloc.1
+		IL_009a: ldc.r8 1
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00a8: stloc.s 8
+		IL_00aa: ldloc.s 7
+		IL_00ac: ldstr "log"
+		IL_00b1: ldloc.s 8
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b8: pop
+		IL_00b9: ldstr "console"
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c8: stloc.s 8
+		IL_00ca: ldloc.1
+		IL_00cb: ldc.r8 2
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00d9: stloc.s 7
+		IL_00db: ldloc.s 8
+		IL_00dd: ldstr "log"
+		IL_00e2: ldloc.s 7
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e9: pop
+		IL_00ea: ldstr "(?:)"
+		IL_00ef: ldstr ""
+		IL_00f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00f9: stloc.s 6
+		IL_00fb: ldstr "abc"
+		IL_0100: ldstr "split"
+		IL_0105: ldloc.s 6
+		IL_0107: ldc.r8 2
+		IL_0110: box [System.Runtime]System.Double
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_011a: stloc.2
+		IL_011b: ldstr "console"
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012a: stloc.s 7
+		IL_012c: ldloc.2
+		IL_012d: ldstr "length"
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0137: stloc.s 8
+		IL_0139: ldloc.s 7
+		IL_013b: ldstr "log"
+		IL_0140: ldloc.s 8
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0147: pop
+		IL_0148: ldstr "console"
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0157: stloc.s 8
+		IL_0159: ldloc.2
+		IL_015a: ldc.r8 0.0
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0168: stloc.s 7
+		IL_016a: ldloc.s 8
+		IL_016c: ldstr "log"
+		IL_0171: ldloc.s 7
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0178: pop
+		IL_0179: ldstr "console"
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0188: stloc.s 7
+		IL_018a: ldloc.2
+		IL_018b: ldc.r8 1
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0199: stloc.s 8
+		IL_019b: ldloc.s 7
+		IL_019d: ldstr "log"
+		IL_01a2: ldloc.s 8
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a9: pop
+		IL_01aa: ldstr "(?:)"
+		IL_01af: ldstr ""
+		IL_01b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_01b9: stloc.s 6
+		IL_01bb: ldstr ""
+		IL_01c0: ldstr "split"
+		IL_01c5: ldloc.s 6
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01cc: stloc.3
+		IL_01cd: ldstr "console"
+		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01dc: stloc.s 8
+		IL_01de: ldloc.3
+		IL_01df: ldstr "length"
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e9: stloc.s 7
+		IL_01eb: ldloc.s 8
+		IL_01ed: ldstr "log"
+		IL_01f2: ldloc.s 7
+		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f9: pop
+		IL_01fa: ldstr "(?:)"
+		IL_01ff: ldstr ""
+		IL_0204: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0209: stloc.s 6
+		IL_020b: ldstr "\ud83d\ude00a"
+		IL_0210: ldstr "split"
+		IL_0215: ldloc.s 6
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_021c: stloc.s 4
+		IL_021e: ldstr "console"
+		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_022d: stloc.s 7
+		IL_022f: ldloc.s 4
+		IL_0231: ldstr "length"
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023b: stloc.s 8
+		IL_023d: ldloc.s 7
+		IL_023f: ldstr "log"
+		IL_0244: ldloc.s 8
+		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024b: pop
+		IL_024c: ldstr "console"
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025b: stloc.s 8
+		IL_025d: ldloc.s 4
+		IL_025f: ldc.r8 0.0
+		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_026d: stloc.s 7
+		IL_026f: ldloc.s 7
+		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0276: ldstr "charCodeAt"
+		IL_027b: ldc.r8 0.0
+		IL_0284: box [System.Runtime]System.Double
+		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028e: stloc.s 7
+		IL_0290: ldloc.s 8
+		IL_0292: ldstr "log"
+		IL_0297: ldloc.s 7
+		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029e: pop
+		IL_029f: ldstr "console"
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ae: stloc.s 7
+		IL_02b0: ldloc.s 4
+		IL_02b2: ldc.r8 1
+		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02c0: stloc.s 8
+		IL_02c2: ldloc.s 8
+		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c9: ldstr "charCodeAt"
+		IL_02ce: ldc.r8 0.0
+		IL_02d7: box [System.Runtime]System.Double
+		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02e1: stloc.s 8
+		IL_02e3: ldloc.s 7
+		IL_02e5: ldstr "log"
+		IL_02ea: ldloc.s 8
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02f1: pop
+		IL_02f2: ldstr "console"
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0301: stloc.s 8
+		IL_0303: ldloc.s 4
+		IL_0305: ldc.r8 2
+		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0313: stloc.s 7
+		IL_0315: ldloc.s 8
+		IL_0317: ldstr "log"
+		IL_031c: ldloc.s 7
+		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0323: pop
+		IL_0324: ldstr "(?:)"
+		IL_0329: ldstr "u"
+		IL_032e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0333: stloc.s 6
+		IL_0335: ldstr "\ud83d\ude00a"
+		IL_033a: ldstr "split"
+		IL_033f: ldloc.s 6
+		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0346: stloc.s 5
+		IL_0348: ldstr "console"
+		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0357: stloc.s 7
+		IL_0359: ldloc.s 5
+		IL_035b: ldstr "length"
+		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0365: stloc.s 8
+		IL_0367: ldloc.s 7
+		IL_0369: ldstr "log"
+		IL_036e: ldloc.s 8
+		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0375: pop
+		IL_0376: ldstr "console"
+		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0385: stloc.s 8
+		IL_0387: ldloc.s 5
+		IL_0389: ldc.r8 0.0
+		IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0397: stloc.s 7
+		IL_0399: ldloc.s 8
+		IL_039b: ldstr "log"
+		IL_03a0: ldloc.s 7
+		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a7: pop
+		IL_03a8: ldstr "console"
+		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03b7: stloc.s 7
+		IL_03b9: ldloc.s 5
+		IL_03bb: ldc.r8 1
+		IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_03c9: stloc.s 8
+		IL_03cb: ldloc.s 7
+		IL_03cd: ldstr "log"
+		IL_03d2: ldloc.s 8
+		IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03d9: pop
+		IL_03da: ret
 	} // end of method String_Split_Regex_Empty::__js_module_init__
 
 } // end of class Modules.String_Split_Regex_Empty
@@ -341,7 +325,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x246d
+		// Method begins at RVA 0x2440
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x209d
+			// Method begins at RVA 0x2094
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,11 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 65 (0x41)
+		// Code size: 56 (0x38)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_StartsWith_Basic/Scope,
-			[1] object,
-			[2] string,
-			[3] bool
+			[1] bool
 		)
 
 		IL_0000: newobj instance void Modules.String_StartsWith_Basic/Scope::.ctor()
@@ -55,21 +53,16 @@
 		IL_0007: ldstr "console"
 		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0016: stloc.1
-		IL_0017: ldstr "abc"
-		IL_001c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0021: stloc.2
-		IL_0022: ldloc.2
-		IL_0023: ldstr "ab"
-		IL_0028: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-		IL_002d: stloc.3
-		IL_002e: ldloc.1
-		IL_002f: ldstr "log"
-		IL_0034: ldloc.3
-		IL_0035: box [System.Runtime]System.Boolean
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_003f: pop
-		IL_0040: ret
+		IL_0016: ldstr "abc"
+		IL_001b: ldstr "ab"
+		IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_0025: stloc.1
+		IL_0026: ldstr "log"
+		IL_002b: ldloc.1
+		IL_002c: box [System.Runtime]System.Boolean
+		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0036: pop
+		IL_0037: ret
 	} // end of method String_StartsWith_Basic::__js_module_init__
 
 } // end of class Modules.String_StartsWith_Basic
@@ -81,7 +74,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20a6
+		// Method begins at RVA 0x209d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ToLowerCase_ToUpperCase_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ToLowerCase_ToUpperCase_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20c2
+			// Method begins at RVA 0x20b0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,12 +40,11 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 102 (0x66)
+		// Code size: 84 (0x54)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_ToLowerCase_ToUpperCase_Basic/Scope,
-			[1] object,
-			[2] string
+			[1] string
 		)
 
 		IL_0000: newobj instance void Modules.String_ToLowerCase_ToUpperCase_Basic/Scope::.ctor()
@@ -54,34 +53,24 @@
 		IL_0007: ldstr "console"
 		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0016: stloc.1
-		IL_0017: ldstr "AbC"
-		IL_001c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0021: stloc.2
-		IL_0022: ldloc.2
-		IL_0023: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
-		IL_0028: stloc.2
-		IL_0029: ldloc.1
-		IL_002a: ldstr "log"
-		IL_002f: ldloc.2
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0035: pop
-		IL_0036: ldstr "console"
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0045: stloc.1
-		IL_0046: ldstr "AbC"
-		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0050: stloc.2
-		IL_0051: ldloc.2
-		IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-		IL_0057: stloc.2
-		IL_0058: ldloc.1
-		IL_0059: ldstr "log"
-		IL_005e: ldloc.2
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0064: pop
-		IL_0065: ret
+		IL_0016: ldstr "AbC"
+		IL_001b: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
+		IL_0020: stloc.1
+		IL_0021: ldstr "log"
+		IL_0026: ldloc.1
+		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_002c: pop
+		IL_002d: ldstr "console"
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003c: ldstr "AbC"
+		IL_0041: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+		IL_0046: stloc.1
+		IL_0047: ldstr "log"
+		IL_004c: ldloc.1
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0052: pop
+		IL_0053: ret
 	} // end of method String_ToLowerCase_ToUpperCase_Basic::__js_module_init__
 
 } // end of class Modules.String_ToLowerCase_ToUpperCase_Basic
@@ -93,7 +82,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20cb
+		// Method begins at RVA 0x20b9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.ArrayBuffer_Construct_ByteLength.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.ArrayBuffer_Construct_ByteLength.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2101
+			// Method begins at RVA 0x20f6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 165 (0xa5)
+		// Code size: 154 (0x9a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrayBuffer_Construct_ByteLength/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
 			[2] object,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
-			[4] object,
-			[5] object
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrayBuffer_Construct_ByteLength/Scope::.ctor()
@@ -59,43 +58,40 @@
 		IL_0015: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer::.ctor(object)
 		IL_001a: stloc.1
 		IL_001b: ldloc.1
-		IL_001c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer>(!!0)
-		IL_0021: stloc.3
-		IL_0022: ldloc.3
-		IL_0023: ldstr "slice"
-		IL_0028: ldc.r8 2
-		IL_0031: box [System.Runtime]System.Double
-		IL_0036: ldc.r8 6
-		IL_003f: box [System.Runtime]System.Double
-		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0049: stloc.2
-		IL_004a: ldstr "console"
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0059: stloc.s 4
-		IL_005b: ldloc.1
-		IL_005c: ldstr "byteLength"
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0066: stloc.s 5
-		IL_0068: ldloc.s 4
-		IL_006a: ldstr "log"
-		IL_006f: ldloc.s 5
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0076: pop
-		IL_0077: ldstr "console"
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0086: stloc.s 5
-		IL_0088: ldloc.2
-		IL_0089: ldstr "byteLength"
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0093: stloc.s 4
-		IL_0095: ldloc.s 5
-		IL_0097: ldstr "log"
-		IL_009c: ldloc.s 4
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a3: pop
-		IL_00a4: ret
+		IL_001c: ldstr "slice"
+		IL_0021: ldc.r8 2
+		IL_002a: box [System.Runtime]System.Double
+		IL_002f: ldc.r8 6
+		IL_0038: box [System.Runtime]System.Double
+		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0042: stloc.2
+		IL_0043: ldstr "console"
+		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0052: stloc.3
+		IL_0053: ldloc.1
+		IL_0054: ldstr "byteLength"
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_005e: stloc.s 4
+		IL_0060: ldloc.3
+		IL_0061: ldstr "log"
+		IL_0066: ldloc.s 4
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006d: pop
+		IL_006e: ldstr "console"
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007d: stloc.s 4
+		IL_007f: ldloc.2
+		IL_0080: ldstr "byteLength"
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_008a: stloc.3
+		IL_008b: ldloc.s 4
+		IL_008d: ldstr "log"
+		IL_0092: ldloc.3
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0098: pop
+		IL_0099: ret
 	} // end of method ArrayBuffer_Construct_ByteLength::__js_module_init__
 
 } // end of class Modules.ArrayBuffer_Construct_ByteLength
@@ -107,7 +103,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x210a
+		// Method begins at RVA 0x20ff
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_BoundsChecks_RangeError.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_BoundsChecks_RangeError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d1
+				// Method begins at RVA 0x21c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21da
+				// Method begins at RVA 0x21ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e3
+				// Method begins at RVA 0x21d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ec
+				// Method begins at RVA 0x21e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c8
+			// Method begins at RVA 0x21bc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 333 (0x14d)
+		// Code size: 324 (0x144)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_BoundsChecks_RangeError/Scope,
@@ -135,9 +135,8 @@
 			[7] object,
 			[8] object,
 			[9] object,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[11] object,
-			[12] object
+			[10] object,
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.DataView_BoundsChecks_RangeError/Scope::.ctor()
@@ -158,110 +157,107 @@
 		{
 			IL_003e: nop
 			IL_003f: ldloc.2
-			IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-			IL_0045: stloc.s 10
-			IL_0047: ldloc.s 10
-			IL_0049: ldstr "getUint32"
-			IL_004e: ldc.r8 0.0
-			IL_0057: box [System.Runtime]System.Double
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0061: pop
-			IL_0062: leave IL_00c9
+			IL_0040: ldstr "getUint32"
+			IL_0045: ldc.r8 0.0
+			IL_004e: box [System.Runtime]System.Double
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0058: pop
+			IL_0059: leave IL_00c0
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0067: stloc.3
-			IL_0068: ldloc.3
-			IL_0069: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_006e: dup
-			IL_006f: brtrue IL_0084
+			IL_005e: stloc.3
+			IL_005f: ldloc.3
+			IL_0060: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0065: dup
+			IL_0066: brtrue IL_007b
 
-			IL_0074: pop
-			IL_0075: ldloc.3
-			IL_0076: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_007b: dup
-			IL_007c: brtrue IL_0090
+			IL_006b: pop
+			IL_006c: ldloc.3
+			IL_006d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0072: dup
+			IL_0073: brtrue IL_0087
 
-			IL_0081: pop
-			IL_0082: rethrow
+			IL_0078: pop
+			IL_0079: rethrow
 
-			IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0089: stloc.s 4
-			IL_008b: br IL_0092
+			IL_007b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0080: stloc.s 4
+			IL_0082: br IL_0089
 
-			IL_0090: stloc.s 4
+			IL_0087: stloc.s 4
 
-			IL_0092: ldloc.s 4
-			IL_0094: stloc.s 5
-			IL_0096: ldstr "console"
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a5: stloc.s 11
-			IL_00a7: ldloc.s 5
-			IL_00a9: ldstr "name"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b3: stloc.s 12
-			IL_00b5: ldloc.s 11
-			IL_00b7: ldstr "log"
-			IL_00bc: ldloc.s 12
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00c3: pop
-			IL_00c4: leave IL_00c9
+			IL_0089: ldloc.s 4
+			IL_008b: stloc.s 5
+			IL_008d: ldstr "console"
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009c: stloc.s 10
+			IL_009e: ldloc.s 5
+			IL_00a0: ldstr "name"
+			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00aa: stloc.s 11
+			IL_00ac: ldloc.s 10
+			IL_00ae: ldstr "log"
+			IL_00b3: ldloc.s 11
+			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ba: pop
+			IL_00bb: leave IL_00c0
 		} // end handler
 		.try
 		{
-			IL_00c9: nop
-			IL_00ca: ldloc.1
-			IL_00cb: ldc.r8 5
-			IL_00d4: box [System.Runtime]System.Double
-			IL_00d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object)
-			IL_00de: pop
-			IL_00df: leave IL_0149
+			IL_00c0: nop
+			IL_00c1: ldloc.1
+			IL_00c2: ldc.r8 5
+			IL_00cb: box [System.Runtime]System.Double
+			IL_00d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object)
+			IL_00d5: pop
+			IL_00d6: leave IL_0140
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00e4: stloc.s 6
-			IL_00e6: ldloc.s 6
-			IL_00e8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00ed: dup
-			IL_00ee: brtrue IL_0104
+			IL_00db: stloc.s 6
+			IL_00dd: ldloc.s 6
+			IL_00df: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00e4: dup
+			IL_00e5: brtrue IL_00fb
 
-			IL_00f3: pop
-			IL_00f4: ldloc.s 6
-			IL_00f6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00fb: dup
-			IL_00fc: brtrue IL_0110
+			IL_00ea: pop
+			IL_00eb: ldloc.s 6
+			IL_00ed: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00f2: dup
+			IL_00f3: brtrue IL_0107
 
-			IL_0101: pop
-			IL_0102: rethrow
+			IL_00f8: pop
+			IL_00f9: rethrow
 
-			IL_0104: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0109: stloc.s 7
-			IL_010b: br IL_0112
+			IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0100: stloc.s 7
+			IL_0102: br IL_0109
 
-			IL_0110: stloc.s 7
+			IL_0107: stloc.s 7
 
-			IL_0112: ldloc.s 7
-			IL_0114: stloc.s 8
-			IL_0116: ldstr "console"
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0125: stloc.s 12
-			IL_0127: ldloc.s 8
-			IL_0129: ldstr "name"
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0133: stloc.s 11
-			IL_0135: ldloc.s 12
-			IL_0137: ldstr "log"
-			IL_013c: ldloc.s 11
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0143: pop
-			IL_0144: leave IL_0149
+			IL_0109: ldloc.s 7
+			IL_010b: stloc.s 8
+			IL_010d: ldstr "console"
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_011c: stloc.s 11
+			IL_011e: ldloc.s 8
+			IL_0120: ldstr "name"
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_012a: stloc.s 10
+			IL_012c: ldloc.s 11
+			IL_012e: ldstr "log"
+			IL_0133: ldloc.s 10
+			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_013a: pop
+			IL_013b: leave IL_0140
 		} // end handler
 
-		IL_0149: ldnull
-		IL_014a: stloc.s 9
-		IL_014c: ret
+		IL_0140: ldnull
+		IL_0141: stloc.s 9
+		IL_0143: ret
 	} // end of method DataView_BoundsChecks_RangeError::__js_module_init__
 
 } // end of class Modules.DataView_BoundsChecks_RangeError
@@ -273,7 +269,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f5
+		// Method begins at RVA 0x21e9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_ByteOffset_ByteLength.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_ByteOffset_ByteLength.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2221
+			// Method begins at RVA 0x21fd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 453 (0x1c5)
+		// Code size: 417 (0x1a1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_ByteOffset_ByteLength/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[5] object,
-			[6] object
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.DataView_ByteOffset_ByteLength/Scope::.ctor()
@@ -70,107 +69,95 @@
 		IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object)
 		IL_0044: stloc.3
 		IL_0045: ldloc.2
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_004b: stloc.s 4
-		IL_004d: ldloc.s 4
-		IL_004f: ldstr "setUint8"
-		IL_0054: ldc.r8 0.0
-		IL_005d: box [System.Runtime]System.Double
-		IL_0062: ldc.r8 10
-		IL_006b: box [System.Runtime]System.Double
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0075: pop
-		IL_0076: ldloc.2
-		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_007c: stloc.s 4
-		IL_007e: ldloc.s 4
-		IL_0080: ldstr "setUint8"
-		IL_0085: ldc.r8 3
-		IL_008e: box [System.Runtime]System.Double
-		IL_0093: ldc.r8 20
-		IL_009c: box [System.Runtime]System.Double
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00a6: pop
-		IL_00a7: ldstr "console"
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b6: stloc.s 5
-		IL_00b8: ldloc.2
-		IL_00b9: ldstr "byteOffset"
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c3: stloc.s 6
-		IL_00c5: ldloc.s 5
-		IL_00c7: ldstr "log"
-		IL_00cc: ldloc.s 6
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ldstr "console"
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e3: stloc.s 6
-		IL_00e5: ldloc.2
-		IL_00e6: ldstr "byteLength"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f0: stloc.s 5
-		IL_00f2: ldloc.s 6
-		IL_00f4: ldstr "log"
-		IL_00f9: ldloc.s 5
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0100: pop
-		IL_0101: ldstr "console"
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0110: stloc.s 5
-		IL_0112: ldloc.2
-		IL_0113: ldstr "buffer"
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_011d: stloc.s 6
-		IL_011f: ldloc.s 6
-		IL_0121: ldstr "byteLength"
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012b: stloc.s 6
-		IL_012d: ldloc.s 5
-		IL_012f: ldstr "log"
-		IL_0134: ldloc.s 6
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013b: pop
-		IL_013c: ldstr "console"
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014b: stloc.s 6
-		IL_014d: ldloc.3
-		IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0153: stloc.s 4
-		IL_0155: ldloc.s 4
-		IL_0157: ldstr "getUint8"
-		IL_015c: ldc.r8 2
-		IL_0165: box [System.Runtime]System.Double
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016f: stloc.s 5
-		IL_0171: ldloc.s 6
-		IL_0173: ldstr "log"
-		IL_0178: ldloc.s 5
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017f: pop
-		IL_0180: ldstr "console"
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0046: ldstr "setUint8"
+		IL_004b: ldc.r8 0.0
+		IL_0054: box [System.Runtime]System.Double
+		IL_0059: ldc.r8 10
+		IL_0062: box [System.Runtime]System.Double
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_006c: pop
+		IL_006d: ldloc.2
+		IL_006e: ldstr "setUint8"
+		IL_0073: ldc.r8 3
+		IL_007c: box [System.Runtime]System.Double
+		IL_0081: ldc.r8 20
+		IL_008a: box [System.Runtime]System.Double
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0094: pop
+		IL_0095: ldstr "console"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a4: stloc.s 4
+		IL_00a6: ldloc.2
+		IL_00a7: ldstr "byteOffset"
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b1: stloc.s 5
+		IL_00b3: ldloc.s 4
+		IL_00b5: ldstr "log"
+		IL_00ba: ldloc.s 5
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c1: pop
+		IL_00c2: ldstr "console"
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d1: stloc.s 5
+		IL_00d3: ldloc.2
+		IL_00d4: ldstr "byteLength"
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00de: stloc.s 4
+		IL_00e0: ldloc.s 5
+		IL_00e2: ldstr "log"
+		IL_00e7: ldloc.s 4
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ee: pop
+		IL_00ef: ldstr "console"
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fe: stloc.s 4
+		IL_0100: ldloc.2
+		IL_0101: ldstr "buffer"
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010b: stloc.s 5
+		IL_010d: ldloc.s 5
+		IL_010f: ldstr "byteLength"
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0119: stloc.s 5
+		IL_011b: ldloc.s 4
+		IL_011d: ldstr "log"
+		IL_0122: ldloc.s 5
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0129: pop
+		IL_012a: ldstr "console"
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0139: stloc.s 5
+		IL_013b: ldloc.3
+		IL_013c: ldstr "getUint8"
+		IL_0141: ldc.r8 2
+		IL_014a: box [System.Runtime]System.Double
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0154: stloc.s 4
+		IL_0156: ldloc.s 5
+		IL_0158: ldstr "log"
+		IL_015d: ldloc.s 4
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0164: pop
+		IL_0165: ldstr "console"
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0174: stloc.s 4
+		IL_0176: ldloc.3
+		IL_0177: ldstr "getUint8"
+		IL_017c: ldc.r8 5
+		IL_0185: box [System.Runtime]System.Double
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_018f: stloc.s 5
-		IL_0191: ldloc.3
-		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0197: stloc.s 4
-		IL_0199: ldloc.s 4
-		IL_019b: ldstr "getUint8"
-		IL_01a0: ldc.r8 5
-		IL_01a9: box [System.Runtime]System.Double
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b3: stloc.s 6
-		IL_01b5: ldloc.s 5
-		IL_01b7: ldstr "log"
-		IL_01bc: ldloc.s 6
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c3: pop
-		IL_01c4: ret
+		IL_0191: ldloc.s 4
+		IL_0193: ldstr "log"
+		IL_0198: ldloc.s 5
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019f: pop
+		IL_01a0: ret
 	} // end of method DataView_ByteOffset_ByteLength::__js_module_init__
 
 } // end of class Modules.DataView_ByteOffset_ByteLength
@@ -182,7 +169,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x222a
+		// Method begins at RVA 0x2206
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_Float32_Float64_RoundTrip.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_Float32_Float64_RoundTrip.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x216d
+			// Method begins at RVA 0x214d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 273 (0x111)
+		// Code size: 241 (0xf1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_Float32_Float64_RoundTrip/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[4] object,
-			[5] object
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.DataView_Float32_Float64_RoundTrip/Scope::.ctor()
@@ -62,68 +61,56 @@
 		IL_001c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object)
 		IL_0021: stloc.2
 		IL_0022: ldloc.2
-		IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0028: stloc.3
-		IL_0029: ldloc.3
-		IL_002a: ldstr "setFloat32"
-		IL_002f: ldc.r8 0.0
-		IL_0038: box [System.Runtime]System.Double
-		IL_003d: ldc.r8 1.25
-		IL_0046: box [System.Runtime]System.Double
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0050: pop
-		IL_0051: ldloc.2
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0057: stloc.3
-		IL_0058: ldloc.3
-		IL_0059: ldstr "setFloat64"
-		IL_005e: ldc.r8 8
+		IL_0023: ldstr "setFloat32"
+		IL_0028: ldc.r8 0.0
+		IL_0031: box [System.Runtime]System.Double
+		IL_0036: ldc.r8 1.25
+		IL_003f: box [System.Runtime]System.Double
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0049: pop
+		IL_004a: ldloc.2
+		IL_004b: ldstr "setFloat64"
+		IL_0050: ldc.r8 8
+		IL_0059: box [System.Runtime]System.Double
+		IL_005e: ldc.r8 3.141592653589793
 		IL_0067: box [System.Runtime]System.Double
-		IL_006c: ldc.r8 3.141592653589793
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: ldc.i4.1
-		IL_007b: box [System.Runtime]System.Boolean
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0085: pop
-		IL_0086: ldstr "console"
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0095: stloc.s 4
-		IL_0097: ldloc.2
-		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_009d: stloc.3
-		IL_009e: ldloc.3
-		IL_009f: ldstr "getFloat32"
-		IL_00a4: ldc.r8 0.0
-		IL_00ad: box [System.Runtime]System.Double
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b7: stloc.s 5
-		IL_00b9: ldloc.s 4
-		IL_00bb: ldstr "log"
-		IL_00c0: ldloc.s 5
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c7: pop
-		IL_00c8: ldstr "console"
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d7: stloc.s 5
-		IL_00d9: ldloc.2
-		IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_00df: stloc.3
-		IL_00e0: ldloc.3
-		IL_00e1: ldstr "getFloat64"
-		IL_00e6: ldc.r8 8
-		IL_00ef: box [System.Runtime]System.Double
-		IL_00f4: ldc.i4.1
-		IL_00f5: box [System.Runtime]System.Boolean
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00ff: stloc.s 4
-		IL_0101: ldloc.s 5
-		IL_0103: ldstr "log"
-		IL_0108: ldloc.s 4
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010f: pop
-		IL_0110: ret
+		IL_006c: ldc.i4.1
+		IL_006d: box [System.Runtime]System.Boolean
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0077: pop
+		IL_0078: ldstr "console"
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0087: stloc.3
+		IL_0088: ldloc.2
+		IL_0089: ldstr "getFloat32"
+		IL_008e: ldc.r8 0.0
+		IL_0097: box [System.Runtime]System.Double
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a1: stloc.s 4
+		IL_00a3: ldloc.3
+		IL_00a4: ldstr "log"
+		IL_00a9: ldloc.s 4
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b0: pop
+		IL_00b1: ldstr "console"
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c0: stloc.s 4
+		IL_00c2: ldloc.2
+		IL_00c3: ldstr "getFloat64"
+		IL_00c8: ldc.r8 8
+		IL_00d1: box [System.Runtime]System.Double
+		IL_00d6: ldc.i4.1
+		IL_00d7: box [System.Runtime]System.Boolean
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00e1: stloc.3
+		IL_00e2: ldloc.s 4
+		IL_00e4: ldstr "log"
+		IL_00e9: ldloc.3
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ef: pop
+		IL_00f0: ret
 	} // end of method DataView_Float32_Float64_RoundTrip::__js_module_init__
 
 } // end of class Modules.DataView_Float32_Float64_RoundTrip
@@ -135,7 +122,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2176
+		// Method begins at RVA 0x2156
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_SetGet_UintAndEndian.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_SetGet_UintAndEndian.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22dc
+			// Method begins at RVA 0x2294
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,17 +40,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 640 (0x280)
+		// Code size: 568 (0x238)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_SetGet_UintAndEndian/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[4] float64,
+			[3] float64,
+			[4] object,
 			[5] object,
-			[6] object,
-			[7] object
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.DataView_SetGet_UintAndEndian/Scope::.ctor()
@@ -64,167 +63,137 @@
 		IL_001c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object)
 		IL_0021: stloc.2
 		IL_0022: ldloc.2
-		IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0028: stloc.3
-		IL_0029: ldloc.3
-		IL_002a: ldstr "setUint8"
-		IL_002f: ldc.r8 0.0
-		IL_0038: box [System.Runtime]System.Double
-		IL_003d: ldc.r8 255
-		IL_0046: box [System.Runtime]System.Double
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0050: pop
-		IL_0051: ldloc.2
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0057: stloc.3
-		IL_0058: ldloc.3
-		IL_0059: ldstr "setUint16"
-		IL_005e: ldc.r8 1
+		IL_0023: ldstr "setUint8"
+		IL_0028: ldc.r8 0.0
+		IL_0031: box [System.Runtime]System.Double
+		IL_0036: ldc.r8 255
+		IL_003f: box [System.Runtime]System.Double
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0049: pop
+		IL_004a: ldloc.2
+		IL_004b: ldstr "setUint16"
+		IL_0050: ldc.r8 1
+		IL_0059: box [System.Runtime]System.Double
+		IL_005e: ldc.r8 4660
 		IL_0067: box [System.Runtime]System.Double
-		IL_006c: ldc.r8 4660
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_007f: pop
-		IL_0080: ldloc.2
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0086: stloc.3
-		IL_0087: ldloc.3
-		IL_0088: ldstr "setUint16"
-		IL_008d: ldc.r8 3
-		IL_0096: box [System.Runtime]System.Double
-		IL_009b: ldc.r8 4660
-		IL_00a4: box [System.Runtime]System.Double
-		IL_00a9: ldc.i4.1
-		IL_00aa: box [System.Runtime]System.Boolean
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00b4: pop
-		IL_00b5: ldloc.2
-		IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_00bb: stloc.3
-		IL_00bc: ldc.r8 1
-		IL_00c5: neg
-		IL_00c6: stloc.s 4
-		IL_00c8: ldloc.s 4
-		IL_00ca: box [System.Runtime]System.Double
-		IL_00cf: stloc.s 5
-		IL_00d1: ldloc.3
-		IL_00d2: ldstr "setInt32"
-		IL_00d7: ldc.r8 4
-		IL_00e0: box [System.Runtime]System.Double
-		IL_00e5: ldloc.s 5
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00ec: pop
-		IL_00ed: ldstr "console"
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fc: stloc.s 6
-		IL_00fe: ldloc.2
-		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0104: stloc.3
-		IL_0105: ldloc.3
-		IL_0106: ldstr "getUint8"
-		IL_010b: ldc.r8 0.0
-		IL_0114: box [System.Runtime]System.Double
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011e: stloc.s 7
-		IL_0120: ldloc.s 6
-		IL_0122: ldstr "log"
-		IL_0127: ldloc.s 7
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012e: pop
-		IL_012f: ldstr "console"
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013e: stloc.s 7
-		IL_0140: ldloc.2
-		IL_0141: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0146: stloc.3
-		IL_0147: ldloc.3
-		IL_0148: ldstr "getUint16"
-		IL_014d: ldc.r8 1
-		IL_0156: box [System.Runtime]System.Double
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0160: stloc.s 6
-		IL_0162: ldloc.s 7
-		IL_0164: ldstr "log"
-		IL_0169: ldloc.s 6
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0170: pop
-		IL_0171: ldstr "console"
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0180: stloc.s 6
-		IL_0182: ldloc.2
-		IL_0183: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0188: stloc.3
-		IL_0189: ldloc.3
-		IL_018a: ldstr "getUint16"
-		IL_018f: ldc.r8 3
-		IL_0198: box [System.Runtime]System.Double
-		IL_019d: ldc.i4.1
-		IL_019e: box [System.Runtime]System.Boolean
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01a8: stloc.s 7
-		IL_01aa: ldloc.s 6
-		IL_01ac: ldstr "log"
-		IL_01b1: ldloc.s 7
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b8: pop
-		IL_01b9: ldstr "console"
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c8: stloc.s 7
-		IL_01ca: ldloc.2
-		IL_01cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_01d0: stloc.3
-		IL_01d1: ldloc.3
-		IL_01d2: ldstr "getUint16"
-		IL_01d7: ldc.r8 3
-		IL_01e0: box [System.Runtime]System.Double
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ea: stloc.s 6
-		IL_01ec: ldloc.s 7
-		IL_01ee: ldstr "log"
-		IL_01f3: ldloc.s 6
-		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fa: pop
-		IL_01fb: ldstr "console"
-		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020a: stloc.s 6
-		IL_020c: ldloc.2
-		IL_020d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0212: stloc.3
-		IL_0213: ldloc.3
-		IL_0214: ldstr "getInt32"
-		IL_0219: ldc.r8 4
-		IL_0222: box [System.Runtime]System.Double
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_022c: stloc.s 7
-		IL_022e: ldloc.s 6
-		IL_0230: ldstr "log"
-		IL_0235: ldloc.s 7
-		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023c: pop
-		IL_023d: ldstr "console"
-		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024c: stloc.s 7
-		IL_024e: ldloc.2
-		IL_024f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0254: stloc.3
-		IL_0255: ldloc.3
-		IL_0256: ldstr "getUint32"
-		IL_025b: ldc.r8 4
-		IL_0264: box [System.Runtime]System.Double
-		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026e: stloc.s 6
-		IL_0270: ldloc.s 7
-		IL_0272: ldstr "log"
-		IL_0277: ldloc.s 6
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027e: pop
-		IL_027f: ret
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0071: pop
+		IL_0072: ldloc.2
+		IL_0073: ldstr "setUint16"
+		IL_0078: ldc.r8 3
+		IL_0081: box [System.Runtime]System.Double
+		IL_0086: ldc.r8 4660
+		IL_008f: box [System.Runtime]System.Double
+		IL_0094: ldc.i4.1
+		IL_0095: box [System.Runtime]System.Boolean
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_009f: pop
+		IL_00a0: ldc.r8 1
+		IL_00a9: neg
+		IL_00aa: stloc.3
+		IL_00ab: ldloc.3
+		IL_00ac: box [System.Runtime]System.Double
+		IL_00b1: stloc.s 4
+		IL_00b3: ldloc.2
+		IL_00b4: ldstr "setInt32"
+		IL_00b9: ldc.r8 4
+		IL_00c2: box [System.Runtime]System.Double
+		IL_00c7: ldloc.s 4
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00ce: pop
+		IL_00cf: ldstr "console"
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00de: stloc.s 5
+		IL_00e0: ldloc.2
+		IL_00e1: ldstr "getUint8"
+		IL_00e6: ldc.r8 0.0
+		IL_00ef: box [System.Runtime]System.Double
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f9: stloc.s 6
+		IL_00fb: ldloc.s 5
+		IL_00fd: ldstr "log"
+		IL_0102: ldloc.s 6
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0109: pop
+		IL_010a: ldstr "console"
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0119: stloc.s 6
+		IL_011b: ldloc.2
+		IL_011c: ldstr "getUint16"
+		IL_0121: ldc.r8 1
+		IL_012a: box [System.Runtime]System.Double
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0134: stloc.s 5
+		IL_0136: ldloc.s 6
+		IL_0138: ldstr "log"
+		IL_013d: ldloc.s 5
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0144: pop
+		IL_0145: ldstr "console"
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0154: stloc.s 5
+		IL_0156: ldloc.2
+		IL_0157: ldstr "getUint16"
+		IL_015c: ldc.r8 3
+		IL_0165: box [System.Runtime]System.Double
+		IL_016a: ldc.i4.1
+		IL_016b: box [System.Runtime]System.Boolean
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0175: stloc.s 6
+		IL_0177: ldloc.s 5
+		IL_0179: ldstr "log"
+		IL_017e: ldloc.s 6
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0185: pop
+		IL_0186: ldstr "console"
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0195: stloc.s 6
+		IL_0197: ldloc.2
+		IL_0198: ldstr "getUint16"
+		IL_019d: ldc.r8 3
+		IL_01a6: box [System.Runtime]System.Double
+		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b0: stloc.s 5
+		IL_01b2: ldloc.s 6
+		IL_01b4: ldstr "log"
+		IL_01b9: ldloc.s 5
+		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c0: pop
+		IL_01c1: ldstr "console"
+		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d0: stloc.s 5
+		IL_01d2: ldloc.2
+		IL_01d3: ldstr "getInt32"
+		IL_01d8: ldc.r8 4
+		IL_01e1: box [System.Runtime]System.Double
+		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01eb: stloc.s 6
+		IL_01ed: ldloc.s 5
+		IL_01ef: ldstr "log"
+		IL_01f4: ldloc.s 6
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01fb: pop
+		IL_01fc: ldstr "console"
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020b: stloc.s 6
+		IL_020d: ldloc.2
+		IL_020e: ldstr "getUint32"
+		IL_0213: ldc.r8 4
+		IL_021c: box [System.Runtime]System.Double
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0226: stloc.s 5
+		IL_0228: ldloc.s 6
+		IL_022a: ldstr "log"
+		IL_022f: ldloc.s 5
+		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0236: pop
+		IL_0237: ret
 	} // end of method DataView_SetGet_UintAndEndian::__js_module_init__
 
 } // end of class Modules.DataView_SetGet_UintAndEndian
@@ -236,7 +205,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e5
+		// Method begins at RVA 0x229d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Callback_Methods.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Callback_Methods.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2487
+				// Method begins at RVA 0x243f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23b4
+			// Method begins at RVA 0x236c
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -72,7 +72,157 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2490
+				// Method begins at RVA 0x2448
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2382
+			// Header size: 1
+			// Code size: 23 (0x17)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0006: ldc.r8 2
+			IL_000f: cgt
+			IL_0011: box [System.Runtime]System.Boolean
+			IL_0016: ret
+		} // end of method FunctionExpression_L9C26::__js_call__
+
+	} // end of class FunctionExpression_L9C26
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L13C25
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2451
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x239a
+			// Header size: 1
+			// Code size: 23 (0x17)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0006: ldc.r8 1
+			IL_000f: cgt
+			IL_0011: box [System.Runtime]System.Boolean
+			IL_0016: ret
+		} // end of method FunctionExpression_L13C25::__js_call__
+
+	} // end of class FunctionExpression_L13C25
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L17C24
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x245a
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x23b2
+			// Header size: 1
+			// Code size: 23 (0x17)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0006: ldc.r8 3
+			IL_000f: cgt
+			IL_0011: box [System.Runtime]System.Boolean
+			IL_0016: ret
+		} // end of method FunctionExpression_L17C24::__js_call__
+
+	} // end of class FunctionExpression_L17C24
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L21C24
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2463
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -107,11 +257,11 @@
 			IL_000f: cgt
 			IL_0011: box [System.Runtime]System.Boolean
 			IL_0016: ret
-		} // end of method FunctionExpression_L9C26::__js_call__
+		} // end of method FunctionExpression_L21C24::__js_call__
 
-	} // end of class FunctionExpression_L9C26
+	} // end of class FunctionExpression_L21C24
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L13C25
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L25C29
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -122,7 +272,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2499
+				// Method begins at RVA 0x246c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -153,156 +303,6 @@
 
 			IL_0000: ldarg.1
 			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0006: ldc.r8 1
-			IL_000f: cgt
-			IL_0011: box [System.Runtime]System.Boolean
-			IL_0016: ret
-		} // end of method FunctionExpression_L13C25::__js_call__
-
-	} // end of class FunctionExpression_L13C25
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L17C24
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x24a2
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object newTarget,
-				object 'value'
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 00 00 00 00 00 00
-			)
-			// Method begins at RVA 0x23fa
-			// Header size: 1
-			// Code size: 23 (0x17)
-			.maxstack 8
-
-			IL_0000: ldarg.1
-			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0006: ldc.r8 3
-			IL_000f: cgt
-			IL_0011: box [System.Runtime]System.Boolean
-			IL_0016: ret
-		} // end of method FunctionExpression_L17C24::__js_call__
-
-	} // end of class FunctionExpression_L17C24
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L21C24
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x24ab
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object newTarget,
-				object 'value'
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 00 00 00 00 00 00
-			)
-			// Method begins at RVA 0x2412
-			// Header size: 1
-			// Code size: 23 (0x17)
-			.maxstack 8
-
-			IL_0000: ldarg.1
-			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0006: ldc.r8 2
-			IL_000f: cgt
-			IL_0011: box [System.Runtime]System.Boolean
-			IL_0016: ret
-		} // end of method FunctionExpression_L21C24::__js_call__
-
-	} // end of class FunctionExpression_L21C24
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L25C29
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x24b4
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object newTarget,
-				object 'value'
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 00 00 00 00 00 00
-			)
-			// Method begins at RVA 0x242a
-			// Header size: 1
-			// Code size: 23 (0x17)
-			.maxstack 8
-
-			IL_0000: ldarg.1
-			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0006: ldc.r8 2
 			IL_000f: cgt
 			IL_0011: box [System.Runtime]System.Boolean
@@ -322,7 +322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24bd
+				// Method begins at RVA 0x2475
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -349,7 +349,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2444
+			// Method begins at RVA 0x23fc
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -385,7 +385,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24c6
+				// Method begins at RVA 0x247e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -410,7 +410,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2468
+			// Method begins at RVA 0x2420
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -442,7 +442,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x247e
+			// Method begins at RVA 0x2436
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -468,17 +468,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 855 (0x357)
+		// Code size: 783 (0x30f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Float64Array_Callback_Methods/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Float64Array,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Float64Array,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[6] object,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
+			[5] object,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		)
 
 		IL_0000: newobj instance void Modules.Float64Array_Callback_Methods/Scope::.ctor()
@@ -503,249 +502,225 @@
 		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0051: stloc.3
-		IL_0052: ldloc.1
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_0058: stloc.s 4
-		IL_005a: ldnull
-		IL_005b: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23::__js_call__(object, object, object)
-		IL_0061: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0066: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_006b: ldc.i4.2
-		IL_006c: conv.r8
-		IL_006d: ldstr ""
-		IL_0072: ldc.i4.0
-		IL_0073: ldc.i4.1
-		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_0079: stloc.s 5
-		IL_007b: ldloc.s 4
-		IL_007d: ldstr "map"
+		IL_0052: ldnull
+		IL_0053: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23::__js_call__(object, object, object)
+		IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_005e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_0063: ldc.i4.2
+		IL_0064: conv.r8
+		IL_0065: ldstr ""
+		IL_006a: ldc.i4.0
+		IL_006b: ldc.i4.1
+		IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_0071: stloc.s 4
+		IL_0073: ldloc.1
+		IL_0074: ldstr "map"
+		IL_0079: ldloc.s 4
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0080: stloc.s 5
 		IL_0082: ldloc.s 5
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0089: stloc.s 6
-		IL_008b: ldloc.s 6
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0092: ldstr "join"
-		IL_0097: ldstr "|"
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a1: stloc.s 6
-		IL_00a3: ldloc.3
-		IL_00a4: ldstr "log"
-		IL_00a9: ldloc.s 6
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b0: pop
-		IL_00b1: ldstr "console"
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c0: stloc.s 6
-		IL_00c2: ldloc.1
-		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_00c8: stloc.s 4
-		IL_00ca: ldnull
-		IL_00cb: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26::__js_call__(object, object)
-		IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00d6: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_00db: ldc.i4.1
-		IL_00dc: conv.r8
-		IL_00dd: ldstr ""
-		IL_00e2: ldc.i4.0
-		IL_00e3: ldc.i4.1
-		IL_00e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_00e9: stloc.s 7
-		IL_00eb: ldloc.s 4
-		IL_00ed: ldstr "filter"
-		IL_00f2: ldloc.s 7
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f9: stloc.3
-		IL_00fa: ldloc.3
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0100: ldstr "join"
-		IL_0105: ldstr "|"
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010f: stloc.3
-		IL_0110: ldloc.s 6
-		IL_0112: ldstr "log"
-		IL_0117: ldloc.3
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011d: pop
-		IL_011e: ldstr "console"
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012d: stloc.3
-		IL_012e: ldloc.1
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_0134: stloc.s 4
-		IL_0136: ldnull
-		IL_0137: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25::__js_call__(object, object)
-		IL_013d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0142: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0147: ldc.i4.1
-		IL_0148: conv.r8
-		IL_0149: ldstr ""
-		IL_014e: ldc.i4.0
-		IL_014f: ldc.i4.1
-		IL_0150: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0155: stloc.s 7
-		IL_0157: ldloc.s 4
-		IL_0159: ldstr "every"
-		IL_015e: ldloc.s 7
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0165: stloc.s 6
-		IL_0167: ldloc.3
-		IL_0168: ldstr "log"
-		IL_016d: ldloc.s 6
-		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0174: pop
-		IL_0175: ldstr "console"
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0184: stloc.s 6
-		IL_0186: ldloc.1
-		IL_0187: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_018c: stloc.s 4
-		IL_018e: ldnull
-		IL_018f: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24::__js_call__(object, object)
-		IL_0195: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_019a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_019f: ldc.i4.1
-		IL_01a0: conv.r8
-		IL_01a1: ldstr ""
-		IL_01a6: ldc.i4.0
-		IL_01a7: ldc.i4.1
-		IL_01a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_01ad: stloc.s 7
-		IL_01af: ldloc.s 4
-		IL_01b1: ldstr "some"
-		IL_01b6: ldloc.s 7
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bd: stloc.3
-		IL_01be: ldloc.s 6
-		IL_01c0: ldstr "log"
-		IL_01c5: ldloc.3
-		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01cb: pop
-		IL_01cc: ldstr "console"
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01db: stloc.3
-		IL_01dc: ldloc.1
-		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_01e2: stloc.s 4
-		IL_01e4: ldnull
-		IL_01e5: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24::__js_call__(object, object)
-		IL_01eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01f0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_01f5: ldc.i4.1
-		IL_01f6: conv.r8
-		IL_01f7: ldstr ""
-		IL_01fc: ldc.i4.0
-		IL_01fd: ldc.i4.1
-		IL_01fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0203: stloc.s 7
-		IL_0205: ldloc.s 4
-		IL_0207: ldstr "find"
-		IL_020c: ldloc.s 7
-		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0213: stloc.s 6
-		IL_0215: ldloc.3
-		IL_0216: ldstr "log"
-		IL_021b: ldloc.s 6
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0222: pop
-		IL_0223: ldstr "console"
-		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0232: stloc.s 6
-		IL_0234: ldloc.1
-		IL_0235: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_023a: stloc.s 4
-		IL_023c: ldnull
-		IL_023d: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29::__js_call__(object, object)
-		IL_0243: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0248: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_024d: ldc.i4.1
-		IL_024e: conv.r8
-		IL_024f: ldstr ""
-		IL_0254: ldc.i4.0
-		IL_0255: ldc.i4.1
-		IL_0256: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_025b: stloc.s 7
-		IL_025d: ldloc.s 4
-		IL_025f: ldstr "findIndex"
-		IL_0264: ldloc.s 7
-		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026b: stloc.3
-		IL_026c: ldloc.s 6
-		IL_026e: ldstr "log"
-		IL_0273: ldloc.3
-		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0279: pop
-		IL_027a: ldloc.0
-		IL_027b: ldc.r8 0.0
-		IL_0284: box [System.Runtime]System.Double
-		IL_0289: stfld object Modules.Float64Array_Callback_Methods/Scope::total
-		IL_028e: ldloc.1
-		IL_028f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_0294: stloc.s 4
-		IL_0296: ldloc.0
-		IL_0297: castclass Modules.Float64Array_Callback_Methods/Scope
-		IL_029c: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15::__js_call__(class Modules.Float64Array_Callback_Methods/Scope, object, object)
-		IL_02a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_02a7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_02ac: ldc.i4.1
-		IL_02ad: conv.r8
-		IL_02ae: ldstr ""
-		IL_02b3: ldc.i4.0
-		IL_02b4: ldc.i4.1
-		IL_02b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_02ba: stloc.s 7
-		IL_02bc: ldloc.s 4
-		IL_02be: ldstr "forEach"
-		IL_02c3: ldloc.s 7
-		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ca: pop
-		IL_02cb: ldstr "console"
-		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02da: stloc.3
-		IL_02db: ldloc.0
-		IL_02dc: ldfld object Modules.Float64Array_Callback_Methods/Scope::total
-		IL_02e1: stloc.s 6
-		IL_02e3: ldloc.3
-		IL_02e4: ldstr "log"
-		IL_02e9: ldloc.s 6
-		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02f0: pop
-		IL_02f1: ldstr "console"
-		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0300: stloc.s 6
-		IL_0302: ldloc.1
-		IL_0303: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_0308: stloc.s 4
-		IL_030a: ldnull
-		IL_030b: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26::__js_call__(object, object, object)
-		IL_0311: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0316: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_031b: ldc.i4.2
-		IL_031c: conv.r8
-		IL_031d: ldstr ""
-		IL_0322: ldc.i4.0
-		IL_0323: ldc.i4.1
-		IL_0324: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_0329: stloc.s 5
-		IL_032b: ldloc.s 4
-		IL_032d: ldstr "reduce"
-		IL_0332: ldloc.s 5
-		IL_0334: ldc.r8 1
-		IL_033d: box [System.Runtime]System.Double
-		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0347: stloc.3
-		IL_0348: ldloc.s 6
-		IL_034a: ldstr "log"
-		IL_034f: ldloc.3
-		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0355: pop
-		IL_0356: ret
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0089: ldstr "join"
+		IL_008e: ldstr "|"
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0098: stloc.s 5
+		IL_009a: ldloc.3
+		IL_009b: ldstr "log"
+		IL_00a0: ldloc.s 5
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a7: pop
+		IL_00a8: ldstr "console"
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b7: stloc.s 5
+		IL_00b9: ldnull
+		IL_00ba: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26::__js_call__(object, object)
+		IL_00c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00c5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_00ca: ldc.i4.1
+		IL_00cb: conv.r8
+		IL_00cc: ldstr ""
+		IL_00d1: ldc.i4.0
+		IL_00d2: ldc.i4.1
+		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_00d8: stloc.s 6
+		IL_00da: ldloc.1
+		IL_00db: ldstr "filter"
+		IL_00e0: ldloc.s 6
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e7: stloc.3
+		IL_00e8: ldloc.3
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ee: ldstr "join"
+		IL_00f3: ldstr "|"
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fd: stloc.3
+		IL_00fe: ldloc.s 5
+		IL_0100: ldstr "log"
+		IL_0105: ldloc.3
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010b: pop
+		IL_010c: ldstr "console"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011b: stloc.3
+		IL_011c: ldnull
+		IL_011d: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25::__js_call__(object, object)
+		IL_0123: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0128: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_012d: ldc.i4.1
+		IL_012e: conv.r8
+		IL_012f: ldstr ""
+		IL_0134: ldc.i4.0
+		IL_0135: ldc.i4.1
+		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_013b: stloc.s 6
+		IL_013d: ldloc.1
+		IL_013e: ldstr "every"
+		IL_0143: ldloc.s 6
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014a: stloc.s 5
+		IL_014c: ldloc.3
+		IL_014d: ldstr "log"
+		IL_0152: ldloc.s 5
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0159: pop
+		IL_015a: ldstr "console"
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0169: stloc.s 5
+		IL_016b: ldnull
+		IL_016c: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24::__js_call__(object, object)
+		IL_0172: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0177: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_017c: ldc.i4.1
+		IL_017d: conv.r8
+		IL_017e: ldstr ""
+		IL_0183: ldc.i4.0
+		IL_0184: ldc.i4.1
+		IL_0185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_018a: stloc.s 6
+		IL_018c: ldloc.1
+		IL_018d: ldstr "some"
+		IL_0192: ldloc.s 6
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0199: stloc.3
+		IL_019a: ldloc.s 5
+		IL_019c: ldstr "log"
+		IL_01a1: ldloc.3
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a7: pop
+		IL_01a8: ldstr "console"
+		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b7: stloc.3
+		IL_01b8: ldnull
+		IL_01b9: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24::__js_call__(object, object)
+		IL_01bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01c4: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_01c9: ldc.i4.1
+		IL_01ca: conv.r8
+		IL_01cb: ldstr ""
+		IL_01d0: ldc.i4.0
+		IL_01d1: ldc.i4.1
+		IL_01d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_01d7: stloc.s 6
+		IL_01d9: ldloc.1
+		IL_01da: ldstr "find"
+		IL_01df: ldloc.s 6
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e6: stloc.s 5
+		IL_01e8: ldloc.3
+		IL_01e9: ldstr "log"
+		IL_01ee: ldloc.s 5
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f5: pop
+		IL_01f6: ldstr "console"
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0205: stloc.s 5
+		IL_0207: ldnull
+		IL_0208: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29::__js_call__(object, object)
+		IL_020e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0213: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0218: ldc.i4.1
+		IL_0219: conv.r8
+		IL_021a: ldstr ""
+		IL_021f: ldc.i4.0
+		IL_0220: ldc.i4.1
+		IL_0221: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0226: stloc.s 6
+		IL_0228: ldloc.1
+		IL_0229: ldstr "findIndex"
+		IL_022e: ldloc.s 6
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0235: stloc.3
+		IL_0236: ldloc.s 5
+		IL_0238: ldstr "log"
+		IL_023d: ldloc.3
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0243: pop
+		IL_0244: ldloc.0
+		IL_0245: ldc.r8 0.0
+		IL_024e: box [System.Runtime]System.Double
+		IL_0253: stfld object Modules.Float64Array_Callback_Methods/Scope::total
+		IL_0258: ldloc.0
+		IL_0259: castclass Modules.Float64Array_Callback_Methods/Scope
+		IL_025e: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15::__js_call__(class Modules.Float64Array_Callback_Methods/Scope, object, object)
+		IL_0264: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0269: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_026e: ldc.i4.1
+		IL_026f: conv.r8
+		IL_0270: ldstr ""
+		IL_0275: ldc.i4.0
+		IL_0276: ldc.i4.1
+		IL_0277: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_027c: stloc.s 6
+		IL_027e: ldloc.1
+		IL_027f: ldstr "forEach"
+		IL_0284: ldloc.s 6
+		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028b: pop
+		IL_028c: ldstr "console"
+		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_029b: stloc.3
+		IL_029c: ldloc.0
+		IL_029d: ldfld object Modules.Float64Array_Callback_Methods/Scope::total
+		IL_02a2: stloc.s 5
+		IL_02a4: ldloc.3
+		IL_02a5: ldstr "log"
+		IL_02aa: ldloc.s 5
+		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b1: pop
+		IL_02b2: ldstr "console"
+		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c1: stloc.s 5
+		IL_02c3: ldnull
+		IL_02c4: ldftn object Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26::__js_call__(object, object, object)
+		IL_02ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_02cf: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_02d4: ldc.i4.2
+		IL_02d5: conv.r8
+		IL_02d6: ldstr ""
+		IL_02db: ldc.i4.0
+		IL_02dc: ldc.i4.1
+		IL_02dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_02e2: stloc.s 4
+		IL_02e4: ldloc.1
+		IL_02e5: ldstr "reduce"
+		IL_02ea: ldloc.s 4
+		IL_02ec: ldc.r8 1
+		IL_02f5: box [System.Runtime]System.Double
+		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02ff: stloc.3
+		IL_0300: ldloc.s 5
+		IL_0302: ldstr "log"
+		IL_0307: ldloc.3
+		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_030d: pop
+		IL_030e: ret
 	} // end of method Float64Array_Callback_Methods::__js_module_init__
 
 } // end of class Modules.Float64Array_Callback_Methods
@@ -757,7 +732,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24cf
+		// Method begins at RVA 0x2487
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Construct_ArrayBuffer_Search.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Construct_ArrayBuffer_Search.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23de
+			// Method begins at RVA 0x23ba
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 898 (0x382)
+		// Code size: 862 (0x35e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Float64Array_Construct_ArrayBuffer_Search/Scope,
@@ -53,8 +53,7 @@
 			[7] object,
 			[8] object,
 			[9] bool,
-			[10] object,
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.Float64Array
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Float64Array_Construct_ArrayBuffer_Search/Scope::.ctor()
@@ -189,118 +188,106 @@
 		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_01e4: stloc.s 8
 		IL_01e6: ldloc.3
-		IL_01e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_01ec: stloc.s 11
-		IL_01ee: ldloc.s 11
-		IL_01f0: ldstr "includes"
-		IL_01f5: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_01fe: box [System.Runtime]System.Double
-		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0208: stloc.s 5
-		IL_020a: ldloc.s 8
-		IL_020c: ldstr "log"
-		IL_0211: ldloc.s 5
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0218: pop
-		IL_0219: ldstr "console"
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0228: stloc.s 5
-		IL_022a: ldloc.3
-		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_0230: stloc.s 11
-		IL_0232: ldloc.s 11
-		IL_0234: ldstr "indexOf"
-		IL_0239: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_0242: box [System.Runtime]System.Double
-		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024c: stloc.s 8
-		IL_024e: ldloc.s 5
-		IL_0250: ldstr "log"
-		IL_0255: ldloc.s 8
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025c: pop
-		IL_025d: ldstr "console"
-		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026c: stloc.s 8
-		IL_026e: ldloc.2
-		IL_026f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_0274: stloc.s 11
-		IL_0276: ldc.r8 1
-		IL_027f: neg
-		IL_0280: stloc.s 6
-		IL_0282: ldloc.s 6
-		IL_0284: box [System.Runtime]System.Double
-		IL_0289: stloc.s 7
-		IL_028b: ldloc.s 11
-		IL_028d: ldstr "at"
-		IL_0292: ldloc.s 7
-		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0299: stloc.s 5
-		IL_029b: ldloc.s 8
-		IL_029d: ldstr "log"
-		IL_02a2: ldloc.s 5
-		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a9: pop
-		IL_02aa: ldloc.3
-		IL_02ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_02b0: stloc.s 11
-		IL_02b2: ldloc.s 11
-		IL_02b4: ldstr "slice"
-		IL_02b9: ldc.r8 1
-		IL_02c2: box [System.Runtime]System.Double
-		IL_02c7: ldc.r8 3
-		IL_02d0: box [System.Runtime]System.Double
-		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02da: stloc.s 4
-		IL_02dc: ldstr "console"
-		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02eb: stloc.s 5
-		IL_02ed: ldloc.s 4
-		IL_02ef: ldstr "buffer"
-		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02f9: stloc.s 8
-		IL_02fb: ldloc.s 8
-		IL_02fd: ldloc.1
-		IL_02fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0303: stloc.s 9
-		IL_0305: ldloc.s 9
-		IL_0307: box [System.Runtime]System.Boolean
-		IL_030c: stloc.s 10
-		IL_030e: ldloc.s 5
-		IL_0310: ldstr "log"
-		IL_0315: ldloc.s 10
-		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_031c: pop
-		IL_031d: ldstr "console"
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_032c: stloc.s 5
-		IL_032e: ldloc.s 4
-		IL_0330: ldc.r8 0.0
-		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_033e: stloc.s 8
-		IL_0340: ldloc.s 5
-		IL_0342: ldstr "log"
-		IL_0347: ldloc.s 8
-		IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_034e: pop
-		IL_034f: ldstr "console"
-		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_035e: stloc.s 8
-		IL_0360: ldloc.s 4
-		IL_0362: ldc.r8 1
-		IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0370: stloc.s 5
-		IL_0372: ldloc.s 8
-		IL_0374: ldstr "log"
-		IL_0379: ldloc.s 5
-		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0380: pop
-		IL_0381: ret
+		IL_01e7: ldstr "includes"
+		IL_01ec: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_01f5: box [System.Runtime]System.Double
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ff: stloc.s 5
+		IL_0201: ldloc.s 8
+		IL_0203: ldstr "log"
+		IL_0208: ldloc.s 5
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_020f: pop
+		IL_0210: ldstr "console"
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021f: stloc.s 5
+		IL_0221: ldloc.3
+		IL_0222: ldstr "indexOf"
+		IL_0227: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_0230: box [System.Runtime]System.Double
+		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023a: stloc.s 8
+		IL_023c: ldloc.s 5
+		IL_023e: ldstr "log"
+		IL_0243: ldloc.s 8
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024a: pop
+		IL_024b: ldstr "console"
+		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025a: stloc.s 8
+		IL_025c: ldc.r8 1
+		IL_0265: neg
+		IL_0266: stloc.s 6
+		IL_0268: ldloc.s 6
+		IL_026a: box [System.Runtime]System.Double
+		IL_026f: stloc.s 7
+		IL_0271: ldloc.2
+		IL_0272: ldstr "at"
+		IL_0277: ldloc.s 7
+		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027e: stloc.s 5
+		IL_0280: ldloc.s 8
+		IL_0282: ldstr "log"
+		IL_0287: ldloc.s 5
+		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028e: pop
+		IL_028f: ldloc.3
+		IL_0290: ldstr "slice"
+		IL_0295: ldc.r8 1
+		IL_029e: box [System.Runtime]System.Double
+		IL_02a3: ldc.r8 3
+		IL_02ac: box [System.Runtime]System.Double
+		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02b6: stloc.s 4
+		IL_02b8: ldstr "console"
+		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c7: stloc.s 5
+		IL_02c9: ldloc.s 4
+		IL_02cb: ldstr "buffer"
+		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02d5: stloc.s 8
+		IL_02d7: ldloc.s 8
+		IL_02d9: ldloc.1
+		IL_02da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02df: stloc.s 9
+		IL_02e1: ldloc.s 9
+		IL_02e3: box [System.Runtime]System.Boolean
+		IL_02e8: stloc.s 10
+		IL_02ea: ldloc.s 5
+		IL_02ec: ldstr "log"
+		IL_02f1: ldloc.s 10
+		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02f8: pop
+		IL_02f9: ldstr "console"
+		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0308: stloc.s 5
+		IL_030a: ldloc.s 4
+		IL_030c: ldc.r8 0.0
+		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_031a: stloc.s 8
+		IL_031c: ldloc.s 5
+		IL_031e: ldstr "log"
+		IL_0323: ldloc.s 8
+		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_032a: pop
+		IL_032b: ldstr "console"
+		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_033a: stloc.s 8
+		IL_033c: ldloc.s 4
+		IL_033e: ldc.r8 1
+		IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_034c: stloc.s 5
+		IL_034e: ldloc.s 8
+		IL_0350: ldstr "log"
+		IL_0355: ldloc.s 5
+		IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_035c: pop
+		IL_035d: ret
 	} // end of method Float64Array_Construct_ArrayBuffer_Search::__js_module_init__
 
 } // end of class Modules.Float64Array_Construct_ArrayBuffer_Search
@@ -312,7 +299,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23e7
+		// Method begins at RVA 0x23c3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Construct_ArrayBuffer_ViewProperties.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Construct_ArrayBuffer_ViewProperties.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2299
+			// Method begins at RVA 0x2275
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,20 +40,19 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 573 (0x23d)
+		// Code size: 537 (0x219)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Construct_ArrayBuffer_ViewProperties/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[5] float64,
+			[4] float64,
+			[5] object,
 			[6] object,
 			[7] object,
-			[8] object,
-			[9] bool,
-			[10] object
+			[8] bool,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Construct_ArrayBuffer_ViewProperties/Scope::.ctor()
@@ -67,148 +66,136 @@
 		IL_001c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object)
 		IL_0021: stloc.2
 		IL_0022: ldloc.2
-		IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0028: stloc.s 4
-		IL_002a: ldloc.s 4
-		IL_002c: ldstr "setInt32"
-		IL_0031: ldc.r8 0.0
-		IL_003a: box [System.Runtime]System.Double
-		IL_003f: ldc.r8 11
-		IL_0048: box [System.Runtime]System.Double
-		IL_004d: ldc.i4.1
-		IL_004e: box [System.Runtime]System.Boolean
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0058: pop
-		IL_0059: ldloc.2
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_005f: stloc.s 4
-		IL_0061: ldc.r8 22
-		IL_006a: neg
-		IL_006b: stloc.s 5
-		IL_006d: ldloc.s 5
-		IL_006f: box [System.Runtime]System.Double
-		IL_0074: stloc.s 6
-		IL_0076: ldloc.s 4
-		IL_0078: ldstr "setInt32"
-		IL_007d: ldc.r8 4
-		IL_0086: box [System.Runtime]System.Double
-		IL_008b: ldloc.s 6
-		IL_008d: ldc.i4.1
-		IL_008e: box [System.Runtime]System.Boolean
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0098: pop
-		IL_0099: ldloc.2
-		IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_009f: stloc.s 4
-		IL_00a1: ldloc.s 4
-		IL_00a3: ldstr "setInt32"
-		IL_00a8: ldc.r8 8
-		IL_00b1: box [System.Runtime]System.Double
-		IL_00b6: ldc.r8 33
+		IL_0023: ldstr "setInt32"
+		IL_0028: ldc.r8 0.0
+		IL_0031: box [System.Runtime]System.Double
+		IL_0036: ldc.r8 11
+		IL_003f: box [System.Runtime]System.Double
+		IL_0044: ldc.i4.1
+		IL_0045: box [System.Runtime]System.Boolean
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_004f: pop
+		IL_0050: ldc.r8 22
+		IL_0059: neg
+		IL_005a: stloc.s 4
+		IL_005c: ldloc.s 4
+		IL_005e: box [System.Runtime]System.Double
+		IL_0063: stloc.s 5
+		IL_0065: ldloc.2
+		IL_0066: ldstr "setInt32"
+		IL_006b: ldc.r8 4
+		IL_0074: box [System.Runtime]System.Double
+		IL_0079: ldloc.s 5
+		IL_007b: ldc.i4.1
+		IL_007c: box [System.Runtime]System.Boolean
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0086: pop
+		IL_0087: ldloc.2
+		IL_0088: ldstr "setInt32"
+		IL_008d: ldc.r8 8
+		IL_0096: box [System.Runtime]System.Double
+		IL_009b: ldc.r8 33
+		IL_00a4: box [System.Runtime]System.Double
+		IL_00a9: ldc.i4.1
+		IL_00aa: box [System.Runtime]System.Boolean
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00b4: pop
+		IL_00b5: ldloc.1
+		IL_00b6: ldc.r8 4
 		IL_00bf: box [System.Runtime]System.Double
-		IL_00c4: ldc.i4.1
-		IL_00c5: box [System.Runtime]System.Boolean
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00cf: pop
-		IL_00d0: ldloc.1
-		IL_00d1: ldc.r8 4
-		IL_00da: box [System.Runtime]System.Double
-		IL_00df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object, object)
-		IL_00e4: stloc.3
-		IL_00e5: ldstr "console"
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f4: ldloc.3
-		IL_00f5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-		IL_00fa: box [System.Runtime]System.Double
-		IL_00ff: stloc.s 6
-		IL_0101: ldstr "log"
-		IL_0106: ldloc.s 6
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010d: pop
-		IL_010e: ldstr "console"
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011d: stloc.s 7
-		IL_011f: ldloc.3
-		IL_0120: ldstr "byteOffset"
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012a: stloc.s 8
-		IL_012c: ldloc.s 7
-		IL_012e: ldstr "log"
-		IL_0133: ldloc.s 8
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013a: pop
-		IL_013b: ldstr "console"
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014a: stloc.s 8
-		IL_014c: ldloc.3
-		IL_014d: ldstr "byteLength"
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0157: stloc.s 7
-		IL_0159: ldloc.s 8
-		IL_015b: ldstr "log"
-		IL_0160: ldloc.s 7
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0167: pop
-		IL_0168: ldstr "console"
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0177: stloc.s 7
-		IL_0179: ldloc.3
-		IL_017a: ldstr "buffer"
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0184: stloc.s 8
-		IL_0186: ldloc.s 8
-		IL_0188: ldloc.1
-		IL_0189: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_018e: stloc.s 9
-		IL_0190: ldloc.s 9
-		IL_0192: box [System.Runtime]System.Boolean
-		IL_0197: stloc.s 10
-		IL_0199: ldloc.s 7
-		IL_019b: ldstr "log"
-		IL_01a0: ldloc.s 10
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a7: pop
-		IL_01a8: ldstr "console"
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b7: ldloc.3
-		IL_01b8: ldc.r8 0.0
-		IL_01c1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_01c6: box [System.Runtime]System.Double
-		IL_01cb: stloc.s 6
-		IL_01cd: ldstr "log"
-		IL_01d2: ldloc.s 6
-		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d9: pop
-		IL_01da: ldloc.3
-		IL_01db: ldc.r8 1
-		IL_01e4: ldc.r8 44
-		IL_01ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-		IL_01f2: ldstr "console"
-		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0201: stloc.s 7
-		IL_0203: ldloc.2
-		IL_0204: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.DataView>(!!0)
-		IL_0209: stloc.s 4
-		IL_020b: ldloc.s 4
-		IL_020d: ldstr "getInt32"
-		IL_0212: ldc.r8 8
-		IL_021b: box [System.Runtime]System.Double
-		IL_0220: ldc.i4.1
-		IL_0221: box [System.Runtime]System.Boolean
-		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_022b: stloc.s 8
-		IL_022d: ldloc.s 7
-		IL_022f: ldstr "log"
-		IL_0234: ldloc.s 8
-		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023b: pop
-		IL_023c: ret
+		IL_00c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object, object)
+		IL_00c9: stloc.3
+		IL_00ca: ldstr "console"
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d9: ldloc.3
+		IL_00da: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+		IL_00df: box [System.Runtime]System.Double
+		IL_00e4: stloc.s 5
+		IL_00e6: ldstr "log"
+		IL_00eb: ldloc.s 5
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f2: pop
+		IL_00f3: ldstr "console"
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0102: stloc.s 6
+		IL_0104: ldloc.3
+		IL_0105: ldstr "byteOffset"
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010f: stloc.s 7
+		IL_0111: ldloc.s 6
+		IL_0113: ldstr "log"
+		IL_0118: ldloc.s 7
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011f: pop
+		IL_0120: ldstr "console"
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012f: stloc.s 7
+		IL_0131: ldloc.3
+		IL_0132: ldstr "byteLength"
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013c: stloc.s 6
+		IL_013e: ldloc.s 7
+		IL_0140: ldstr "log"
+		IL_0145: ldloc.s 6
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014c: pop
+		IL_014d: ldstr "console"
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015c: stloc.s 6
+		IL_015e: ldloc.3
+		IL_015f: ldstr "buffer"
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0169: stloc.s 7
+		IL_016b: ldloc.s 7
+		IL_016d: ldloc.1
+		IL_016e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0173: stloc.s 8
+		IL_0175: ldloc.s 8
+		IL_0177: box [System.Runtime]System.Boolean
+		IL_017c: stloc.s 9
+		IL_017e: ldloc.s 6
+		IL_0180: ldstr "log"
+		IL_0185: ldloc.s 9
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018c: pop
+		IL_018d: ldstr "console"
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019c: ldloc.3
+		IL_019d: ldc.r8 0.0
+		IL_01a6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_01ab: box [System.Runtime]System.Double
+		IL_01b0: stloc.s 5
+		IL_01b2: ldstr "log"
+		IL_01b7: ldloc.s 5
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01be: pop
+		IL_01bf: ldloc.3
+		IL_01c0: ldc.r8 1
+		IL_01c9: ldc.r8 44
+		IL_01d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+		IL_01d7: ldstr "console"
+		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e6: stloc.s 6
+		IL_01e8: ldloc.2
+		IL_01e9: ldstr "getInt32"
+		IL_01ee: ldc.r8 8
+		IL_01f7: box [System.Runtime]System.Double
+		IL_01fc: ldc.i4.1
+		IL_01fd: box [System.Runtime]System.Boolean
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0207: stloc.s 7
+		IL_0209: ldloc.s 6
+		IL_020b: ldstr "log"
+		IL_0210: ldloc.s 7
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0217: pop
+		IL_0218: ret
 	} // end of method Int32Array_Construct_ArrayBuffer_ViewProperties::__js_module_init__
 
 } // end of class Modules.Int32Array_Construct_ArrayBuffer_ViewProperties
@@ -220,7 +207,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22a2
+		// Method begins at RVA 0x227e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Fill_Reverse_Join_LastIndexOf.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Fill_Reverse_Join_LastIndexOf.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2218
+			// Method begins at RVA 0x21eb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 444 (0x1bc)
+		// Code size: 399 (0x18f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Fill_Reverse_Join_LastIndexOf/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
-			[5] object
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Fill_Reverse_Join_LastIndexOf/Scope::.ctor()
@@ -77,102 +76,87 @@
 		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0060: stloc.3
 		IL_0061: ldloc.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0067: stloc.s 4
-		IL_0069: ldloc.s 4
-		IL_006b: ldstr "lastIndexOf"
-		IL_0070: ldc.r8 2
-		IL_0079: box [System.Runtime]System.Double
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0083: stloc.s 5
-		IL_0085: ldloc.3
-		IL_0086: ldstr "log"
-		IL_008b: ldloc.s 5
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0092: pop
-		IL_0093: ldstr "console"
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a2: stloc.s 5
-		IL_00a4: ldloc.1
-		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_00aa: stloc.s 4
-		IL_00ac: ldloc.s 4
-		IL_00ae: ldstr "fill"
-		IL_00b3: ldc.r8 9
-		IL_00bc: box [System.Runtime]System.Double
-		IL_00c1: ldc.r8 1
-		IL_00ca: box [System.Runtime]System.Double
-		IL_00cf: ldc.r8 3
-		IL_00d8: box [System.Runtime]System.Double
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00e2: stloc.3
-		IL_00e3: ldloc.3
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e9: ldstr "join"
-		IL_00ee: ldstr "|"
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f8: stloc.3
-		IL_00f9: ldloc.s 5
-		IL_00fb: ldstr "log"
-		IL_0100: ldloc.3
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0106: pop
-		IL_0107: ldstr "console"
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0116: stloc.3
-		IL_0117: ldloc.1
-		IL_0118: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_011d: stloc.s 4
-		IL_011f: ldloc.s 4
-		IL_0121: ldstr "reverse"
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_012b: stloc.s 5
-		IL_012d: ldloc.s 5
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0134: ldstr "toString"
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_013e: stloc.s 5
-		IL_0140: ldloc.3
-		IL_0141: ldstr "log"
-		IL_0146: ldloc.s 5
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014d: pop
-		IL_014e: ldstr "console"
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015d: stloc.s 5
-		IL_015f: ldloc.1
-		IL_0160: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0165: stloc.s 4
-		IL_0167: ldloc.s 4
-		IL_0169: ldstr "toString"
-		IL_016e: ldstr "|"
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0178: stloc.3
-		IL_0179: ldloc.s 5
-		IL_017b: ldstr "log"
+		IL_0062: ldstr "lastIndexOf"
+		IL_0067: ldc.r8 2
+		IL_0070: box [System.Runtime]System.Double
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007a: stloc.s 4
+		IL_007c: ldloc.3
+		IL_007d: ldstr "log"
+		IL_0082: ldloc.s 4
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0089: pop
+		IL_008a: ldstr "console"
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0099: stloc.s 4
+		IL_009b: ldloc.1
+		IL_009c: ldstr "fill"
+		IL_00a1: ldc.r8 9
+		IL_00aa: box [System.Runtime]System.Double
+		IL_00af: ldc.r8 1
+		IL_00b8: box [System.Runtime]System.Double
+		IL_00bd: ldc.r8 3
+		IL_00c6: box [System.Runtime]System.Double
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00d0: stloc.3
+		IL_00d1: ldloc.3
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d7: ldstr "join"
+		IL_00dc: ldstr "|"
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e6: stloc.3
+		IL_00e7: ldloc.s 4
+		IL_00e9: ldstr "log"
+		IL_00ee: ldloc.3
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f4: pop
+		IL_00f5: ldstr "console"
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0104: stloc.3
+		IL_0105: ldloc.1
+		IL_0106: ldstr "reverse"
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0110: stloc.s 4
+		IL_0112: ldloc.s 4
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0119: ldstr "toString"
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0123: stloc.s 4
+		IL_0125: ldloc.3
+		IL_0126: ldstr "log"
+		IL_012b: ldloc.s 4
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0132: pop
+		IL_0133: ldstr "console"
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0142: stloc.s 4
+		IL_0144: ldloc.1
+		IL_0145: ldstr "toString"
+		IL_014a: ldstr "|"
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0154: stloc.3
+		IL_0155: ldloc.s 4
+		IL_0157: ldstr "log"
+		IL_015c: ldloc.3
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0162: pop
+		IL_0163: ldstr "console"
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0172: stloc.3
+		IL_0173: ldloc.1
+		IL_0174: ldstr "toLocaleString"
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_017e: stloc.s 4
 		IL_0180: ldloc.3
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0186: pop
-		IL_0187: ldstr "console"
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0196: stloc.3
-		IL_0197: ldloc.1
-		IL_0198: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_019d: stloc.s 4
-		IL_019f: ldloc.s 4
-		IL_01a1: ldstr "toLocaleString"
-		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01ab: stloc.s 5
-		IL_01ad: ldloc.3
-		IL_01ae: ldstr "log"
-		IL_01b3: ldloc.s 5
-		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ba: pop
-		IL_01bb: ret
+		IL_0181: ldstr "log"
+		IL_0186: ldloc.s 4
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018d: pop
+		IL_018e: ret
 	} // end of method Int32Array_Fill_Reverse_Join_LastIndexOf::__js_module_init__
 
 } // end of class Modules.Int32Array_Fill_Reverse_Join_LastIndexOf
@@ -184,7 +168,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2221
+		// Method begins at RVA 0x21f4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_BoundsChecks.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_BoundsChecks.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2429
+				// Method begins at RVA 0x23fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2432
+				// Method begins at RVA 0x2406
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243b
+				// Method begins at RVA 0x240f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2444
+				// Method begins at RVA 0x2418
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23fc
+			// Method begins at RVA 0x23d0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x240e
+				// Method begins at RVA 0x23e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2405
+			// Method begins at RVA 0x23d9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2420
+				// Method begins at RVA 0x23f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +180,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2417
+			// Method begins at RVA 0x23eb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -206,7 +206,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 899 (0x383)
+		// Code size: 854 (0x356)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Set_BoundsChecks/Scope,
@@ -222,12 +222,11 @@
 			[10] object,
 			[11] object,
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[13] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[13] float64,
 			[14] float64,
-			[15] float64,
+			[15] object,
 			[16] object,
-			[17] object,
-			[18] object
+			[17] object
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope::.ctor()
@@ -251,272 +250,257 @@
 		IL_004b: ldloc.s 12
 		IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
 		IL_0052: stloc.1
-		IL_0053: ldloc.1
-		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0059: stloc.s 13
-		IL_005b: ldc.i4.2
-		IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0061: dup
-		IL_0062: ldc.r8 9
-		IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0070: dup
-		IL_0071: ldc.r8 8
-		IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_007f: stloc.s 12
-		IL_0081: ldloc.s 13
-		IL_0083: ldstr "set"
-		IL_0088: ldloc.s 12
-		IL_008a: ldc.r8 2
-		IL_0093: box [System.Runtime]System.Double
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_009d: pop
-		IL_009e: ldc.r8 0.0
-		IL_00a7: stloc.2
-		// loop start (head: IL_00a8)
-			IL_00a8: ldloc.2
-			IL_00a9: stloc.s 14
-			IL_00ab: ldloc.1
-			IL_00ac: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-			IL_00b1: stloc.s 15
-			IL_00b3: ldloc.s 14
-			IL_00b5: ldloc.s 15
-			IL_00b7: clt
-			IL_00b9: brfalse IL_00f9
+		IL_0053: ldc.i4.2
+		IL_0054: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0059: dup
+		IL_005a: ldc.r8 9
+		IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0068: dup
+		IL_0069: ldc.r8 8
+		IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0077: stloc.s 12
+		IL_0079: ldloc.1
+		IL_007a: ldstr "set"
+		IL_007f: ldloc.s 12
+		IL_0081: ldc.r8 2
+		IL_008a: box [System.Runtime]System.Double
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0094: pop
+		IL_0095: ldc.r8 0.0
+		IL_009e: stloc.2
+		// loop start (head: IL_009f)
+			IL_009f: ldloc.2
+			IL_00a0: stloc.s 13
+			IL_00a2: ldloc.1
+			IL_00a3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+			IL_00a8: stloc.s 14
+			IL_00aa: ldloc.s 13
+			IL_00ac: ldloc.s 14
+			IL_00ae: clt
+			IL_00b0: brfalse IL_00f0
 
-			IL_00be: ldstr "console"
-			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00cd: ldloc.1
-			IL_00ce: ldloc.2
-			IL_00cf: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_00d4: box [System.Runtime]System.Double
-			IL_00d9: stloc.s 16
-			IL_00db: ldstr "log"
-			IL_00e0: ldloc.s 16
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00e7: pop
-			IL_00e8: ldloc.2
-			IL_00e9: ldc.r8 1
-			IL_00f2: add
-			IL_00f3: stloc.2
-			IL_00f4: br IL_00a8
+			IL_00b5: ldstr "console"
+			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c4: ldloc.1
+			IL_00c5: ldloc.2
+			IL_00c6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_00cb: box [System.Runtime]System.Double
+			IL_00d0: stloc.s 15
+			IL_00d2: ldstr "log"
+			IL_00d7: ldloc.s 15
+			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00de: pop
+			IL_00df: ldloc.2
+			IL_00e0: ldc.r8 1
+			IL_00e9: add
+			IL_00ea: stloc.2
+			IL_00eb: br IL_009f
 		// end loop
 
-		IL_00f9: ldloc.1
-		IL_00fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_00ff: stloc.s 13
-		IL_0101: ldloc.s 13
-		IL_0103: ldstr "subarray"
-		IL_0108: ldc.r8 1
-		IL_0111: box [System.Runtime]System.Double
-		IL_0116: ldc.r8 3
-		IL_011f: box [System.Runtime]System.Double
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0129: stloc.3
-		IL_012a: ldloc.1
-		IL_012b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0130: stloc.s 13
-		IL_0132: ldloc.s 13
-		IL_0134: ldstr "set"
-		IL_0139: ldloc.3
-		IL_013a: ldc.r8 0.0
-		IL_0143: box [System.Runtime]System.Double
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_014d: pop
-		IL_014e: ldc.r8 0.0
-		IL_0157: stloc.s 4
-		// loop start (head: IL_0159)
-			IL_0159: ldloc.s 4
-			IL_015b: stloc.s 15
-			IL_015d: ldloc.1
-			IL_015e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-			IL_0163: stloc.s 14
-			IL_0165: ldloc.s 15
-			IL_0167: ldloc.s 14
-			IL_0169: clt
-			IL_016b: brfalse IL_01ae
+		IL_00f0: ldloc.1
+		IL_00f1: ldstr "subarray"
+		IL_00f6: ldc.r8 1
+		IL_00ff: box [System.Runtime]System.Double
+		IL_0104: ldc.r8 3
+		IL_010d: box [System.Runtime]System.Double
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0117: stloc.3
+		IL_0118: ldloc.1
+		IL_0119: ldstr "set"
+		IL_011e: ldloc.3
+		IL_011f: ldc.r8 0.0
+		IL_0128: box [System.Runtime]System.Double
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0132: pop
+		IL_0133: ldc.r8 0.0
+		IL_013c: stloc.s 4
+		// loop start (head: IL_013e)
+			IL_013e: ldloc.s 4
+			IL_0140: stloc.s 14
+			IL_0142: ldloc.1
+			IL_0143: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+			IL_0148: stloc.s 13
+			IL_014a: ldloc.s 14
+			IL_014c: ldloc.s 13
+			IL_014e: clt
+			IL_0150: brfalse IL_0193
 
-			IL_0170: ldstr "console"
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_017f: ldloc.1
+			IL_0155: ldstr "console"
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0164: ldloc.1
+			IL_0165: ldloc.s 4
+			IL_0167: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_016c: box [System.Runtime]System.Double
+			IL_0171: stloc.s 15
+			IL_0173: ldstr "log"
+			IL_0178: ldloc.s 15
+			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_017f: pop
 			IL_0180: ldloc.s 4
-			IL_0182: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0187: box [System.Runtime]System.Double
-			IL_018c: stloc.s 16
-			IL_018e: ldstr "log"
-			IL_0193: ldloc.s 16
-			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_019a: pop
-			IL_019b: ldloc.s 4
-			IL_019d: ldc.r8 1
-			IL_01a6: add
-			IL_01a7: stloc.s 4
-			IL_01a9: br IL_0159
+			IL_0182: ldc.r8 1
+			IL_018b: add
+			IL_018c: stloc.s 4
+			IL_018e: br IL_013e
 		// end loop
 		.try
 		{
-			IL_01ae: nop
-			IL_01af: ldloc.1
-			IL_01b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-			IL_01b5: stloc.s 13
-			IL_01b7: ldc.i4.3
-			IL_01b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_01bd: dup
-			IL_01be: ldc.r8 7
-			IL_01c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_01cc: dup
-			IL_01cd: ldc.r8 6
-			IL_01d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_01db: dup
-			IL_01dc: ldc.r8 5
-			IL_01e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_01ea: stloc.s 12
-			IL_01ec: ldloc.s 13
-			IL_01ee: ldstr "set"
-			IL_01f3: ldloc.s 12
-			IL_01f5: ldc.r8 2
-			IL_01fe: box [System.Runtime]System.Double
-			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0208: pop
-			IL_0209: leave IL_02a1
+			IL_0193: nop
+			IL_0194: ldc.i4.3
+			IL_0195: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_019a: dup
+			IL_019b: ldc.r8 7
+			IL_01a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_01a9: dup
+			IL_01aa: ldc.r8 6
+			IL_01b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_01b8: dup
+			IL_01b9: ldc.r8 5
+			IL_01c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_01c7: stloc.s 12
+			IL_01c9: ldloc.1
+			IL_01ca: ldstr "set"
+			IL_01cf: ldloc.s 12
+			IL_01d1: ldc.r8 2
+			IL_01da: box [System.Runtime]System.Double
+			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01e4: pop
+			IL_01e5: leave IL_027d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_020e: stloc.s 5
-			IL_0210: ldloc.s 5
-			IL_0212: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0217: dup
-			IL_0218: brtrue IL_022e
+			IL_01ea: stloc.s 5
+			IL_01ec: ldloc.s 5
+			IL_01ee: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_01f3: dup
+			IL_01f4: brtrue IL_020a
 
-			IL_021d: pop
-			IL_021e: ldloc.s 5
-			IL_0220: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0225: dup
-			IL_0226: brtrue IL_023a
+			IL_01f9: pop
+			IL_01fa: ldloc.s 5
+			IL_01fc: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0201: dup
+			IL_0202: brtrue IL_0216
 
-			IL_022b: pop
-			IL_022c: rethrow
+			IL_0207: pop
+			IL_0208: rethrow
 
-			IL_022e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0233: stloc.s 6
-			IL_0235: br IL_023c
+			IL_020a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_020f: stloc.s 6
+			IL_0211: br IL_0218
 
-			IL_023a: stloc.s 6
+			IL_0216: stloc.s 6
 
-			IL_023c: ldloc.s 6
-			IL_023e: stloc.s 7
-			IL_0240: ldstr "console"
-			IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_024f: stloc.s 17
-			IL_0251: ldloc.s 7
-			IL_0253: ldstr "name"
-			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_025d: stloc.s 18
-			IL_025f: ldloc.s 17
-			IL_0261: ldstr "log"
-			IL_0266: ldloc.s 18
-			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_026d: pop
-			IL_026e: ldstr "console"
-			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027d: stloc.s 18
-			IL_027f: ldloc.s 7
-			IL_0281: ldstr "message"
-			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_028b: stloc.s 17
-			IL_028d: ldloc.s 18
-			IL_028f: ldstr "log"
-			IL_0294: ldloc.s 17
-			IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_029b: pop
-			IL_029c: leave IL_02a1
+			IL_0218: ldloc.s 6
+			IL_021a: stloc.s 7
+			IL_021c: ldstr "console"
+			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_022b: stloc.s 16
+			IL_022d: ldloc.s 7
+			IL_022f: ldstr "name"
+			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0239: stloc.s 17
+			IL_023b: ldloc.s 16
+			IL_023d: ldstr "log"
+			IL_0242: ldloc.s 17
+			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0249: pop
+			IL_024a: ldstr "console"
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0259: stloc.s 17
+			IL_025b: ldloc.s 7
+			IL_025d: ldstr "message"
+			IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0267: stloc.s 16
+			IL_0269: ldloc.s 17
+			IL_026b: ldstr "log"
+			IL_0270: ldloc.s 16
+			IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0277: pop
+			IL_0278: leave IL_027d
 		} // end handler
 		.try
 		{
-			IL_02a1: nop
-			IL_02a2: ldloc.1
-			IL_02a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-			IL_02a8: stloc.s 13
-			IL_02aa: ldc.i4.1
-			IL_02ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02b0: dup
-			IL_02b1: ldc.r8 1
-			IL_02ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_02bf: stloc.s 12
-			IL_02c1: ldc.r8 1
-			IL_02ca: neg
-			IL_02cb: stloc.s 14
-			IL_02cd: ldloc.s 14
-			IL_02cf: box [System.Runtime]System.Double
-			IL_02d4: stloc.s 16
-			IL_02d6: ldloc.s 13
-			IL_02d8: ldstr "set"
-			IL_02dd: ldloc.s 12
-			IL_02df: ldloc.s 16
-			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_02e6: pop
-			IL_02e7: leave IL_037f
+			IL_027d: nop
+			IL_027e: ldc.i4.1
+			IL_027f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0284: dup
+			IL_0285: ldc.r8 1
+			IL_028e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_0293: stloc.s 12
+			IL_0295: ldc.r8 1
+			IL_029e: neg
+			IL_029f: stloc.s 13
+			IL_02a1: ldloc.s 13
+			IL_02a3: box [System.Runtime]System.Double
+			IL_02a8: stloc.s 15
+			IL_02aa: ldloc.1
+			IL_02ab: ldstr "set"
+			IL_02b0: ldloc.s 12
+			IL_02b2: ldloc.s 15
+			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_02b9: pop
+			IL_02ba: leave IL_0352
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02ec: stloc.s 8
-			IL_02ee: ldloc.s 8
-			IL_02f0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02f5: dup
-			IL_02f6: brtrue IL_030c
+			IL_02bf: stloc.s 8
+			IL_02c1: ldloc.s 8
+			IL_02c3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02c8: dup
+			IL_02c9: brtrue IL_02df
 
-			IL_02fb: pop
-			IL_02fc: ldloc.s 8
-			IL_02fe: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0303: dup
-			IL_0304: brtrue IL_0318
+			IL_02ce: pop
+			IL_02cf: ldloc.s 8
+			IL_02d1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02d6: dup
+			IL_02d7: brtrue IL_02eb
 
-			IL_0309: pop
-			IL_030a: rethrow
+			IL_02dc: pop
+			IL_02dd: rethrow
 
-			IL_030c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0311: stloc.s 9
-			IL_0313: br IL_031a
+			IL_02df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02e4: stloc.s 9
+			IL_02e6: br IL_02ed
 
-			IL_0318: stloc.s 9
+			IL_02eb: stloc.s 9
 
-			IL_031a: ldloc.s 9
-			IL_031c: stloc.s 10
-			IL_031e: ldstr "console"
-			IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_032d: stloc.s 17
-			IL_032f: ldloc.s 10
-			IL_0331: ldstr "name"
-			IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_033b: stloc.s 18
-			IL_033d: ldloc.s 17
-			IL_033f: ldstr "log"
-			IL_0344: ldloc.s 18
-			IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_034b: pop
-			IL_034c: ldstr "console"
-			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_035b: stloc.s 18
-			IL_035d: ldloc.s 10
-			IL_035f: ldstr "message"
-			IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0369: stloc.s 17
-			IL_036b: ldloc.s 18
-			IL_036d: ldstr "log"
-			IL_0372: ldloc.s 17
-			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0379: pop
-			IL_037a: leave IL_037f
+			IL_02ed: ldloc.s 9
+			IL_02ef: stloc.s 10
+			IL_02f1: ldstr "console"
+			IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0300: stloc.s 16
+			IL_0302: ldloc.s 10
+			IL_0304: ldstr "name"
+			IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_030e: stloc.s 17
+			IL_0310: ldloc.s 16
+			IL_0312: ldstr "log"
+			IL_0317: ldloc.s 17
+			IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_031e: pop
+			IL_031f: ldstr "console"
+			IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_032e: stloc.s 17
+			IL_0330: ldloc.s 10
+			IL_0332: ldstr "message"
+			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_033c: stloc.s 16
+			IL_033e: ldloc.s 17
+			IL_0340: ldstr "log"
+			IL_0345: ldloc.s 16
+			IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_034c: pop
+			IL_034d: leave IL_0352
 		} // end handler
 
-		IL_037f: ldnull
-		IL_0380: stloc.s 11
-		IL_0382: ret
+		IL_0352: ldnull
+		IL_0353: stloc.s 11
+		IL_0355: ret
 	} // end of method Int32Array_Set_BoundsChecks::__js_module_init__
 
 } // end of class Modules.Int32Array_Set_BoundsChecks
@@ -528,7 +512,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x244d
+		// Method begins at RVA 0x2421
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_FromArray_WithOffset.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_FromArray_WithOffset.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x212c
+			// Method begins at RVA 0x2123
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -34,7 +34,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2135
+			// Method begins at RVA 0x212c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -60,17 +60,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 208 (0xd0)
+		// Code size: 199 (0xc7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Set_FromArray_WithOffset/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] float64,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[4] float64,
 			[5] float64,
-			[6] float64,
-			[7] object
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Set_FromArray_WithOffset/Scope::.ctor()
@@ -94,48 +93,45 @@
 		IL_004a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_004f: stloc.2
 		IL_0050: ldloc.1
-		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0056: stloc.s 4
-		IL_0058: ldloc.s 4
-		IL_005a: ldstr "set"
-		IL_005f: ldloc.2
-		IL_0060: ldc.r8 1
-		IL_0069: box [System.Runtime]System.Double
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0073: pop
-		IL_0074: ldc.r8 0.0
-		IL_007d: stloc.3
-		// loop start (head: IL_007e)
-			IL_007e: ldloc.3
-			IL_007f: stloc.s 5
-			IL_0081: ldloc.1
-			IL_0082: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-			IL_0087: stloc.s 6
-			IL_0089: ldloc.s 5
-			IL_008b: ldloc.s 6
-			IL_008d: clt
-			IL_008f: brfalse IL_00cf
+		IL_0051: ldstr "set"
+		IL_0056: ldloc.2
+		IL_0057: ldc.r8 1
+		IL_0060: box [System.Runtime]System.Double
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_006a: pop
+		IL_006b: ldc.r8 0.0
+		IL_0074: stloc.3
+		// loop start (head: IL_0075)
+			IL_0075: ldloc.3
+			IL_0076: stloc.s 4
+			IL_0078: ldloc.1
+			IL_0079: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+			IL_007e: stloc.s 5
+			IL_0080: ldloc.s 4
+			IL_0082: ldloc.s 5
+			IL_0084: clt
+			IL_0086: brfalse IL_00c6
 
-			IL_0094: ldstr "console"
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a3: ldloc.1
-			IL_00a4: ldloc.3
-			IL_00a5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_00aa: box [System.Runtime]System.Double
-			IL_00af: stloc.s 7
-			IL_00b1: ldstr "log"
-			IL_00b6: ldloc.s 7
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00bd: pop
-			IL_00be: ldloc.3
-			IL_00bf: ldc.r8 1
-			IL_00c8: add
-			IL_00c9: stloc.3
-			IL_00ca: br IL_007e
+			IL_008b: ldstr "console"
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009a: ldloc.1
+			IL_009b: ldloc.3
+			IL_009c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_00a1: box [System.Runtime]System.Double
+			IL_00a6: stloc.s 6
+			IL_00a8: ldstr "log"
+			IL_00ad: ldloc.s 6
+			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00b4: pop
+			IL_00b5: ldloc.3
+			IL_00b6: ldc.r8 1
+			IL_00bf: add
+			IL_00c0: stloc.3
+			IL_00c1: br IL_0075
 		// end loop
 
-		IL_00cf: ret
+		IL_00c6: ret
 	} // end of method Int32Array_Set_FromArray_WithOffset::__js_module_init__
 
 } // end of class Modules.Int32Array_Set_FromArray_WithOffset
@@ -147,7 +143,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x213e
+		// Method begins at RVA 0x2135
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_Basic.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x223d
+			// Method begins at RVA 0x222b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x224f
+				// Method begins at RVA 0x223d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2246
+			// Method begins at RVA 0x2234
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 481 (0x1e1)
+		// Code size: 463 (0x1cf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Slice_Basic/Scope,
@@ -91,12 +91,11 @@
 			[3] float64,
 			[4] object,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[6] object,
 			[7] object,
-			[8] object,
+			[8] float64,
 			[9] float64,
-			[10] float64,
-			[11] object
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Slice_Basic/Scope::.ctor()
@@ -124,114 +123,108 @@
 		IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
 		IL_0061: stloc.1
 		IL_0062: ldloc.1
-		IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0068: stloc.s 6
-		IL_006a: ldloc.s 6
-		IL_006c: ldstr "slice"
-		IL_0071: ldc.r8 1
-		IL_007a: box [System.Runtime]System.Double
-		IL_007f: ldc.r8 4
-		IL_0088: box [System.Runtime]System.Double
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0092: stloc.2
-		IL_0093: ldstr "console"
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a2: stloc.s 7
-		IL_00a4: ldloc.2
-		IL_00a5: ldstr "length"
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00af: stloc.s 8
-		IL_00b1: ldloc.s 7
-		IL_00b3: ldstr "log"
-		IL_00b8: ldloc.s 8
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bf: pop
-		IL_00c0: ldc.r8 0.0
-		IL_00c9: stloc.3
-		// loop start (head: IL_00ca)
-			IL_00ca: ldloc.3
-			IL_00cb: stloc.s 9
-			IL_00cd: ldloc.2
-			IL_00ce: ldstr "length"
-			IL_00d3: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_00d8: stloc.s 10
-			IL_00da: ldloc.s 9
-			IL_00dc: ldloc.s 10
-			IL_00de: clt
-			IL_00e0: brfalse IL_011f
+		IL_0063: ldstr "slice"
+		IL_0068: ldc.r8 1
+		IL_0071: box [System.Runtime]System.Double
+		IL_0076: ldc.r8 4
+		IL_007f: box [System.Runtime]System.Double
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0089: stloc.2
+		IL_008a: ldstr "console"
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0099: stloc.s 6
+		IL_009b: ldloc.2
+		IL_009c: ldstr "length"
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a6: stloc.s 7
+		IL_00a8: ldloc.s 6
+		IL_00aa: ldstr "log"
+		IL_00af: ldloc.s 7
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b6: pop
+		IL_00b7: ldc.r8 0.0
+		IL_00c0: stloc.3
+		// loop start (head: IL_00c1)
+			IL_00c1: ldloc.3
+			IL_00c2: stloc.s 8
+			IL_00c4: ldloc.2
+			IL_00c5: ldstr "length"
+			IL_00ca: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_00cf: stloc.s 9
+			IL_00d1: ldloc.s 8
+			IL_00d3: ldloc.s 9
+			IL_00d5: clt
+			IL_00d7: brfalse IL_0116
 
-			IL_00e5: ldstr "console"
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f4: stloc.s 8
-			IL_00f6: ldloc.2
-			IL_00f7: ldloc.3
-			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00fd: stloc.s 7
-			IL_00ff: ldloc.s 8
-			IL_0101: ldstr "log"
-			IL_0106: ldloc.s 7
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_010d: pop
-			IL_010e: ldloc.3
-			IL_010f: ldc.r8 1
-			IL_0118: add
-			IL_0119: stloc.3
-			IL_011a: br IL_00ca
+			IL_00dc: ldstr "console"
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00eb: stloc.s 7
+			IL_00ed: ldloc.2
+			IL_00ee: ldloc.3
+			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00f4: stloc.s 6
+			IL_00f6: ldloc.s 7
+			IL_00f8: ldstr "log"
+			IL_00fd: ldloc.s 6
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0104: pop
+			IL_0105: ldloc.3
+			IL_0106: ldc.r8 1
+			IL_010f: add
+			IL_0110: stloc.3
+			IL_0111: br IL_00c1
 		// end loop
 
-		IL_011f: ldloc.2
-		IL_0120: ldc.r8 0.0
-		IL_0129: ldc.r8 99
-		IL_0132: ldc.i4.1
-		IL_0133: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_0138: ldstr "console"
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0147: ldloc.1
-		IL_0148: ldc.r8 1
-		IL_0151: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_0156: box [System.Runtime]System.Double
-		IL_015b: stloc.s 11
-		IL_015d: ldstr "log"
-		IL_0162: ldloc.s 11
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0169: pop
-		IL_016a: ldloc.1
-		IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0170: stloc.s 6
-		IL_0172: ldloc.s 6
-		IL_0174: ldstr "slice"
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_017e: stloc.s 4
-		IL_0180: ldstr "console"
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018f: stloc.s 7
-		IL_0191: ldloc.s 4
-		IL_0193: ldstr "length"
-		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_019d: stloc.s 8
-		IL_019f: ldloc.s 7
-		IL_01a1: ldstr "log"
-		IL_01a6: ldloc.s 8
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ad: pop
-		IL_01ae: ldstr "console"
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bd: stloc.s 8
-		IL_01bf: ldloc.s 4
-		IL_01c1: ldc.r8 4
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01cf: stloc.s 7
-		IL_01d1: ldloc.s 8
-		IL_01d3: ldstr "log"
-		IL_01d8: ldloc.s 7
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01df: pop
-		IL_01e0: ret
+		IL_0116: ldloc.2
+		IL_0117: ldc.r8 0.0
+		IL_0120: ldc.r8 99
+		IL_0129: ldc.i4.1
+		IL_012a: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_012f: ldstr "console"
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013e: ldloc.1
+		IL_013f: ldc.r8 1
+		IL_0148: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_014d: box [System.Runtime]System.Double
+		IL_0152: stloc.s 10
+		IL_0154: ldstr "log"
+		IL_0159: ldloc.s 10
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0160: pop
+		IL_0161: ldloc.1
+		IL_0162: ldstr "slice"
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_016c: stloc.s 4
+		IL_016e: ldstr "console"
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017d: stloc.s 6
+		IL_017f: ldloc.s 4
+		IL_0181: ldstr "length"
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018b: stloc.s 7
+		IL_018d: ldloc.s 6
+		IL_018f: ldstr "log"
+		IL_0194: ldloc.s 7
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019b: pop
+		IL_019c: ldstr "console"
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ab: stloc.s 7
+		IL_01ad: ldloc.s 4
+		IL_01af: ldc.r8 4
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01bd: stloc.s 6
+		IL_01bf: ldloc.s 7
+		IL_01c1: ldstr "log"
+		IL_01c6: ldloc.s 6
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01cd: pop
+		IL_01ce: ret
 	} // end of method Int32Array_Slice_Basic::__js_module_init__
 
 } // end of class Modules.Int32Array_Slice_Basic
@@ -243,7 +236,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2258
+		// Method begins at RVA 0x2246
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_RelativeIndices.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_RelativeIndices.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x230f
+			// Method begins at RVA 0x22eb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2321
+				// Method begins at RVA 0x22fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2318
+			// Method begins at RVA 0x22f4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2333
+				// Method begins at RVA 0x230f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x232a
+			// Method begins at RVA 0x2306
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -124,7 +124,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 691 (0x2b3)
+		// Code size: 655 (0x28f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Slice_RelativeIndices/Scope,
@@ -134,13 +134,12 @@
 			[4] object,
 			[5] float64,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
-			[8] float64,
+			[7] float64,
+			[8] object,
 			[9] object,
 			[10] object,
 			[11] object,
-			[12] object,
-			[13] float64
+			[12] float64
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Slice_RelativeIndices/Scope::.ctor()
@@ -167,184 +166,172 @@
 		IL_005a: ldloc.s 6
 		IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
 		IL_0061: stloc.1
-		IL_0062: ldloc.1
-		IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0068: stloc.s 7
-		IL_006a: ldc.r8 3
-		IL_0073: neg
-		IL_0074: stloc.s 8
-		IL_0076: ldloc.s 8
-		IL_0078: box [System.Runtime]System.Double
-		IL_007d: stloc.s 9
-		IL_007f: ldc.r8 1
-		IL_0088: neg
-		IL_0089: stloc.s 8
-		IL_008b: ldloc.s 8
-		IL_008d: box [System.Runtime]System.Double
-		IL_0092: stloc.s 10
-		IL_0094: ldloc.s 7
-		IL_0096: ldstr "slice"
-		IL_009b: ldloc.s 9
-		IL_009d: ldloc.s 10
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00a4: stloc.2
-		IL_00a5: ldstr "console"
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b4: stloc.s 11
-		IL_00b6: ldloc.2
-		IL_00b7: ldstr "length"
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c1: stloc.s 12
-		IL_00c3: ldloc.s 11
-		IL_00c5: ldstr "log"
-		IL_00ca: ldloc.s 12
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d1: pop
-		IL_00d2: ldc.r8 0.0
-		IL_00db: stloc.3
-		// loop start (head: IL_00dc)
-			IL_00dc: ldloc.3
-			IL_00dd: stloc.s 8
-			IL_00df: ldloc.2
-			IL_00e0: ldstr "length"
-			IL_00e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_00ea: stloc.s 13
-			IL_00ec: ldloc.s 8
-			IL_00ee: ldloc.s 13
-			IL_00f0: clt
-			IL_00f2: brfalse IL_0131
+		IL_0062: ldc.r8 3
+		IL_006b: neg
+		IL_006c: stloc.s 7
+		IL_006e: ldloc.s 7
+		IL_0070: box [System.Runtime]System.Double
+		IL_0075: stloc.s 8
+		IL_0077: ldc.r8 1
+		IL_0080: neg
+		IL_0081: stloc.s 7
+		IL_0083: ldloc.s 7
+		IL_0085: box [System.Runtime]System.Double
+		IL_008a: stloc.s 9
+		IL_008c: ldloc.1
+		IL_008d: ldstr "slice"
+		IL_0092: ldloc.s 8
+		IL_0094: ldloc.s 9
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_009b: stloc.2
+		IL_009c: ldstr "console"
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ab: stloc.s 10
+		IL_00ad: ldloc.2
+		IL_00ae: ldstr "length"
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b8: stloc.s 11
+		IL_00ba: ldloc.s 10
+		IL_00bc: ldstr "log"
+		IL_00c1: ldloc.s 11
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c8: pop
+		IL_00c9: ldc.r8 0.0
+		IL_00d2: stloc.3
+		// loop start (head: IL_00d3)
+			IL_00d3: ldloc.3
+			IL_00d4: stloc.s 7
+			IL_00d6: ldloc.2
+			IL_00d7: ldstr "length"
+			IL_00dc: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_00e1: stloc.s 12
+			IL_00e3: ldloc.s 7
+			IL_00e5: ldloc.s 12
+			IL_00e7: clt
+			IL_00e9: brfalse IL_0128
 
-			IL_00f7: ldstr "console"
-			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0106: stloc.s 12
-			IL_0108: ldloc.2
-			IL_0109: ldloc.3
-			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_010f: stloc.s 11
-			IL_0111: ldloc.s 12
-			IL_0113: ldstr "log"
-			IL_0118: ldloc.s 11
-			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_011f: pop
-			IL_0120: ldloc.3
-			IL_0121: ldc.r8 1
-			IL_012a: add
-			IL_012b: stloc.3
-			IL_012c: br IL_00dc
+			IL_00ee: ldstr "console"
+			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00fd: stloc.s 11
+			IL_00ff: ldloc.2
+			IL_0100: ldloc.3
+			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0106: stloc.s 10
+			IL_0108: ldloc.s 11
+			IL_010a: ldstr "log"
+			IL_010f: ldloc.s 10
+			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0116: pop
+			IL_0117: ldloc.3
+			IL_0118: ldc.r8 1
+			IL_0121: add
+			IL_0122: stloc.3
+			IL_0123: br IL_00d3
 		// end loop
 
-		IL_0131: ldloc.1
-		IL_0132: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0137: stloc.s 7
-		IL_0139: ldc.r8 20
-		IL_0142: neg
-		IL_0143: stloc.s 13
-		IL_0145: ldloc.s 13
-		IL_0147: box [System.Runtime]System.Double
-		IL_014c: stloc.s 10
-		IL_014e: ldloc.s 7
-		IL_0150: ldstr "slice"
-		IL_0155: ldloc.s 10
-		IL_0157: ldc.r8 2
-		IL_0160: box [System.Runtime]System.Double
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_016a: stloc.s 4
-		IL_016c: ldstr "console"
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017b: stloc.s 11
-		IL_017d: ldloc.s 4
-		IL_017f: ldstr "length"
-		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0189: stloc.s 12
-		IL_018b: ldloc.s 11
-		IL_018d: ldstr "log"
-		IL_0192: ldloc.s 12
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0199: pop
-		IL_019a: ldc.r8 0.0
-		IL_01a3: stloc.s 5
-		// loop start (head: IL_01a5)
-			IL_01a5: ldloc.s 5
-			IL_01a7: stloc.s 13
-			IL_01a9: ldloc.s 4
-			IL_01ab: ldstr "length"
-			IL_01b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_01b5: stloc.s 8
-			IL_01b7: ldloc.s 13
-			IL_01b9: ldloc.s 8
-			IL_01bb: clt
-			IL_01bd: brfalse IL_0200
+		IL_0128: ldc.r8 20
+		IL_0131: neg
+		IL_0132: stloc.s 12
+		IL_0134: ldloc.s 12
+		IL_0136: box [System.Runtime]System.Double
+		IL_013b: stloc.s 9
+		IL_013d: ldloc.1
+		IL_013e: ldstr "slice"
+		IL_0143: ldloc.s 9
+		IL_0145: ldc.r8 2
+		IL_014e: box [System.Runtime]System.Double
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0158: stloc.s 4
+		IL_015a: ldstr "console"
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0169: stloc.s 10
+		IL_016b: ldloc.s 4
+		IL_016d: ldstr "length"
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0177: stloc.s 11
+		IL_0179: ldloc.s 10
+		IL_017b: ldstr "log"
+		IL_0180: ldloc.s 11
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0187: pop
+		IL_0188: ldc.r8 0.0
+		IL_0191: stloc.s 5
+		// loop start (head: IL_0193)
+			IL_0193: ldloc.s 5
+			IL_0195: stloc.s 12
+			IL_0197: ldloc.s 4
+			IL_0199: ldstr "length"
+			IL_019e: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_01a3: stloc.s 7
+			IL_01a5: ldloc.s 12
+			IL_01a7: ldloc.s 7
+			IL_01a9: clt
+			IL_01ab: brfalse IL_01ee
 
-			IL_01c2: ldstr "console"
-			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01d1: stloc.s 12
-			IL_01d3: ldloc.s 4
-			IL_01d5: ldloc.s 5
-			IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01dc: stloc.s 11
-			IL_01de: ldloc.s 12
-			IL_01e0: ldstr "log"
-			IL_01e5: ldloc.s 11
-			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01ec: pop
-			IL_01ed: ldloc.s 5
-			IL_01ef: ldc.r8 1
-			IL_01f8: add
-			IL_01f9: stloc.s 5
-			IL_01fb: br IL_01a5
+			IL_01b0: ldstr "console"
+			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01bf: stloc.s 11
+			IL_01c1: ldloc.s 4
+			IL_01c3: ldloc.s 5
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01ca: stloc.s 10
+			IL_01cc: ldloc.s 11
+			IL_01ce: ldstr "log"
+			IL_01d3: ldloc.s 10
+			IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01da: pop
+			IL_01db: ldloc.s 5
+			IL_01dd: ldc.r8 1
+			IL_01e6: add
+			IL_01e7: stloc.s 5
+			IL_01e9: br IL_0193
 		// end loop
 
-		IL_0200: ldstr "console"
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020f: stloc.s 11
-		IL_0211: ldloc.1
-		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0217: stloc.s 7
-		IL_0219: ldloc.s 7
-		IL_021b: ldstr "slice"
-		IL_0220: ldc.r8 3
-		IL_0229: box [System.Runtime]System.Double
-		IL_022e: ldc.r8 1
-		IL_0237: box [System.Runtime]System.Double
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0241: stloc.s 12
-		IL_0243: ldloc.s 12
-		IL_0245: ldstr "length"
-		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_024f: stloc.s 12
-		IL_0251: ldloc.s 11
-		IL_0253: ldstr "log"
-		IL_0258: ldloc.s 12
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025f: pop
-		IL_0260: ldstr "console"
-		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026f: stloc.s 12
-		IL_0271: ldloc.1
-		IL_0272: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0277: stloc.s 7
-		IL_0279: ldloc.s 7
-		IL_027b: ldstr "slice"
-		IL_0280: ldc.r8 10
-		IL_0289: box [System.Runtime]System.Double
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0293: stloc.s 11
-		IL_0295: ldloc.s 11
-		IL_0297: ldstr "length"
-		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a1: stloc.s 11
-		IL_02a3: ldloc.s 12
-		IL_02a5: ldstr "log"
-		IL_02aa: ldloc.s 11
-		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b1: pop
-		IL_02b2: ret
+		IL_01ee: ldstr "console"
+		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01fd: stloc.s 10
+		IL_01ff: ldloc.1
+		IL_0200: ldstr "slice"
+		IL_0205: ldc.r8 3
+		IL_020e: box [System.Runtime]System.Double
+		IL_0213: ldc.r8 1
+		IL_021c: box [System.Runtime]System.Double
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0226: stloc.s 11
+		IL_0228: ldloc.s 11
+		IL_022a: ldstr "length"
+		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0234: stloc.s 11
+		IL_0236: ldloc.s 10
+		IL_0238: ldstr "log"
+		IL_023d: ldloc.s 11
+		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0244: pop
+		IL_0245: ldstr "console"
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0254: stloc.s 11
+		IL_0256: ldloc.1
+		IL_0257: ldstr "slice"
+		IL_025c: ldc.r8 10
+		IL_0265: box [System.Runtime]System.Double
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_026f: stloc.s 10
+		IL_0271: ldloc.s 10
+		IL_0273: ldstr "length"
+		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_027d: stloc.s 10
+		IL_027f: ldloc.s 11
+		IL_0281: ldstr "log"
+		IL_0286: ldloc.s 10
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028d: pop
+		IL_028e: ret
 	} // end of method Int32Array_Slice_RelativeIndices::__js_module_init__
 
 } // end of class Modules.Int32Array_Slice_RelativeIndices
@@ -356,7 +343,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x233c
+		// Method begins at RVA 0x2318
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Subarray_ViewSemantics.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Subarray_ViewSemantics.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e0
+			// Method begins at RVA 0x22d7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 644 (0x284)
+		// Code size: 635 (0x27b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Subarray_ViewSemantics/Scope,
@@ -48,14 +48,13 @@
 			[2] object,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[5] object,
 			[6] object,
 			[7] object,
-			[8] object,
-			[9] bool,
+			[8] bool,
+			[9] object,
 			[10] object,
-			[11] object,
-			[12] float64
+			[11] float64
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Subarray_ViewSemantics/Scope::.ctor()
@@ -80,160 +79,157 @@
 		IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
 		IL_0052: stloc.1
 		IL_0053: ldloc.1
-		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0059: stloc.s 5
-		IL_005b: ldloc.s 5
-		IL_005d: ldstr "subarray"
-		IL_0062: ldc.r8 1
-		IL_006b: box [System.Runtime]System.Double
-		IL_0070: ldc.r8 3
-		IL_0079: box [System.Runtime]System.Double
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0083: stloc.2
-		IL_0084: ldstr "console"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0093: stloc.s 6
-		IL_0095: ldloc.2
-		IL_0096: ldstr "length"
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a0: stloc.s 7
-		IL_00a2: ldloc.s 6
-		IL_00a4: ldstr "log"
-		IL_00a9: ldloc.s 7
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b0: pop
-		IL_00b1: ldstr "console"
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c0: stloc.s 7
-		IL_00c2: ldloc.2
-		IL_00c3: ldstr "byteOffset"
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00cd: stloc.s 6
-		IL_00cf: ldloc.s 7
-		IL_00d1: ldstr "log"
-		IL_00d6: ldloc.s 6
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00dd: pop
-		IL_00de: ldstr "console"
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ed: stloc.s 6
-		IL_00ef: ldloc.2
-		IL_00f0: ldstr "byteLength"
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fa: stloc.s 7
-		IL_00fc: ldloc.s 6
-		IL_00fe: ldstr "log"
-		IL_0103: ldloc.s 7
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010a: pop
-		IL_010b: ldstr "console"
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011a: stloc.s 7
-		IL_011c: ldloc.2
-		IL_011d: ldstr "buffer"
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0127: stloc.s 6
-		IL_0129: ldloc.1
-		IL_012a: ldstr "buffer"
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0134: stloc.s 8
-		IL_0136: ldloc.s 6
+		IL_0054: ldstr "subarray"
+		IL_0059: ldc.r8 1
+		IL_0062: box [System.Runtime]System.Double
+		IL_0067: ldc.r8 3
+		IL_0070: box [System.Runtime]System.Double
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_007a: stloc.2
+		IL_007b: ldstr "console"
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008a: stloc.s 5
+		IL_008c: ldloc.2
+		IL_008d: ldstr "length"
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0097: stloc.s 6
+		IL_0099: ldloc.s 5
+		IL_009b: ldstr "log"
+		IL_00a0: ldloc.s 6
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a7: pop
+		IL_00a8: ldstr "console"
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b7: stloc.s 6
+		IL_00b9: ldloc.2
+		IL_00ba: ldstr "byteOffset"
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c4: stloc.s 5
+		IL_00c6: ldloc.s 6
+		IL_00c8: ldstr "log"
+		IL_00cd: ldloc.s 5
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d4: pop
+		IL_00d5: ldstr "console"
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e4: stloc.s 5
+		IL_00e6: ldloc.2
+		IL_00e7: ldstr "byteLength"
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f1: stloc.s 6
+		IL_00f3: ldloc.s 5
+		IL_00f5: ldstr "log"
+		IL_00fa: ldloc.s 6
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0101: pop
+		IL_0102: ldstr "console"
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0111: stloc.s 6
+		IL_0113: ldloc.2
+		IL_0114: ldstr "buffer"
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011e: stloc.s 5
+		IL_0120: ldloc.1
+		IL_0121: ldstr "buffer"
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012b: stloc.s 7
+		IL_012d: ldloc.s 5
+		IL_012f: ldloc.s 7
+		IL_0131: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0136: stloc.s 8
 		IL_0138: ldloc.s 8
-		IL_013a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_013a: box [System.Runtime]System.Boolean
 		IL_013f: stloc.s 9
-		IL_0141: ldloc.s 9
-		IL_0143: box [System.Runtime]System.Boolean
-		IL_0148: stloc.s 10
-		IL_014a: ldloc.s 7
-		IL_014c: ldstr "log"
-		IL_0151: ldloc.s 10
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0158: pop
-		IL_0159: ldloc.2
-		IL_015a: ldc.r8 0.0
-		IL_0163: ldc.r8 99
-		IL_016c: ldc.i4.1
-		IL_016d: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_0172: ldstr "console"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0181: ldloc.1
-		IL_0182: ldc.r8 1
-		IL_018b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_0190: box [System.Runtime]System.Double
-		IL_0195: stloc.s 11
-		IL_0197: ldstr "log"
-		IL_019c: ldloc.s 11
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a3: pop
-		IL_01a4: ldloc.2
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01aa: ldstr "slice"
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01b4: stloc.3
-		IL_01b5: ldstr "console"
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c4: stloc.s 7
-		IL_01c6: ldloc.3
-		IL_01c7: ldstr "buffer"
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01d1: stloc.s 8
-		IL_01d3: ldloc.1
-		IL_01d4: ldstr "buffer"
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01de: stloc.s 6
-		IL_01e0: ldloc.s 8
-		IL_01e2: ldloc.s 6
-		IL_01e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0141: ldloc.s 6
+		IL_0143: ldstr "log"
+		IL_0148: ldloc.s 9
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014f: pop
+		IL_0150: ldloc.2
+		IL_0151: ldc.r8 0.0
+		IL_015a: ldc.r8 99
+		IL_0163: ldc.i4.1
+		IL_0164: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0169: ldstr "console"
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0178: ldloc.1
+		IL_0179: ldc.r8 1
+		IL_0182: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_0187: box [System.Runtime]System.Double
+		IL_018c: stloc.s 10
+		IL_018e: ldstr "log"
+		IL_0193: ldloc.s 10
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019a: pop
+		IL_019b: ldloc.2
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a1: ldstr "slice"
+		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01ab: stloc.3
+		IL_01ac: ldstr "console"
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01bb: stloc.s 6
+		IL_01bd: ldloc.3
+		IL_01be: ldstr "buffer"
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c8: stloc.s 7
+		IL_01ca: ldloc.1
+		IL_01cb: ldstr "buffer"
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d5: stloc.s 5
+		IL_01d7: ldloc.s 7
+		IL_01d9: ldloc.s 5
+		IL_01db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01e0: stloc.s 8
+		IL_01e2: ldloc.s 8
+		IL_01e4: box [System.Runtime]System.Boolean
 		IL_01e9: stloc.s 9
-		IL_01eb: ldloc.s 9
-		IL_01ed: box [System.Runtime]System.Boolean
-		IL_01f2: stloc.s 10
-		IL_01f4: ldloc.s 7
-		IL_01f6: ldstr "log"
-		IL_01fb: ldloc.s 10
-		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0202: pop
-		IL_0203: ldc.r8 7
-		IL_020c: neg
-		IL_020d: stloc.s 12
-		IL_020f: ldloc.3
-		IL_0210: ldc.r8 0.0
-		IL_0219: ldloc.s 12
-		IL_021b: ldc.i4.1
-		IL_021c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_0221: ldstr "console"
-		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0230: stloc.s 7
-		IL_0232: ldloc.2
-		IL_0233: ldc.r8 0.0
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0241: stloc.s 6
-		IL_0243: ldloc.s 7
-		IL_0245: ldstr "log"
-		IL_024a: ldloc.s 6
-		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0251: pop
-		IL_0252: ldstr "console"
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0261: stloc.s 6
-		IL_0263: ldloc.3
-		IL_0264: ldc.r8 0.0
-		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0272: stloc.s 7
-		IL_0274: ldloc.s 6
-		IL_0276: ldstr "log"
-		IL_027b: ldloc.s 7
-		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0282: pop
-		IL_0283: ret
+		IL_01eb: ldloc.s 6
+		IL_01ed: ldstr "log"
+		IL_01f2: ldloc.s 9
+		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f9: pop
+		IL_01fa: ldc.r8 7
+		IL_0203: neg
+		IL_0204: stloc.s 11
+		IL_0206: ldloc.3
+		IL_0207: ldc.r8 0.0
+		IL_0210: ldloc.s 11
+		IL_0212: ldc.i4.1
+		IL_0213: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0218: ldstr "console"
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0227: stloc.s 6
+		IL_0229: ldloc.2
+		IL_022a: ldc.r8 0.0
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0238: stloc.s 5
+		IL_023a: ldloc.s 6
+		IL_023c: ldstr "log"
+		IL_0241: ldloc.s 5
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0248: pop
+		IL_0249: ldstr "console"
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0258: stloc.s 5
+		IL_025a: ldloc.3
+		IL_025b: ldc.r8 0.0
+		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0269: stloc.s 6
+		IL_026b: ldloc.s 5
+		IL_026d: ldstr "log"
+		IL_0272: ldloc.s 6
+		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0279: pop
+		IL_027a: ret
 	} // end of method Int32Array_Subarray_ViewSemantics::__js_module_init__
 
 } // end of class Modules.Int32Array_Subarray_ViewSemantics
@@ -245,7 +241,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e9
+		// Method begins at RVA 0x22e0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ConstructorAndSet_Errors.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ConstructorAndSet_Errors.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f5
+				// Method begins at RVA 0x23e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23fe
+				// Method begins at RVA 0x23ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2407
+				// Method begins at RVA 0x23f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2410
+				// Method begins at RVA 0x2400
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2419
+				// Method begins at RVA 0x2409
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2422
+				// Method begins at RVA 0x2412
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x242b
+				// Method begins at RVA 0x241b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +158,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2434
+				// Method begins at RVA 0x2424
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -176,7 +176,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23ec
+			// Method begins at RVA 0x23dc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -202,7 +202,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 859 (0x35b)
+		// Code size: 841 (0x349)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_ConstructorAndSet_Errors/Scope,
@@ -224,8 +224,7 @@
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
 			[17] float64,
 			[18] object,
-			[19] object,
-			[20] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+			[19] object
 		)
 
 		IL_0000: newobj instance void Modules.TypedArray_ConstructorAndSet_Errors/Scope::.ctor()
@@ -406,138 +405,132 @@
 		{
 			IL_01f3: nop
 			IL_01f4: ldloc.s 7
-			IL_01f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-			IL_01fb: stloc.s 20
-			IL_01fd: ldloc.s 20
-			IL_01ff: ldstr "set"
-			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0209: pop
-			IL_020a: leave IL_02a2
+			IL_01f6: ldstr "set"
+			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0200: pop
+			IL_0201: leave IL_0299
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_020f: stloc.s 8
-			IL_0211: ldloc.s 8
-			IL_0213: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0218: dup
-			IL_0219: brtrue IL_022f
+			IL_0206: stloc.s 8
+			IL_0208: ldloc.s 8
+			IL_020a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_020f: dup
+			IL_0210: brtrue IL_0226
 
-			IL_021e: pop
-			IL_021f: ldloc.s 8
-			IL_0221: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0226: dup
-			IL_0227: brtrue IL_023b
+			IL_0215: pop
+			IL_0216: ldloc.s 8
+			IL_0218: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_021d: dup
+			IL_021e: brtrue IL_0232
 
-			IL_022c: pop
-			IL_022d: rethrow
+			IL_0223: pop
+			IL_0224: rethrow
 
-			IL_022f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0234: stloc.s 9
-			IL_0236: br IL_023d
+			IL_0226: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_022b: stloc.s 9
+			IL_022d: br IL_0234
 
-			IL_023b: stloc.s 9
+			IL_0232: stloc.s 9
 
-			IL_023d: ldloc.s 9
-			IL_023f: stloc.s 10
-			IL_0241: ldstr "console"
-			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0250: stloc.s 15
-			IL_0252: ldloc.s 10
-			IL_0254: ldstr "name"
-			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_025e: stloc.s 19
-			IL_0260: ldloc.s 15
-			IL_0262: ldstr "log"
-			IL_0267: ldloc.s 19
-			IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_026e: pop
-			IL_026f: ldstr "console"
-			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027e: stloc.s 19
-			IL_0280: ldloc.s 10
-			IL_0282: ldstr "message"
-			IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_028c: stloc.s 15
-			IL_028e: ldloc.s 19
-			IL_0290: ldstr "log"
-			IL_0295: ldloc.s 15
-			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_029c: pop
-			IL_029d: leave IL_02a2
+			IL_0234: ldloc.s 9
+			IL_0236: stloc.s 10
+			IL_0238: ldstr "console"
+			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0247: stloc.s 15
+			IL_0249: ldloc.s 10
+			IL_024b: ldstr "name"
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0255: stloc.s 19
+			IL_0257: ldloc.s 15
+			IL_0259: ldstr "log"
+			IL_025e: ldloc.s 19
+			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0265: pop
+			IL_0266: ldstr "console"
+			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0275: stloc.s 19
+			IL_0277: ldloc.s 10
+			IL_0279: ldstr "message"
+			IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0283: stloc.s 15
+			IL_0285: ldloc.s 19
+			IL_0287: ldstr "log"
+			IL_028c: ldloc.s 15
+			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0293: pop
+			IL_0294: leave IL_0299
 		} // end handler
 		.try
 		{
-			IL_02a2: nop
-			IL_02a3: ldloc.s 7
-			IL_02a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-			IL_02aa: stloc.s 20
-			IL_02ac: ldloc.s 20
-			IL_02ae: ldstr "set"
-			IL_02b3: ldc.i4.0
-			IL_02b4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02be: pop
-			IL_02bf: leave IL_0357
+			IL_0299: nop
+			IL_029a: ldloc.s 7
+			IL_029c: ldstr "set"
+			IL_02a1: ldc.i4.0
+			IL_02a2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02ac: pop
+			IL_02ad: leave IL_0345
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02c4: stloc.s 11
-			IL_02c6: ldloc.s 11
-			IL_02c8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02cd: dup
-			IL_02ce: brtrue IL_02e4
+			IL_02b2: stloc.s 11
+			IL_02b4: ldloc.s 11
+			IL_02b6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02bb: dup
+			IL_02bc: brtrue IL_02d2
 
-			IL_02d3: pop
-			IL_02d4: ldloc.s 11
-			IL_02d6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02db: dup
-			IL_02dc: brtrue IL_02f0
+			IL_02c1: pop
+			IL_02c2: ldloc.s 11
+			IL_02c4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02c9: dup
+			IL_02ca: brtrue IL_02de
 
-			IL_02e1: pop
-			IL_02e2: rethrow
+			IL_02cf: pop
+			IL_02d0: rethrow
 
-			IL_02e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02e9: stloc.s 12
-			IL_02eb: br IL_02f2
+			IL_02d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02d7: stloc.s 12
+			IL_02d9: br IL_02e0
 
-			IL_02f0: stloc.s 12
+			IL_02de: stloc.s 12
 
-			IL_02f2: ldloc.s 12
-			IL_02f4: stloc.s 13
-			IL_02f6: ldstr "console"
-			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0305: stloc.s 15
-			IL_0307: ldloc.s 13
-			IL_0309: ldstr "name"
-			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0313: stloc.s 19
-			IL_0315: ldloc.s 15
-			IL_0317: ldstr "log"
-			IL_031c: ldloc.s 19
-			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0323: pop
-			IL_0324: ldstr "console"
-			IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0333: stloc.s 19
-			IL_0335: ldloc.s 13
-			IL_0337: ldstr "message"
-			IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0341: stloc.s 15
-			IL_0343: ldloc.s 19
-			IL_0345: ldstr "log"
-			IL_034a: ldloc.s 15
-			IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0351: pop
-			IL_0352: leave IL_0357
+			IL_02e0: ldloc.s 12
+			IL_02e2: stloc.s 13
+			IL_02e4: ldstr "console"
+			IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02f3: stloc.s 15
+			IL_02f5: ldloc.s 13
+			IL_02f7: ldstr "name"
+			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0301: stloc.s 19
+			IL_0303: ldloc.s 15
+			IL_0305: ldstr "log"
+			IL_030a: ldloc.s 19
+			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0311: pop
+			IL_0312: ldstr "console"
+			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0321: stloc.s 19
+			IL_0323: ldloc.s 13
+			IL_0325: ldstr "message"
+			IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_032f: stloc.s 15
+			IL_0331: ldloc.s 19
+			IL_0333: ldstr "log"
+			IL_0338: ldloc.s 15
+			IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_033f: pop
+			IL_0340: leave IL_0345
 		} // end handler
 
-		IL_0357: ldnull
-		IL_0358: stloc.s 14
-		IL_035a: ret
+		IL_0345: ldnull
+		IL_0346: stloc.s 14
+		IL_0348: ret
 	} // end of method TypedArray_ConstructorAndSet_Errors::__js_module_init__
 
 } // end of class Modules.TypedArray_ConstructorAndSet_Errors
@@ -549,7 +542,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x243d
+		// Method begins at RVA 0x242d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2528
+				// Method begins at RVA 0x2504
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x24e0
+			// Method begins at RVA 0x24bc
 			// Header size: 12
 			// Code size: 51 (0x33)
 			.maxstack 8
@@ -87,7 +87,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2531
+				// Method begins at RVA 0x250d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -107,7 +107,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x253a
+				// Method begins at RVA 0x2516
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -128,7 +128,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x251f
+			// Method begins at RVA 0x24fb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -154,7 +154,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1140 (0x474)
+		// Code size: 1104 (0x450)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope,
@@ -170,12 +170,8 @@
 			[10] object,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[12] object,
-			[13] class [JavaScriptRuntime]JavaScriptRuntime.Int8Array,
-			[14] object,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.Int16Array,
-			[16] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
-			[17] class [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray,
-			[18] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			[13] object,
+			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
 		)
 
 		IL_0000: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::.ctor()
@@ -219,276 +215,264 @@
 		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00a1: stloc.s 12
 		IL_00a3: ldloc.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int8Array>(!!0)
-		IL_00a9: stloc.s 13
-		IL_00ab: ldloc.s 13
-		IL_00ad: ldstr "join"
-		IL_00b2: ldstr "|"
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bc: stloc.s 14
-		IL_00be: ldloc.s 12
-		IL_00c0: ldstr "log"
-		IL_00c5: ldloc.s 14
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cc: pop
-		IL_00cd: ldc.i4.8
-		IL_00ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00d3: dup
-		IL_00d4: ldc.r8 32769
-		IL_00dd: neg
-		IL_00de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00e3: dup
-		IL_00e4: ldc.r8 32768
-		IL_00ed: neg
-		IL_00ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00f3: dup
-		IL_00f4: ldc.r8 32767
-		IL_00fd: neg
-		IL_00fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0103: dup
-		IL_0104: ldc.r8 32767
-		IL_010d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0112: dup
-		IL_0113: ldc.r8 32768
-		IL_011c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0121: dup
-		IL_0122: ldc.r8 32769
-		IL_012b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0130: dup
-		IL_0131: ldc.r8 65535
-		IL_013a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_013f: dup
-		IL_0140: ldc.r8 65536
-		IL_0149: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_014e: stloc.s 11
-		IL_0150: ldloc.s 11
-		IL_0152: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int16Array::.ctor(object)
-		IL_0157: stloc.2
-		IL_0158: ldstr "console"
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0167: stloc.s 14
-		IL_0169: ldloc.2
-		IL_016a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int16Array>(!!0)
-		IL_016f: stloc.s 15
-		IL_0171: ldloc.s 15
-		IL_0173: ldstr "join"
-		IL_0178: ldstr "|"
-		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0182: stloc.s 12
-		IL_0184: ldloc.s 14
-		IL_0186: ldstr "log"
-		IL_018b: ldloc.s 12
-		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0192: pop
-		IL_0193: ldc.i4.8
-		IL_0194: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0199: dup
-		IL_019a: ldc.r8 1
-		IL_01a3: neg
-		IL_01a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01a9: dup
-		IL_01aa: ldc.r8 0.0
-		IL_01b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01b8: dup
-		IL_01b9: ldc.r8 1
-		IL_01c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01c7: dup
-		IL_01c8: ldc.r8 255
-		IL_01d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01d6: dup
-		IL_01d7: ldc.r8 256
-		IL_01e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01e5: dup
-		IL_01e6: ldc.r8 257
-		IL_01ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01f4: dup
-		IL_01f5: ldc.r8 511
-		IL_01fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0203: dup
-		IL_0204: ldc.r8 1.9
-		IL_020d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0212: stloc.s 11
-		IL_0214: ldloc.s 11
-		IL_0216: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_021b: stloc.3
-		IL_021c: ldstr "console"
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022b: stloc.s 12
-		IL_022d: ldloc.3
-		IL_022e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
-		IL_0233: stloc.s 16
-		IL_0235: ldloc.s 16
-		IL_0237: ldstr "join"
-		IL_023c: ldstr "|"
-		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0246: stloc.s 14
-		IL_0248: ldloc.s 12
-		IL_024a: ldstr "log"
-		IL_024f: ldloc.s 14
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0256: pop
-		IL_0257: ldc.i4.s 10
-		IL_0259: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_025e: dup
-		IL_025f: ldc.r8 20
-		IL_0268: neg
-		IL_0269: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_026e: dup
-		IL_026f: ldc.r8 0.5
-		IL_0278: neg
-		IL_0279: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_027e: dup
-		IL_027f: ldc.r8 0.49
-		IL_0288: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_028d: dup
-		IL_028e: ldc.r8 0.5
-		IL_0297: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_029c: dup
-		IL_029d: ldc.r8 1.5
-		IL_02a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02ab: dup
-		IL_02ac: ldc.r8 2.5
-		IL_02b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02ba: dup
-		IL_02bb: ldc.r8 254.6
-		IL_02c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02c9: dup
-		IL_02ca: ldc.r8 255.4
-		IL_02d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02d8: dup
-		IL_02d9: ldc.r8 300
-		IL_02e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02e7: dup
-		IL_02e8: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_02f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02f6: stloc.s 11
-		IL_02f8: ldloc.s 11
-		IL_02fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::.ctor(object)
-		IL_02ff: stloc.s 4
-		IL_0301: ldstr "console"
-		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0310: stloc.s 14
-		IL_0312: ldloc.s 4
-		IL_0314: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray>(!!0)
-		IL_0319: stloc.s 17
-		IL_031b: ldloc.s 17
-		IL_031d: ldstr "join"
-		IL_0322: ldstr "|"
-		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_032c: stloc.s 12
-		IL_032e: ldloc.s 14
-		IL_0330: ldstr "log"
-		IL_0335: ldloc.s 12
-		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_033c: pop
-		IL_033d: ldloc.0
-		IL_033e: ldc.r8 0.0
-		IL_0347: box [System.Runtime]System.Double
-		IL_034c: stfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
-		IL_0351: ldloc.0
-		IL_0352: castclass Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope
-		IL_0357: ldftn object Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue::__js_call__(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope, object)
-		IL_035d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0362: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0367: ldc.i4.0
-		IL_0368: conv.r8
-		IL_0369: ldstr ""
-		IL_036e: ldc.i4.0
-		IL_036f: ldc.i4.1
-		IL_0370: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0375: stloc.s 18
-		IL_0377: ldloc.s 18
-		IL_0379: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_037e: stloc.s 18
-		IL_0380: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0385: dup
-		IL_0386: ldstr "valueOf"
-		IL_038b: ldloc.s 18
-		IL_038d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0392: stloc.s 5
-		IL_0394: ldc.r8 0.0
-		IL_039d: box [System.Runtime]System.Double
-		IL_03a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_03a7: stloc.s 6
-		IL_03a9: ldloc.s 6
-		IL_03ab: ldc.r8 0.0
-		IL_03b4: ldloc.s 5
-		IL_03b6: ldc.i4.1
-		IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_03bc: pop
-		IL_03bd: ldstr "console"
-		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03cc: stloc.s 12
-		IL_03ce: ldloc.0
-		IL_03cf: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
-		IL_03d4: stloc.s 14
-		IL_03d6: ldloc.s 12
-		IL_03d8: ldstr "log"
-		IL_03dd: ldloc.s 14
-		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03e4: pop
+		IL_00a4: ldstr "join"
+		IL_00a9: ldstr "|"
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b3: stloc.s 13
+		IL_00b5: ldloc.s 12
+		IL_00b7: ldstr "log"
+		IL_00bc: ldloc.s 13
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c3: pop
+		IL_00c4: ldc.i4.8
+		IL_00c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00ca: dup
+		IL_00cb: ldc.r8 32769
+		IL_00d4: neg
+		IL_00d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00da: dup
+		IL_00db: ldc.r8 32768
+		IL_00e4: neg
+		IL_00e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00ea: dup
+		IL_00eb: ldc.r8 32767
+		IL_00f4: neg
+		IL_00f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00fa: dup
+		IL_00fb: ldc.r8 32767
+		IL_0104: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0109: dup
+		IL_010a: ldc.r8 32768
+		IL_0113: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0118: dup
+		IL_0119: ldc.r8 32769
+		IL_0122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0127: dup
+		IL_0128: ldc.r8 65535
+		IL_0131: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0136: dup
+		IL_0137: ldc.r8 65536
+		IL_0140: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0145: stloc.s 11
+		IL_0147: ldloc.s 11
+		IL_0149: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int16Array::.ctor(object)
+		IL_014e: stloc.2
+		IL_014f: ldstr "console"
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015e: stloc.s 13
+		IL_0160: ldloc.2
+		IL_0161: ldstr "join"
+		IL_0166: ldstr "|"
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0170: stloc.s 12
+		IL_0172: ldloc.s 13
+		IL_0174: ldstr "log"
+		IL_0179: ldloc.s 12
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0180: pop
+		IL_0181: ldc.i4.8
+		IL_0182: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0187: dup
+		IL_0188: ldc.r8 1
+		IL_0191: neg
+		IL_0192: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0197: dup
+		IL_0198: ldc.r8 0.0
+		IL_01a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01a6: dup
+		IL_01a7: ldc.r8 1
+		IL_01b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01b5: dup
+		IL_01b6: ldc.r8 255
+		IL_01bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01c4: dup
+		IL_01c5: ldc.r8 256
+		IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01d3: dup
+		IL_01d4: ldc.r8 257
+		IL_01dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01e2: dup
+		IL_01e3: ldc.r8 511
+		IL_01ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01f1: dup
+		IL_01f2: ldc.r8 1.9
+		IL_01fb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0200: stloc.s 11
+		IL_0202: ldloc.s 11
+		IL_0204: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_0209: stloc.3
+		IL_020a: ldstr "console"
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0219: stloc.s 12
+		IL_021b: ldloc.3
+		IL_021c: ldstr "join"
+		IL_0221: ldstr "|"
+		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_022b: stloc.s 13
+		IL_022d: ldloc.s 12
+		IL_022f: ldstr "log"
+		IL_0234: ldloc.s 13
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023b: pop
+		IL_023c: ldc.i4.s 10
+		IL_023e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0243: dup
+		IL_0244: ldc.r8 20
+		IL_024d: neg
+		IL_024e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0253: dup
+		IL_0254: ldc.r8 0.5
+		IL_025d: neg
+		IL_025e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0263: dup
+		IL_0264: ldc.r8 0.49
+		IL_026d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0272: dup
+		IL_0273: ldc.r8 0.5
+		IL_027c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0281: dup
+		IL_0282: ldc.r8 1.5
+		IL_028b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0290: dup
+		IL_0291: ldc.r8 2.5
+		IL_029a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_029f: dup
+		IL_02a0: ldc.r8 254.6
+		IL_02a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02ae: dup
+		IL_02af: ldc.r8 255.4
+		IL_02b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02bd: dup
+		IL_02be: ldc.r8 300
+		IL_02c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02cc: dup
+		IL_02cd: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_02d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02db: stloc.s 11
+		IL_02dd: ldloc.s 11
+		IL_02df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::.ctor(object)
+		IL_02e4: stloc.s 4
+		IL_02e6: ldstr "console"
+		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f5: stloc.s 13
+		IL_02f7: ldloc.s 4
+		IL_02f9: ldstr "join"
+		IL_02fe: ldstr "|"
+		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0308: stloc.s 12
+		IL_030a: ldloc.s 13
+		IL_030c: ldstr "log"
+		IL_0311: ldloc.s 12
+		IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0318: pop
+		IL_0319: ldloc.0
+		IL_031a: ldc.r8 0.0
+		IL_0323: box [System.Runtime]System.Double
+		IL_0328: stfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
+		IL_032d: ldloc.0
+		IL_032e: castclass Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope
+		IL_0333: ldftn object Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue::__js_call__(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope, object)
+		IL_0339: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_033e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0343: ldc.i4.0
+		IL_0344: conv.r8
+		IL_0345: ldstr ""
+		IL_034a: ldc.i4.0
+		IL_034b: ldc.i4.1
+		IL_034c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0351: stloc.s 14
+		IL_0353: ldloc.s 14
+		IL_0355: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_035a: stloc.s 14
+		IL_035c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0361: dup
+		IL_0362: ldstr "valueOf"
+		IL_0367: ldloc.s 14
+		IL_0369: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_036e: stloc.s 5
+		IL_0370: ldc.r8 0.0
+		IL_0379: box [System.Runtime]System.Double
+		IL_037e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_0383: stloc.s 6
+		IL_0385: ldloc.s 6
+		IL_0387: ldc.r8 0.0
+		IL_0390: ldloc.s 5
+		IL_0392: ldc.i4.1
+		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_0398: pop
+		IL_0399: ldstr "console"
+		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03a8: stloc.s 12
+		IL_03aa: ldloc.0
+		IL_03ab: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
+		IL_03b0: stloc.s 13
+		IL_03b2: ldloc.s 12
+		IL_03b4: ldstr "log"
+		IL_03b9: ldloc.s 13
+		IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03c0: pop
 		.try
 		{
-			IL_03e5: nop
-			IL_03e6: ldstr "value"
-			IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
-			IL_03f0: stloc.s 14
-			IL_03f2: ldloc.s 6
-			IL_03f4: ldc.r8 0.0
-			IL_03fd: ldloc.s 14
-			IL_03ff: ldc.i4.1
-			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0405: pop
-			IL_0406: leave IL_0470
+			IL_03c1: nop
+			IL_03c2: ldstr "value"
+			IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
+			IL_03cc: stloc.s 13
+			IL_03ce: ldloc.s 6
+			IL_03d0: ldc.r8 0.0
+			IL_03d9: ldloc.s 13
+			IL_03db: ldc.i4.1
+			IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_03e1: pop
+			IL_03e2: leave IL_044c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_040b: stloc.s 7
-			IL_040d: ldloc.s 7
-			IL_040f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0414: dup
-			IL_0415: brtrue IL_042b
+			IL_03e7: stloc.s 7
+			IL_03e9: ldloc.s 7
+			IL_03eb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03f0: dup
+			IL_03f1: brtrue IL_0407
 
-			IL_041a: pop
-			IL_041b: ldloc.s 7
-			IL_041d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0422: dup
-			IL_0423: brtrue IL_0437
+			IL_03f6: pop
+			IL_03f7: ldloc.s 7
+			IL_03f9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03fe: dup
+			IL_03ff: brtrue IL_0413
 
-			IL_0428: pop
-			IL_0429: rethrow
+			IL_0404: pop
+			IL_0405: rethrow
 
-			IL_042b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0430: stloc.s 8
-			IL_0432: br IL_0439
+			IL_0407: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_040c: stloc.s 8
+			IL_040e: br IL_0415
 
-			IL_0437: stloc.s 8
+			IL_0413: stloc.s 8
 
-			IL_0439: ldloc.s 8
-			IL_043b: stloc.s 9
-			IL_043d: ldstr "console"
-			IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_044c: stloc.s 14
-			IL_044e: ldloc.s 9
-			IL_0450: ldstr "name"
-			IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_045a: stloc.s 12
-			IL_045c: ldloc.s 14
-			IL_045e: ldstr "log"
-			IL_0463: ldloc.s 12
-			IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_046a: pop
-			IL_046b: leave IL_0470
+			IL_0415: ldloc.s 8
+			IL_0417: stloc.s 9
+			IL_0419: ldstr "console"
+			IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0428: stloc.s 13
+			IL_042a: ldloc.s 9
+			IL_042c: ldstr "name"
+			IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0436: stloc.s 12
+			IL_0438: ldloc.s 13
+			IL_043a: ldstr "log"
+			IL_043f: ldloc.s 12
+			IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0446: pop
+			IL_0447: leave IL_044c
 		} // end handler
 
-		IL_0470: ldnull
-		IL_0471: stloc.s 10
-		IL_0473: ret
+		IL_044c: ldnull
+		IL_044d: stloc.s 10
+		IL_044f: ret
 	} // end of method TypedArray_SignedAndClamped_ConversionSemantics::__js_module_init__
 
 } // end of class Modules.TypedArray_SignedAndClamped_ConversionSemantics
@@ -500,7 +484,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2543
+		// Method begins at RVA 0x251f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Construct_ArrayLike_Buffer_Search.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Construct_ArrayLike_Buffer_Search.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2389
+			// Method begins at RVA 0x236e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x239b
+				// Method begins at RVA 0x2380
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2392
+			// Method begins at RVA 0x2377
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 813 (0x32d)
+		// Code size: 786 (0x312)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search/Scope,
@@ -98,8 +98,7 @@
 			[10] float64,
 			[11] object,
 			[12] bool,
-			[13] object,
-			[14] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array
+			[13] object
 		)
 
 		IL_0000: newobj instance void Modules.Uint8Array_Construct_ArrayLike_Buffer_Search/Scope::.ctor()
@@ -273,61 +272,52 @@
 		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0263: stloc.s 11
 		IL_0265: ldloc.s 4
-		IL_0267: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
-		IL_026c: stloc.s 14
-		IL_026e: ldloc.s 14
-		IL_0270: ldstr "includes"
-		IL_0275: ldc.r8 43
-		IL_027e: box [System.Runtime]System.Double
-		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0288: stloc.s 7
-		IL_028a: ldloc.s 11
-		IL_028c: ldstr "log"
-		IL_0291: ldloc.s 7
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0298: pop
-		IL_0299: ldstr "console"
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a8: stloc.s 7
-		IL_02aa: ldloc.s 4
-		IL_02ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
-		IL_02b1: stloc.s 14
-		IL_02b3: ldloc.s 14
-		IL_02b5: ldstr "indexOf"
-		IL_02ba: ldc.r8 42
-		IL_02c3: box [System.Runtime]System.Double
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02cd: stloc.s 11
-		IL_02cf: ldloc.s 7
-		IL_02d1: ldstr "log"
-		IL_02d6: ldloc.s 11
-		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02dd: pop
-		IL_02de: ldstr "console"
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ed: stloc.s 11
-		IL_02ef: ldloc.s 4
-		IL_02f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
-		IL_02f6: stloc.s 14
-		IL_02f8: ldc.r8 1
-		IL_0301: neg
-		IL_0302: stloc.s 10
-		IL_0304: ldloc.s 10
-		IL_0306: box [System.Runtime]System.Double
-		IL_030b: stloc.s 9
-		IL_030d: ldloc.s 14
-		IL_030f: ldstr "at"
-		IL_0314: ldloc.s 9
-		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_031b: stloc.s 7
-		IL_031d: ldloc.s 11
-		IL_031f: ldstr "log"
-		IL_0324: ldloc.s 7
-		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_032b: pop
-		IL_032c: ret
+		IL_0267: ldstr "includes"
+		IL_026c: ldc.r8 43
+		IL_0275: box [System.Runtime]System.Double
+		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027f: stloc.s 7
+		IL_0281: ldloc.s 11
+		IL_0283: ldstr "log"
+		IL_0288: ldloc.s 7
+		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028f: pop
+		IL_0290: ldstr "console"
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_029f: stloc.s 7
+		IL_02a1: ldloc.s 4
+		IL_02a3: ldstr "indexOf"
+		IL_02a8: ldc.r8 42
+		IL_02b1: box [System.Runtime]System.Double
+		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02bb: stloc.s 11
+		IL_02bd: ldloc.s 7
+		IL_02bf: ldstr "log"
+		IL_02c4: ldloc.s 11
+		IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02cb: pop
+		IL_02cc: ldstr "console"
+		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02db: stloc.s 11
+		IL_02dd: ldc.r8 1
+		IL_02e6: neg
+		IL_02e7: stloc.s 10
+		IL_02e9: ldloc.s 10
+		IL_02eb: box [System.Runtime]System.Double
+		IL_02f0: stloc.s 9
+		IL_02f2: ldloc.s 4
+		IL_02f4: ldstr "at"
+		IL_02f9: ldloc.s 9
+		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0300: stloc.s 7
+		IL_0302: ldloc.s 11
+		IL_0304: ldstr "log"
+		IL_0309: ldloc.s 7
+		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0310: pop
+		IL_0311: ret
 	} // end of method Uint8Array_Construct_ArrayLike_Buffer_Search::__js_module_init__
 
 } // end of class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search
@@ -339,7 +329,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23a4
+		// Method begins at RVA 0x2389
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Iterator_Metadata.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Iterator_Metadata.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22ee
+			// Method begins at RVA 0x22c7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 658 (0x292)
+		// Code size: 619 (0x26b)
 		.maxstack 11
 		.locals init (
 			[0] class Modules.Uint8Array_Iterator_Metadata/Scope,
@@ -48,10 +48,8 @@
 			[2] object,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
-			[6] object,
-			[7] object,
-			[8] object[]
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Uint8Array_Iterator_Metadata/Scope::.ctor()
@@ -70,178 +68,163 @@
 		IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
 		IL_0034: stloc.1
 		IL_0035: ldloc.1
-		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
-		IL_003b: stloc.s 5
-		IL_003d: ldloc.s 5
-		IL_003f: ldstr "keys"
-		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0049: stloc.2
-		IL_004a: ldstr "console"
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0059: stloc.s 6
-		IL_005b: ldloc.2
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0061: ldstr "next"
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_006b: stloc.s 7
-		IL_006d: ldloc.s 7
-		IL_006f: ldstr "value"
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0079: stloc.s 7
-		IL_007b: ldloc.s 6
-		IL_007d: ldstr "log"
-		IL_0082: ldloc.s 7
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0089: pop
-		IL_008a: ldstr "console"
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0099: stloc.s 7
-		IL_009b: ldloc.2
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a1: ldstr "next"
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00ab: stloc.s 6
-		IL_00ad: ldloc.s 6
-		IL_00af: ldstr "value"
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b9: stloc.s 6
-		IL_00bb: ldloc.s 7
-		IL_00bd: ldstr "log"
-		IL_00c2: ldloc.s 6
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c9: pop
-		IL_00ca: ldstr "console"
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d9: stloc.s 6
-		IL_00db: ldloc.2
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e1: ldstr "next"
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00eb: stloc.s 7
-		IL_00ed: ldloc.s 7
-		IL_00ef: ldstr "done"
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f9: stloc.s 7
-		IL_00fb: ldloc.s 6
-		IL_00fd: ldstr "log"
-		IL_0102: ldloc.s 7
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0109: pop
-		IL_010a: ldloc.1
-		IL_010b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
-		IL_0110: stloc.s 5
-		IL_0112: ldloc.s 5
-		IL_0114: ldstr "entries"
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_011e: stloc.s 7
-		IL_0120: ldloc.s 7
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0127: ldstr "next"
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0131: stloc.s 7
-		IL_0133: ldloc.s 7
-		IL_0135: ldstr "value"
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013f: stloc.3
-		IL_0140: ldstr "console"
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014f: stloc.s 7
-		IL_0151: ldloc.3
-		IL_0152: ldc.r8 0.0
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0160: stloc.s 6
-		IL_0162: ldloc.s 7
-		IL_0164: ldstr "log"
-		IL_0169: ldloc.s 6
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0170: pop
-		IL_0171: ldstr "console"
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0180: stloc.s 6
-		IL_0182: ldloc.3
-		IL_0183: ldc.r8 1
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0191: stloc.s 7
-		IL_0193: ldloc.s 6
-		IL_0195: ldstr "log"
-		IL_019a: ldloc.s 7
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a1: pop
-		IL_01a2: ldstr "console"
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b1: stloc.s 7
-		IL_01b3: ldloc.1
-		IL_01b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
-		IL_01b9: stloc.s 5
-		IL_01bb: ldstr "iterator"
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_01c5: stloc.s 6
-		IL_01c7: ldc.i4.0
-		IL_01c8: newarr [System.Runtime]System.Object
-		IL_01cd: stloc.s 8
-		IL_01cf: ldloc.s 5
-		IL_01d1: ldloc.s 6
-		IL_01d3: ldloc.s 8
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_01da: stloc.s 6
-		IL_01dc: ldloc.s 6
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e3: ldstr "next"
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01ed: stloc.s 6
-		IL_01ef: ldloc.s 6
-		IL_01f1: ldstr "value"
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01fb: stloc.s 6
-		IL_01fd: ldloc.s 7
-		IL_01ff: ldstr "log"
-		IL_0204: ldloc.s 6
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020b: pop
-		IL_020c: ldstr "console"
-		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021b: stloc.s 6
-		IL_021d: ldstr "Object"
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0227: ldstr "prototype"
-		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0231: stloc.s 7
-		IL_0233: ldloc.s 7
-		IL_0235: ldstr "toString"
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_023f: stloc.s 7
-		IL_0241: ldloc.s 7
-		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0248: ldstr "call"
-		IL_024d: ldloc.1
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0253: stloc.s 7
-		IL_0255: ldloc.s 6
-		IL_0257: ldstr "log"
-		IL_025c: ldloc.s 7
-		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0263: pop
-		IL_0264: ldstr "console"
-		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0273: stloc.s 7
-		IL_0275: ldloc.1
-		IL_0276: ldstr "BYTES_PER_ELEMENT"
-		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0280: stloc.s 6
-		IL_0282: ldloc.s 7
-		IL_0284: ldstr "log"
-		IL_0289: ldloc.s 6
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0290: pop
-		IL_0291: ret
+		IL_0036: ldstr "keys"
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0040: stloc.2
+		IL_0041: ldstr "console"
+		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0050: stloc.s 5
+		IL_0052: ldloc.2
+		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0058: ldstr "next"
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0062: stloc.s 6
+		IL_0064: ldloc.s 6
+		IL_0066: ldstr "value"
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0070: stloc.s 6
+		IL_0072: ldloc.s 5
+		IL_0074: ldstr "log"
+		IL_0079: ldloc.s 6
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0080: pop
+		IL_0081: ldstr "console"
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0090: stloc.s 6
+		IL_0092: ldloc.2
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0098: ldstr "next"
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00a2: stloc.s 5
+		IL_00a4: ldloc.s 5
+		IL_00a6: ldstr "value"
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b0: stloc.s 5
+		IL_00b2: ldloc.s 6
+		IL_00b4: ldstr "log"
+		IL_00b9: ldloc.s 5
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c0: pop
+		IL_00c1: ldstr "console"
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d0: stloc.s 5
+		IL_00d2: ldloc.2
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d8: ldstr "next"
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00e2: stloc.s 6
+		IL_00e4: ldloc.s 6
+		IL_00e6: ldstr "done"
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f0: stloc.s 6
+		IL_00f2: ldloc.s 5
+		IL_00f4: ldstr "log"
+		IL_00f9: ldloc.s 6
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0100: pop
+		IL_0101: ldloc.1
+		IL_0102: ldstr "entries"
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_010c: stloc.s 6
+		IL_010e: ldloc.s 6
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0115: ldstr "next"
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_011f: stloc.s 6
+		IL_0121: ldloc.s 6
+		IL_0123: ldstr "value"
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012d: stloc.3
+		IL_012e: ldstr "console"
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013d: stloc.s 6
+		IL_013f: ldloc.3
+		IL_0140: ldc.r8 0.0
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_014e: stloc.s 5
+		IL_0150: ldloc.s 6
+		IL_0152: ldstr "log"
+		IL_0157: ldloc.s 5
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015e: pop
+		IL_015f: ldstr "console"
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016e: stloc.s 5
+		IL_0170: ldloc.3
+		IL_0171: ldc.r8 1
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_017f: stloc.s 6
+		IL_0181: ldloc.s 5
+		IL_0183: ldstr "log"
+		IL_0188: ldloc.s 6
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018f: pop
+		IL_0190: ldstr "console"
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019f: stloc.s 6
+		IL_01a1: ldloc.1
+		IL_01a2: ldstr "iterator"
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_01ac: ldc.i4.0
+		IL_01ad: newarr [System.Runtime]System.Object
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01bc: ldstr "next"
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01c6: stloc.s 5
+		IL_01c8: ldloc.s 5
+		IL_01ca: ldstr "value"
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d4: stloc.s 5
+		IL_01d6: ldloc.s 6
+		IL_01d8: ldstr "log"
+		IL_01dd: ldloc.s 5
+		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e4: pop
+		IL_01e5: ldstr "console"
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f4: stloc.s 5
+		IL_01f6: ldstr "Object"
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0200: ldstr "prototype"
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_020a: stloc.s 6
+		IL_020c: ldloc.s 6
+		IL_020e: ldstr "toString"
+		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0218: stloc.s 6
+		IL_021a: ldloc.s 6
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0221: ldstr "call"
+		IL_0226: ldloc.1
+		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_022c: stloc.s 6
+		IL_022e: ldloc.s 5
+		IL_0230: ldstr "log"
+		IL_0235: ldloc.s 6
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023c: pop
+		IL_023d: ldstr "console"
+		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024c: stloc.s 6
+		IL_024e: ldloc.1
+		IL_024f: ldstr "BYTES_PER_ELEMENT"
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0259: stloc.s 5
+		IL_025b: ldloc.s 6
+		IL_025d: ldstr "log"
+		IL_0262: ldloc.s 5
+		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0269: pop
+		IL_026a: ret
 	} // end of method Uint8Array_Iterator_Metadata::__js_module_init__
 
 } // end of class Modules.Uint8Array_Iterator_Metadata
@@ -253,7 +236,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22f7
+		// Method begins at RVA 0x22d0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Values_Iterator.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Values_Iterator.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2244
+			// Method begins at RVA 0x223c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2256
+				// Method begins at RVA 0x224e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x224d
+			// Method begins at RVA 0x2245
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 472 (0x1d8)
+		// Code size: 463 (0x1cf)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Uint8Array_Values_Iterator/Scope,
@@ -93,10 +93,9 @@
 			[5] bool,
 			[6] object,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[8] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
+			[8] object,
 			[9] object,
-			[10] object,
-			[11] bool
+			[10] bool
 		)
 
 		IL_0000: newobj instance void Modules.Uint8Array_Values_Iterator/Scope::.ctor()
@@ -118,142 +117,139 @@
 		IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
 		IL_0043: stloc.1
 		IL_0044: ldloc.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
-		IL_004a: stloc.s 8
-		IL_004c: ldloc.s 8
-		IL_004e: ldstr "values"
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0058: stloc.2
-		IL_0059: ldstr "console"
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0068: stloc.s 9
-		IL_006a: ldloc.2
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0070: ldstr "next"
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_007a: stloc.s 10
-		IL_007c: ldloc.s 10
-		IL_007e: ldstr "value"
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0088: stloc.s 10
-		IL_008a: ldloc.s 9
-		IL_008c: ldstr "log"
-		IL_0091: ldloc.s 10
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0098: pop
-		IL_0099: ldstr "console"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a8: stloc.s 10
-		IL_00aa: ldloc.2
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b0: ldstr "next"
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00ba: stloc.s 9
-		IL_00bc: ldloc.s 9
-		IL_00be: ldstr "value"
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c8: stloc.s 9
-		IL_00ca: ldloc.s 10
-		IL_00cc: ldstr "log"
-		IL_00d1: ldloc.s 9
-		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d8: pop
-		IL_00d9: ldstr "console"
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e8: stloc.s 9
-		IL_00ea: ldloc.2
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f0: ldstr "next"
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00fa: stloc.s 10
-		IL_00fc: ldloc.s 10
-		IL_00fe: ldstr "value"
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0108: stloc.s 10
-		IL_010a: ldloc.s 9
-		IL_010c: ldstr "log"
-		IL_0111: ldloc.s 10
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0118: pop
-		IL_0119: ldstr "console"
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0128: stloc.s 10
-		IL_012a: ldloc.2
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0130: ldstr "next"
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_013a: stloc.s 9
-		IL_013c: ldloc.s 9
-		IL_013e: ldstr "done"
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0148: stloc.s 9
-		IL_014a: ldloc.s 10
-		IL_014c: ldstr "log"
-		IL_0151: ldloc.s 9
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0158: pop
-		IL_0159: ldloc.1
-		IL_015a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-		IL_015f: stloc.3
-		IL_0160: ldc.i4.0
-		IL_0161: stloc.s 4
-		IL_0163: ldc.i4.0
-		IL_0164: stloc.s 5
+		IL_0045: ldstr "values"
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_004f: stloc.2
+		IL_0050: ldstr "console"
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005f: stloc.s 8
+		IL_0061: ldloc.2
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0067: ldstr "next"
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0071: stloc.s 9
+		IL_0073: ldloc.s 9
+		IL_0075: ldstr "value"
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_007f: stloc.s 9
+		IL_0081: ldloc.s 8
+		IL_0083: ldstr "log"
+		IL_0088: ldloc.s 9
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008f: pop
+		IL_0090: ldstr "console"
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009f: stloc.s 9
+		IL_00a1: ldloc.2
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a7: ldstr "next"
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00b1: stloc.s 8
+		IL_00b3: ldloc.s 8
+		IL_00b5: ldstr "value"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00bf: stloc.s 8
+		IL_00c1: ldloc.s 9
+		IL_00c3: ldstr "log"
+		IL_00c8: ldloc.s 8
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cf: pop
+		IL_00d0: ldstr "console"
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00df: stloc.s 8
+		IL_00e1: ldloc.2
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e7: ldstr "next"
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00f1: stloc.s 9
+		IL_00f3: ldloc.s 9
+		IL_00f5: ldstr "value"
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ff: stloc.s 9
+		IL_0101: ldloc.s 8
+		IL_0103: ldstr "log"
+		IL_0108: ldloc.s 9
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010f: pop
+		IL_0110: ldstr "console"
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011f: stloc.s 9
+		IL_0121: ldloc.2
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0127: ldstr "next"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0131: stloc.s 8
+		IL_0133: ldloc.s 8
+		IL_0135: ldstr "done"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013f: stloc.s 8
+		IL_0141: ldloc.s 9
+		IL_0143: ldstr "log"
+		IL_0148: ldloc.s 8
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014f: pop
+		IL_0150: ldloc.1
+		IL_0151: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+		IL_0156: stloc.3
+		IL_0157: ldc.i4.0
+		IL_0158: stloc.s 4
+		IL_015a: ldc.i4.0
+		IL_015b: stloc.s 5
 		.try
 		{
-			// loop start (head: IL_0166)
-				IL_0166: ldloc.3
-				IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-				IL_016c: stloc.s 9
-				IL_016e: ldloc.s 9
-				IL_0170: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-				IL_0175: stloc.s 11
-				IL_0177: ldloc.s 11
-				IL_0179: brtrue IL_01ba
+			// loop start (head: IL_015d)
+				IL_015d: ldloc.3
+				IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+				IL_0163: stloc.s 8
+				IL_0165: ldloc.s 8
+				IL_0167: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+				IL_016c: stloc.s 10
+				IL_016e: ldloc.s 10
+				IL_0170: brtrue IL_01b1
 
-				IL_017e: ldloc.s 9
-				IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-				IL_0185: stloc.s 9
-				IL_0187: ldloc.s 9
-				IL_0189: stloc.s 6
-				IL_018b: ldstr "console"
-				IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_019a: ldstr "log"
-				IL_019f: ldloc.s 6
-				IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_01a6: pop
-				IL_01a7: br IL_0166
+				IL_0175: ldloc.s 8
+				IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+				IL_017c: stloc.s 8
+				IL_017e: ldloc.s 8
+				IL_0180: stloc.s 6
+				IL_0182: ldstr "console"
+				IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0191: ldstr "log"
+				IL_0196: ldloc.s 6
+				IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_019d: pop
+				IL_019e: br IL_015d
 			// end loop
-			IL_01ac: ldloc.3
-			IL_01ad: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-			IL_01b2: ldc.i4.1
-			IL_01b3: stloc.s 5
-			IL_01b5: leave IL_01d7
+			IL_01a3: ldloc.3
+			IL_01a4: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+			IL_01a9: ldc.i4.1
+			IL_01aa: stloc.s 5
+			IL_01ac: leave IL_01ce
 
-			IL_01ba: ldc.i4.1
-			IL_01bb: stloc.s 4
-			IL_01bd: leave IL_01d7
+			IL_01b1: ldc.i4.1
+			IL_01b2: stloc.s 4
+			IL_01b4: leave IL_01ce
 		} // end .try
 		finally
 		{
-			IL_01c2: ldloc.s 4
-			IL_01c4: brtrue IL_01d6
+			IL_01b9: ldloc.s 4
+			IL_01bb: brtrue IL_01cd
 
-			IL_01c9: ldloc.s 5
-			IL_01cb: brtrue IL_01d6
+			IL_01c0: ldloc.s 5
+			IL_01c2: brtrue IL_01cd
 
-			IL_01d0: ldloc.3
-			IL_01d1: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+			IL_01c7: ldloc.3
+			IL_01c8: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-			IL_01d6: endfinally
+			IL_01cd: endfinally
 		} // end handler
 
-		IL_01d7: ret
+		IL_01ce: ret
 	} // end of method Uint8Array_Values_Iterator::__js_module_init__
 
 } // end of class Modules.Uint8Array_Values_Iterator
@@ -265,7 +261,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x225f
+		// Method begins at RVA 0x2257
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Delete_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Delete_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2136
+			// Method begins at RVA 0x2112
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 218 (0xda)
+		// Code size: 182 (0xb6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Delete_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
-			[5] object,
-			[6] object
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakMap_Delete_Basic/Scope::.ctor()
@@ -60,68 +59,56 @@
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0012: stloc.2
 		IL_0013: ldloc.1
-		IL_0014: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_0019: stloc.s 4
-		IL_001b: ldloc.s 4
-		IL_001d: ldstr "set"
-		IL_0022: ldloc.2
-		IL_0023: ldstr "value1"
-		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_002d: pop
-		IL_002e: ldstr "console"
-		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003d: stloc.s 5
-		IL_003f: ldloc.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_0045: stloc.s 4
-		IL_0047: ldloc.s 4
-		IL_0049: ldstr "delete"
-		IL_004e: ldloc.2
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0054: stloc.s 6
-		IL_0056: ldloc.s 5
-		IL_0058: ldstr "log"
-		IL_005d: ldloc.s 6
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0064: pop
-		IL_0065: ldstr "console"
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0074: stloc.s 6
-		IL_0076: ldloc.1
-		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_007c: stloc.s 4
-		IL_007e: ldloc.s 4
-		IL_0080: ldstr "has"
-		IL_0085: ldloc.2
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008b: stloc.s 5
-		IL_008d: ldloc.s 6
-		IL_008f: ldstr "log"
-		IL_0094: ldloc.s 5
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009b: pop
-		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00a1: stloc.3
-		IL_00a2: ldstr "console"
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b1: stloc.s 5
-		IL_00b3: ldloc.1
-		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_00b9: stloc.s 4
-		IL_00bb: ldloc.s 4
-		IL_00bd: ldstr "delete"
-		IL_00c2: ldloc.3
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c8: stloc.s 6
-		IL_00ca: ldloc.s 5
-		IL_00cc: ldstr "log"
-		IL_00d1: ldloc.s 6
-		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d8: pop
-		IL_00d9: ret
+		IL_0014: ldstr "set"
+		IL_0019: ldloc.2
+		IL_001a: ldstr "value1"
+		IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0024: pop
+		IL_0025: ldstr "console"
+		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0034: stloc.s 4
+		IL_0036: ldloc.1
+		IL_0037: ldstr "delete"
+		IL_003c: ldloc.2
+		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0042: stloc.s 5
+		IL_0044: ldloc.s 4
+		IL_0046: ldstr "log"
+		IL_004b: ldloc.s 5
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0052: pop
+		IL_0053: ldstr "console"
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0062: stloc.s 5
+		IL_0064: ldloc.1
+		IL_0065: ldstr "has"
+		IL_006a: ldloc.2
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0070: stloc.s 4
+		IL_0072: ldloc.s 5
+		IL_0074: ldstr "log"
+		IL_0079: ldloc.s 4
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0080: pop
+		IL_0081: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0086: stloc.3
+		IL_0087: ldstr "console"
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0096: stloc.s 4
+		IL_0098: ldloc.1
+		IL_0099: ldstr "delete"
+		IL_009e: ldloc.3
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a4: stloc.s 5
+		IL_00a6: ldloc.s 4
+		IL_00a8: ldstr "log"
+		IL_00ad: ldloc.s 5
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b4: pop
+		IL_00b5: ret
 	} // end of method WeakMap_Delete_Basic::__js_module_init__
 
 } // end of class Modules.WeakMap_Delete_Basic
@@ -133,7 +120,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x213f
+		// Method begins at RVA 0x211b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Has_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Has_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20ff
+			// Method begins at RVA 0x20e4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 163 (0xa3)
+		// Code size: 136 (0x88)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Has_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
-			[5] object,
-			[6] object
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakMap_Has_Basic/Scope::.ctor()
@@ -62,49 +61,40 @@
 		IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0018: stloc.3
 		IL_0019: ldloc.1
-		IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_001f: stloc.s 4
-		IL_0021: ldloc.s 4
-		IL_0023: ldstr "set"
-		IL_0028: ldloc.2
-		IL_0029: ldstr "value1"
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0033: pop
-		IL_0034: ldstr "console"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0043: stloc.s 5
-		IL_0045: ldloc.1
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_004b: stloc.s 4
-		IL_004d: ldloc.s 4
-		IL_004f: ldstr "has"
-		IL_0054: ldloc.2
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005a: stloc.s 6
-		IL_005c: ldloc.s 5
-		IL_005e: ldstr "log"
-		IL_0063: ldloc.s 6
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006a: pop
-		IL_006b: ldstr "console"
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007a: stloc.s 6
-		IL_007c: ldloc.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_0082: stloc.s 4
-		IL_0084: ldloc.s 4
-		IL_0086: ldstr "has"
-		IL_008b: ldloc.3
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0091: stloc.s 5
-		IL_0093: ldloc.s 6
-		IL_0095: ldstr "log"
-		IL_009a: ldloc.s 5
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a1: pop
-		IL_00a2: ret
+		IL_001a: ldstr "set"
+		IL_001f: ldloc.2
+		IL_0020: ldstr "value1"
+		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_002a: pop
+		IL_002b: ldstr "console"
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003a: stloc.s 4
+		IL_003c: ldloc.1
+		IL_003d: ldstr "has"
+		IL_0042: ldloc.2
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0048: stloc.s 5
+		IL_004a: ldloc.s 4
+		IL_004c: ldstr "log"
+		IL_0051: ldloc.s 5
+		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0058: pop
+		IL_0059: ldstr "console"
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0068: stloc.s 5
+		IL_006a: ldloc.1
+		IL_006b: ldstr "has"
+		IL_0070: ldloc.3
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0076: stloc.s 4
+		IL_0078: ldloc.s 5
+		IL_007a: ldstr "log"
+		IL_007f: ldloc.s 4
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0086: pop
+		IL_0087: ret
 	} // end of method WeakMap_Has_Basic::__js_module_init__
 
 } // end of class Modules.WeakMap_Has_Basic
@@ -116,7 +106,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2108
+		// Method begins at RVA 0x20ed
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Object_Keys.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Object_Keys.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x213a
+			// Method begins at RVA 0x2116
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 222 (0xde)
+		// Code size: 186 (0xba)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Object_Keys/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
-			[5] object,
-			[6] object
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakMap_Object_Keys/Scope::.ctor()
@@ -70,58 +69,46 @@
 		IL_0033: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_0038: stloc.3
 		IL_0039: ldloc.1
-		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_003f: stloc.s 4
-		IL_0041: ldloc.s 4
-		IL_0043: ldstr "set"
-		IL_0048: ldloc.2
-		IL_0049: ldstr "value1"
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0053: pop
-		IL_0054: ldloc.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_005a: stloc.s 4
-		IL_005c: ldloc.s 4
-		IL_005e: ldstr "set"
-		IL_0063: ldloc.3
-		IL_0064: ldstr "value2"
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_006e: pop
-		IL_006f: ldstr "console"
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007e: stloc.s 5
-		IL_0080: ldloc.1
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_0086: stloc.s 4
-		IL_0088: ldloc.s 4
-		IL_008a: ldstr "get"
-		IL_008f: ldloc.2
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0095: stloc.s 6
-		IL_0097: ldloc.s 5
-		IL_0099: ldstr "log"
-		IL_009e: ldloc.s 6
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a5: pop
-		IL_00a6: ldstr "console"
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b5: stloc.s 6
-		IL_00b7: ldloc.1
-		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_00bd: stloc.s 4
-		IL_00bf: ldloc.s 4
-		IL_00c1: ldstr "get"
-		IL_00c6: ldloc.3
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cc: stloc.s 5
-		IL_00ce: ldloc.s 6
-		IL_00d0: ldstr "log"
-		IL_00d5: ldloc.s 5
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00dc: pop
-		IL_00dd: ret
+		IL_003a: ldstr "set"
+		IL_003f: ldloc.2
+		IL_0040: ldstr "value1"
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_004a: pop
+		IL_004b: ldloc.1
+		IL_004c: ldstr "set"
+		IL_0051: ldloc.3
+		IL_0052: ldstr "value2"
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_005c: pop
+		IL_005d: ldstr "console"
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006c: stloc.s 4
+		IL_006e: ldloc.1
+		IL_006f: ldstr "get"
+		IL_0074: ldloc.2
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007a: stloc.s 5
+		IL_007c: ldloc.s 4
+		IL_007e: ldstr "log"
+		IL_0083: ldloc.s 5
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008a: pop
+		IL_008b: ldstr "console"
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009a: stloc.s 5
+		IL_009c: ldloc.1
+		IL_009d: ldstr "get"
+		IL_00a2: ldloc.3
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a8: stloc.s 4
+		IL_00aa: ldloc.s 5
+		IL_00ac: ldstr "log"
+		IL_00b1: ldloc.s 4
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b8: pop
+		IL_00b9: ret
 	} // end of method WeakMap_Object_Keys::__js_module_init__
 
 } // end of class Modules.WeakMap_Object_Keys
@@ -133,7 +120,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2143
+		// Method begins at RVA 0x211f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Set_Get_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Set_Get_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20be
+			// Method begins at RVA 0x20ae
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 98 (0x62)
+		// Code size: 82 (0x52)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Set_Get_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
-			[4] object,
-			[5] object
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakMap_Set_Get_Basic/Scope::.ctor()
@@ -59,32 +58,26 @@
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0012: stloc.2
 		IL_0013: ldloc.1
-		IL_0014: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_0019: stloc.3
-		IL_001a: ldloc.3
-		IL_001b: ldstr "set"
-		IL_0020: ldloc.2
-		IL_0021: ldstr "value1"
-		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_002b: pop
-		IL_002c: ldstr "console"
-		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003b: stloc.s 4
-		IL_003d: ldloc.1
-		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakMap>(!!0)
-		IL_0043: stloc.3
-		IL_0044: ldloc.3
-		IL_0045: ldstr "get"
-		IL_004a: ldloc.2
+		IL_0014: ldstr "set"
+		IL_0019: ldloc.2
+		IL_001a: ldstr "value1"
+		IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0024: pop
+		IL_0025: ldstr "console"
+		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0034: stloc.3
+		IL_0035: ldloc.1
+		IL_0036: ldstr "get"
+		IL_003b: ldloc.2
+		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0041: stloc.s 4
+		IL_0043: ldloc.3
+		IL_0044: ldstr "log"
+		IL_0049: ldloc.s 4
 		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0050: stloc.s 5
-		IL_0052: ldloc.s 4
-		IL_0054: ldstr "log"
-		IL_0059: ldloc.s 5
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0060: pop
-		IL_0061: ret
+		IL_0050: pop
+		IL_0051: ret
 	} // end of method WeakMap_Set_Get_Basic::__js_module_init__
 
 } // end of class Modules.WeakMap_Set_Get_Basic
@@ -96,7 +89,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20c7
+		// Method begins at RVA 0x20b7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
+++ b/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2340
+				// Method begins at RVA 0x232c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,14 +46,13 @@
 			)
 			// Method begins at RVA 0x222c
 			// Header size: 12
-			// Code size: 163 (0xa3)
+			// Code size: 143 (0x8f)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakRef,
 				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.WeakRef,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -70,45 +69,39 @@
 			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002c: stloc.2
 			IL_002d: ldloc.1
-			IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakRef>(!!0)
-			IL_0033: stloc.3
-			IL_0034: ldloc.3
-			IL_0035: ldstr "deref"
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_003f: stloc.s 4
-			IL_0041: ldloc.s 4
-			IL_0043: ldstr "name"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 4
-			IL_004f: ldloc.2
-			IL_0050: ldstr "log"
-			IL_0055: ldloc.s 4
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_005c: pop
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
-			IL_0062: pop
-			IL_0063: ldstr "console"
-			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0072: stloc.s 4
-			IL_0074: ldloc.1
-			IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakRef>(!!0)
-			IL_007a: stloc.3
-			IL_007b: ldloc.3
-			IL_007c: ldstr "deref"
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0086: stloc.2
-			IL_0087: ldloc.2
-			IL_0088: ldstr "name"
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0092: stloc.2
-			IL_0093: ldloc.s 4
-			IL_0095: ldstr "log"
-			IL_009a: ldloc.2
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00a0: pop
-			IL_00a1: ldloc.1
-			IL_00a2: ret
+			IL_002e: ldstr "deref"
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0038: stloc.3
+			IL_0039: ldloc.3
+			IL_003a: ldstr "name"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0044: stloc.3
+			IL_0045: ldloc.2
+			IL_0046: ldstr "log"
+			IL_004b: ldloc.3
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0051: pop
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
+			IL_0057: pop
+			IL_0058: ldstr "console"
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0067: stloc.3
+			IL_0068: ldloc.1
+			IL_0069: ldstr "deref"
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0073: stloc.2
+			IL_0074: ldloc.2
+			IL_0075: ldstr "name"
+			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007f: stloc.2
+			IL_0080: ldloc.3
+			IL_0081: ldstr "log"
+			IL_0086: ldloc.2
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_008c: pop
+			IL_008d: ldloc.1
+			IL_008e: ret
 		} // end of method createWeakRef::__js_call__
 
 	} // end of class createWeakRef
@@ -124,7 +117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x235b
+				// Method begins at RVA 0x2347
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -150,7 +143,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x22dc
+			// Method begins at RVA 0x22c8
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -209,7 +202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2349
+				// Method begins at RVA 0x2335
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -229,7 +222,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2352
+				// Method begins at RVA 0x233e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -251,7 +244,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2337
+			// Method begins at RVA 0x2323
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -453,7 +446,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2364
+		// Method begins at RVA 0x2350
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Add_Has_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Add_Has_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20fa
+			// Method begins at RVA 0x20df
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 158 (0x9e)
+		// Code size: 131 (0x83)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakSet_Add_Has_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
-			[5] object,
-			[6] object
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakSet_Add_Has_Basic/Scope::.ctor()
@@ -60,50 +59,41 @@
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0012: stloc.2
 		IL_0013: ldloc.1
-		IL_0014: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
-		IL_0019: stloc.s 4
-		IL_001b: ldloc.s 4
-		IL_001d: ldstr "add"
-		IL_0022: ldloc.2
-		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0028: pop
-		IL_0029: ldstr "console"
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0038: stloc.s 5
-		IL_003a: ldloc.1
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
-		IL_0040: stloc.s 4
-		IL_0042: ldloc.s 4
-		IL_0044: ldstr "has"
-		IL_0049: ldloc.2
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004f: stloc.s 6
-		IL_0051: ldloc.s 5
-		IL_0053: ldstr "log"
-		IL_0058: ldloc.s 6
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005f: pop
-		IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0065: stloc.3
-		IL_0066: ldstr "console"
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0075: stloc.s 6
-		IL_0077: ldloc.1
-		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
-		IL_007d: stloc.s 4
-		IL_007f: ldloc.s 4
-		IL_0081: ldstr "has"
-		IL_0086: ldloc.3
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008c: stloc.s 5
-		IL_008e: ldloc.s 6
-		IL_0090: ldstr "log"
-		IL_0095: ldloc.s 5
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009c: pop
-		IL_009d: ret
+		IL_0014: ldstr "add"
+		IL_0019: ldloc.2
+		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_001f: pop
+		IL_0020: ldstr "console"
+		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_002f: stloc.s 4
+		IL_0031: ldloc.1
+		IL_0032: ldstr "has"
+		IL_0037: ldloc.2
+		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_003d: stloc.s 5
+		IL_003f: ldloc.s 4
+		IL_0041: ldstr "log"
+		IL_0046: ldloc.s 5
+		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004d: pop
+		IL_004e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0053: stloc.3
+		IL_0054: ldstr "console"
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0063: stloc.s 5
+		IL_0065: ldloc.1
+		IL_0066: ldstr "has"
+		IL_006b: ldloc.3
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0071: stloc.s 4
+		IL_0073: ldloc.s 5
+		IL_0075: ldstr "log"
+		IL_007a: ldloc.s 4
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0081: pop
+		IL_0082: ret
 	} // end of method WeakSet_Add_Has_Basic::__js_module_init__
 
 } // end of class Modules.WeakSet_Add_Has_Basic
@@ -115,7 +105,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2103
+		// Method begins at RVA 0x20e8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Delete_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Delete_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2131
+			// Method begins at RVA 0x210d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 213 (0xd5)
+		// Code size: 177 (0xb1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakSet_Delete_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
-			[5] object,
-			[6] object
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakSet_Delete_Basic/Scope::.ctor()
@@ -60,67 +59,55 @@
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0012: stloc.2
 		IL_0013: ldloc.1
-		IL_0014: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
-		IL_0019: stloc.s 4
-		IL_001b: ldloc.s 4
-		IL_001d: ldstr "add"
-		IL_0022: ldloc.2
-		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0028: pop
-		IL_0029: ldstr "console"
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0038: stloc.s 5
-		IL_003a: ldloc.1
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
-		IL_0040: stloc.s 4
-		IL_0042: ldloc.s 4
-		IL_0044: ldstr "delete"
-		IL_0049: ldloc.2
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004f: stloc.s 6
-		IL_0051: ldloc.s 5
-		IL_0053: ldstr "log"
-		IL_0058: ldloc.s 6
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005f: pop
-		IL_0060: ldstr "console"
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: stloc.s 6
-		IL_0071: ldloc.1
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
-		IL_0077: stloc.s 4
-		IL_0079: ldloc.s 4
-		IL_007b: ldstr "has"
-		IL_0080: ldloc.2
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0086: stloc.s 5
-		IL_0088: ldloc.s 6
-		IL_008a: ldstr "log"
-		IL_008f: ldloc.s 5
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0096: pop
-		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_009c: stloc.3
-		IL_009d: ldstr "console"
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ac: stloc.s 5
-		IL_00ae: ldloc.1
-		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
-		IL_00b4: stloc.s 4
-		IL_00b6: ldloc.s 4
-		IL_00b8: ldstr "delete"
-		IL_00bd: ldloc.3
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c3: stloc.s 6
-		IL_00c5: ldloc.s 5
-		IL_00c7: ldstr "log"
-		IL_00cc: ldloc.s 6
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ret
+		IL_0014: ldstr "add"
+		IL_0019: ldloc.2
+		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_001f: pop
+		IL_0020: ldstr "console"
+		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_002f: stloc.s 4
+		IL_0031: ldloc.1
+		IL_0032: ldstr "delete"
+		IL_0037: ldloc.2
+		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_003d: stloc.s 5
+		IL_003f: ldloc.s 4
+		IL_0041: ldstr "log"
+		IL_0046: ldloc.s 5
+		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004d: pop
+		IL_004e: ldstr "console"
+		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005d: stloc.s 5
+		IL_005f: ldloc.1
+		IL_0060: ldstr "has"
+		IL_0065: ldloc.2
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006b: stloc.s 4
+		IL_006d: ldloc.s 5
+		IL_006f: ldstr "log"
+		IL_0074: ldloc.s 4
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007b: pop
+		IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0081: stloc.3
+		IL_0082: ldstr "console"
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0091: stloc.s 4
+		IL_0093: ldloc.1
+		IL_0094: ldstr "delete"
+		IL_0099: ldloc.3
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009f: stloc.s 5
+		IL_00a1: ldloc.s 4
+		IL_00a3: ldstr "log"
+		IL_00a8: ldloc.s 5
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00af: pop
+		IL_00b0: ret
 	} // end of method WeakSet_Delete_Basic::__js_module_init__
 
 } // end of class Modules.WeakSet_Delete_Basic
@@ -132,7 +119,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x213a
+		// Method begins at RVA 0x2116
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Object_Values.verified.txt
+++ b/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Object_Values.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2130
+			// Method begins at RVA 0x210c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,16 +40,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 212 (0xd4)
+		// Code size: 176 (0xb0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakSet_Object_Values/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
-			[5] object,
-			[6] object
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakSet_Object_Values/Scope::.ctor()
@@ -70,56 +69,44 @@
 		IL_0033: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_0038: stloc.3
 		IL_0039: ldloc.1
-		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
-		IL_003f: stloc.s 4
-		IL_0041: ldloc.s 4
-		IL_0043: ldstr "add"
-		IL_0048: ldloc.2
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004e: pop
-		IL_004f: ldloc.1
-		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
-		IL_0055: stloc.s 4
-		IL_0057: ldloc.s 4
-		IL_0059: ldstr "add"
-		IL_005e: ldloc.3
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0064: pop
-		IL_0065: ldstr "console"
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0074: stloc.s 5
-		IL_0076: ldloc.1
-		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
-		IL_007c: stloc.s 4
-		IL_007e: ldloc.s 4
-		IL_0080: ldstr "has"
-		IL_0085: ldloc.2
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008b: stloc.s 6
-		IL_008d: ldloc.s 5
-		IL_008f: ldstr "log"
-		IL_0094: ldloc.s 6
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009b: pop
-		IL_009c: ldstr "console"
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ab: stloc.s 6
-		IL_00ad: ldloc.1
-		IL_00ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.WeakSet>(!!0)
-		IL_00b3: stloc.s 4
-		IL_00b5: ldloc.s 4
-		IL_00b7: ldstr "has"
-		IL_00bc: ldloc.3
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c2: stloc.s 5
-		IL_00c4: ldloc.s 6
-		IL_00c6: ldstr "log"
-		IL_00cb: ldloc.s 5
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d2: pop
-		IL_00d3: ret
+		IL_003a: ldstr "add"
+		IL_003f: ldloc.2
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0045: pop
+		IL_0046: ldloc.1
+		IL_0047: ldstr "add"
+		IL_004c: ldloc.3
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0052: pop
+		IL_0053: ldstr "console"
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0062: stloc.s 4
+		IL_0064: ldloc.1
+		IL_0065: ldstr "has"
+		IL_006a: ldloc.2
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0070: stloc.s 5
+		IL_0072: ldloc.s 4
+		IL_0074: ldstr "log"
+		IL_0079: ldloc.s 5
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0080: pop
+		IL_0081: ldstr "console"
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0090: stloc.s 5
+		IL_0092: ldloc.1
+		IL_0093: ldstr "has"
+		IL_0098: ldloc.3
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009e: stloc.s 4
+		IL_00a0: ldloc.s 5
+		IL_00a2: ldstr "log"
+		IL_00a7: ldloc.s 4
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ae: pop
+		IL_00af: ret
 	} // end of method WeakSet_Object_Values::__js_module_init__
 
 } // end of class Modules.WeakSet_Object_Values
@@ -131,7 +118,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2139
+		// Method begins at RVA 0x2115
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary
- omit `RequireObjectCoercible` only for LIR receivers proven non-null by object construction or safe copies
- preserve typed `RegExp` receivers through member-call normalization for direct instance calls
- retain coercion guards for typed bindings and arbitrary helper results, which may hold JavaScript `null` or `undefined`
- update the affected ArrowFunction regression, broad generated IL snapshots, and the Unreleased changelog

Closes #1685.

## Validation
- `dotnet build jroc.sln --no-restore --nologo`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-build --nologo --filter "FullyQualifiedName~ArrowFunction_ForOfIterableArrowCallback"`
- generator snapshot update workflow for the 69 CI-reported snapshot mismatches