### PR TITLE
docs(skills): add benchmark performance investigation guide

### DIFF
--- a/.github/skills/investigating-benchmark-performance/SKILL.md
+++ b/.github/skills/investigating-benchmark-performance/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: investigating-benchmark-performance
+description: Investigate JROC benchmark performance with local artifacts, GitHub workflow provenance, and Supabase perf_results data.
+tier: standard
+applyTo: 'tests/performance/**,.github/workflows/benchmarkdotnet-suite.yml,.github/workflows/mitata-suite.yml,.github/workflows/performance-comparison.yml'
+---
+
+# Investigating Benchmark Performance
+
+Use this skill when investigating a performance regression, improvement, or
+cross-runtime comparison. Start with the generated IL and benchmark artifact
+for the exact scenario before drawing conclusions from aggregate results.
+
+## Data Sources
+
+GitHub Actions ingests benchmark results into the Supabase `perf_results`
+table. The shared ingestion implementation is
+`tests/performance/ingestPerfToSupabase.js`.
+
+| Workflow | Source | Input |
+| --- | --- | --- |
+| `.github/workflows/benchmarkdotnet-suite.yml` | `benchmarkdotnet` | `tests/performance/Benchmarks/BenchmarkDotNet.Artifacts/results/*.json` |
+| `.github/workflows/mitata-suite.yml` | `mitata` | `tests/performance/mitata/results.json` |
+| `.github/workflows/performance-comparison.yml` | `prime-script` | `tests/performance/results.json` |
+
+The BenchmarkDotNet and Mitata workflows run for published releases and can
+also be dispatched manually. The Prime comparison workflow is manually
+dispatchable. Workflow ingestion is best-effort (`continue-on-error`), so
+verify that a workflow produced its artifact before treating a missing table
+row as a benchmark failure.
+
+## Local Supabase Access
+
+Development desktops can use these environment variables for read-only
+analysis:
+
+```bash
+export SUPABASE_URL="https://<project>.supabase.co"
+export SUPABASE_PUBLISHABLE_KEY="<publishable-key>"
+```
+
+Neither Bash nor Copilot automatically loads a project `.env` file. If a
+developer stores these values in an ignored local `.env`, they must load it
+explicitly in a trusted shell before running analysis commands.
+
+Never print either value, commit it, or place it in generated reports. Do not
+use the CI-only `SUPABASE_SERVICE_ROLE_KEY` for desktop analysis. The workflow
+ingester requires the service role key because it upserts rows; the publishable
+key is appropriate only when the database's row-level security policy permits
+the desired reads.
+
+Example query for recent rows:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  "$SUPABASE_URL/rest/v1/perf_results?select=run_at,source,scenario,runtime,metric,value,unit,branch,sha&order=run_at.desc&limit=100" \
+  -H "apikey: $SUPABASE_PUBLISHABLE_KEY" \
+  -H "Authorization: Bearer $SUPABASE_PUBLISHABLE_KEY" |
+  jq .
+```
+
+Filter at the database whenever possible. For example, compare the latest
+`mean_ns` rows for a scenario:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  "$SUPABASE_URL/rest/v1/perf_results?source=eq.benchmarkdotnet&scenario=eq.prime-javascript&metric=eq.mean_ns&order=run_at.desc&limit=100" \
+  -H "apikey: $SUPABASE_PUBLISHABLE_KEY" \
+  -H "Authorization: Bearer $SUPABASE_PUBLISHABLE_KEY" |
+  jq .
+```
+
+Use URL encoding for filter values that contain spaces or punctuation. When
+reading a large result set, constrain `source`, `scenario`, `metric`, and a
+recent time range; do not fetch the full table by default.
+
+## `perf_results` Ingestion Schema
+
+The checked-in ingester is the authoritative write contract. It writes one row
+per metric, not one row per benchmark case. The conflict identity is:
+
+```text
+(run_id, run_attempt, source, scenario, runtime, metric)
+```
+
+Core columns written by every row:
+
+| Column | Value |
+| --- | --- |
+| `run_id` | GitHub Actions run ID, or a local timestamp-derived ID |
+| `run_attempt` | GitHub run attempt; `1` locally |
+| `workflow` | GitHub workflow name, or `local` |
+| `repo` | `owner/repository`, or `local/local` |
+| `branch` | Git ref name; may be null |
+| `sha` | Commit SHA, or `local` |
+| `source` | `benchmarkdotnet`, `mitata`, or `prime-script` |
+| `scenario` | Lowercase slug for the benchmark/script scenario |
+| `runtime` | Normalized runtime identity |
+| `runtime_version` | Version matched to the normalized runtime when known; may be null |
+| `metric` | Measurement name |
+| `value` | Numeric measurement |
+| `unit` | Unit for `value` |
+| `run_at` | Source timestamp or ingestion timestamp |
+| `meta` | Source-specific JSON metadata |
+
+The current schema may also have these structured host columns:
+
+```text
+os_type, os_platform, os_release, os_version, os_arch,
+cpu_model, cpu_logical_cores, total_memory_bytes,
+runner_os, runner_arch, github_image_os, github_image_version
+```
+
+They are optional for backward compatibility: if the deployed table does not
+yet have them, the ingester retries with these columns and `runtime_version`
+removed, retaining the data in `meta`. Do not assume a structured host column
+exists without checking the deployed schema or an actual returned row.
+
+The table can have database-managed columns (for example an ID or creation
+timestamp) that are not supplied by the ingester. Obtain exact SQL types,
+constraints, indexes, and row-level-security policies from the Supabase
+dashboard or the database migration/schema source; do not infer them from the
+REST payload.
+
+## Metric Catalog
+
+| Source | Metrics |
+| --- | --- |
+| `benchmarkdotnet` | `mean_ns`, `median_ns`, `stddev_ns`, `allocated_bytes`, `allocated_native_memory_bytes`, `gen0_collections_per_1000_ops`, `gen1_collections_per_1000_ops`, `gen2_collections_per_1000_ops` |
+| `mitata` | `avg_ns`, `total_ns`, `iterations`, `error` |
+| `prime-script` | `passes`, `passes_per_second`, `compile_duration_ms` |
+
+Interpret lower values as better for duration/allocation/GC metrics and higher
+values as better for `passes_per_second`. Never compare values across different
+metrics or units.
+
+Runtime names are normalized by the ingester. Relevant examples include
+`jroc`, `jroc-compile`, `jroc-execute`, `jroc-total`, `node`, `jint`,
+`jint-prepare`, `jint-execute`, `jint-execute-prepared`, `clearscript`,
+`yantrajs`, and `yantrajs-execute`.
+
+## Investigation Workflow
+
+1. Identify the exact scenario, source, metric, runtime, commit SHA, and
+   runner/host. Do not compare unrelated benchmark types or machines.
+2. Retrieve the matching workflow artifact and inspect the raw JSON before
+   querying aggregate table results.
+3. Query recent comparable rows using the same `source`, `scenario`, `metric`,
+   runtime, and host metadata. Compare several runs to account for noise.
+4. Inspect the generated IL snapshot or disassembly for the scenario. For
+   compiler changes, explain which call, allocation, coercion, or branch
+   changed in the hot path.
+5. Reproduce locally only with the documented single-scenario benchmark
+   command. For Dromaeo use:
+
+   ```bash
+   node scripts/runPhasedBenchmarkScenario.js <scenario>
+   ```
+
+6. Report the result with provenance: workflow run, SHA, source, scenario,
+   metric/unit, runtime version, host, and sample size. State uncertainty when
+   data is sparse or runners differ.
+
+## Guardrails
+
+- Do not claim a compiler optimization caused a benchmark change without an IL
+  or runtime-path explanation.
+- Treat release and manually dispatched runs separately unless versions, SHA,
+  runtime, host, and benchmark parameters match.
+- Preserve JavaScript semantics over a benchmark-only optimization. Dynamic
+  property overrides, aliases, and escape paths must retain their fallback
+  behavior.
+- Do not write to Supabase from a development desktop unless the task
+  explicitly requires ingestion and the correct credentials and policy are
+  available.


### PR DESCRIPTION
Adds a project skill for investigating benchmark regressions and comparisons using local artifacts, workflow provenance, and Supabase performance data.