### PR TITLE
perf(il): omit safe Node module override guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,10 +73,10 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   module contracts. Calls such as `require("fs").readFileSync(...)` now use
   `RequireObject<IFsModule>` and direct interface dispatch, including typed
   parameters, contract properties, overloads, rest arguments, and `node:`
-  aliases. Whole-program escape and mutation analysis removes the per-call
-  property-override guard for pristine module imports while preserving dynamic
-  fallback after aliasing, mutation, deletion, reflection, or escape; dynamic
-  and non-contract requires retain the existing dispatcher.
+  aliases. Whole-program escape and mutation analysis also removes the
+  property-override guard for pristine direct destructuring requires while
+  preserving dynamic fallback after aliasing, mutation, deletion, reflection,
+  or escape; dynamic and non-contract requires retain the existing dispatcher.
 - compiler: preserve all proven-stable CLR reference types when reading
   bindings, extending existing string and array specialization to captured
   strings and other safe reference values instead of widening them to

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.Destructuring.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.Destructuring.cs
@@ -172,22 +172,24 @@ public sealed partial class HIRToLIRLowerer
                                 out var propertyType)
                             && TryGetNodeModuleContractType(propertyType) != null)
                         {
-                            // Node modules are cached mutable objects. A prior require can
-                            // replace this own property, so retain the override guard.
+                            var requiresOverrideGuard = !(_scope?.CanSkipDirectRequireNodeModuleOverrideGuard(
+                                sourceContract) ?? false);
                             _methodBodyIR.Instructions.Add(new LIRCallNodeModuleContractMember(
                                 sourceValue,
                                 sourceContract,
                                 getterName,
                                 prop.Key!,
                                 IsPropertyGet: true,
-                                RequiresOverrideGuard: true,
+                                RequiresOverrideGuard: requiresOverrideGuard,
                                 Array.Empty<TempVariable>(),
                                 getResult));
-                            // The override branch can return any JavaScript value, including
-                            // an object with an inherited implementation of this member.
+                            // An override can return any JavaScript value, including an object
+                            // with an inherited implementation of this member.
                             DefineTempStorage(
                                 getResult,
-                                new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+                                new ValueStorage(
+                                    ValueStorageKind.Reference,
+                                    requiresOverrideGuard ? typeof(object) : propertyType));
                         }
                         else
                         {

--- a/src/Compiler/SymbolTable/Scope.cs
+++ b/src/Compiler/SymbolTable/Scope.cs
@@ -27,6 +27,20 @@ public class Scope
     public List<Scope> Children { get; } = new();
     public Dictionary<string, BindingInfo> Bindings { get; } = new();
     public Dictionary<Node, SourceSpan> DebugSequencePointOverrides { get; } = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Type> _directRequireContractsWithoutOverrides = new();
+
+    /// <summary>
+    /// True when whole-program analysis proves that a direct destructuring require of
+    /// <paramref name="contractType"/> cannot observe an own-property override.
+    /// </summary>
+    public bool CanSkipDirectRequireNodeModuleOverrideGuard(Type contractType)
+        => _directRequireContractsWithoutOverrides.Contains(contractType);
+
+    internal void ClearDirectRequireNodeModuleOverrideGuards()
+        => _directRequireContractsWithoutOverrides.Clear();
+
+    internal void MarkDirectRequireNodeModuleOverrideGuardSafe(Type contractType)
+        => _directRequireContractsWithoutOverrides.Add(contractType);
 
     /// <summary>
     /// Stable inferred CLR types for JavaScript class instance fields.

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.NodeModuleContracts.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.NodeModuleContracts.cs
@@ -12,6 +12,7 @@ public partial class SymbolTableBuilder
     {
         var candidates = new Dictionary<BindingInfo, Type>(ReferenceEqualityComparer.Instance);
         var moduleAnalyses = new List<NodeModuleAnalysis>();
+        var directDestructuringContracts = new Dictionary<Scope, HashSet<Type>>();
 
         foreach (var module in modules)
         {
@@ -24,6 +25,8 @@ public partial class SymbolTableBuilder
 
             foreach (var scope in EnumerateScopes(root))
             {
+                scope.ClearDirectRequireNodeModuleOverrideGuards();
+
                 foreach (var binding in scope.Bindings.Values)
                 {
                     binding.CanSkipNodeModuleOverrideGuard = false;
@@ -54,11 +57,6 @@ public partial class SymbolTableBuilder
                     candidates[binding] = binding.ClrType;
                 }
             }
-        }
-
-        if (candidates.Count == 0)
-        {
-            return;
         }
 
         var unsafeContracts = new HashSet<Type>();
@@ -109,6 +107,16 @@ public partial class SymbolTableBuilder
                     {
                         hasDynamicRequire |= call.Arguments.Count != 1
                             || call.Arguments[0] is not Literal { Value: string };
+                    }
+                    else if (IsDirectDestructuringAcquisition(call, analysis.ParentMap))
+                    {
+                        if (!directDestructuringContracts.TryGetValue(scope, out var contracts))
+                        {
+                            contracts = new HashSet<Type>();
+                            directDestructuringContracts.Add(scope, contracts);
+                        }
+
+                        contracts.Add(contractType);
                     }
                     else if (!IsSafeNodeModuleAcquisition(
                         call,
@@ -178,6 +186,17 @@ public partial class SymbolTableBuilder
         foreach (var (binding, contractType) in candidates)
         {
             binding.CanSkipNodeModuleOverrideGuard = !unsafeContracts.Contains(contractType);
+        }
+
+        foreach (var (scope, contractTypes) in directDestructuringContracts)
+        {
+            foreach (var contractType in contractTypes)
+            {
+                if (!unsafeContracts.Contains(contractType))
+                {
+                    scope.MarkDirectRequireNodeModuleOverrideGuardSafe(contractType);
+                }
+            }
         }
     }
 
@@ -278,6 +297,14 @@ public partial class SymbolTableBuilder
             && !IsNodeModuleMemberMutation(member, parentMap)
             && !NodeModuleMemberCanReturnContract(member, contractType);
     }
+
+    private static bool IsDirectDestructuringAcquisition(
+        CallExpression call,
+        Dictionary<Node, Node> parentMap)
+        => parentMap.TryGetValue(call, out var parent)
+            && parent is VariableDeclarator declarator
+            && ReferenceEquals(declarator.Init, call)
+            && declarator.Id is not Identifier;
 
     private static bool IsNodeModuleBindingValueReference(
         Identifier identifier,

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30d7
+						// Method begins at RVA 0x30b3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30ce
+					// Method begins at RVA 0x30aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30c5
+				// Method begins at RVA 0x30a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,7 +101,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x245c
+			// Method begins at RVA 0x2438
 			// Header size: 12
 			// Code size: 237 (0xed)
 			.maxstack 8
@@ -227,7 +227,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30e0
+				// Method begins at RVA 0x30bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -254,7 +254,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2558
+			// Method begins at RVA 0x2534
 			// Header size: 12
 			// Code size: 533 (0x215)
 			.maxstack 8
@@ -471,7 +471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fb7
+				// Method begins at RVA 0x2f93
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -491,7 +491,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fc0
+				// Method begins at RVA 0x2f9c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -511,7 +511,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fc9
+				// Method begins at RVA 0x2fa5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -539,7 +539,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fe4
+						// Method begins at RVA 0x2fc0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -563,7 +563,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2ff6
+							// Method begins at RVA 0x2fd2
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -581,7 +581,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fed
+						// Method begins at RVA 0x2fc9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -599,7 +599,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fdb
+					// Method begins at RVA 0x2fb7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -627,7 +627,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3011
+							// Method begins at RVA 0x2fed
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -645,7 +645,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3008
+						// Method begins at RVA 0x2fe4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -663,7 +663,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fff
+					// Method begins at RVA 0x2fdb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -687,7 +687,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3023
+						// Method begins at RVA 0x2fff
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -705,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x301a
+					// Method begins at RVA 0x2ff6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -723,7 +723,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fd2
+				// Method begins at RVA 0x2fae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -743,7 +743,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x302c
+				// Method begins at RVA 0x3008
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -767,7 +767,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x303e
+					// Method begins at RVA 0x301a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -785,7 +785,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3035
+				// Method begins at RVA 0x3011
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -813,7 +813,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27e0
+			// Method begins at RVA 0x27bc
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -861,7 +861,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a4c
+			// Method begins at RVA 0x2a28
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -925,7 +925,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2864
+			// Method begins at RVA 0x2840
 			// Header size: 12
 			// Code size: 475 (0x1db)
 			.maxstack 8
@@ -1192,7 +1192,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2aac
+			// Method begins at RVA 0x2a88
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -1249,7 +1249,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x282c
+			// Method begins at RVA 0x2808
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1294,7 +1294,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3047
+				// Method begins at RVA 0x3023
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1314,7 +1314,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3050
+				// Method begins at RVA 0x302c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1338,7 +1338,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3062
+					// Method begins at RVA 0x303e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1356,7 +1356,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3059
+				// Method begins at RVA 0x3035
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1376,7 +1376,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x306b
+				// Method begins at RVA 0x3047
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1404,7 +1404,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3086
+						// Method begins at RVA 0x3062
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1422,7 +1422,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x307d
+					// Method begins at RVA 0x3059
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1440,7 +1440,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3074
+				// Method begins at RVA 0x3050
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1464,7 +1464,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3098
+					// Method begins at RVA 0x3074
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1488,7 +1488,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30aa
+						// Method begins at RVA 0x3086
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1506,7 +1506,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30a1
+					// Method begins at RVA 0x307d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1524,7 +1524,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x308f
+				// Method begins at RVA 0x306b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1548,7 +1548,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30bc
+					// Method begins at RVA 0x3098
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1566,7 +1566,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30b3
+				// Method begins at RVA 0x308f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1596,7 +1596,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x277c
+			// Method begins at RVA 0x2758
 			// Header size: 12
 			// Code size: 85 (0x55)
 			.maxstack 8
@@ -1652,7 +1652,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2afc
+			// Method begins at RVA 0x2ad8
 			// Header size: 12
 			// Code size: 168 (0xa8)
 			.maxstack 8
@@ -1740,7 +1740,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e50
+			// Method begins at RVA 0x2e2c
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -1805,7 +1805,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ec8
+			// Method begins at RVA 0x2ea4
 			// Header size: 12
 			// Code size: 218 (0xda)
 			.maxstack 8
@@ -1913,7 +1913,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bb0
+			// Method begins at RVA 0x2b8c
 			// Header size: 12
 			// Code size: 658 (0x292)
 			.maxstack 8
@@ -2147,7 +2147,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2fae
+			// Method begins at RVA 0x2f8a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2177,7 +2177,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30e9
+				// Method begins at RVA 0x30c5
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2190,7 +2190,7 @@
 			.method public hidebysig 
 				instance float64 get_sieveSize () cil managed 
 			{
-				// Method begins at RVA 0x30f1
+				// Method begins at RVA 0x30cd
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2205,7 +2205,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x30f9
+				// Method begins at RVA 0x30d5
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2223,7 +2223,7 @@
 			.method public hidebysig 
 				instance float64 get_timeLimitSeconds () cil managed 
 			{
-				// Method begins at RVA 0x310e
+				// Method begins at RVA 0x30ea
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2238,7 +2238,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3116
+				// Method begins at RVA 0x30f2
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2256,7 +2256,7 @@
 			.method public hidebysig 
 				instance object get_verbose () cil managed 
 			{
-				// Method begins at RVA 0x312b
+				// Method begins at RVA 0x3107
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2271,7 +2271,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3133
+				// Method begins at RVA 0x310f
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2289,7 +2289,7 @@
 			.method public hidebysig 
 				instance object get_runtime () cil managed 
 			{
-				// Method begins at RVA 0x3148
+				// Method begins at RVA 0x3124
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2304,7 +2304,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3150
+				// Method begins at RVA 0x312c
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2337,7 +2337,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1023 (0x3ff)
+		// Code size: 987 (0x3db)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Compile_Performance_PrimeJavaScript/Scope,
@@ -2345,13 +2345,14 @@
 			[2] object,
 			[3] object,
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule,
-			[5] object,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[7] float64,
-			[8] class [System.Runtime]System.Type,
-			[9] object[],
-			[10] class [System.Runtime]System.Func`4<object, float64, object, object>,
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[5] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance,
+			[6] object,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[8] float64,
+			[9] class [System.Runtime]System.Type,
+			[10] object[],
+			[11] class [System.Runtime]System.Func`4<object, float64, object, object>,
+			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Performance_PrimeJavaScript/Scope::.ctor()
@@ -2389,361 +2390,349 @@
 		IL_006e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
 		IL_0073: ldloc.s 4
-		IL_0075: ldstr "performance"
-		IL_007a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_007f: brtrue IL_0092
-
-		IL_0084: ldloc.s 4
-		IL_0086: callvirt instance class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule::get_performance()
-		IL_008b: stloc.s 5
-		IL_008d: br IL_00a0
-
-		IL_0092: ldloc.s 4
-		IL_0094: ldstr "performance"
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_009e: stloc.s 5
-
-		IL_00a0: ldloc.0
-		IL_00a1: ldloc.s 5
-		IL_00a3: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-		IL_00a8: ldstr "process"
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b2: ldstr "argv"
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00bc: stloc.s 5
-		IL_00be: ldloc.s 5
-		IL_00c0: ldc.r8 0.0
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00ce: stloc.s 5
-		IL_00d0: ldloc.s 5
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d7: stloc.s 5
-		IL_00d9: ldstr "[\\\\/]"
-		IL_00de: ldstr ""
-		IL_00e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00e8: stloc.s 6
-		IL_00ea: ldloc.s 5
-		IL_00ec: ldstr "split"
-		IL_00f1: ldloc.s 6
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f8: stloc.2
-		IL_00f9: ldloc.2
-		IL_00fa: ldstr "length"
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0104: stloc.s 5
-		IL_0106: ldloc.s 5
-		IL_0108: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_010d: ldc.r8 1
-		IL_0116: sub
-		IL_0117: stloc.s 7
-		IL_0119: ldloc.2
-		IL_011a: ldloc.s 7
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0121: stloc.s 5
-		IL_0123: ldloc.1
-		IL_0124: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
-		IL_0129: ldloc.s 5
-		IL_012b: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_runtime(object)
-		IL_0130: ldstr "process"
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013a: ldstr "argv"
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0144: stloc.s 5
-		IL_0146: ldloc.s 5
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014d: ldstr "includes"
-		IL_0152: ldstr "verbose"
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015c: stloc.s 5
-		IL_015e: ldloc.1
-		IL_015f: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
-		IL_0164: ldloc.s 5
-		IL_0166: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
-		IL_016b: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0170: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0175: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_017a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_017f: stloc.s 8
-		IL_0181: ldc.i4.1
-		IL_0182: newarr [System.Runtime]System.Object
-		IL_0187: dup
-		IL_0188: ldc.i4.0
-		IL_0189: ldloc.0
-		IL_018a: stelem.ref
-		IL_018b: stloc.s 9
-		IL_018d: ldc.i4.s 10
-		IL_018f: newarr [System.Runtime]System.Object
-		IL_0194: dup
-		IL_0195: ldc.i4.0
-		IL_0196: ldloc.s 8
-		IL_0198: stelem.ref
-		IL_0199: dup
-		IL_019a: ldc.i4.1
-		IL_019b: ldstr "setBitTrue"
-		IL_01a0: stelem.ref
-		IL_01a1: dup
-		IL_01a2: ldc.i4.2
-		IL_01a3: ldstr "setBitTrue"
-		IL_01a8: stelem.ref
-		IL_01a9: dup
-		IL_01aa: ldc.i4.3
-		IL_01ab: ldc.r8 1
-		IL_01b4: box [System.Runtime]System.Double
-		IL_01b9: stelem.ref
-		IL_01ba: dup
-		IL_01bb: ldc.i4.4
-		IL_01bc: ldstr "setBitTrue"
+		IL_0075: callvirt instance class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule::get_performance()
+		IL_007a: stloc.s 5
+		IL_007c: ldloc.0
+		IL_007d: ldloc.s 5
+		IL_007f: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+		IL_0084: ldstr "process"
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008e: ldstr "argv"
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0098: stloc.s 6
+		IL_009a: ldloc.s 6
+		IL_009c: ldc.r8 0.0
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00aa: stloc.s 6
+		IL_00ac: ldloc.s 6
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b3: stloc.s 6
+		IL_00b5: ldstr "[\\\\/]"
+		IL_00ba: ldstr ""
+		IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00c4: stloc.s 7
+		IL_00c6: ldloc.s 6
+		IL_00c8: ldstr "split"
+		IL_00cd: ldloc.s 7
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d4: stloc.2
+		IL_00d5: ldloc.2
+		IL_00d6: ldstr "length"
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e0: stloc.s 6
+		IL_00e2: ldloc.s 6
+		IL_00e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00e9: ldc.r8 1
+		IL_00f2: sub
+		IL_00f3: stloc.s 8
+		IL_00f5: ldloc.2
+		IL_00f6: ldloc.s 8
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00fd: stloc.s 6
+		IL_00ff: ldloc.1
+		IL_0100: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
+		IL_0105: ldloc.s 6
+		IL_0107: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_runtime(object)
+		IL_010c: ldstr "process"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0116: ldstr "argv"
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0120: stloc.s 6
+		IL_0122: ldloc.s 6
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0129: ldstr "includes"
+		IL_012e: ldstr "verbose"
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0138: stloc.s 6
+		IL_013a: ldloc.1
+		IL_013b: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
+		IL_0140: ldloc.s 6
+		IL_0142: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
+		IL_0147: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_014c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0151: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_0156: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_015b: stloc.s 9
+		IL_015d: ldc.i4.1
+		IL_015e: newarr [System.Runtime]System.Object
+		IL_0163: dup
+		IL_0164: ldc.i4.0
+		IL_0165: ldloc.0
+		IL_0166: stelem.ref
+		IL_0167: stloc.s 10
+		IL_0169: ldc.i4.s 10
+		IL_016b: newarr [System.Runtime]System.Object
+		IL_0170: dup
+		IL_0171: ldc.i4.0
+		IL_0172: ldloc.s 9
+		IL_0174: stelem.ref
+		IL_0175: dup
+		IL_0176: ldc.i4.1
+		IL_0177: ldstr "setBitTrue"
+		IL_017c: stelem.ref
+		IL_017d: dup
+		IL_017e: ldc.i4.2
+		IL_017f: ldstr "setBitTrue"
+		IL_0184: stelem.ref
+		IL_0185: dup
+		IL_0186: ldc.i4.3
+		IL_0187: ldc.r8 1
+		IL_0190: box [System.Runtime]System.Double
+		IL_0195: stelem.ref
+		IL_0196: dup
+		IL_0197: ldc.i4.4
+		IL_0198: ldstr "setBitTrue"
+		IL_019d: stelem.ref
+		IL_019e: dup
+		IL_019f: ldc.i4.5
+		IL_01a0: ldc.i4.0
+		IL_01a1: box [System.Runtime]System.Boolean
+		IL_01a6: stelem.ref
+		IL_01a7: dup
+		IL_01a8: ldc.i4.6
+		IL_01a9: ldc.i4.0
+		IL_01aa: box [System.Runtime]System.Boolean
+		IL_01af: stelem.ref
+		IL_01b0: dup
+		IL_01b1: ldc.i4.7
+		IL_01b2: ldc.i4.0
+		IL_01b3: box [System.Runtime]System.Boolean
+		IL_01b8: stelem.ref
+		IL_01b9: dup
+		IL_01ba: ldc.i4.8
+		IL_01bb: ldc.i4.0
+		IL_01bc: box [System.Runtime]System.Boolean
 		IL_01c1: stelem.ref
 		IL_01c2: dup
-		IL_01c3: ldc.i4.5
-		IL_01c4: ldc.i4.0
-		IL_01c5: box [System.Runtime]System.Boolean
-		IL_01ca: stelem.ref
-		IL_01cb: dup
-		IL_01cc: ldc.i4.6
-		IL_01cd: ldc.i4.0
-		IL_01ce: box [System.Runtime]System.Boolean
-		IL_01d3: stelem.ref
-		IL_01d4: dup
-		IL_01d5: ldc.i4.7
+		IL_01c3: ldc.i4.s 9
+		IL_01c5: ldloc.s 10
+		IL_01c7: stelem.ref
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_01cd: pop
+		IL_01ce: ldc.i4.s 10
+		IL_01d0: newarr [System.Runtime]System.Object
+		IL_01d5: dup
 		IL_01d6: ldc.i4.0
-		IL_01d7: box [System.Runtime]System.Boolean
-		IL_01dc: stelem.ref
-		IL_01dd: dup
-		IL_01de: ldc.i4.8
-		IL_01df: ldc.i4.0
-		IL_01e0: box [System.Runtime]System.Boolean
-		IL_01e5: stelem.ref
-		IL_01e6: dup
-		IL_01e7: ldc.i4.s 9
-		IL_01e9: ldloc.s 9
-		IL_01eb: stelem.ref
-		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_01f1: pop
-		IL_01f2: ldc.i4.s 10
-		IL_01f4: newarr [System.Runtime]System.Object
-		IL_01f9: dup
-		IL_01fa: ldc.i4.0
-		IL_01fb: ldloc.s 8
-		IL_01fd: stelem.ref
-		IL_01fe: dup
-		IL_01ff: ldc.i4.1
-		IL_0200: ldstr "setBitsTrue"
-		IL_0205: stelem.ref
-		IL_0206: dup
-		IL_0207: ldc.i4.2
-		IL_0208: ldstr "setBitsTrue"
-		IL_020d: stelem.ref
-		IL_020e: dup
-		IL_020f: ldc.i4.3
-		IL_0210: ldc.r8 3
-		IL_0219: box [System.Runtime]System.Double
-		IL_021e: stelem.ref
-		IL_021f: dup
-		IL_0220: ldc.i4.4
-		IL_0221: ldstr "setBitsTrue"
+		IL_01d7: ldloc.s 9
+		IL_01d9: stelem.ref
+		IL_01da: dup
+		IL_01db: ldc.i4.1
+		IL_01dc: ldstr "setBitsTrue"
+		IL_01e1: stelem.ref
+		IL_01e2: dup
+		IL_01e3: ldc.i4.2
+		IL_01e4: ldstr "setBitsTrue"
+		IL_01e9: stelem.ref
+		IL_01ea: dup
+		IL_01eb: ldc.i4.3
+		IL_01ec: ldc.r8 3
+		IL_01f5: box [System.Runtime]System.Double
+		IL_01fa: stelem.ref
+		IL_01fb: dup
+		IL_01fc: ldc.i4.4
+		IL_01fd: ldstr "setBitsTrue"
+		IL_0202: stelem.ref
+		IL_0203: dup
+		IL_0204: ldc.i4.5
+		IL_0205: ldc.i4.0
+		IL_0206: box [System.Runtime]System.Boolean
+		IL_020b: stelem.ref
+		IL_020c: dup
+		IL_020d: ldc.i4.6
+		IL_020e: ldc.i4.0
+		IL_020f: box [System.Runtime]System.Boolean
+		IL_0214: stelem.ref
+		IL_0215: dup
+		IL_0216: ldc.i4.7
+		IL_0217: ldc.i4.0
+		IL_0218: box [System.Runtime]System.Boolean
+		IL_021d: stelem.ref
+		IL_021e: dup
+		IL_021f: ldc.i4.8
+		IL_0220: ldc.i4.0
+		IL_0221: box [System.Runtime]System.Boolean
 		IL_0226: stelem.ref
 		IL_0227: dup
-		IL_0228: ldc.i4.5
-		IL_0229: ldc.i4.0
-		IL_022a: box [System.Runtime]System.Boolean
-		IL_022f: stelem.ref
-		IL_0230: dup
-		IL_0231: ldc.i4.6
-		IL_0232: ldc.i4.0
-		IL_0233: box [System.Runtime]System.Boolean
-		IL_0238: stelem.ref
-		IL_0239: dup
-		IL_023a: ldc.i4.7
+		IL_0228: ldc.i4.s 9
+		IL_022a: ldloc.s 10
+		IL_022c: stelem.ref
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0232: pop
+		IL_0233: ldc.i4.s 10
+		IL_0235: newarr [System.Runtime]System.Object
+		IL_023a: dup
 		IL_023b: ldc.i4.0
-		IL_023c: box [System.Runtime]System.Boolean
-		IL_0241: stelem.ref
-		IL_0242: dup
-		IL_0243: ldc.i4.8
-		IL_0244: ldc.i4.0
-		IL_0245: box [System.Runtime]System.Boolean
-		IL_024a: stelem.ref
-		IL_024b: dup
-		IL_024c: ldc.i4.s 9
-		IL_024e: ldloc.s 9
-		IL_0250: stelem.ref
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0256: pop
-		IL_0257: ldc.i4.s 10
-		IL_0259: newarr [System.Runtime]System.Object
-		IL_025e: dup
-		IL_025f: ldc.i4.0
-		IL_0260: ldloc.s 8
-		IL_0262: stelem.ref
-		IL_0263: dup
-		IL_0264: ldc.i4.1
-		IL_0265: ldstr "testBitTrue"
-		IL_026a: stelem.ref
-		IL_026b: dup
-		IL_026c: ldc.i4.2
-		IL_026d: ldstr "testBitTrue"
-		IL_0272: stelem.ref
-		IL_0273: dup
-		IL_0274: ldc.i4.3
-		IL_0275: ldc.r8 1
-		IL_027e: box [System.Runtime]System.Double
-		IL_0283: stelem.ref
-		IL_0284: dup
-		IL_0285: ldc.i4.4
-		IL_0286: ldstr "testBitTrue"
+		IL_023c: ldloc.s 9
+		IL_023e: stelem.ref
+		IL_023f: dup
+		IL_0240: ldc.i4.1
+		IL_0241: ldstr "testBitTrue"
+		IL_0246: stelem.ref
+		IL_0247: dup
+		IL_0248: ldc.i4.2
+		IL_0249: ldstr "testBitTrue"
+		IL_024e: stelem.ref
+		IL_024f: dup
+		IL_0250: ldc.i4.3
+		IL_0251: ldc.r8 1
+		IL_025a: box [System.Runtime]System.Double
+		IL_025f: stelem.ref
+		IL_0260: dup
+		IL_0261: ldc.i4.4
+		IL_0262: ldstr "testBitTrue"
+		IL_0267: stelem.ref
+		IL_0268: dup
+		IL_0269: ldc.i4.5
+		IL_026a: ldc.i4.0
+		IL_026b: box [System.Runtime]System.Boolean
+		IL_0270: stelem.ref
+		IL_0271: dup
+		IL_0272: ldc.i4.6
+		IL_0273: ldc.i4.0
+		IL_0274: box [System.Runtime]System.Boolean
+		IL_0279: stelem.ref
+		IL_027a: dup
+		IL_027b: ldc.i4.7
+		IL_027c: ldc.i4.0
+		IL_027d: box [System.Runtime]System.Boolean
+		IL_0282: stelem.ref
+		IL_0283: dup
+		IL_0284: ldc.i4.8
+		IL_0285: ldc.i4.0
+		IL_0286: box [System.Runtime]System.Boolean
 		IL_028b: stelem.ref
 		IL_028c: dup
-		IL_028d: ldc.i4.5
-		IL_028e: ldc.i4.0
-		IL_028f: box [System.Runtime]System.Boolean
-		IL_0294: stelem.ref
-		IL_0295: dup
-		IL_0296: ldc.i4.6
-		IL_0297: ldc.i4.0
-		IL_0298: box [System.Runtime]System.Boolean
-		IL_029d: stelem.ref
-		IL_029e: dup
-		IL_029f: ldc.i4.7
+		IL_028d: ldc.i4.s 9
+		IL_028f: ldloc.s 10
+		IL_0291: stelem.ref
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0297: pop
+		IL_0298: ldc.i4.s 10
+		IL_029a: newarr [System.Runtime]System.Object
+		IL_029f: dup
 		IL_02a0: ldc.i4.0
-		IL_02a1: box [System.Runtime]System.Boolean
-		IL_02a6: stelem.ref
-		IL_02a7: dup
-		IL_02a8: ldc.i4.8
-		IL_02a9: ldc.i4.0
-		IL_02aa: box [System.Runtime]System.Boolean
-		IL_02af: stelem.ref
-		IL_02b0: dup
-		IL_02b1: ldc.i4.s 9
-		IL_02b3: ldloc.s 9
-		IL_02b5: stelem.ref
-		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_02bb: pop
-		IL_02bc: ldc.i4.s 10
-		IL_02be: newarr [System.Runtime]System.Object
-		IL_02c3: dup
-		IL_02c4: ldc.i4.0
-		IL_02c5: ldloc.s 8
-		IL_02c7: stelem.ref
-		IL_02c8: dup
-		IL_02c9: ldc.i4.1
-		IL_02ca: ldstr "searchBitFalse"
-		IL_02cf: stelem.ref
-		IL_02d0: dup
-		IL_02d1: ldc.i4.2
-		IL_02d2: ldstr "searchBitFalse"
-		IL_02d7: stelem.ref
-		IL_02d8: dup
-		IL_02d9: ldc.i4.3
-		IL_02da: ldc.r8 1
-		IL_02e3: box [System.Runtime]System.Double
-		IL_02e8: stelem.ref
-		IL_02e9: dup
-		IL_02ea: ldc.i4.4
-		IL_02eb: ldstr "searchBitFalse"
+		IL_02a1: ldloc.s 9
+		IL_02a3: stelem.ref
+		IL_02a4: dup
+		IL_02a5: ldc.i4.1
+		IL_02a6: ldstr "searchBitFalse"
+		IL_02ab: stelem.ref
+		IL_02ac: dup
+		IL_02ad: ldc.i4.2
+		IL_02ae: ldstr "searchBitFalse"
+		IL_02b3: stelem.ref
+		IL_02b4: dup
+		IL_02b5: ldc.i4.3
+		IL_02b6: ldc.r8 1
+		IL_02bf: box [System.Runtime]System.Double
+		IL_02c4: stelem.ref
+		IL_02c5: dup
+		IL_02c6: ldc.i4.4
+		IL_02c7: ldstr "searchBitFalse"
+		IL_02cc: stelem.ref
+		IL_02cd: dup
+		IL_02ce: ldc.i4.5
+		IL_02cf: ldc.i4.0
+		IL_02d0: box [System.Runtime]System.Boolean
+		IL_02d5: stelem.ref
+		IL_02d6: dup
+		IL_02d7: ldc.i4.6
+		IL_02d8: ldc.i4.0
+		IL_02d9: box [System.Runtime]System.Boolean
+		IL_02de: stelem.ref
+		IL_02df: dup
+		IL_02e0: ldc.i4.7
+		IL_02e1: ldc.i4.0
+		IL_02e2: box [System.Runtime]System.Boolean
+		IL_02e7: stelem.ref
+		IL_02e8: dup
+		IL_02e9: ldc.i4.8
+		IL_02ea: ldc.i4.0
+		IL_02eb: box [System.Runtime]System.Boolean
 		IL_02f0: stelem.ref
 		IL_02f1: dup
-		IL_02f2: ldc.i4.5
-		IL_02f3: ldc.i4.0
-		IL_02f4: box [System.Runtime]System.Boolean
-		IL_02f9: stelem.ref
-		IL_02fa: dup
-		IL_02fb: ldc.i4.6
-		IL_02fc: ldc.i4.0
-		IL_02fd: box [System.Runtime]System.Boolean
-		IL_0302: stelem.ref
+		IL_02f2: ldc.i4.s 9
+		IL_02f4: ldloc.s 10
+		IL_02f6: stelem.ref
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_02fc: pop
+		IL_02fd: ldc.i4.1
+		IL_02fe: newarr [System.Runtime]System.Object
 		IL_0303: dup
-		IL_0304: ldc.i4.7
-		IL_0305: ldc.i4.0
-		IL_0306: box [System.Runtime]System.Boolean
-		IL_030b: stelem.ref
-		IL_030c: dup
-		IL_030d: ldc.i4.8
-		IL_030e: ldc.i4.0
-		IL_030f: box [System.Runtime]System.Boolean
-		IL_0314: stelem.ref
-		IL_0315: dup
-		IL_0316: ldc.i4.s 9
-		IL_0318: ldloc.s 9
-		IL_031a: stelem.ref
-		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0320: pop
-		IL_0321: ldc.i4.1
-		IL_0322: newarr [System.Runtime]System.Object
-		IL_0327: dup
-		IL_0328: ldc.i4.0
-		IL_0329: ldloc.0
-		IL_032a: stelem.ref
-		IL_032b: stloc.s 9
-		IL_032d: ldloc.s 8
-		IL_032f: ldloc.s 9
-		IL_0331: ldc.r8 1
-		IL_033a: box [System.Runtime]System.Double
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0344: stloc.s 5
-		IL_0346: ldloc.0
-		IL_0347: ldloc.s 5
-		IL_0349: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
-		IL_034e: nop
-		IL_034f: ldloc.0
-		IL_0350: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_0355: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, float64, object)
-		IL_035b: newobj instance void class [System.Runtime]System.Func`4<object, float64, object, object>::.ctor(object, native int)
-		IL_0360: ldc.i4.1
-		IL_0361: newarr [System.Runtime]System.Object
-		IL_0366: dup
-		IL_0367: ldc.i4.0
-		IL_0368: ldloc.0
-		IL_0369: stelem.ref
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0374: castclass class [System.Runtime]System.Func`4<object, float64, object, object>
-		IL_0379: ldc.i4.1
-		IL_037a: conv.r8
-		IL_037b: ldstr ""
-		IL_0380: ldc.i4.0
-		IL_0381: ldc.i4.0
-		IL_0382: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`4<object, float64, object, object>>(!!0, float64, string, bool, bool)
-		IL_0387: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [System.Runtime]System.Func`4<object, float64, object, object>>(!!0)
-		IL_038c: stloc.s 10
-		IL_038e: ldloc.s 10
-		IL_0390: ldstr "runSieveBatch"
-		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_039a: stloc.s 5
-		IL_039c: ldloc.0
-		IL_039d: ldloc.s 5
-		IL_039f: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-		IL_03a4: ldloc.0
-		IL_03a5: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_03aa: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_03b0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_03b5: ldc.i4.1
-		IL_03b6: newarr [System.Runtime]System.Object
-		IL_03bb: dup
-		IL_03bc: ldc.i4.0
-		IL_03bd: ldloc.0
-		IL_03be: stelem.ref
-		IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_03c9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_03ce: ldc.i4.1
-		IL_03cf: conv.r8
-		IL_03d0: ldstr ""
-		IL_03d5: ldc.i4.0
-		IL_03d6: ldc.i4.0
-		IL_03d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_03dc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_03e1: stloc.s 11
-		IL_03e3: ldloc.s 11
-		IL_03e5: ldstr "main"
-		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_03ef: stloc.3
-		IL_03f0: ldloc.0
-		IL_03f1: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_03f6: ldnull
-		IL_03f7: ldloc.1
-		IL_03f8: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_03fd: pop
-		IL_03fe: ret
+		IL_0304: ldc.i4.0
+		IL_0305: ldloc.0
+		IL_0306: stelem.ref
+		IL_0307: stloc.s 10
+		IL_0309: ldloc.s 9
+		IL_030b: ldloc.s 10
+		IL_030d: ldc.r8 1
+		IL_0316: box [System.Runtime]System.Double
+		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0320: stloc.s 6
+		IL_0322: ldloc.0
+		IL_0323: ldloc.s 6
+		IL_0325: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
+		IL_032a: nop
+		IL_032b: ldloc.0
+		IL_032c: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_0331: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, float64, object)
+		IL_0337: newobj instance void class [System.Runtime]System.Func`4<object, float64, object, object>::.ctor(object, native int)
+		IL_033c: ldc.i4.1
+		IL_033d: newarr [System.Runtime]System.Object
+		IL_0342: dup
+		IL_0343: ldc.i4.0
+		IL_0344: ldloc.0
+		IL_0345: stelem.ref
+		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0350: castclass class [System.Runtime]System.Func`4<object, float64, object, object>
+		IL_0355: ldc.i4.1
+		IL_0356: conv.r8
+		IL_0357: ldstr ""
+		IL_035c: ldc.i4.0
+		IL_035d: ldc.i4.0
+		IL_035e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`4<object, float64, object, object>>(!!0, float64, string, bool, bool)
+		IL_0363: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [System.Runtime]System.Func`4<object, float64, object, object>>(!!0)
+		IL_0368: stloc.s 11
+		IL_036a: ldloc.s 11
+		IL_036c: ldstr "runSieveBatch"
+		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0376: stloc.s 6
+		IL_0378: ldloc.0
+		IL_0379: ldloc.s 6
+		IL_037b: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+		IL_0380: ldloc.0
+		IL_0381: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_0386: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_038c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0391: ldc.i4.1
+		IL_0392: newarr [System.Runtime]System.Object
+		IL_0397: dup
+		IL_0398: ldc.i4.0
+		IL_0399: ldloc.0
+		IL_039a: stelem.ref
+		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_03a5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_03aa: ldc.i4.1
+		IL_03ab: conv.r8
+		IL_03ac: ldstr ""
+		IL_03b1: ldc.i4.0
+		IL_03b2: ldc.i4.0
+		IL_03b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_03b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_03bd: stloc.s 12
+		IL_03bf: ldloc.s 12
+		IL_03c1: ldstr "main"
+		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_03cb: stloc.3
+		IL_03cc: ldloc.0
+		IL_03cd: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_03d2: ldnull
+		IL_03d3: ldloc.1
+		IL_03d4: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_03d9: pop
+		IL_03da: ret
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript
@@ -2755,7 +2744,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3165
+		// Method begins at RVA 0x3141
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3237
+						// Method begins at RVA 0x3213
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x322e
+					// Method begins at RVA 0x320a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3225
+				// Method begins at RVA 0x3201
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,7 +101,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2638
+			// Method begins at RVA 0x2614
 			// Header size: 12
 			// Code size: 232 (0xe8)
 			.maxstack 8
@@ -226,7 +226,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3240
+				// Method begins at RVA 0x321c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -253,7 +253,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x272c
+			// Method begins at RVA 0x2708
 			// Header size: 12
 			// Code size: 431 (0x1af)
 			.maxstack 8
@@ -428,7 +428,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3117
+				// Method begins at RVA 0x30f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -448,7 +448,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3120
+				// Method begins at RVA 0x30fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -468,7 +468,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3129
+				// Method begins at RVA 0x3105
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -496,7 +496,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3144
+						// Method begins at RVA 0x3120
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -520,7 +520,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3156
+							// Method begins at RVA 0x3132
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -538,7 +538,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x314d
+						// Method begins at RVA 0x3129
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -556,7 +556,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x313b
+					// Method begins at RVA 0x3117
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -584,7 +584,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3171
+							// Method begins at RVA 0x314d
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -602,7 +602,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3168
+						// Method begins at RVA 0x3144
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -620,7 +620,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x315f
+					// Method begins at RVA 0x313b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -644,7 +644,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3183
+						// Method begins at RVA 0x315f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -662,7 +662,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x317a
+					// Method begins at RVA 0x3156
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -680,7 +680,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3132
+				// Method begins at RVA 0x310e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -700,7 +700,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x318c
+				// Method begins at RVA 0x3168
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -724,7 +724,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x319e
+					// Method begins at RVA 0x317a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -742,7 +742,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3195
+				// Method begins at RVA 0x3171
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -770,7 +770,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2950
+			// Method begins at RVA 0x292c
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -818,7 +818,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bbc
+			// Method begins at RVA 0x2b98
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -882,7 +882,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29d4
+			// Method begins at RVA 0x29b0
 			// Header size: 12
 			// Code size: 475 (0x1db)
 			.maxstack 8
@@ -1149,7 +1149,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c1c
+			// Method begins at RVA 0x2bf8
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -1206,7 +1206,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x299c
+			// Method begins at RVA 0x2978
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1251,7 +1251,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31a7
+				// Method begins at RVA 0x3183
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1271,7 +1271,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31b0
+				// Method begins at RVA 0x318c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1295,7 +1295,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31c2
+					// Method begins at RVA 0x319e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1313,7 +1313,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31b9
+				// Method begins at RVA 0x3195
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1333,7 +1333,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31cb
+				// Method begins at RVA 0x31a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1361,7 +1361,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31e6
+						// Method begins at RVA 0x31c2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1379,7 +1379,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31dd
+					// Method begins at RVA 0x31b9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1397,7 +1397,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31d4
+				// Method begins at RVA 0x31b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1421,7 +1421,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31f8
+					// Method begins at RVA 0x31d4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1445,7 +1445,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x320a
+						// Method begins at RVA 0x31e6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1463,7 +1463,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3201
+					// Method begins at RVA 0x31dd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1481,7 +1481,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31ef
+				// Method begins at RVA 0x31cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1505,7 +1505,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x321c
+					// Method begins at RVA 0x31f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1523,7 +1523,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3213
+				// Method begins at RVA 0x31ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1553,7 +1553,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28e8
+			// Method begins at RVA 0x28c4
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -1612,7 +1612,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c6c
+			// Method begins at RVA 0x2c48
 			// Header size: 12
 			// Code size: 168 (0xa8)
 			.maxstack 8
@@ -1700,7 +1700,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fb0
+			// Method begins at RVA 0x2f8c
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -1765,7 +1765,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3028
+			// Method begins at RVA 0x3004
 			// Header size: 12
 			// Code size: 218 (0xda)
 			.maxstack 8
@@ -1873,7 +1873,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d20
+			// Method begins at RVA 0x2cfc
 			// Header size: 12
 			// Code size: 643 (0x283)
 			.maxstack 8
@@ -2102,7 +2102,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x310e
+			// Method begins at RVA 0x30ea
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2132,7 +2132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3249
+				// Method begins at RVA 0x3225
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2145,7 +2145,7 @@
 			.method public hidebysig 
 				instance float64 get_sieveSize () cil managed 
 			{
-				// Method begins at RVA 0x3251
+				// Method begins at RVA 0x322d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2160,7 +2160,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3259
+				// Method begins at RVA 0x3235
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2178,7 +2178,7 @@
 			.method public hidebysig 
 				instance float64 get_timeLimitSeconds () cil managed 
 			{
-				// Method begins at RVA 0x326e
+				// Method begins at RVA 0x324a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2193,7 +2193,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3276
+				// Method begins at RVA 0x3252
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2211,7 +2211,7 @@
 			.method public hidebysig 
 				instance object get_verbose () cil managed 
 			{
-				// Method begins at RVA 0x328b
+				// Method begins at RVA 0x3267
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2226,7 +2226,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3293
+				// Method begins at RVA 0x326f
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2244,7 +2244,7 @@
 			.method public hidebysig 
 				instance object get_runtime () cil managed 
 			{
-				// Method begins at RVA 0x32a8
+				// Method begins at RVA 0x3284
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2259,7 +2259,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x32b0
+				// Method begins at RVA 0x328c
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2292,7 +2292,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1497 (0x5d9)
+		// Code size: 1461 (0x5b5)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope,
@@ -2301,13 +2301,14 @@
 			[3] object,
 			[4] object,
 			[5] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule,
-			[6] object,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[8] float64,
-			[9] class [System.Runtime]System.Type,
-			[10] object[],
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
-			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			[6] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance,
+			[7] object,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[9] float64,
+			[10] class [System.Runtime]System.Type,
+			[11] object[],
+			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		)
 
 		IL_0000: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::.ctor()
@@ -2345,581 +2346,569 @@
 		IL_006e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
 		IL_0073: ldloc.s 5
-		IL_0075: ldstr "performance"
-		IL_007a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_007f: brtrue IL_0092
-
-		IL_0084: ldloc.s 5
-		IL_0086: callvirt instance class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule::get_performance()
-		IL_008b: stloc.s 6
-		IL_008d: br IL_00a0
-
-		IL_0092: ldloc.s 5
-		IL_0094: ldstr "performance"
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_009e: stloc.s 6
-
-		IL_00a0: ldloc.0
-		IL_00a1: ldloc.s 6
-		IL_00a3: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
-		IL_00a8: ldstr "process"
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b2: ldstr "argv"
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00bc: stloc.s 6
-		IL_00be: ldloc.s 6
-		IL_00c0: ldc.r8 0.0
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00ce: stloc.s 6
-		IL_00d0: ldloc.s 6
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d7: stloc.s 6
-		IL_00d9: ldstr "[\\\\/]"
-		IL_00de: ldstr ""
-		IL_00e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00e8: stloc.s 7
-		IL_00ea: ldloc.s 6
-		IL_00ec: ldstr "split"
-		IL_00f1: ldloc.s 7
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f8: stloc.2
-		IL_00f9: ldloc.2
-		IL_00fa: ldstr "length"
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0104: stloc.s 6
-		IL_0106: ldloc.s 6
-		IL_0108: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_010d: ldc.r8 1
-		IL_0116: sub
-		IL_0117: stloc.s 8
-		IL_0119: ldloc.2
-		IL_011a: ldloc.s 8
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0121: stloc.s 6
-		IL_0123: ldloc.1
-		IL_0124: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
-		IL_0129: ldloc.s 6
-		IL_012b: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_runtime(object)
-		IL_0130: ldstr "process"
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013a: ldstr "argv"
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0144: stloc.s 6
-		IL_0146: ldloc.s 6
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014d: ldstr "includes"
-		IL_0152: ldstr "verbose"
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015c: stloc.s 6
-		IL_015e: ldloc.1
-		IL_015f: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
-		IL_0164: ldloc.s 6
-		IL_0166: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
-		IL_016b: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0170: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0175: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_017a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_017f: stloc.s 9
-		IL_0181: ldc.i4.1
-		IL_0182: newarr [System.Runtime]System.Object
-		IL_0187: dup
-		IL_0188: ldc.i4.0
-		IL_0189: ldloc.0
-		IL_018a: stelem.ref
-		IL_018b: stloc.s 10
-		IL_018d: ldc.i4.s 10
-		IL_018f: newarr [System.Runtime]System.Object
-		IL_0194: dup
-		IL_0195: ldc.i4.0
-		IL_0196: ldloc.s 9
-		IL_0198: stelem.ref
-		IL_0199: dup
-		IL_019a: ldc.i4.1
-		IL_019b: ldstr "setBitTrue"
-		IL_01a0: stelem.ref
-		IL_01a1: dup
-		IL_01a2: ldc.i4.2
-		IL_01a3: ldstr "setBitTrue"
-		IL_01a8: stelem.ref
-		IL_01a9: dup
-		IL_01aa: ldc.i4.3
-		IL_01ab: ldc.r8 1
-		IL_01b4: box [System.Runtime]System.Double
-		IL_01b9: stelem.ref
-		IL_01ba: dup
-		IL_01bb: ldc.i4.4
-		IL_01bc: ldstr "setBitTrue"
+		IL_0075: callvirt instance class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule::get_performance()
+		IL_007a: stloc.s 6
+		IL_007c: ldloc.0
+		IL_007d: ldloc.s 6
+		IL_007f: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
+		IL_0084: ldstr "process"
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008e: ldstr "argv"
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0098: stloc.s 7
+		IL_009a: ldloc.s 7
+		IL_009c: ldc.r8 0.0
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00aa: stloc.s 7
+		IL_00ac: ldloc.s 7
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b3: stloc.s 7
+		IL_00b5: ldstr "[\\\\/]"
+		IL_00ba: ldstr ""
+		IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00c4: stloc.s 8
+		IL_00c6: ldloc.s 7
+		IL_00c8: ldstr "split"
+		IL_00cd: ldloc.s 8
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d4: stloc.2
+		IL_00d5: ldloc.2
+		IL_00d6: ldstr "length"
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e0: stloc.s 7
+		IL_00e2: ldloc.s 7
+		IL_00e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00e9: ldc.r8 1
+		IL_00f2: sub
+		IL_00f3: stloc.s 9
+		IL_00f5: ldloc.2
+		IL_00f6: ldloc.s 9
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00fd: stloc.s 7
+		IL_00ff: ldloc.1
+		IL_0100: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
+		IL_0105: ldloc.s 7
+		IL_0107: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_runtime(object)
+		IL_010c: ldstr "process"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0116: ldstr "argv"
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0120: stloc.s 7
+		IL_0122: ldloc.s 7
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0129: ldstr "includes"
+		IL_012e: ldstr "verbose"
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0138: stloc.s 7
+		IL_013a: ldloc.1
+		IL_013b: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
+		IL_0140: ldloc.s 7
+		IL_0142: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
+		IL_0147: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_014c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0151: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_0156: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_015b: stloc.s 10
+		IL_015d: ldc.i4.1
+		IL_015e: newarr [System.Runtime]System.Object
+		IL_0163: dup
+		IL_0164: ldc.i4.0
+		IL_0165: ldloc.0
+		IL_0166: stelem.ref
+		IL_0167: stloc.s 11
+		IL_0169: ldc.i4.s 10
+		IL_016b: newarr [System.Runtime]System.Object
+		IL_0170: dup
+		IL_0171: ldc.i4.0
+		IL_0172: ldloc.s 10
+		IL_0174: stelem.ref
+		IL_0175: dup
+		IL_0176: ldc.i4.1
+		IL_0177: ldstr "setBitTrue"
+		IL_017c: stelem.ref
+		IL_017d: dup
+		IL_017e: ldc.i4.2
+		IL_017f: ldstr "setBitTrue"
+		IL_0184: stelem.ref
+		IL_0185: dup
+		IL_0186: ldc.i4.3
+		IL_0187: ldc.r8 1
+		IL_0190: box [System.Runtime]System.Double
+		IL_0195: stelem.ref
+		IL_0196: dup
+		IL_0197: ldc.i4.4
+		IL_0198: ldstr "setBitTrue"
+		IL_019d: stelem.ref
+		IL_019e: dup
+		IL_019f: ldc.i4.5
+		IL_01a0: ldc.i4.0
+		IL_01a1: box [System.Runtime]System.Boolean
+		IL_01a6: stelem.ref
+		IL_01a7: dup
+		IL_01a8: ldc.i4.6
+		IL_01a9: ldc.i4.0
+		IL_01aa: box [System.Runtime]System.Boolean
+		IL_01af: stelem.ref
+		IL_01b0: dup
+		IL_01b1: ldc.i4.7
+		IL_01b2: ldc.i4.0
+		IL_01b3: box [System.Runtime]System.Boolean
+		IL_01b8: stelem.ref
+		IL_01b9: dup
+		IL_01ba: ldc.i4.8
+		IL_01bb: ldc.i4.0
+		IL_01bc: box [System.Runtime]System.Boolean
 		IL_01c1: stelem.ref
 		IL_01c2: dup
-		IL_01c3: ldc.i4.5
-		IL_01c4: ldc.i4.0
-		IL_01c5: box [System.Runtime]System.Boolean
-		IL_01ca: stelem.ref
-		IL_01cb: dup
-		IL_01cc: ldc.i4.6
-		IL_01cd: ldc.i4.0
-		IL_01ce: box [System.Runtime]System.Boolean
-		IL_01d3: stelem.ref
-		IL_01d4: dup
-		IL_01d5: ldc.i4.7
+		IL_01c3: ldc.i4.s 9
+		IL_01c5: ldloc.s 11
+		IL_01c7: stelem.ref
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_01cd: pop
+		IL_01ce: ldc.i4.s 10
+		IL_01d0: newarr [System.Runtime]System.Object
+		IL_01d5: dup
 		IL_01d6: ldc.i4.0
-		IL_01d7: box [System.Runtime]System.Boolean
-		IL_01dc: stelem.ref
-		IL_01dd: dup
-		IL_01de: ldc.i4.8
-		IL_01df: ldc.i4.0
-		IL_01e0: box [System.Runtime]System.Boolean
-		IL_01e5: stelem.ref
-		IL_01e6: dup
-		IL_01e7: ldc.i4.s 9
-		IL_01e9: ldloc.s 10
-		IL_01eb: stelem.ref
-		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_01f1: pop
-		IL_01f2: ldc.i4.s 10
-		IL_01f4: newarr [System.Runtime]System.Object
-		IL_01f9: dup
-		IL_01fa: ldc.i4.0
-		IL_01fb: ldloc.s 9
-		IL_01fd: stelem.ref
-		IL_01fe: dup
-		IL_01ff: ldc.i4.1
-		IL_0200: ldstr "setBitsTrue"
-		IL_0205: stelem.ref
-		IL_0206: dup
-		IL_0207: ldc.i4.2
-		IL_0208: ldstr "setBitsTrue"
-		IL_020d: stelem.ref
-		IL_020e: dup
-		IL_020f: ldc.i4.3
-		IL_0210: ldc.r8 3
-		IL_0219: box [System.Runtime]System.Double
-		IL_021e: stelem.ref
-		IL_021f: dup
-		IL_0220: ldc.i4.4
-		IL_0221: ldstr "setBitsTrue"
+		IL_01d7: ldloc.s 10
+		IL_01d9: stelem.ref
+		IL_01da: dup
+		IL_01db: ldc.i4.1
+		IL_01dc: ldstr "setBitsTrue"
+		IL_01e1: stelem.ref
+		IL_01e2: dup
+		IL_01e3: ldc.i4.2
+		IL_01e4: ldstr "setBitsTrue"
+		IL_01e9: stelem.ref
+		IL_01ea: dup
+		IL_01eb: ldc.i4.3
+		IL_01ec: ldc.r8 3
+		IL_01f5: box [System.Runtime]System.Double
+		IL_01fa: stelem.ref
+		IL_01fb: dup
+		IL_01fc: ldc.i4.4
+		IL_01fd: ldstr "setBitsTrue"
+		IL_0202: stelem.ref
+		IL_0203: dup
+		IL_0204: ldc.i4.5
+		IL_0205: ldc.i4.0
+		IL_0206: box [System.Runtime]System.Boolean
+		IL_020b: stelem.ref
+		IL_020c: dup
+		IL_020d: ldc.i4.6
+		IL_020e: ldc.i4.0
+		IL_020f: box [System.Runtime]System.Boolean
+		IL_0214: stelem.ref
+		IL_0215: dup
+		IL_0216: ldc.i4.7
+		IL_0217: ldc.i4.0
+		IL_0218: box [System.Runtime]System.Boolean
+		IL_021d: stelem.ref
+		IL_021e: dup
+		IL_021f: ldc.i4.8
+		IL_0220: ldc.i4.0
+		IL_0221: box [System.Runtime]System.Boolean
 		IL_0226: stelem.ref
 		IL_0227: dup
-		IL_0228: ldc.i4.5
-		IL_0229: ldc.i4.0
-		IL_022a: box [System.Runtime]System.Boolean
-		IL_022f: stelem.ref
-		IL_0230: dup
-		IL_0231: ldc.i4.6
-		IL_0232: ldc.i4.0
-		IL_0233: box [System.Runtime]System.Boolean
-		IL_0238: stelem.ref
-		IL_0239: dup
-		IL_023a: ldc.i4.7
+		IL_0228: ldc.i4.s 9
+		IL_022a: ldloc.s 11
+		IL_022c: stelem.ref
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0232: pop
+		IL_0233: ldc.i4.s 10
+		IL_0235: newarr [System.Runtime]System.Object
+		IL_023a: dup
 		IL_023b: ldc.i4.0
-		IL_023c: box [System.Runtime]System.Boolean
-		IL_0241: stelem.ref
-		IL_0242: dup
-		IL_0243: ldc.i4.8
-		IL_0244: ldc.i4.0
-		IL_0245: box [System.Runtime]System.Boolean
-		IL_024a: stelem.ref
-		IL_024b: dup
-		IL_024c: ldc.i4.s 9
-		IL_024e: ldloc.s 10
-		IL_0250: stelem.ref
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0256: pop
-		IL_0257: ldc.i4.s 10
-		IL_0259: newarr [System.Runtime]System.Object
-		IL_025e: dup
-		IL_025f: ldc.i4.0
-		IL_0260: ldloc.s 9
-		IL_0262: stelem.ref
-		IL_0263: dup
-		IL_0264: ldc.i4.1
-		IL_0265: ldstr "testBitTrue"
-		IL_026a: stelem.ref
-		IL_026b: dup
-		IL_026c: ldc.i4.2
-		IL_026d: ldstr "testBitTrue"
-		IL_0272: stelem.ref
-		IL_0273: dup
-		IL_0274: ldc.i4.3
-		IL_0275: ldc.r8 1
-		IL_027e: box [System.Runtime]System.Double
-		IL_0283: stelem.ref
-		IL_0284: dup
-		IL_0285: ldc.i4.4
-		IL_0286: ldstr "testBitTrue"
+		IL_023c: ldloc.s 10
+		IL_023e: stelem.ref
+		IL_023f: dup
+		IL_0240: ldc.i4.1
+		IL_0241: ldstr "testBitTrue"
+		IL_0246: stelem.ref
+		IL_0247: dup
+		IL_0248: ldc.i4.2
+		IL_0249: ldstr "testBitTrue"
+		IL_024e: stelem.ref
+		IL_024f: dup
+		IL_0250: ldc.i4.3
+		IL_0251: ldc.r8 1
+		IL_025a: box [System.Runtime]System.Double
+		IL_025f: stelem.ref
+		IL_0260: dup
+		IL_0261: ldc.i4.4
+		IL_0262: ldstr "testBitTrue"
+		IL_0267: stelem.ref
+		IL_0268: dup
+		IL_0269: ldc.i4.5
+		IL_026a: ldc.i4.0
+		IL_026b: box [System.Runtime]System.Boolean
+		IL_0270: stelem.ref
+		IL_0271: dup
+		IL_0272: ldc.i4.6
+		IL_0273: ldc.i4.0
+		IL_0274: box [System.Runtime]System.Boolean
+		IL_0279: stelem.ref
+		IL_027a: dup
+		IL_027b: ldc.i4.7
+		IL_027c: ldc.i4.0
+		IL_027d: box [System.Runtime]System.Boolean
+		IL_0282: stelem.ref
+		IL_0283: dup
+		IL_0284: ldc.i4.8
+		IL_0285: ldc.i4.0
+		IL_0286: box [System.Runtime]System.Boolean
 		IL_028b: stelem.ref
 		IL_028c: dup
-		IL_028d: ldc.i4.5
-		IL_028e: ldc.i4.0
-		IL_028f: box [System.Runtime]System.Boolean
-		IL_0294: stelem.ref
-		IL_0295: dup
-		IL_0296: ldc.i4.6
-		IL_0297: ldc.i4.0
-		IL_0298: box [System.Runtime]System.Boolean
-		IL_029d: stelem.ref
-		IL_029e: dup
-		IL_029f: ldc.i4.7
+		IL_028d: ldc.i4.s 9
+		IL_028f: ldloc.s 11
+		IL_0291: stelem.ref
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0297: pop
+		IL_0298: ldc.i4.s 10
+		IL_029a: newarr [System.Runtime]System.Object
+		IL_029f: dup
 		IL_02a0: ldc.i4.0
-		IL_02a1: box [System.Runtime]System.Boolean
-		IL_02a6: stelem.ref
-		IL_02a7: dup
-		IL_02a8: ldc.i4.8
-		IL_02a9: ldc.i4.0
-		IL_02aa: box [System.Runtime]System.Boolean
-		IL_02af: stelem.ref
-		IL_02b0: dup
-		IL_02b1: ldc.i4.s 9
-		IL_02b3: ldloc.s 10
-		IL_02b5: stelem.ref
-		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_02bb: pop
-		IL_02bc: ldc.i4.s 10
-		IL_02be: newarr [System.Runtime]System.Object
-		IL_02c3: dup
-		IL_02c4: ldc.i4.0
-		IL_02c5: ldloc.s 9
-		IL_02c7: stelem.ref
-		IL_02c8: dup
-		IL_02c9: ldc.i4.1
-		IL_02ca: ldstr "searchBitFalse"
-		IL_02cf: stelem.ref
-		IL_02d0: dup
-		IL_02d1: ldc.i4.2
-		IL_02d2: ldstr "searchBitFalse"
-		IL_02d7: stelem.ref
-		IL_02d8: dup
-		IL_02d9: ldc.i4.3
-		IL_02da: ldc.r8 1
-		IL_02e3: box [System.Runtime]System.Double
-		IL_02e8: stelem.ref
-		IL_02e9: dup
-		IL_02ea: ldc.i4.4
-		IL_02eb: ldstr "searchBitFalse"
+		IL_02a1: ldloc.s 10
+		IL_02a3: stelem.ref
+		IL_02a4: dup
+		IL_02a5: ldc.i4.1
+		IL_02a6: ldstr "searchBitFalse"
+		IL_02ab: stelem.ref
+		IL_02ac: dup
+		IL_02ad: ldc.i4.2
+		IL_02ae: ldstr "searchBitFalse"
+		IL_02b3: stelem.ref
+		IL_02b4: dup
+		IL_02b5: ldc.i4.3
+		IL_02b6: ldc.r8 1
+		IL_02bf: box [System.Runtime]System.Double
+		IL_02c4: stelem.ref
+		IL_02c5: dup
+		IL_02c6: ldc.i4.4
+		IL_02c7: ldstr "searchBitFalse"
+		IL_02cc: stelem.ref
+		IL_02cd: dup
+		IL_02ce: ldc.i4.5
+		IL_02cf: ldc.i4.0
+		IL_02d0: box [System.Runtime]System.Boolean
+		IL_02d5: stelem.ref
+		IL_02d6: dup
+		IL_02d7: ldc.i4.6
+		IL_02d8: ldc.i4.0
+		IL_02d9: box [System.Runtime]System.Boolean
+		IL_02de: stelem.ref
+		IL_02df: dup
+		IL_02e0: ldc.i4.7
+		IL_02e1: ldc.i4.0
+		IL_02e2: box [System.Runtime]System.Boolean
+		IL_02e7: stelem.ref
+		IL_02e8: dup
+		IL_02e9: ldc.i4.8
+		IL_02ea: ldc.i4.0
+		IL_02eb: box [System.Runtime]System.Boolean
 		IL_02f0: stelem.ref
 		IL_02f1: dup
-		IL_02f2: ldc.i4.5
-		IL_02f3: ldc.i4.0
-		IL_02f4: box [System.Runtime]System.Boolean
-		IL_02f9: stelem.ref
-		IL_02fa: dup
-		IL_02fb: ldc.i4.6
-		IL_02fc: ldc.i4.0
-		IL_02fd: box [System.Runtime]System.Boolean
-		IL_0302: stelem.ref
+		IL_02f2: ldc.i4.s 9
+		IL_02f4: ldloc.s 11
+		IL_02f6: stelem.ref
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_02fc: pop
+		IL_02fd: ldc.i4.1
+		IL_02fe: newarr [System.Runtime]System.Object
 		IL_0303: dup
-		IL_0304: ldc.i4.7
-		IL_0305: ldc.i4.0
-		IL_0306: box [System.Runtime]System.Boolean
-		IL_030b: stelem.ref
-		IL_030c: dup
-		IL_030d: ldc.i4.8
-		IL_030e: ldc.i4.0
-		IL_030f: box [System.Runtime]System.Boolean
-		IL_0314: stelem.ref
-		IL_0315: dup
-		IL_0316: ldc.i4.s 9
-		IL_0318: ldloc.s 10
-		IL_031a: stelem.ref
-		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0320: pop
-		IL_0321: ldc.i4.1
-		IL_0322: newarr [System.Runtime]System.Object
-		IL_0327: dup
-		IL_0328: ldc.i4.0
-		IL_0329: ldloc.0
-		IL_032a: stelem.ref
-		IL_032b: stloc.s 10
-		IL_032d: ldloc.s 9
-		IL_032f: ldloc.s 10
-		IL_0331: ldc.r8 1
-		IL_033a: box [System.Runtime]System.Double
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0344: stloc.s 6
-		IL_0346: ldloc.0
-		IL_0347: ldloc.s 6
-		IL_0349: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
-		IL_034e: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0353: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0358: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_035d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0362: stloc.s 9
-		IL_0364: ldc.i4.1
-		IL_0365: newarr [System.Runtime]System.Object
-		IL_036a: dup
-		IL_036b: ldc.i4.0
-		IL_036c: ldloc.0
-		IL_036d: stelem.ref
-		IL_036e: stloc.s 10
-		IL_0370: ldc.i4.s 10
-		IL_0372: newarr [System.Runtime]System.Object
-		IL_0377: dup
-		IL_0378: ldc.i4.0
-		IL_0379: ldloc.s 9
-		IL_037b: stelem.ref
-		IL_037c: dup
-		IL_037d: ldc.i4.1
-		IL_037e: ldstr "runSieve"
-		IL_0383: stelem.ref
-		IL_0384: dup
-		IL_0385: ldc.i4.2
-		IL_0386: ldstr "runSieve"
-		IL_038b: stelem.ref
-		IL_038c: dup
-		IL_038d: ldc.i4.3
-		IL_038e: ldc.r8 0.0
-		IL_0397: box [System.Runtime]System.Double
-		IL_039c: stelem.ref
-		IL_039d: dup
-		IL_039e: ldc.i4.4
-		IL_039f: ldstr "runSieve"
+		IL_0304: ldc.i4.0
+		IL_0305: ldloc.0
+		IL_0306: stelem.ref
+		IL_0307: stloc.s 11
+		IL_0309: ldloc.s 10
+		IL_030b: ldloc.s 11
+		IL_030d: ldc.r8 1
+		IL_0316: box [System.Runtime]System.Double
+		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0320: stloc.s 7
+		IL_0322: ldloc.0
+		IL_0323: ldloc.s 7
+		IL_0325: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
+		IL_032a: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_032f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0334: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_0339: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_033e: stloc.s 10
+		IL_0340: ldc.i4.1
+		IL_0341: newarr [System.Runtime]System.Object
+		IL_0346: dup
+		IL_0347: ldc.i4.0
+		IL_0348: ldloc.0
+		IL_0349: stelem.ref
+		IL_034a: stloc.s 11
+		IL_034c: ldc.i4.s 10
+		IL_034e: newarr [System.Runtime]System.Object
+		IL_0353: dup
+		IL_0354: ldc.i4.0
+		IL_0355: ldloc.s 10
+		IL_0357: stelem.ref
+		IL_0358: dup
+		IL_0359: ldc.i4.1
+		IL_035a: ldstr "runSieve"
+		IL_035f: stelem.ref
+		IL_0360: dup
+		IL_0361: ldc.i4.2
+		IL_0362: ldstr "runSieve"
+		IL_0367: stelem.ref
+		IL_0368: dup
+		IL_0369: ldc.i4.3
+		IL_036a: ldc.r8 0.0
+		IL_0373: box [System.Runtime]System.Double
+		IL_0378: stelem.ref
+		IL_0379: dup
+		IL_037a: ldc.i4.4
+		IL_037b: ldstr "runSieve"
+		IL_0380: stelem.ref
+		IL_0381: dup
+		IL_0382: ldc.i4.5
+		IL_0383: ldc.i4.0
+		IL_0384: box [System.Runtime]System.Boolean
+		IL_0389: stelem.ref
+		IL_038a: dup
+		IL_038b: ldc.i4.6
+		IL_038c: ldc.i4.0
+		IL_038d: box [System.Runtime]System.Boolean
+		IL_0392: stelem.ref
+		IL_0393: dup
+		IL_0394: ldc.i4.7
+		IL_0395: ldc.i4.0
+		IL_0396: box [System.Runtime]System.Boolean
+		IL_039b: stelem.ref
+		IL_039c: dup
+		IL_039d: ldc.i4.8
+		IL_039e: ldc.i4.0
+		IL_039f: box [System.Runtime]System.Boolean
 		IL_03a4: stelem.ref
 		IL_03a5: dup
-		IL_03a6: ldc.i4.5
-		IL_03a7: ldc.i4.0
-		IL_03a8: box [System.Runtime]System.Boolean
-		IL_03ad: stelem.ref
-		IL_03ae: dup
-		IL_03af: ldc.i4.6
-		IL_03b0: ldc.i4.0
-		IL_03b1: box [System.Runtime]System.Boolean
-		IL_03b6: stelem.ref
-		IL_03b7: dup
-		IL_03b8: ldc.i4.7
+		IL_03a6: ldc.i4.s 9
+		IL_03a8: ldloc.s 11
+		IL_03aa: stelem.ref
+		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_03b0: pop
+		IL_03b1: ldc.i4.s 10
+		IL_03b3: newarr [System.Runtime]System.Object
+		IL_03b8: dup
 		IL_03b9: ldc.i4.0
-		IL_03ba: box [System.Runtime]System.Boolean
-		IL_03bf: stelem.ref
-		IL_03c0: dup
-		IL_03c1: ldc.i4.8
-		IL_03c2: ldc.i4.0
-		IL_03c3: box [System.Runtime]System.Boolean
-		IL_03c8: stelem.ref
-		IL_03c9: dup
-		IL_03ca: ldc.i4.s 9
-		IL_03cc: ldloc.s 10
-		IL_03ce: stelem.ref
-		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_03d4: pop
-		IL_03d5: ldc.i4.s 10
-		IL_03d7: newarr [System.Runtime]System.Object
-		IL_03dc: dup
-		IL_03dd: ldc.i4.0
-		IL_03de: ldloc.s 9
-		IL_03e0: stelem.ref
-		IL_03e1: dup
-		IL_03e2: ldc.i4.1
-		IL_03e3: ldstr "countPrimes"
-		IL_03e8: stelem.ref
-		IL_03e9: dup
-		IL_03ea: ldc.i4.2
-		IL_03eb: ldstr "countPrimes"
-		IL_03f0: stelem.ref
-		IL_03f1: dup
-		IL_03f2: ldc.i4.3
-		IL_03f3: ldc.r8 0.0
-		IL_03fc: box [System.Runtime]System.Double
-		IL_0401: stelem.ref
-		IL_0402: dup
-		IL_0403: ldc.i4.4
-		IL_0404: ldstr "countPrimes"
+		IL_03ba: ldloc.s 10
+		IL_03bc: stelem.ref
+		IL_03bd: dup
+		IL_03be: ldc.i4.1
+		IL_03bf: ldstr "countPrimes"
+		IL_03c4: stelem.ref
+		IL_03c5: dup
+		IL_03c6: ldc.i4.2
+		IL_03c7: ldstr "countPrimes"
+		IL_03cc: stelem.ref
+		IL_03cd: dup
+		IL_03ce: ldc.i4.3
+		IL_03cf: ldc.r8 0.0
+		IL_03d8: box [System.Runtime]System.Double
+		IL_03dd: stelem.ref
+		IL_03de: dup
+		IL_03df: ldc.i4.4
+		IL_03e0: ldstr "countPrimes"
+		IL_03e5: stelem.ref
+		IL_03e6: dup
+		IL_03e7: ldc.i4.5
+		IL_03e8: ldc.i4.0
+		IL_03e9: box [System.Runtime]System.Boolean
+		IL_03ee: stelem.ref
+		IL_03ef: dup
+		IL_03f0: ldc.i4.6
+		IL_03f1: ldc.i4.0
+		IL_03f2: box [System.Runtime]System.Boolean
+		IL_03f7: stelem.ref
+		IL_03f8: dup
+		IL_03f9: ldc.i4.7
+		IL_03fa: ldc.i4.0
+		IL_03fb: box [System.Runtime]System.Boolean
+		IL_0400: stelem.ref
+		IL_0401: dup
+		IL_0402: ldc.i4.8
+		IL_0403: ldc.i4.0
+		IL_0404: box [System.Runtime]System.Boolean
 		IL_0409: stelem.ref
 		IL_040a: dup
-		IL_040b: ldc.i4.5
-		IL_040c: ldc.i4.0
-		IL_040d: box [System.Runtime]System.Boolean
-		IL_0412: stelem.ref
-		IL_0413: dup
-		IL_0414: ldc.i4.6
-		IL_0415: ldc.i4.0
-		IL_0416: box [System.Runtime]System.Boolean
-		IL_041b: stelem.ref
-		IL_041c: dup
-		IL_041d: ldc.i4.7
+		IL_040b: ldc.i4.s 9
+		IL_040d: ldloc.s 11
+		IL_040f: stelem.ref
+		IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0415: pop
+		IL_0416: ldc.i4.s 10
+		IL_0418: newarr [System.Runtime]System.Object
+		IL_041d: dup
 		IL_041e: ldc.i4.0
-		IL_041f: box [System.Runtime]System.Boolean
-		IL_0424: stelem.ref
-		IL_0425: dup
-		IL_0426: ldc.i4.8
-		IL_0427: ldc.i4.0
-		IL_0428: box [System.Runtime]System.Boolean
-		IL_042d: stelem.ref
-		IL_042e: dup
-		IL_042f: ldc.i4.s 9
-		IL_0431: ldloc.s 10
-		IL_0433: stelem.ref
-		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0439: pop
-		IL_043a: ldc.i4.s 10
-		IL_043c: newarr [System.Runtime]System.Object
-		IL_0441: dup
-		IL_0442: ldc.i4.0
-		IL_0443: ldloc.s 9
-		IL_0445: stelem.ref
-		IL_0446: dup
-		IL_0447: ldc.i4.1
-		IL_0448: ldstr "getPrimes"
-		IL_044d: stelem.ref
-		IL_044e: dup
-		IL_044f: ldc.i4.2
-		IL_0450: ldstr "getPrimes"
-		IL_0455: stelem.ref
-		IL_0456: dup
-		IL_0457: ldc.i4.3
-		IL_0458: ldc.r8 0.0
-		IL_0461: box [System.Runtime]System.Double
-		IL_0466: stelem.ref
-		IL_0467: dup
-		IL_0468: ldc.i4.4
-		IL_0469: ldstr "getPrimes"
+		IL_041f: ldloc.s 10
+		IL_0421: stelem.ref
+		IL_0422: dup
+		IL_0423: ldc.i4.1
+		IL_0424: ldstr "getPrimes"
+		IL_0429: stelem.ref
+		IL_042a: dup
+		IL_042b: ldc.i4.2
+		IL_042c: ldstr "getPrimes"
+		IL_0431: stelem.ref
+		IL_0432: dup
+		IL_0433: ldc.i4.3
+		IL_0434: ldc.r8 0.0
+		IL_043d: box [System.Runtime]System.Double
+		IL_0442: stelem.ref
+		IL_0443: dup
+		IL_0444: ldc.i4.4
+		IL_0445: ldstr "getPrimes"
+		IL_044a: stelem.ref
+		IL_044b: dup
+		IL_044c: ldc.i4.5
+		IL_044d: ldc.i4.0
+		IL_044e: box [System.Runtime]System.Boolean
+		IL_0453: stelem.ref
+		IL_0454: dup
+		IL_0455: ldc.i4.6
+		IL_0456: ldc.i4.0
+		IL_0457: box [System.Runtime]System.Boolean
+		IL_045c: stelem.ref
+		IL_045d: dup
+		IL_045e: ldc.i4.7
+		IL_045f: ldc.i4.0
+		IL_0460: box [System.Runtime]System.Boolean
+		IL_0465: stelem.ref
+		IL_0466: dup
+		IL_0467: ldc.i4.8
+		IL_0468: ldc.i4.0
+		IL_0469: box [System.Runtime]System.Boolean
 		IL_046e: stelem.ref
 		IL_046f: dup
-		IL_0470: ldc.i4.5
-		IL_0471: ldc.i4.0
-		IL_0472: box [System.Runtime]System.Boolean
-		IL_0477: stelem.ref
-		IL_0478: dup
-		IL_0479: ldc.i4.6
-		IL_047a: ldc.i4.0
-		IL_047b: box [System.Runtime]System.Boolean
-		IL_0480: stelem.ref
-		IL_0481: dup
-		IL_0482: ldc.i4.7
+		IL_0470: ldc.i4.s 9
+		IL_0472: ldloc.s 11
+		IL_0474: stelem.ref
+		IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_047a: pop
+		IL_047b: ldc.i4.s 10
+		IL_047d: newarr [System.Runtime]System.Object
+		IL_0482: dup
 		IL_0483: ldc.i4.0
-		IL_0484: box [System.Runtime]System.Boolean
-		IL_0489: stelem.ref
-		IL_048a: dup
-		IL_048b: ldc.i4.8
-		IL_048c: ldc.i4.0
-		IL_048d: box [System.Runtime]System.Boolean
-		IL_0492: stelem.ref
-		IL_0493: dup
-		IL_0494: ldc.i4.s 9
-		IL_0496: ldloc.s 10
-		IL_0498: stelem.ref
-		IL_0499: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_049e: pop
-		IL_049f: ldc.i4.s 10
-		IL_04a1: newarr [System.Runtime]System.Object
-		IL_04a6: dup
-		IL_04a7: ldc.i4.0
-		IL_04a8: ldloc.s 9
-		IL_04aa: stelem.ref
-		IL_04ab: dup
-		IL_04ac: ldc.i4.1
-		IL_04ad: ldstr "validatePrimeCount"
-		IL_04b2: stelem.ref
-		IL_04b3: dup
-		IL_04b4: ldc.i4.2
-		IL_04b5: ldstr "validatePrimeCount"
-		IL_04ba: stelem.ref
-		IL_04bb: dup
-		IL_04bc: ldc.i4.3
-		IL_04bd: ldc.r8 1
-		IL_04c6: box [System.Runtime]System.Double
-		IL_04cb: stelem.ref
-		IL_04cc: dup
-		IL_04cd: ldc.i4.4
-		IL_04ce: ldstr "validatePrimeCount"
+		IL_0484: ldloc.s 10
+		IL_0486: stelem.ref
+		IL_0487: dup
+		IL_0488: ldc.i4.1
+		IL_0489: ldstr "validatePrimeCount"
+		IL_048e: stelem.ref
+		IL_048f: dup
+		IL_0490: ldc.i4.2
+		IL_0491: ldstr "validatePrimeCount"
+		IL_0496: stelem.ref
+		IL_0497: dup
+		IL_0498: ldc.i4.3
+		IL_0499: ldc.r8 1
+		IL_04a2: box [System.Runtime]System.Double
+		IL_04a7: stelem.ref
+		IL_04a8: dup
+		IL_04a9: ldc.i4.4
+		IL_04aa: ldstr "validatePrimeCount"
+		IL_04af: stelem.ref
+		IL_04b0: dup
+		IL_04b1: ldc.i4.5
+		IL_04b2: ldc.i4.0
+		IL_04b3: box [System.Runtime]System.Boolean
+		IL_04b8: stelem.ref
+		IL_04b9: dup
+		IL_04ba: ldc.i4.6
+		IL_04bb: ldc.i4.0
+		IL_04bc: box [System.Runtime]System.Boolean
+		IL_04c1: stelem.ref
+		IL_04c2: dup
+		IL_04c3: ldc.i4.7
+		IL_04c4: ldc.i4.0
+		IL_04c5: box [System.Runtime]System.Boolean
+		IL_04ca: stelem.ref
+		IL_04cb: dup
+		IL_04cc: ldc.i4.8
+		IL_04cd: ldc.i4.0
+		IL_04ce: box [System.Runtime]System.Boolean
 		IL_04d3: stelem.ref
 		IL_04d4: dup
-		IL_04d5: ldc.i4.5
-		IL_04d6: ldc.i4.0
-		IL_04d7: box [System.Runtime]System.Boolean
-		IL_04dc: stelem.ref
-		IL_04dd: dup
-		IL_04de: ldc.i4.6
-		IL_04df: ldc.i4.0
-		IL_04e0: box [System.Runtime]System.Boolean
-		IL_04e5: stelem.ref
+		IL_04d5: ldc.i4.s 9
+		IL_04d7: ldloc.s 11
+		IL_04d9: stelem.ref
+		IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_04df: pop
+		IL_04e0: ldc.i4.1
+		IL_04e1: newarr [System.Runtime]System.Object
 		IL_04e6: dup
-		IL_04e7: ldc.i4.7
-		IL_04e8: ldc.i4.0
-		IL_04e9: box [System.Runtime]System.Boolean
-		IL_04ee: stelem.ref
-		IL_04ef: dup
-		IL_04f0: ldc.i4.8
-		IL_04f1: ldc.i4.0
-		IL_04f2: box [System.Runtime]System.Boolean
-		IL_04f7: stelem.ref
-		IL_04f8: dup
-		IL_04f9: ldc.i4.s 9
-		IL_04fb: ldloc.s 10
-		IL_04fd: stelem.ref
-		IL_04fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0503: pop
-		IL_0504: ldc.i4.1
-		IL_0505: newarr [System.Runtime]System.Object
-		IL_050a: dup
-		IL_050b: ldc.i4.0
-		IL_050c: ldloc.0
-		IL_050d: stelem.ref
-		IL_050e: stloc.s 10
-		IL_0510: ldloc.s 9
-		IL_0512: ldloc.s 10
-		IL_0514: ldc.r8 1
-		IL_051d: box [System.Runtime]System.Double
-		IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0527: stloc.s 6
-		IL_0529: ldloc.0
-		IL_052a: ldloc.s 6
-		IL_052c: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
-		IL_0531: ldloc.0
-		IL_0532: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0537: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object, object)
-		IL_053d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0542: ldc.i4.1
-		IL_0543: newarr [System.Runtime]System.Object
-		IL_0548: dup
-		IL_0549: ldc.i4.0
-		IL_054a: ldloc.0
-		IL_054b: stelem.ref
-		IL_054c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0556: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_055b: ldc.i4.1
-		IL_055c: conv.r8
-		IL_055d: ldstr ""
-		IL_0562: ldc.i4.0
-		IL_0563: ldc.i4.0
-		IL_0564: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_0569: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
-		IL_056e: stloc.s 11
-		IL_0570: ldloc.s 11
-		IL_0572: ldstr "runSieveBatch"
-		IL_0577: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_057c: stloc.3
-		IL_057d: ldloc.0
-		IL_057e: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0583: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_0589: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_058e: ldc.i4.1
-		IL_058f: newarr [System.Runtime]System.Object
-		IL_0594: dup
-		IL_0595: ldc.i4.0
-		IL_0596: ldloc.0
-		IL_0597: stelem.ref
-		IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_05a2: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_05a7: ldc.i4.1
-		IL_05a8: conv.r8
-		IL_05a9: ldstr ""
-		IL_05ae: ldc.i4.0
-		IL_05af: ldc.i4.0
-		IL_05b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_05b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_05ba: stloc.s 12
-		IL_05bc: ldloc.s 12
-		IL_05be: ldstr "main"
-		IL_05c3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_05c8: stloc.s 4
-		IL_05ca: ldloc.0
-		IL_05cb: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_05d0: ldnull
-		IL_05d1: ldloc.1
-		IL_05d2: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_05d7: pop
-		IL_05d8: ret
+		IL_04e7: ldc.i4.0
+		IL_04e8: ldloc.0
+		IL_04e9: stelem.ref
+		IL_04ea: stloc.s 11
+		IL_04ec: ldloc.s 10
+		IL_04ee: ldloc.s 11
+		IL_04f0: ldc.r8 1
+		IL_04f9: box [System.Runtime]System.Double
+		IL_04fe: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0503: stloc.s 7
+		IL_0505: ldloc.0
+		IL_0506: ldloc.s 7
+		IL_0508: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
+		IL_050d: ldloc.0
+		IL_050e: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_0513: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object, object)
+		IL_0519: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_051e: ldc.i4.1
+		IL_051f: newarr [System.Runtime]System.Object
+		IL_0524: dup
+		IL_0525: ldc.i4.0
+		IL_0526: ldloc.0
+		IL_0527: stelem.ref
+		IL_0528: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0532: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_0537: ldc.i4.1
+		IL_0538: conv.r8
+		IL_0539: ldstr ""
+		IL_053e: ldc.i4.0
+		IL_053f: ldc.i4.0
+		IL_0540: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_0545: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
+		IL_054a: stloc.s 12
+		IL_054c: ldloc.s 12
+		IL_054e: ldstr "runSieveBatch"
+		IL_0553: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0558: stloc.3
+		IL_0559: ldloc.0
+		IL_055a: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_055f: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_0565: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_056a: ldc.i4.1
+		IL_056b: newarr [System.Runtime]System.Object
+		IL_0570: dup
+		IL_0571: ldc.i4.0
+		IL_0572: ldloc.0
+		IL_0573: stelem.ref
+		IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_057e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0583: ldc.i4.1
+		IL_0584: conv.r8
+		IL_0585: ldstr ""
+		IL_058a: ldc.i4.0
+		IL_058b: ldc.i4.0
+		IL_058c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0591: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_0596: stloc.s 13
+		IL_0598: ldloc.s 13
+		IL_059a: ldstr "main"
+		IL_059f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_05a4: stloc.s 4
+		IL_05a6: ldloc.0
+		IL_05a7: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_05ac: ldnull
+		IL_05ad: ldloc.1
+		IL_05ae: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_05b3: pop
+		IL_05b4: ret
 	} // end of method Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes::__js_module_init__
 
 } // end of class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
@@ -2931,7 +2920,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x32c5
+		// Method begins at RVA 0x32a1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Require_Buffer_Undici_Core.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Require_Buffer_Undici_Core.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x249d
+			// Method begins at RVA 0x2479
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1089 (0x441)
+		// Code size: 1053 (0x41d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Buffer_Undici_Core/Scope,
@@ -159,220 +159,208 @@
 		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_014f: stloc.s 8
 		IL_0151: ldloc.s 4
-		IL_0153: ldstr "Buffer"
-		IL_0158: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_015d: brtrue IL_0170
-
-		IL_0162: ldloc.s 4
-		IL_0164: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IBufferModule::get_Buffer()
-		IL_0169: stloc.s 11
-		IL_016b: br IL_017e
-
-		IL_0170: ldloc.s 4
-		IL_0172: ldstr "Buffer"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_017c: stloc.s 11
-
-		IL_017e: ldloc.s 11
-		IL_0180: ldloc.1
-		IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0186: stloc.s 12
-		IL_0188: ldloc.s 12
-		IL_018a: box [System.Runtime]System.Boolean
-		IL_018f: stloc.s 13
-		IL_0191: ldloc.s 8
-		IL_0193: ldstr "log"
-		IL_0198: ldloc.s 13
-		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019f: pop
-		IL_01a0: ldstr "console"
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01af: stloc.s 8
-		IL_01b1: ldloc.s 5
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b8: ldstr "toString"
-		IL_01bd: ldstr "hex"
-		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c7: stloc.s 11
-		IL_01c9: ldloc.s 8
-		IL_01cb: ldstr "log"
-		IL_01d0: ldloc.s 11
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d7: pop
-		IL_01d8: ldstr "console"
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e7: stloc.s 11
-		IL_01e9: ldloc.s 6
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f0: ldstr "readUInt16BE"
-		IL_01f5: ldc.r8 2
-		IL_01fe: box [System.Runtime]System.Double
-		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0208: stloc.s 8
-		IL_020a: ldloc.s 11
-		IL_020c: ldstr "log"
-		IL_0211: ldloc.s 8
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0218: pop
-		IL_0219: ldstr "console"
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0228: stloc.s 8
-		IL_022a: ldloc.s 6
-		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0231: ldstr "subarray"
-		IL_0236: ldc.r8 0.0
-		IL_023f: box [System.Runtime]System.Double
-		IL_0244: ldc.r8 2
-		IL_024d: box [System.Runtime]System.Double
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0257: stloc.s 11
-		IL_0259: ldloc.s 11
-		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0260: ldstr "toString"
-		IL_0265: ldstr "hex"
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026f: stloc.s 11
-		IL_0271: ldloc.s 8
-		IL_0273: ldstr "log"
-		IL_0278: ldloc.s 11
-		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027f: pop
-		IL_0280: ldstr "console"
-		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028f: stloc.s 11
-		IL_0291: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0296: stloc.s 14
-		IL_0298: ldloc.1
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_029e: ldstr "from"
-		IL_02a3: ldstr "valid"
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ad: stloc.s 8
-		IL_02af: ldloc.2
-		IL_02b0: ldloc.s 14
-		IL_02b2: ldloc.s 8
-		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_02b9: stloc.s 8
-		IL_02bb: ldloc.s 11
-		IL_02bd: ldstr "log"
-		IL_02c2: ldloc.s 8
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c9: pop
-		IL_02ca: ldstr "console"
-		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d9: stloc.s 8
-		IL_02db: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02e0: stloc.s 14
-		IL_02e2: ldloc.1
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e8: ldc.i4.2
-		IL_02e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02ee: dup
-		IL_02ef: ldc.r8 195
-		IL_02f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02fd: dup
-		IL_02fe: ldc.r8 40
-		IL_0307: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_030c: stloc.s 9
-		IL_030e: ldstr "from"
-		IL_0313: ldloc.s 9
-		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_031a: stloc.s 11
-		IL_031c: ldloc.2
-		IL_031d: ldloc.s 14
-		IL_031f: ldloc.s 11
-		IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0326: stloc.s 11
-		IL_0328: ldloc.s 8
-		IL_032a: ldstr "log"
-		IL_032f: ldloc.s 11
-		IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0336: pop
-		IL_0337: ldstr "console"
-		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0346: stloc.s 11
-		IL_0348: ldloc.s 6
-		IL_034a: ldstr "byteLength"
-		IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0354: stloc.s 8
-		IL_0356: ldloc.s 11
-		IL_0358: ldstr "log"
-		IL_035d: ldloc.s 8
-		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0364: pop
-		IL_0365: ldstr "console"
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0374: stloc.s 8
-		IL_0376: ldloc.s 6
-		IL_0378: ldstr "buffer"
-		IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0382: stloc.s 11
-		IL_0384: ldloc.s 11
-		IL_0386: ldstr "byteLength"
-		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0390: stloc.s 11
-		IL_0392: ldloc.s 8
-		IL_0394: ldstr "log"
-		IL_0399: ldloc.s 11
-		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03a0: pop
-		IL_03a1: ldstr "console"
-		IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b0: stloc.s 11
-		IL_03b2: ldloc.s 6
-		IL_03b4: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_03b9: ldc.i4.1
-		IL_03ba: newarr [System.Runtime]System.Object
-		IL_03bf: dup
-		IL_03c0: ldc.i4.0
-		IL_03c1: ldstr ","
-		IL_03c6: stelem.ref
-		IL_03c7: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_03cc: stloc.s 15
-		IL_03ce: ldloc.s 11
-		IL_03d0: ldstr "log"
-		IL_03d5: ldloc.s 15
-		IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03dc: pop
-		IL_03dd: ldstr "console"
-		IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03ec: stloc.s 11
-		IL_03ee: ldloc.s 6
-		IL_03f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_03f5: stloc.s 16
-		IL_03f7: ldloc.s 16
-		IL_03f9: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
-		IL_03fe: stloc.s 17
-		IL_0400: ldloc.s 17
-		IL_0402: box [System.Runtime]System.Double
-		IL_0407: stloc.s 18
-		IL_0409: ldloc.s 11
-		IL_040b: ldstr "log"
-		IL_0410: ldloc.s 18
-		IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0417: pop
-		IL_0418: ldstr "console"
-		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0427: stloc.s 11
-		IL_0429: ldloc.3
-		IL_042a: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_042f: stloc.s 15
-		IL_0431: ldloc.s 11
-		IL_0433: ldstr "log"
-		IL_0438: ldloc.s 15
-		IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_043f: pop
-		IL_0440: ret
+		IL_0153: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IBufferModule::get_Buffer()
+		IL_0158: stloc.s 11
+		IL_015a: ldloc.s 11
+		IL_015c: ldloc.1
+		IL_015d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0162: stloc.s 12
+		IL_0164: ldloc.s 12
+		IL_0166: box [System.Runtime]System.Boolean
+		IL_016b: stloc.s 13
+		IL_016d: ldloc.s 8
+		IL_016f: ldstr "log"
+		IL_0174: ldloc.s 13
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017b: pop
+		IL_017c: ldstr "console"
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018b: stloc.s 8
+		IL_018d: ldloc.s 5
+		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0194: ldstr "toString"
+		IL_0199: ldstr "hex"
+		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a3: stloc.s 11
+		IL_01a5: ldloc.s 8
+		IL_01a7: ldstr "log"
+		IL_01ac: ldloc.s 11
+		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b3: pop
+		IL_01b4: ldstr "console"
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c3: stloc.s 11
+		IL_01c5: ldloc.s 6
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01cc: ldstr "readUInt16BE"
+		IL_01d1: ldc.r8 2
+		IL_01da: box [System.Runtime]System.Double
+		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e4: stloc.s 8
+		IL_01e6: ldloc.s 11
+		IL_01e8: ldstr "log"
+		IL_01ed: ldloc.s 8
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f4: pop
+		IL_01f5: ldstr "console"
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0204: stloc.s 8
+		IL_0206: ldloc.s 6
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020d: ldstr "subarray"
+		IL_0212: ldc.r8 0.0
+		IL_021b: box [System.Runtime]System.Double
+		IL_0220: ldc.r8 2
+		IL_0229: box [System.Runtime]System.Double
+		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0233: stloc.s 11
+		IL_0235: ldloc.s 11
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_023c: ldstr "toString"
+		IL_0241: ldstr "hex"
+		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024b: stloc.s 11
+		IL_024d: ldloc.s 8
+		IL_024f: ldstr "log"
+		IL_0254: ldloc.s 11
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025b: pop
+		IL_025c: ldstr "console"
+		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_026b: stloc.s 11
+		IL_026d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0272: stloc.s 14
+		IL_0274: ldloc.1
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_027a: ldstr "from"
+		IL_027f: ldstr "valid"
+		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0289: stloc.s 8
+		IL_028b: ldloc.2
+		IL_028c: ldloc.s 14
+		IL_028e: ldloc.s 8
+		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0295: stloc.s 8
+		IL_0297: ldloc.s 11
+		IL_0299: ldstr "log"
+		IL_029e: ldloc.s 8
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a5: pop
+		IL_02a6: ldstr "console"
+		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b5: stloc.s 8
+		IL_02b7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02bc: stloc.s 14
+		IL_02be: ldloc.1
+		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c4: ldc.i4.2
+		IL_02c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02ca: dup
+		IL_02cb: ldc.r8 195
+		IL_02d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02d9: dup
+		IL_02da: ldc.r8 40
+		IL_02e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02e8: stloc.s 9
+		IL_02ea: ldstr "from"
+		IL_02ef: ldloc.s 9
+		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02f6: stloc.s 11
+		IL_02f8: ldloc.2
+		IL_02f9: ldloc.s 14
+		IL_02fb: ldloc.s 11
+		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0302: stloc.s 11
+		IL_0304: ldloc.s 8
+		IL_0306: ldstr "log"
+		IL_030b: ldloc.s 11
+		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0312: pop
+		IL_0313: ldstr "console"
+		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0322: stloc.s 11
+		IL_0324: ldloc.s 6
+		IL_0326: ldstr "byteLength"
+		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0330: stloc.s 8
+		IL_0332: ldloc.s 11
+		IL_0334: ldstr "log"
+		IL_0339: ldloc.s 8
+		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0340: pop
+		IL_0341: ldstr "console"
+		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0350: stloc.s 8
+		IL_0352: ldloc.s 6
+		IL_0354: ldstr "buffer"
+		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_035e: stloc.s 11
+		IL_0360: ldloc.s 11
+		IL_0362: ldstr "byteLength"
+		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_036c: stloc.s 11
+		IL_036e: ldloc.s 8
+		IL_0370: ldstr "log"
+		IL_0375: ldloc.s 11
+		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_037c: pop
+		IL_037d: ldstr "console"
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_038c: stloc.s 11
+		IL_038e: ldloc.s 6
+		IL_0390: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0395: ldc.i4.1
+		IL_0396: newarr [System.Runtime]System.Object
+		IL_039b: dup
+		IL_039c: ldc.i4.0
+		IL_039d: ldstr ","
+		IL_03a2: stelem.ref
+		IL_03a3: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_03a8: stloc.s 15
+		IL_03aa: ldloc.s 11
+		IL_03ac: ldstr "log"
+		IL_03b1: ldloc.s 15
+		IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03b8: pop
+		IL_03b9: ldstr "console"
+		IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03c8: stloc.s 11
+		IL_03ca: ldloc.s 6
+		IL_03cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_03d1: stloc.s 16
+		IL_03d3: ldloc.s 16
+		IL_03d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
+		IL_03da: stloc.s 17
+		IL_03dc: ldloc.s 17
+		IL_03de: box [System.Runtime]System.Double
+		IL_03e3: stloc.s 18
+		IL_03e5: ldloc.s 11
+		IL_03e7: ldstr "log"
+		IL_03ec: ldloc.s 18
+		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03f3: pop
+		IL_03f4: ldstr "console"
+		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0403: stloc.s 11
+		IL_0405: ldloc.3
+		IL_0406: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_040b: stloc.s 15
+		IL_040d: ldloc.s 11
+		IL_040f: ldstr "log"
+		IL_0414: ldloc.s 15
+		IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_041b: pop
+		IL_041c: ret
 	} // end of method Require_Buffer_Undici_Core::__js_module_init__
 
 } // end of class Modules.Require_Buffer_Undici_Core
@@ -384,7 +372,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24a6
+		// Method begins at RVA 0x2482
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Snapshots/GeneratorTests.PerfHooks_PerformanceNow_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Snapshots/GeneratorTests.PerfHooks_PerformanceNow_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2225
+				// Method begins at RVA 0x2265
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222e
+				// Method begins at RVA 0x226e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2237
+				// Method begins at RVA 0x2277
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x221c
+			// Method begins at RVA 0x225c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -102,11 +102,11 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 431 (0x1af)
+		// Code size: 494 (0x1ee)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.PerfHooks_PerformanceNow_Basic/Scope,
-			[1] object,
+			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance,
 			[2] object,
 			[3] float64,
 			[4] float64,
@@ -144,144 +144,170 @@
 		IL_0033: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
 		IL_0038: ldloc.s 12
-		IL_003a: ldstr "performance"
-		IL_003f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_0044: brtrue IL_0056
+		IL_003a: callvirt instance class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule::get_performance()
+		IL_003f: stloc.1
+		IL_0040: ldloc.1
+		IL_0041: ldstr "now"
+		IL_0046: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_004b: brtrue IL_0061
 
-		IL_0049: ldloc.s 12
-		IL_004b: callvirt instance class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule::get_performance()
-		IL_0050: stloc.1
-		IL_0051: br IL_0063
+		IL_0050: ldloc.1
+		IL_0051: callvirt instance float64 [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance::now()
+		IL_0056: box [System.Runtime]System.Double
+		IL_005b: stloc.2
+		IL_005c: br IL_0073
 
-		IL_0056: ldloc.s 12
-		IL_0058: ldstr "performance"
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0062: stloc.1
+		IL_0061: ldloc.1
+		IL_0062: ldstr "now"
+		IL_0067: ldc.i4.0
+		IL_0068: newarr [System.Runtime]System.Object
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+		IL_0072: stloc.2
 
-		IL_0063: ldloc.1
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0069: ldstr "now"
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0073: stloc.2
-		IL_0074: ldc.r8 0.0
-		IL_007d: stloc.3
-		IL_007e: ldc.r8 0.0
-		IL_0087: stloc.s 4
-		// loop start (head: IL_0089)
-			IL_0089: ldloc.s 4
-			IL_008b: stloc.s 13
-			IL_008d: ldloc.s 13
-			IL_008f: ldc.r8 10000
-			IL_0098: clt
-			IL_009a: brfalse IL_00c7
+		IL_0073: ldc.r8 0.0
+		IL_007c: stloc.3
+		IL_007d: ldc.r8 0.0
+		IL_0086: stloc.s 4
+		// loop start (head: IL_0088)
+			IL_0088: ldloc.s 4
+			IL_008a: stloc.s 13
+			IL_008c: ldloc.s 13
+			IL_008e: ldc.r8 10000
+			IL_0097: clt
+			IL_0099: brfalse IL_00c6
 
-			IL_009f: ldloc.3
-			IL_00a0: stloc.s 13
-			IL_00a2: ldloc.s 13
-			IL_00a4: ldloc.s 4
-			IL_00a6: add
-			IL_00a7: stloc.s 13
-			IL_00a9: ldloc.s 13
-			IL_00ab: stloc.3
-			IL_00ac: ldloc.s 4
-			IL_00ae: stloc.s 13
-			IL_00b0: ldloc.s 13
-			IL_00b2: ldc.r8 1
-			IL_00bb: add
-			IL_00bc: stloc.s 13
-			IL_00be: ldloc.s 13
-			IL_00c0: stloc.s 4
-			IL_00c2: br IL_0089
+			IL_009e: ldloc.3
+			IL_009f: stloc.s 13
+			IL_00a1: ldloc.s 13
+			IL_00a3: ldloc.s 4
+			IL_00a5: add
+			IL_00a6: stloc.s 13
+			IL_00a8: ldloc.s 13
+			IL_00aa: stloc.3
+			IL_00ab: ldloc.s 4
+			IL_00ad: stloc.s 13
+			IL_00af: ldloc.s 13
+			IL_00b1: ldc.r8 1
+			IL_00ba: add
+			IL_00bb: stloc.s 13
+			IL_00bd: ldloc.s 13
+			IL_00bf: stloc.s 4
+			IL_00c1: br IL_0088
 		// end loop
 
-		IL_00c7: ldloc.1
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cd: ldstr "now"
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00d7: stloc.s 5
-		IL_00d9: ldc.i4.1
-		IL_00da: stloc.s 6
+		IL_00c6: ldloc.1
+		IL_00c7: ldstr "now"
+		IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_00d1: brtrue IL_00e8
+
+		IL_00d6: ldloc.1
+		IL_00d7: callvirt instance float64 [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance::now()
+		IL_00dc: box [System.Runtime]System.Double
+		IL_00e1: stloc.s 5
+		IL_00e3: br IL_00fb
+
+		IL_00e8: ldloc.1
+		IL_00e9: ldstr "now"
+		IL_00ee: ldc.i4.0
+		IL_00ef: newarr [System.Runtime]System.Object
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+		IL_00f9: stloc.s 5
+
+		IL_00fb: ldc.i4.1
+		IL_00fc: stloc.s 6
 		.try
 		{
-			IL_00dc: nop
-			IL_00dd: ldloc.1
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e3: ldstr "now"
-			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_00ed: pop
-			IL_00ee: leave IL_012d
+			IL_00fe: nop
+			IL_00ff: ldloc.1
+			IL_0100: ldstr "now"
+			IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_010a: brtrue IL_011b
+
+			IL_010f: ldloc.1
+			IL_0110: callvirt instance float64 [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance::now()
+			IL_0115: pop
+			IL_0116: br IL_012d
+
+			IL_011b: ldloc.1
+			IL_011c: ldstr "now"
+			IL_0121: ldc.i4.0
+			IL_0122: newarr [System.Runtime]System.Object
+			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_012c: pop
+
+			IL_012d: leave IL_016c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00f3: stloc.s 7
-			IL_00f5: ldloc.s 7
-			IL_00f7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00fc: dup
-			IL_00fd: brtrue IL_0113
+			IL_0132: stloc.s 7
+			IL_0134: ldloc.s 7
+			IL_0136: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_013b: dup
+			IL_013c: brtrue IL_0152
 
-			IL_0102: pop
-			IL_0103: ldloc.s 7
-			IL_0105: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_010a: dup
-			IL_010b: brtrue IL_011f
+			IL_0141: pop
+			IL_0142: ldloc.s 7
+			IL_0144: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0149: dup
+			IL_014a: brtrue IL_015e
 
-			IL_0110: pop
-			IL_0111: rethrow
+			IL_014f: pop
+			IL_0150: rethrow
 
-			IL_0113: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0118: stloc.s 8
-			IL_011a: br IL_0121
+			IL_0152: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0157: stloc.s 8
+			IL_0159: br IL_0160
 
-			IL_011f: stloc.s 8
+			IL_015e: stloc.s 8
 
-			IL_0121: ldloc.s 8
-			IL_0123: stloc.s 9
-			IL_0125: ldc.i4.0
-			IL_0126: stloc.s 6
-			IL_0128: leave IL_012d
+			IL_0160: ldloc.s 8
+			IL_0162: stloc.s 9
+			IL_0164: ldc.i4.0
+			IL_0165: stloc.s 6
+			IL_0167: leave IL_016c
 		} // end handler
 
-		IL_012d: ldloc.s 5
-		IL_012f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0134: ldloc.2
-		IL_0135: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_013a: sub
-		IL_013b: stloc.s 10
-		IL_013d: ldstr "console"
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014c: ldloc.s 6
-		IL_014e: box [System.Runtime]System.Boolean
-		IL_0153: stloc.s 14
-		IL_0155: ldstr "log"
-		IL_015a: ldstr "hasNow="
-		IL_015f: ldloc.s 14
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0166: pop
-		IL_0167: ldstr "console"
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0176: stloc.s 15
-		IL_0178: ldloc.s 10
-		IL_017a: ldc.r8 0.0
-		IL_0183: clt
-		IL_0185: stloc.s 16
-		IL_0187: ldloc.s 16
-		IL_0189: ldc.i4.0
-		IL_018a: ceq
-		IL_018c: stloc.s 16
-		IL_018e: ldloc.s 16
-		IL_0190: box [System.Runtime]System.Boolean
-		IL_0195: stloc.s 14
-		IL_0197: ldloc.s 15
-		IL_0199: ldstr "log"
-		IL_019e: ldstr "elapsedMsNonNegative="
-		IL_01a3: ldloc.s 14
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01aa: pop
-		IL_01ab: ldnull
-		IL_01ac: stloc.s 11
-		IL_01ae: ret
+		IL_016c: ldloc.s 5
+		IL_016e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0173: ldloc.2
+		IL_0174: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0179: sub
+		IL_017a: stloc.s 10
+		IL_017c: ldstr "console"
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018b: ldloc.s 6
+		IL_018d: box [System.Runtime]System.Boolean
+		IL_0192: stloc.s 14
+		IL_0194: ldstr "log"
+		IL_0199: ldstr "hasNow="
+		IL_019e: ldloc.s 14
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01a5: pop
+		IL_01a6: ldstr "console"
+		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b5: stloc.s 15
+		IL_01b7: ldloc.s 10
+		IL_01b9: ldc.r8 0.0
+		IL_01c2: clt
+		IL_01c4: stloc.s 16
+		IL_01c6: ldloc.s 16
+		IL_01c8: ldc.i4.0
+		IL_01c9: ceq
+		IL_01cb: stloc.s 16
+		IL_01cd: ldloc.s 16
+		IL_01cf: box [System.Runtime]System.Boolean
+		IL_01d4: stloc.s 14
+		IL_01d6: ldloc.s 15
+		IL_01d8: ldstr "log"
+		IL_01dd: ldstr "elapsedMsNonNegative="
+		IL_01e2: ldloc.s 14
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01e9: pop
+		IL_01ea: ldnull
+		IL_01eb: stloc.s 11
+		IL_01ed: ret
 	} // end of method PerfHooks_PerformanceNow_Basic::__js_module_init__
 
 } // end of class Modules.PerfHooks_PerformanceNow_Basic
@@ -293,7 +319,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2240
+		// Method begins at RVA 0x2280
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary
- propagate whole-program Node module override-safety proofs to direct destructuring `require` calls
- emit direct nested contract property getters for pristine module imports, including `perf_hooks.performance`
- preserve dynamic override dispatch when a cached module can be aliased, mutated, deleted, reflected on, escaped, or dynamically required

Closes #1698

## Validation
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --nologo --filter "FullyQualifiedName~PrimeJavaScript|FullyQualifiedName~PerfHooks_DestructuredPerformanceOverride"`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --nologo --filter "FullyQualifiedName~Jroc.Tests.Node"`
- `dotnet build --no-restore --nologo`