### PR TITLE
perf(il): type dynamic import results as Promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - compiler: omit member-call object-coercibility guards for receivers proven
   non-null by object construction, preserving their concrete CLR types for
   direct instance calls.
+- compiler: preserve `DynamicImport.Import` results as concrete JavaScript
+  `Promise` values instead of widening them to `object`.
 
 ## v0.12.1 - 2026-08-02
 

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionImport.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionImport.cs
@@ -113,8 +113,9 @@ public sealed partial class HIRToLIRLowerer
         // Emit the import call
         _methodBodyIR.Instructions.Add(new LIRCallImport(specifierTemp, currentModuleIdTemp, resultTempVar));
         
-        // Import returns a Promise<object>
-        DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        DefineTempStorage(
+            resultTempVar,
+            new ValueStorage(ValueStorageKind.Reference, typeof(JavaScriptRuntime.Promise)));
 
         return true;
     }

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_BasicImport.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_BasicImport.verified.txt
@@ -202,8 +202,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_BasicImport/Scope,
-			[1] object,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[1] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Import_BasicImport/Scope::.ctor()
@@ -221,7 +222,7 @@
 		IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.CommonJS.DynamicImport::Import(object, object)
 		IL_0035: stloc.1
 		IL_0036: ldloc.1
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0037: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
 		IL_003c: stloc.1
 		IL_003d: ldnull
 		IL_003e: ldftn object Modules.Import_BasicImport/ArrowFunction_L7C26::__js_call__(object, object)
@@ -247,10 +248,10 @@
 		IL_0077: ldstr "then"
 		IL_007c: ldloc.2
 		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0082: stloc.1
-		IL_0083: ldloc.1
+		IL_0082: stloc.3
+		IL_0083: ldloc.3
 		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0089: stloc.1
+		IL_0089: stloc.3
 		IL_008a: ldnull
 		IL_008b: ldftn object Modules.Import_BasicImport/ArrowFunction_L11C10::__js_call__(object, object)
 		IL_0091: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
@@ -271,7 +272,7 @@
 		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
 		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
 		IL_00c2: stloc.2
-		IL_00c3: ldloc.1
+		IL_00c3: ldloc.3
 		IL_00c4: ldstr "catch"
 		IL_00c9: ldloc.2
 		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
@@ -268,8 +268,9 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope,
-				[1] object,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1,
+				[3] object
 			)
 
 			IL_0000: newobj instance void Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::.ctor()
@@ -282,7 +283,7 @@
 			IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.CommonJS.DynamicImport::Import(object, object)
 			IL_001c: stloc.1
 			IL_001d: ldloc.1
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
 			IL_0023: stloc.1
 			IL_0024: ldnull
 			IL_0025: ldftn object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/ArrowFunction_L4C72::__js_call__(object[], object, object)
@@ -312,8 +313,8 @@
 			IL_0062: ldstr "then"
 			IL_0067: ldloc.2
 			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_006d: stloc.1
-			IL_006e: ldloc.1
+			IL_006d: stloc.3
+			IL_006e: ldloc.3
 			IL_006f: ret
 		} // end of method ArrowFunction_L3C61::__js_call__
 
@@ -465,8 +466,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_DynamicImport_Cjs_Namespace/Scope,
-			[1] object,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[1] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Import_DynamicImport_Cjs_Namespace/Scope::.ctor()
@@ -477,7 +479,7 @@
 		IL_0011: call class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.CommonJS.DynamicImport::Import(object, object)
 		IL_0016: stloc.1
 		IL_0017: ldloc.1
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0018: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
 		IL_001d: stloc.1
 		IL_001e: ldloc.0
 		IL_001f: castclass Modules.Import_DynamicImport_Cjs_Namespace/Scope
@@ -504,10 +506,10 @@
 		IL_005d: ldstr "then"
 		IL_0062: ldloc.2
 		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0068: stloc.1
-		IL_0069: ldloc.1
+		IL_0068: stloc.3
+		IL_0069: ldloc.3
 		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: stloc.1
+		IL_006f: stloc.3
 		IL_0070: ldnull
 		IL_0071: ldftn object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L13C10::__js_call__(object, object)
 		IL_0077: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
@@ -528,7 +530,7 @@
 		IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
 		IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
 		IL_00a8: stloc.2
-		IL_00a9: ldloc.1
+		IL_00a9: ldloc.3
 		IL_00aa: ldstr "catch"
 		IL_00af: ldloc.2
 		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
@@ -231,8 +231,9 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope,
-				[1] object,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1,
+				[3] object
 			)
 
 			IL_0000: newobj instance void Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::.ctor()
@@ -245,7 +246,7 @@
 			IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.CommonJS.DynamicImport::Import(object, object)
 			IL_001c: stloc.1
 			IL_001d: ldloc.1
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
 			IL_0023: stloc.1
 			IL_0024: ldnull
 			IL_0025: ldftn object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/ArrowFunction_L4C72::__js_call__(object[], object, object)
@@ -275,8 +276,8 @@
 			IL_0062: ldstr "then"
 			IL_0067: ldloc.2
 			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_006d: stloc.1
-			IL_006e: ldloc.1
+			IL_006d: stloc.3
+			IL_006e: ldloc.3
 			IL_006f: ret
 		} // end of method ArrowFunction_L3C61::__js_call__
 
@@ -428,8 +429,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_DynamicImport_Esm_Namespace/Scope,
-			[1] object,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[1] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Import_DynamicImport_Esm_Namespace/Scope::.ctor()
@@ -440,7 +442,7 @@
 		IL_0011: call class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.CommonJS.DynamicImport::Import(object, object)
 		IL_0016: stloc.1
 		IL_0017: ldloc.1
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0018: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
 		IL_001d: stloc.1
 		IL_001e: ldloc.0
 		IL_001f: castclass Modules.Import_DynamicImport_Esm_Namespace/Scope
@@ -467,10 +469,10 @@
 		IL_005d: ldstr "then"
 		IL_0062: ldloc.2
 		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0068: stloc.1
-		IL_0069: ldloc.1
+		IL_0068: stloc.3
+		IL_0069: ldloc.3
 		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: stloc.1
+		IL_006f: stloc.3
 		IL_0070: ldnull
 		IL_0071: ldftn object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L12C10::__js_call__(object, object)
 		IL_0077: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
@@ -491,7 +493,7 @@
 		IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
 		IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
 		IL_00a8: stloc.2
-		IL_00a9: ldloc.1
+		IL_00a9: ldloc.3
 		IL_00aa: ldstr "catch"
 		IL_00af: ldloc.2
 		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DynamicImportOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DynamicImportOverride.verified.txt
@@ -260,7 +260,7 @@
 		.locals init (
 			[0] class Modules.Require_Path_DynamicImportOverride/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
-			[2] object,
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		)
 
@@ -279,7 +279,7 @@
 		IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.CommonJS.DynamicImport::Import(object, object)
 		IL_0029: stloc.2
 		IL_002a: ldloc.2
-		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_002b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Promise>(!!0)
 		IL_0030: stloc.2
 		IL_0031: ldloc.0
 		IL_0032: castclass Modules.Require_Path_DynamicImportOverride/Scope


### PR DESCRIPTION
## Summary
- preserve `DynamicImport.Import` results as concrete `JavaScriptRuntime.Promise` values during LIR lowering
- emit typed locals for dynamic-import expressions instead of widening them to `object`
- update the Path and Import dynamic-import generator regressions and the Unreleased changelog

Closes #1683.

## Validation
- `dotnet build jroc.sln --no-restore --nologo`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-build --nologo --filter "FullyQualifiedName~Require_Path_DynamicImportOverride"`
- generator snapshot update workflow for the three CI-reported Import snapshot mismatches