### PR TITLE
test(architecture): establish callable representation baselines

### DIFF
--- a/docs/compiler/CallableArchitectureBaselines.md
+++ b/docs/compiler/CallableArchitectureBaselines.md
@@ -1,0 +1,86 @@
+# Callable architecture baselines
+
+This document defines the baseline used while replacing delegate-backed
+compiled functions under issue #1707. It separates semantic compatibility,
+generated signatures, callable materialization, and steady-state invocation so
+later changes cannot trade one dimension for another without visible evidence.
+
+## Boundary inventory
+
+`CallableBoundaryInventory.json` classifies the current compiler and runtime
+callable producers and consumers as direct calls, materialization, dynamic
+calls, construction, callbacks, export/interop, or reflection. Each entry maps
+to one or more #1707 implementation issues.
+
+`CallableBoundaryInventoryTests` scans source files for the current callable
+markers and fails when a detected boundary is not covered by the inventory. Add
+or refine an inventory entry whenever a callable boundary moves or a new one is
+introduced.
+
+## Semantic baseline
+
+`Function_CallableArchitecture_SemanticBaseline.js` locks the behavior that
+must survive representation changes:
+
+- function identity across repeated evaluations;
+- shared mutable captures and independent closure instances;
+- ordinary and lexical `this`;
+- recursion and callback reentrancy;
+- `new.target`, constructability, and arrow non-constructability;
+- function `length` descriptors;
+- proxy `apply`;
+- runtime callback invocation.
+
+The execution snapshot records observable behavior. The inferred-signature
+generator snapshot below records representative IL and delegate materialization
+paths so each migration can show exactly what changed.
+
+## Inferred signature baseline
+
+`Function_CallableArchitecture_InferredSignatureBaseline.js` and its generator
+test inspect the emitted `__js_call__` methods directly.
+
+| Callable | Emitted return | Emitted JavaScript parameters | Baseline purpose |
+| --- | --- | --- | --- |
+| `returnNumber` | `double` | none | Typed zero-argument numeric return |
+| `returnBoolean` | `object` | none | Inferred boolean currently adapted through the generic return ABI |
+| `negate` | `object` | `bool` | Typed boolean parameter with generic return |
+| `returnString` | `object` | none | Inferred string currently adapted through the generic return ABI |
+| `stringLength` | `object` | `string` | Typed string parameter with generic return |
+| `identity` | `object` | `object` | Polymorphic fallback |
+
+The object-return rows are intentional records of current adapter boundaries,
+not the desired final architecture. Generated function-object work must retain
+the typed rows and make any widening or boxing at the generic adapter boundary
+explicit.
+
+## Performance baseline
+
+Run the focused BenchmarkDotNet pair:
+
+```bash
+dotnet run -c Release \
+  --project tests/performance/Benchmarks/Benchmarks.csproj -- \
+  --callable-baselines --filter '*'
+```
+
+`Arrow delegate materialization` calls the current `Closure.BindArrow` path for
+every benchmark operation. It isolates expression-tree compilation,
+`DynamicMethod` creation, delegate setup, and callable metadata allocation from
+module startup and runtime teardown.
+
+`Loaded module direct-call loop` loads the same module once during setup, then
+invokes an exported loop containing 1,000 direct calls to a compiled function.
+The single host invocation is amortized across those calls and
+`OperationsPerInvoke` reports normalized per-call timing and allocation.
+
+A reference ShortRun on 2026-08-05 used .NET 10.0.10 on Linux x64:
+
+| Phase | Mean | Allocated |
+| --- | ---: | ---: |
+| Arrow delegate materialization | 150.743 us | 5,841 B |
+| Loaded module direct-call loop | 163.9 ns | 89 B |
+
+These values are diagnostic reference points, not cross-machine pass/fail
+thresholds. Compare changes on the same host and commit configuration, and
+retain the end-to-end Dromaeo benchmarks for user-visible performance claims.

--- a/docs/compiler/CallableBoundaryInventory.json
+++ b/docs/compiler/CallableBoundaryInventory.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": 1,
+  "umbrellaIssue": 1707,
+  "boundaries": [
+    {
+      "id": "compiler-callable-planning",
+      "roles": [ "producer", "consumer" ],
+      "classifications": [ "direct-call", "materialization" ],
+      "trackingIssues": [ 1711, 1712, 1721 ],
+      "sourceGlobs": [
+        "src/Compiler/Services/TwoPhaseCompilation/*.cs"
+      ],
+      "rationale": "Discovers every compiled callable, plans signatures and dependency order, and allocates the metadata tokens used by direct calls and materialized values."
+    },
+    {
+      "id": "compiler-invocation-lowering",
+      "roles": [ "producer", "consumer" ],
+      "classifications": [ "direct-call", "materialization", "dynamic-call", "construction" ],
+      "trackingIssues": [ 768, 1710, 1713, 1721 ],
+      "sourceGlobs": [
+        "src/Compiler/IR/*.cs",
+        "src/Compiler/IR/**/*.cs",
+        "src/Compiler/IL/*.cs"
+      ],
+      "rationale": "Chooses direct, dynamic, member, spread, and construction call paths and emits their IL."
+    },
+    {
+      "id": "compiler-callable-generators",
+      "roles": [ "producer", "consumer" ],
+      "classifications": [ "direct-call", "materialization", "construction" ],
+      "trackingIssues": [ 1706, 1711, 1712, 1713, 1714, 1717, 1718 ],
+      "sourceGlobs": [
+        "src/Compiler/JsMethodCompiler.cs",
+        "src/Compiler/Services/ILGenerators/*.cs"
+      ],
+      "rationale": "Emits function, arrow, class, async, and generator bodies plus the current delegate materialization sites."
+    },
+    {
+      "id": "compiler-callable-support",
+      "roles": [ "producer", "consumer" ],
+      "classifications": [ "direct-call", "materialization", "dynamic-call", "export-interop", "reflection" ],
+      "trackingIssues": [ 1709, 1711, 1720, 1722 ],
+      "sourceGlobs": [
+        "src/Compiler/Services/AssemblyGenerator.cs",
+        "src/Compiler/Services/BaseClassLibraryReferences.cs",
+        "src/Compiler/Services/Runtime.cs",
+        "src/Compiler/Services/TypeGenerator.cs",
+        "src/Compiler/Services/Contracts/*.cs",
+        "src/Compiler/Utilities/Ecma335/*.cs",
+        "src/Compiler/Utilities/JavaScriptCallableNaming.cs"
+      ],
+      "rationale": "Defines delegate/runtime references, emitted module contracts, and CLR metadata used to expose callable values."
+    },
+    {
+      "id": "runtime-core-callables",
+      "roles": [ "producer", "consumer" ],
+      "classifications": [ "materialization", "dynamic-call", "construction", "callback", "reflection" ],
+      "trackingIssues": [ 1709, 1710, 1713, 1715, 1716, 1717, 1718, 1719, 1722 ],
+      "sourceGlobs": [
+        "src/JavaScriptRuntime/*.cs"
+      ],
+      "rationale": "Contains Closure, Function, object/proxy operations, async/generator runtime support, built-in callables, and callback dispatch."
+    },
+    {
+      "id": "runtime-engine-callbacks",
+      "roles": [ "consumer" ],
+      "classifications": [ "dynamic-call", "callback", "export-interop" ],
+      "trackingIssues": [ 1719, 1720 ],
+      "sourceGlobs": [
+        "src/JavaScriptRuntime/Engine/*.cs"
+      ],
+      "rationale": "Stores and dispatches callbacks on the runtime scheduler while preserving module-hosting lifetime and thread affinity."
+    },
+    {
+      "id": "runtime-node-callbacks",
+      "roles": [ "producer", "consumer" ],
+      "classifications": [ "dynamic-call", "construction", "callback" ],
+      "trackingIssues": [ 1709, 1719 ],
+      "sourceGlobs": [
+        "src/JavaScriptRuntime/Node/*.cs",
+        "src/JavaScriptRuntime/Node/**/*.cs"
+      ],
+      "rationale": "Accepts, stores, invokes, and occasionally constructs JavaScript-visible callbacks across Node module APIs."
+    },
+    {
+      "id": "runtime-hosting-exports",
+      "roles": [ "producer", "consumer" ],
+      "classifications": [ "dynamic-call", "export-interop", "reflection" ],
+      "trackingIssues": [ 1709, 1710, 1720 ],
+      "sourceGlobs": [
+        "src/JavaScriptRuntime/Hosting/*.cs"
+      ],
+      "rationale": "Adapts module exports and host calls between JavaScript callable values and CLR-facing APIs."
+    },
+    {
+      "id": "runtime-commonjs-boundaries",
+      "roles": [ "producer", "consumer" ],
+      "classifications": [ "dynamic-call", "callback", "export-interop" ],
+      "trackingIssues": [ 1709, 1719, 1720 ],
+      "sourceGlobs": [
+        "src/JavaScriptRuntime/CommonJS/*.cs"
+      ],
+      "rationale": "Creates module-main and require delegates and moves callable values through CommonJS exports."
+    }
+  ]
+}

--- a/tests/Jroc.Tests/Architecture/CallableBoundaryInventoryTests.cs
+++ b/tests/Jroc.Tests/Architecture/CallableBoundaryInventoryTests.cs
@@ -1,0 +1,236 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Jroc.Tests.Architecture;
+
+public sealed class CallableBoundaryInventoryTests
+{
+    private static readonly CallableSourceMarker[] CallableSourceMarkers =
+    [
+        new("CallableId", [ "consumer" ], [ "direct-call" ]),
+        new("CallableSignature", [ "consumer" ], [ "direct-call" ]),
+        new("InvokeWithArgs", [ "consumer" ], [ "dynamic-call" ]),
+        new("BindArrow", [ "producer" ], [ "materialization" ]),
+        new("CreateBoundDelegate", [ "producer" ], [ "materialization" ]),
+        new(" is Delegate", [ "consumer" ], [ "dynamic-call" ]),
+        new(" is not Delegate", [ "consumer" ], [ "dynamic-call" ]),
+        new("Delegate del", [ "consumer" ], [ "dynamic-call" ]),
+        new("Delegate d", [ "consumer" ], [ "dynamic-call" ]),
+        new("DynamicInvoke(", [ "consumer" ], [ "dynamic-call" ]),
+        new("InvokeJsDelegate", [ "consumer" ], [ "export-interop" ])
+    ];
+
+    private static readonly string[] RequiredRoles = ["producer", "consumer"];
+
+    private static readonly string[] RequiredClassifications =
+    [
+        "direct-call",
+        "materialization",
+        "dynamic-call",
+        "construction",
+        "callback",
+        "export-interop",
+        "reflection"
+    ];
+
+    [Fact]
+    public void CallableBoundaryInventory_ClassifiesEveryDetectedSourceBoundary()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var inventory = LoadInventory(repositoryRoot);
+
+        Assert.Equal(1, inventory.SchemaVersion);
+        Assert.Equal(1707, inventory.UmbrellaIssue);
+        Assert.NotEmpty(inventory.Boundaries);
+        Assert.Equal(
+            inventory.Boundaries.Count,
+            inventory.Boundaries.Select(entry => entry.Id).Distinct(StringComparer.Ordinal).Count());
+
+        foreach (var role in RequiredRoles)
+        {
+            Assert.Contains(inventory.Boundaries, entry => entry.Roles.Contains(role, StringComparer.Ordinal));
+        }
+
+        foreach (var classification in RequiredClassifications)
+        {
+            Assert.Contains(
+                inventory.Boundaries,
+                entry => entry.Classifications.Contains(classification, StringComparer.Ordinal));
+        }
+
+        var sourceFiles = Directory
+            .EnumerateFiles(Path.Combine(repositoryRoot, "src"), "*.cs", SearchOption.AllDirectories)
+            .Select(path => new SourceFile(
+                Path.GetRelativePath(repositoryRoot, path).Replace('\\', '/'),
+                File.ReadAllText(path)))
+            .ToArray();
+
+        foreach (var entry in inventory.Boundaries)
+        {
+            Assert.NotEmpty(entry.Roles);
+            Assert.NotEmpty(entry.Classifications);
+            Assert.NotEmpty(entry.TrackingIssues);
+            Assert.NotEmpty(entry.SourceGlobs);
+            Assert.False(string.IsNullOrWhiteSpace(entry.Rationale));
+            Assert.All(entry.TrackingIssues, issue => Assert.True(issue > 0, $"{entry.Id} has an invalid tracking issue."));
+
+            foreach (var sourceGlob in entry.SourceGlobs)
+            {
+                Assert.True(
+                    sourceFiles.Any(file => MatchesGlob(file.RelativePath, sourceGlob)),
+                    $"Inventory entry '{entry.Id}' glob '{sourceGlob}' does not match a source file.");
+            }
+        }
+
+        var detectedBoundaries = sourceFiles
+            .Where(file => CallableSourceMarkers.Any(marker => file.Content.Contains(marker.Text, StringComparison.Ordinal)))
+            .Select(file => file.RelativePath)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.NotEmpty(detectedBoundaries);
+
+        var unclassified = detectedBoundaries
+            .Where(path => !inventory.Boundaries.Any(entry =>
+                entry.SourceGlobs.Any(sourceGlob => MatchesGlob(path, sourceGlob))))
+            .ToArray();
+
+        Assert.True(
+            unclassified.Length == 0,
+            "Callable source boundaries missing from docs/compiler/CallableBoundaryInventory.json:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, unclassified.Select(path => $"  - {path}")));
+
+        var mismatched = sourceFiles
+            .Select(file => ValidateDetectedBoundary(file, inventory.Boundaries))
+            .Where(message => message != null)
+            .ToArray();
+
+        Assert.True(
+            mismatched.Length == 0,
+            "Callable source boundaries have incomplete roles/classifications:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, mismatched));
+    }
+
+    private static CallableBoundaryInventory LoadInventory(string repositoryRoot)
+    {
+        var path = Path.Combine(repositoryRoot, "docs", "compiler", "CallableBoundaryInventory.json");
+        var inventory = JsonSerializer.Deserialize<CallableBoundaryInventory>(
+            File.ReadAllText(path),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        return inventory ?? throw new InvalidOperationException($"Could not deserialize callable boundary inventory '{path}'.");
+    }
+
+    private static bool MatchesGlob(string relativePath, string glob)
+    {
+        var regex = new StringBuilder("^");
+        for (var index = 0; index < glob.Length; index++)
+        {
+            var character = glob[index];
+            if (character == '*')
+            {
+                if (index + 1 < glob.Length && glob[index + 1] == '*')
+                {
+                    regex.Append(".*");
+                    index++;
+                }
+                else
+                {
+                    regex.Append("[^/]*");
+                }
+            }
+            else if (character == '?')
+            {
+                regex.Append("[^/]");
+            }
+            else
+            {
+                regex.Append(Regex.Escape(character.ToString()));
+            }
+        }
+
+        regex.Append('$');
+        return Regex.IsMatch(relativePath, regex.ToString(), RegexOptions.CultureInvariant);
+    }
+
+    private static string? ValidateDetectedBoundary(
+        SourceFile file,
+        IReadOnlyList<CallableBoundary> boundaries)
+    {
+        var detectedMarkers = CallableSourceMarkers
+            .Where(marker => file.Content.Contains(marker.Text, StringComparison.Ordinal))
+            .ToArray();
+        if (detectedMarkers.Length == 0)
+        {
+            return null;
+        }
+
+        var matchingEntries = boundaries
+            .Where(entry => entry.SourceGlobs.Any(sourceGlob => MatchesGlob(file.RelativePath, sourceGlob)))
+            .ToArray();
+        var classifiedRoles = matchingEntries
+            .SelectMany(entry => entry.Roles)
+            .ToHashSet(StringComparer.Ordinal);
+        var classifiedOperations = matchingEntries
+            .SelectMany(entry => entry.Classifications)
+            .ToHashSet(StringComparer.Ordinal);
+        var expectedRoles = detectedMarkers
+            .SelectMany(marker => marker.RequiredRoles)
+            .Distinct(StringComparer.Ordinal)
+            .Where(role => !classifiedRoles.Contains(role))
+            .ToArray();
+        var expectedOperations = detectedMarkers
+            .SelectMany(marker => marker.RequiredClassifications)
+            .Distinct(StringComparer.Ordinal)
+            .Where(classification => !classifiedOperations.Contains(classification))
+            .ToArray();
+
+        if (expectedRoles.Length == 0 && expectedOperations.Length == 0)
+        {
+            return null;
+        }
+
+        return $"  - {file.RelativePath}: missing roles [{string.Join(", ", expectedRoles)}], "
+            + $"classifications [{string.Join(", ", expectedOperations)}]";
+    }
+
+    private static string FindRepositoryRoot([CallerFilePath] string sourceFilePath = "")
+    {
+        var directory = new DirectoryInfo(Path.GetDirectoryName(sourceFilePath)!);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "jroc.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException($"Could not find the repository root from '{sourceFilePath}'.");
+    }
+
+    private sealed record SourceFile(string RelativePath, string Content);
+
+    private sealed record CallableSourceMarker(
+        string Text,
+        IReadOnlyList<string> RequiredRoles,
+        IReadOnlyList<string> RequiredClassifications);
+
+    private sealed record CallableBoundaryInventory(
+        int SchemaVersion,
+        int UmbrellaIssue,
+        IReadOnlyList<CallableBoundary> Boundaries);
+
+    private sealed record CallableBoundary(
+        string Id,
+        IReadOnlyList<string> Roles,
+        IReadOnlyList<string> Classifications,
+        IReadOnlyList<int> TrackingIssues,
+        IReadOnlyList<string> SourceGlobs,
+        string Rationale);
+}

--- a/tests/Jroc.Tests/Function/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Function/ExecutionTests.cs
@@ -285,6 +285,12 @@ namespace Jroc.Tests.Function
         [Fact]
         public Task Function_ParameterTypeInference_BinaryArguments() { var testName = nameof(Function_ParameterTypeInference_BinaryArguments); return ExecutionTest(testName); }
 
+        [Fact]
+        public Task Function_CallableArchitecture_SemanticBaseline() { var testName = nameof(Function_CallableArchitecture_SemanticBaseline); return ExecutionTest(testName); }
+
+        [Fact]
+        public Task Function_CallableArchitecture_InferredSignatureBaseline() { var testName = nameof(Function_CallableArchitecture_InferredSignatureBaseline); return ExecutionTest(testName); }
+
         // ABI optimization tests: non-capturing functions should NOT have scopes parameter
         [Fact]
         public Task Function_NoCapture_NoScopesParameter() { var testName = nameof(Function_NoCapture_NoScopesParameter); return ExecutionTest(testName); }

--- a/tests/Jroc.Tests/Function/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Function/GeneratorTests.cs
@@ -329,6 +329,23 @@ namespace Jroc.Tests.Function
             });
         }
 
+        [Fact]
+        public Task Function_CallableArchitecture_InferredSignatureBaseline()
+        {
+            var testName = nameof(Function_CallableArchitecture_InferredSignatureBaseline);
+            return GenerateTest(testName, verifyAssembly: assembly =>
+            {
+                var moduleType = assembly.GetType($"Modules.{testName}", throwOnError: true)!;
+
+                AssertSignature(moduleType, "returnNumber", typeof(double), []);
+                AssertSignature(moduleType, "returnBoolean", typeof(object), []);
+                AssertSignature(moduleType, "negate", typeof(object), [typeof(bool)]);
+                AssertSignature(moduleType, "returnString", typeof(object), []);
+                AssertSignature(moduleType, "stringLength", typeof(object), [typeof(string)]);
+                AssertSignature(moduleType, "identity", typeof(object), [typeof(object)]);
+            });
+        }
+
         // ABI optimization tests: non-capturing functions should NOT have scopes parameter
         [Fact]
         public Task Function_NoCapture_NoScopesParameter() { var testName = nameof(Function_NoCapture_NoScopesParameter); return GenerateTest(testName); }
@@ -341,5 +358,24 @@ namespace Jroc.Tests.Function
 
         [Fact]
         public Task Arrow_Capture_HasScopesParameter() { var testName = nameof(Arrow_Capture_HasScopesParameter); return GenerateTest(testName); }
+
+        private static void AssertSignature(
+            Type moduleType,
+            string functionName,
+            Type expectedReturnType,
+            Type[] expectedParameterTypes)
+        {
+            var functionType = moduleType.GetNestedType(functionName, BindingFlags.Public | BindingFlags.NonPublic)!;
+            var callMethod = functionType.GetMethod("__js_call__", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
+            var jsParameterTypes = callMethod.GetParameters().Select(parameter => parameter.ParameterType).Skip(1).ToArray();
+
+            Assert.True(
+                callMethod.ReturnType == expectedReturnType,
+                $"{functionName} return type: expected {expectedReturnType}, actual {callMethod.ReturnType}.");
+            Assert.True(
+                expectedParameterTypes.SequenceEqual(jsParameterTypes),
+                $"{functionName} parameters: expected [{string.Join(", ", expectedParameterTypes.Select(type => type.Name))}], "
+                + $"actual [{string.Join(", ", jsParameterTypes.Select(type => type.Name))}].");
+        }
     }
 }

--- a/tests/Jroc.Tests/Function/JavaScript/Function_CallableArchitecture_InferredSignatureBaseline.js
+++ b/tests/Jroc.Tests/Function/JavaScript/Function_CallableArchitecture_InferredSignatureBaseline.js
@@ -1,0 +1,33 @@
+"use strict";
+
+function returnNumber() {
+    return 42;
+}
+
+function returnBoolean() {
+    return true;
+}
+
+function negate(value) {
+    return !value;
+}
+
+function returnString() {
+    return "typed!";
+}
+
+function stringLength(value) {
+    return value.length;
+}
+
+function identity(value) {
+    return value;
+}
+
+console.log(returnNumber());
+console.log(returnBoolean());
+console.log(negate(true));
+console.log(returnString());
+console.log(stringLength("typed"));
+console.log(identity(1));
+console.log(identity("dynamic"));

--- a/tests/Jroc.Tests/Function/JavaScript/Function_CallableArchitecture_SemanticBaseline.js
+++ b/tests/Jroc.Tests/Function/JavaScript/Function_CallableArchitecture_SemanticBaseline.js
@@ -1,0 +1,77 @@
+"use strict";
+
+function makeCounter() {
+    let value = 0;
+    return {
+        increment: function () {
+            value++;
+            return value;
+        },
+        read: () => value
+    };
+}
+
+const firstCounter = makeCounter();
+const secondCounter = makeCounter();
+console.log("identity", firstCounter.increment === firstCounter.increment, firstCounter.increment !== secondCounter.increment);
+console.log("capture", firstCounter.increment(), firstCounter.read(), secondCounter.read());
+
+function readValue() {
+    return this.value;
+}
+
+const lexicalReceiver = {
+    value: 9,
+    createReader: function () {
+        return () => this.value;
+    }
+};
+
+console.log("this", readValue.call({ value: 7 }), lexicalReceiver.createReader().call({ value: 100 }));
+
+function sumRecursively(value, callback) {
+    if (value === 0) {
+        return 0;
+    }
+
+    return callback(value) + sumRecursively(value - 1, callback);
+}
+
+console.log("recursion", sumRecursively(4, value => value));
+
+function Receiver(value) {
+    this.value = value;
+    this.wasConstructed = new.target === Receiver;
+}
+
+const receiver = new Receiver(13);
+const arrow = () => 1;
+let arrowConstructionThrows = false;
+try {
+    new arrow();
+} catch (error) {
+    arrowConstructionThrows = error instanceof TypeError;
+}
+
+console.log("construct", receiver.value, receiver.wasConstructed, arrowConstructionThrows, typeof arrow.prototype);
+
+const lengthDescriptor = Object.getOwnPropertyDescriptor(Receiver, "length");
+console.log(
+    "descriptor",
+    lengthDescriptor.value,
+    lengthDescriptor.writable,
+    lengthDescriptor.enumerable,
+    lengthDescriptor.configurable);
+
+const proxied = new Proxy(
+    function (value) {
+        return value + 1;
+    },
+    {
+        apply: function (target, thisArgument, argumentsList) {
+            return Reflect.apply(target, thisArgument, argumentsList) + 1;
+        }
+    });
+
+console.log("proxy", proxied(5));
+console.log("callback", [1, 2, 3].map(value => value * 2).join(","));

--- a/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_CallableArchitecture_InferredSignatureBaseline.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_CallableArchitecture_InferredSignatureBaseline.verified.txt
@@ -1,0 +1,7 @@
+42
+true
+false
+typed!
+5
+1
+dynamic

--- a/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_CallableArchitecture_SemanticBaseline.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_CallableArchitecture_SemanticBaseline.verified.txt
@@ -1,0 +1,8 @@
+identity true true
+capture 1 1 0
+this 7 9
+recursion 10
+construct 13 true true undefined
+descriptor 1 false false true
+proxy 7
+callback 2,4,6

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableArchitecture_InferredSignatureBaseline.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableArchitecture_InferredSignatureBaseline.verified.txt
@@ -1,0 +1,571 @@
+﻿// IL code: Function_CallableArchitecture_InferredSignatureBaseline
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Function_CallableArchitecture_InferredSignatureBaseline
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit returnNumber
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22e9
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			float64 __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x229a
+			// Header size: 1
+			// Code size: 10 (0xa)
+			.maxstack 8
+
+			IL_0000: ldc.r8 42
+			IL_0009: ret
+		} // end of method returnNumber::__js_call__
+
+	} // end of class returnNumber
+
+	.class nested public auto ansi abstract sealed beforefieldinit returnBoolean
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22f2
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x22a5
+			// Header size: 1
+			// Code size: 7 (0x7)
+			.maxstack 8
+
+			IL_0000: ldc.i4.1
+			IL_0001: box [System.Runtime]System.Boolean
+			IL_0006: ret
+		} // end of method returnBoolean::__js_call__
+
+	} // end of class returnBoolean
+
+	.class nested public auto ansi abstract sealed beforefieldinit negate
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22fb
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				bool 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x22b0
+			// Header size: 12
+			// Code size: 12 (0xc)
+			.maxstack 8
+			.locals init (
+				[0] bool
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: ldc.i4.0
+			IL_0002: ceq
+			IL_0004: stloc.0
+			IL_0005: ldloc.0
+			IL_0006: box [System.Runtime]System.Boolean
+			IL_000b: ret
+		} // end of method negate::__js_call__
+
+	} // end of class negate
+
+	.class nested public auto ansi abstract sealed beforefieldinit returnString
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2304
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x22c8
+			// Header size: 1
+			// Code size: 6 (0x6)
+			.maxstack 8
+
+			IL_0000: ldstr "typed!"
+			IL_0005: ret
+		} // end of method returnString::__js_call__
+
+	} // end of class returnString
+
+	.class nested public auto ansi abstract sealed beforefieldinit stringLength
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x230d
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				string 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x22cf
+			// Header size: 1
+			// Code size: 13 (0xd)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: callvirt instance int32 [System.Runtime]System.String::get_Length()
+			IL_0006: conv.r8
+			IL_0007: box [System.Runtime]System.Double
+			IL_000c: ret
+		} // end of method stringLength::__js_call__
+
+	} // end of class stringLength
+
+	.class nested public auto ansi abstract sealed beforefieldinit identity
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2316
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x22dd
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: ret
+		} // end of method identity::__js_call__
+
+	} // end of class identity
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 80 a0 53 63 6f 70 65 20 72 65 74 75 72 6e
+			4e 75 6d 62 65 72 3d 7b 72 65 74 75 72 6e 4e 75
+			6d 62 65 72 7d 2c 20 72 65 74 75 72 6e 42 6f 6f
+			6c 65 61 6e 3d 7b 72 65 74 75 72 6e 42 6f 6f 6c
+			65 61 6e 7d 2c 20 6e 65 67 61 74 65 3d 7b 6e 65
+			67 61 74 65 7d 2c 20 72 65 74 75 72 6e 53 74 72
+			69 6e 67 3d 7b 72 65 74 75 72 6e 53 74 72 69 6e
+			67 7d 2c 20 73 74 72 69 6e 67 4c 65 6e 67 74 68
+			3d 7b 73 74 72 69 6e 67 4c 65 6e 67 74 68 7d 2c
+			20 69 64 65 6e 74 69 74 79 3d 7b 69 64 65 6e 74
+			69 74 79 7d 00 00
+		)
+		// Fields
+		.field public object returnNumber
+		.field public object returnBoolean
+		.field public object negate
+		.field public object returnString
+		.field public object stringLength
+		.field public object identity
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x22e0
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 574 (0x23e)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/Scope,
+			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0,
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+			[3] class [System.Runtime]System.Func`3<object, bool, object>,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+			[5] class [System.Runtime]System.Func`3<object, string, object>,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[7] object,
+			[8] object,
+			[9] object[]
+		)
+
+		IL_0000: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn float64 Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber::__js_call__(object)
+		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
+		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0
+		IL_0017: ldc.i4.0
+		IL_0018: conv.r8
+		IL_0019: ldstr "returnNumber"
+		IL_001e: ldc.i4.0
+		IL_001f: ldc.i4.1
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0025: stloc.1
+		IL_0026: ldnull
+		IL_0027: ldftn object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean::__js_call__(object)
+		IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0032: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0037: ldc.i4.0
+		IL_0038: conv.r8
+		IL_0039: ldstr "returnBoolean"
+		IL_003e: ldc.i4.0
+		IL_003f: ldc.i4.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.2
+		IL_0046: ldnull
+		IL_0047: ldftn object Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate::__js_call__(object, bool)
+		IL_004d: newobj instance void class [System.Runtime]System.Func`3<object, bool, object>::.ctor(object, native int)
+		IL_0052: castclass class [System.Runtime]System.Func`3<object, bool, object>
+		IL_0057: ldc.i4.1
+		IL_0058: conv.r8
+		IL_0059: ldstr "negate"
+		IL_005e: ldc.i4.0
+		IL_005f: ldc.i4.1
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, bool, object>>(!!0, float64, string, bool, bool)
+		IL_0065: stloc.3
+		IL_0066: ldnull
+		IL_0067: ldftn object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString::__js_call__(object)
+		IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0072: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0077: ldc.i4.0
+		IL_0078: conv.r8
+		IL_0079: ldstr "returnString"
+		IL_007e: ldc.i4.0
+		IL_007f: ldc.i4.1
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0085: stloc.s 4
+		IL_0087: ldnull
+		IL_0088: ldftn object Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength::__js_call__(object, string)
+		IL_008e: newobj instance void class [System.Runtime]System.Func`3<object, string, object>::.ctor(object, native int)
+		IL_0093: castclass class [System.Runtime]System.Func`3<object, string, object>
+		IL_0098: ldc.i4.1
+		IL_0099: conv.r8
+		IL_009a: ldstr "stringLength"
+		IL_009f: ldc.i4.0
+		IL_00a0: ldc.i4.1
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, string, object>>(!!0, float64, string, bool, bool)
+		IL_00a6: stloc.s 5
+		IL_00a8: ldnull
+		IL_00a9: ldftn object Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity::__js_call__(object, object)
+		IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00b4: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_00b9: ldc.i4.1
+		IL_00ba: conv.r8
+		IL_00bb: ldstr "identity"
+		IL_00c0: ldc.i4.0
+		IL_00c1: ldc.i4.1
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_00c7: stloc.s 6
+		IL_00c9: nop
+		IL_00ca: nop
+		IL_00cb: nop
+		IL_00cc: nop
+		IL_00cd: nop
+		IL_00ce: nop
+		IL_00cf: nop
+		IL_00d0: ldstr "console"
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00df: stloc.s 7
+		IL_00e1: ldloc.1
+		IL_00e2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ec: stloc.s 8
+		IL_00ee: ldloc.s 7
+		IL_00f0: ldstr "log"
+		IL_00f5: ldloc.s 8
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fc: pop
+		IL_00fd: ldstr "console"
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010c: stloc.s 8
+		IL_010e: ldloc.2
+		IL_010f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_0119: stloc.s 7
+		IL_011b: ldloc.s 8
+		IL_011d: ldstr "log"
+		IL_0122: ldloc.s 7
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0129: pop
+		IL_012a: ldstr "console"
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0139: stloc.s 7
+		IL_013b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0140: stloc.s 9
+		IL_0142: ldloc.3
+		IL_0143: ldloc.s 9
+		IL_0145: ldc.i4.1
+		IL_0146: box [System.Runtime]System.Boolean
+		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0150: stloc.s 8
+		IL_0152: ldloc.s 7
+		IL_0154: ldstr "log"
+		IL_0159: ldloc.s 8
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0160: pop
+		IL_0161: ldstr "console"
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0170: stloc.s 8
+		IL_0172: ldloc.s 4
+		IL_0174: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_017e: stloc.s 7
+		IL_0180: ldloc.s 8
+		IL_0182: ldstr "log"
+		IL_0187: ldloc.s 7
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018e: pop
+		IL_018f: ldstr "console"
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019e: stloc.s 7
+		IL_01a0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01a5: stloc.s 9
+		IL_01a7: ldloc.s 5
+		IL_01a9: ldloc.s 9
+		IL_01ab: ldstr "typed"
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_01b5: stloc.s 8
+		IL_01b7: ldloc.s 7
+		IL_01b9: ldstr "log"
+		IL_01be: ldloc.s 8
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c5: pop
+		IL_01c6: ldstr "console"
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d5: stloc.s 8
+		IL_01d7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01dc: stloc.s 9
+		IL_01de: ldloc.s 6
+		IL_01e0: ldloc.s 9
+		IL_01e2: ldc.r8 1
+		IL_01eb: box [System.Runtime]System.Double
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[], object)
+		IL_01f5: stloc.s 7
+		IL_01f7: ldloc.s 8
+		IL_01f9: ldstr "log"
+		IL_01fe: ldloc.s 7
+		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0205: pop
+		IL_0206: ldstr "console"
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0215: stloc.s 7
+		IL_0217: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_021c: stloc.s 9
+		IL_021e: ldloc.s 6
+		IL_0220: ldloc.s 9
+		IL_0222: ldstr "dynamic"
+		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[], object)
+		IL_022c: stloc.s 8
+		IL_022e: ldloc.s 7
+		IL_0230: ldstr "log"
+		IL_0235: ldloc.s 8
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023c: pop
+		IL_023d: ret
+	} // end of method Function_CallableArchitecture_InferredSignatureBaseline::__js_module_init__
+
+} // end of class Modules.Function_CallableArchitecture_InferredSignatureBaseline
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x231f
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Function_CallableArchitecture_InferredSignatureBaseline::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/tests/performance/Benchmarks/CallableArchitectureBenchmarks.cs
+++ b/tests/performance/Benchmarks/CallableArchitectureBenchmarks.cs
@@ -1,0 +1,99 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Order;
+using Jroc;
+using Jroc.Runtime;
+
+namespace Benchmarks;
+
+/// <summary>
+/// Separates arrow callable materialization from calls made after a compiled
+/// module has already been loaded.
+/// </summary>
+[MemoryDiagnoser]
+[Config(typeof(FullParamsConfig))]
+[ShortRunJob]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[HideColumns("Error", "StdDev")]
+public class CallableArchitectureBenchmarks : IDisposable
+{
+    private const int DirectCallsPerOperation = 1_000;
+    private static readonly Func<object[], object?> ArrowTarget = static _ => 0d;
+
+    private const string Source = """
+        "use strict";
+
+        const arrow0 = () => 0;
+        const arrow1 = () => 1;
+        const arrow2 = () => 2;
+        const arrow3 = () => 3;
+        const arrow4 = () => 4;
+        const arrow5 = () => 5;
+        const arrow6 = () => 6;
+        const arrow7 = () => 7;
+        const arrow8 = () => 8;
+        const arrow9 = () => 9;
+        const arrow10 = () => 10;
+        const arrow11 = () => 11;
+        const arrow12 = () => 12;
+        const arrow13 = () => 13;
+
+        function increment(value) {
+            return value + 1;
+        }
+
+        function run(iterations) {
+            let result = 0;
+            for (let index = 0; index < iterations; index++) {
+                result = increment(result);
+            }
+
+            return result + arrow0();
+        }
+
+        module.exports = { run };
+        """;
+
+    private JrocLoadedAssembly? _assembly;
+    private IDisposable? _steadyStateExports;
+    private dynamic _steadyState = null!;
+    private string _moduleId = string.Empty;
+    private readonly object[] _boundScopes = [new object()];
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var request = new JrocInMemoryCompileRequest(
+            Path.Combine(Path.GetTempPath(), "jroc-callable-architecture-baseline.js"))
+        {
+            SourceText = Source
+        };
+
+        var artifact = JrocInMemoryCompiler.Compile(request);
+        _assembly = JrocInMemoryAssemblyLoader.Load(artifact);
+        _moduleId = artifact.ModuleIds.Single();
+        _steadyStateExports = JsEngine.LoadModule(_assembly.Assembly, _moduleId);
+        _steadyState = _steadyStateExports;
+    }
+
+    [GlobalCleanup]
+    public void Dispose()
+    {
+        _steadyStateExports?.Dispose();
+        _steadyStateExports = null;
+        _steadyState = null!;
+        _assembly?.Dispose();
+        _assembly = null;
+    }
+
+    [Benchmark(Description = "Arrow delegate materialization")]
+    public object MaterializeArrow()
+        => JavaScriptRuntime.Closure.BindArrow(ArrowTarget, _boundScopes, boundThis: null);
+
+    [Benchmark(Description = "Loaded module direct-call loop", OperationsPerInvoke = DirectCallsPerOperation)]
+    public double InvokeSteadyState()
+        => (double)_steadyState.run(DirectCallsPerOperation);
+}

--- a/tests/performance/Benchmarks/Program.cs
+++ b/tests/performance/Benchmarks/Program.cs
@@ -40,6 +40,11 @@ else
         var summary = BenchmarkRunner.Run<PrototypeStorageBenchmarks>(args: programArgs.Skip(1).ToArray());
         SetExitCodeFromSummaries([summary]);
     }
+    else if (programArgs.Length > 0 && programArgs[0] == "--callable-baselines")
+    {
+        var summary = BenchmarkRunner.Run<CallableArchitectureBenchmarks>(args: programArgs.Skip(1).ToArray());
+        SetExitCodeFromSummaries([summary]);
+    }
 #if SOURCE_JROC_PROJECTS
     else if (programArgs.Length > 0 && programArgs[0] == "--shape-storage")
     {
@@ -116,6 +121,7 @@ Console.WriteLine("  dotnet run -c Release --object-operations # Run ordinary-ob
 Console.WriteLine("  dotnet run -c Release --descriptor-storage # Run inline descriptor storage microbenchmarks");
 Console.WriteLine("  dotnet run -c Release --array-operations # Run dense-array operation microbenchmarks");
 Console.WriteLine("  dotnet run -c Release --prototype-storage # Run prototype storage allocation microbenchmarks");
+Console.WriteLine("  dotnet run -c Release --callable-baselines # Run callable materialization and steady-state baselines");
 Console.WriteLine("  dotnet run -c Release -- --dromaeo # Run Dromaeo execution benchmarks");
 Console.WriteLine("  dotnet run -c Release -- --kracken --scenario audio-oscillator # Run one Kraken scenario");
 Console.WriteLine("  dotnet run -c Release -- --prime-execute # Run the one-pass Prime sieve execution benchmark");


### PR DESCRIPTION
## Summary

- add a machine-checked inventory of compiled callable producers and consumers, including role, operation classification, and follow-up issue mapping
- add focused semantic and inferred-signature execution/IL baselines for the generated function-object migration
- add BenchmarkDotNet baselines that isolate `Closure.BindArrow` materialization from calls made after module load

## Baseline coverage

- function identity and shared mutable captures
- ordinary and lexical `this`
- recursion, callbacks, `new.target`, constructability, descriptors, and proxy `apply`
- typed numeric/boolean/string parameter and return paths plus polymorphic fallback
- current arrow materialization timing/allocation versus loaded-module direct-call timing/allocation

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --filter 'FullyQualifiedName~CallableBoundaryInventoryTests|FullyQualifiedName~Function_CallableArchitecture'`
- `dotnet build tests/performance/Benchmarks/Benchmarks.csproj`
- `dotnet run -c Release --project tests/performance/Benchmarks/Benchmarks.csproj -- --callable-baselines --filter '*'`

Closes #1708
