### PR TITLE
feat(runtime): add JsFunctionObject foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- runtime: add the `JsFunctionObject : JsObject` foundation, centralized
+  callable/constructor operations, and an explicit transitional adapter for
+  delegate-backed functions. Function objects now share ordinary object,
+  descriptor, prototype, proxy, and integrity behavior without storing mutable
+  per-invocation receiver or argument state.
 
 ## v0.12.3 - 2026-08-05
 

--- a/docs/runtime/OrdinaryObjectRepresentation.md
+++ b/docs/runtime/OrdinaryObjectRepresentation.md
@@ -89,6 +89,27 @@ Array intrinsic prototypes, per-thread prototype overlays, and
 matches all other runtime-owned intrinsic prototypes and leaves no
 `ExpandoObject` representation in the runtime.
 
+## Function object foundation
+
+`JsFunctionObject : JsObject` is the common base for object-backed JavaScript
+callables. It inherits ordinary property, symbol, descriptor, prototype,
+integrity, deletion, and identity behavior from `JsObject`, and its
+`[[Prototype]]` is initialized to `Function.prototype`.
+
+`CallableOperations` is the centralized runtime boundary for `IsCallable`,
+`[[Call]]`, `IsConstructor`, and `[[Construct]]`. Receiver, arguments, callee,
+and `newTarget` are passed per invocation and installed in the runtime's
+`AsyncLocal` execution context only for the duration of the call. They are
+never stored as mutable fields on the function object, so recursion,
+reentrancy, and concurrent calls remain isolated.
+
+`LegacyDelegateFunctionAdapter` keeps existing delegate-backed compiled
+functions available during the staged migration. New object-backed callables
+derive from `JsFunctionObject`; the final fixed-arity and arbitrary-argument ABI
+and compiler-generated subclasses are tracked separately under
+[#1710](https://github.com/tomacox74/js2il/issues/1710) and
+[#1711](https://github.com/tomacox74/js2il/issues/1711).
+
 ## Host boundary
 
 C# dynamic interoperability is a hosting concern. `JsObject` still carries

--- a/src/JavaScriptRuntime/CallableOperations.cs
+++ b/src/JavaScriptRuntime/CallableOperations.cs
@@ -1,0 +1,127 @@
+namespace JavaScriptRuntime;
+
+/// <summary>
+/// Centralized ECMAScript callable and constructor operations.
+/// </summary>
+public static class CallableOperations
+{
+    public static bool IsCallable(object? value)
+    {
+        return value switch
+        {
+            JsFunctionObject => true,
+            Delegate => true,
+            ClassConstructorValue => true,
+            Proxy proxy => proxy.IsCallableTarget,
+            _ => false
+        };
+    }
+
+    public static object? Call(object? target, object? thisArgument, object?[]? arguments)
+    {
+        var callArguments = arguments ?? System.Array.Empty<object?>();
+
+        return target switch
+        {
+            JsFunctionObject functionObject => CallFunctionObject(functionObject, thisArgument, callArguments),
+            Delegate legacyDelegate => LegacyDelegateFunctionAdapter.Invoke(
+                legacyDelegate,
+                RuntimeServices.EmptyScopes,
+                thisArgument,
+                callArguments),
+            Proxy proxy when proxy.IsCallableTarget => CallProxy(proxy, thisArgument, callArguments),
+            ClassConstructorValue => throw new TypeError("Class constructor cannot be invoked without 'new'"),
+            _ => throw new TypeError("Value is not callable")
+        };
+    }
+
+    public static bool IsConstructor(object? value)
+    {
+        return value switch
+        {
+            JsFunctionObject functionObject => functionObject.IsConstructor,
+            _ => ObjectRuntime.IsConstructibleValue(value)
+        };
+    }
+
+    public static object? Construct(object? target, object?[]? arguments)
+        => Construct(target, arguments, target);
+
+    public static object? Construct(object? target, object?[]? arguments, object? newTarget)
+    {
+        var constructArguments = arguments ?? System.Array.Empty<object?>();
+
+        if (target is JsFunctionObject functionObject)
+        {
+            if (!functionObject.IsConstructor)
+            {
+                throw new TypeError("Value is not a constructor");
+            }
+
+            return ConstructFunctionObject(functionObject, constructArguments, newTarget);
+        }
+
+        if (!ObjectRuntime.IsConstructibleValue(target))
+        {
+            throw new TypeError("Value is not a constructor");
+        }
+
+        var legacyArguments = System.Array.ConvertAll(constructArguments, static argument => argument!);
+        return ObjectRuntime.ConstructValue(target!, legacyArguments, newTarget);
+    }
+
+    private static object? CallFunctionObject(
+        JsFunctionObject functionObject,
+        object? thisArgument,
+        object?[] arguments)
+    {
+        var previousThis = RuntimeServices.SetCurrentThis(thisArgument);
+        var previousArguments = RuntimeServices.SetCurrentArguments(arguments);
+        var previousCallee = RuntimeServices.SetCurrentCallee(functionObject);
+        var previousNewTarget = RuntimeServices.SetCurrentNewTarget(null);
+        try
+        {
+            return functionObject.InvokeCall(thisArgument, arguments);
+        }
+        finally
+        {
+            RuntimeServices.SetCurrentNewTarget(previousNewTarget);
+            RuntimeServices.SetCurrentCallee(previousCallee);
+            RuntimeServices.SetCurrentArguments(previousArguments);
+            RuntimeServices.SetCurrentThis(previousThis);
+        }
+    }
+
+    private static object? ConstructFunctionObject(
+        JsFunctionObject functionObject,
+        object?[] arguments,
+        object? newTarget)
+    {
+        var previousArguments = RuntimeServices.SetCurrentArguments(arguments);
+        var previousCallee = RuntimeServices.SetCurrentCallee(functionObject);
+        var previousNewTarget = RuntimeServices.SetCurrentNewTarget(newTarget);
+        try
+        {
+            return functionObject.InvokeConstruct(arguments, newTarget);
+        }
+        finally
+        {
+            RuntimeServices.SetCurrentNewTarget(previousNewTarget);
+            RuntimeServices.SetCurrentCallee(previousCallee);
+            RuntimeServices.SetCurrentArguments(previousArguments);
+        }
+    }
+
+    private static object? CallProxy(Proxy proxy, object? thisArgument, object?[] arguments)
+    {
+        var previousThis = RuntimeServices.SetCurrentThis(thisArgument);
+        try
+        {
+            return Closure.InvokeWithArgs(proxy, RuntimeServices.EmptyScopes, arguments);
+        }
+        finally
+        {
+            RuntimeServices.SetCurrentThis(previousThis);
+        }
+    }
+}

--- a/src/JavaScriptRuntime/Closure.cs
+++ b/src/JavaScriptRuntime/Closure.cs
@@ -746,6 +746,13 @@ namespace JavaScriptRuntime
                     return InvokeWithArgsCore(proxyTarget, scopes, newTarget, args);
                 }
 
+                if (target is JsFunctionObject functionObject)
+                {
+                    return CallableOperations.Call(
+                        functionObject,
+                        RuntimeServices.GetCurrentThis(),
+                        args)!;
+                }
 
                 // CommonJS require(...) is passed into scripts as a RequireDelegate, which does not include
                 // the standard jroc scopes array parameter. Support calling it via the generic dispatcher.

--- a/src/JavaScriptRuntime/Function.cs
+++ b/src/JavaScriptRuntime/Function.cs
@@ -157,7 +157,7 @@ public static class Function
     }
 
         private static bool IsCallableObject(object? target)
-            => target is Delegate || target is Proxy proxy && proxy.IsCallableTarget;
+            => CallableOperations.IsCallable(target);
 
         private static object? PrototypeApply(object[] scopes, object?[]? args)
         {
@@ -300,23 +300,10 @@ public static class Function
 
         public static object? Apply(object target, object? thisArg, object? argArray)
         {
-            if (target is Delegate del)
-            {
-                return Apply(del, thisArg, argArray);
-            }
-
-            if (target is Proxy proxy && proxy.IsCallableTarget)
+            if (CallableOperations.IsCallable(target))
             {
                 var argsList = NormalizeApplyArguments(argArray);
-                var prevThis = RuntimeServices.SetCurrentThis(thisArg);
-                try
-                {
-                    return Closure.InvokeWithArgs(proxy, System.Array.Empty<object>(), argsList);
-                }
-                finally
-                {
-                    RuntimeServices.SetCurrentThis(prevThis);
-                }
+                return CallableOperations.Call(target, thisArg, argsList);
             }
 
             throw new TypeError("Function.prototype.apply called on non-function");
@@ -341,23 +328,10 @@ public static class Function
 
         public static object? Call(object target, object? thisArg, object?[] args)
         {
-            if (target is Delegate del)
-            {
-                return Call(del, thisArg, args);
-            }
-
-            if (target is Proxy proxy && proxy.IsCallableTarget)
+            if (CallableOperations.IsCallable(target))
             {
                 args ??= System.Array.Empty<object?>();
-                var prevThis = RuntimeServices.SetCurrentThis(thisArg);
-                try
-                {
-                    return Closure.InvokeWithArgs(proxy, System.Array.Empty<object>(), args);
-                }
-                finally
-                {
-                    RuntimeServices.SetCurrentThis(prevThis);
-                }
+                return CallableOperations.Call(target, thisArg, args);
             }
 
             throw new TypeError("Function.prototype.call called on non-function");

--- a/src/JavaScriptRuntime/JsFunctionObject.cs
+++ b/src/JavaScriptRuntime/JsFunctionObject.cs
@@ -1,0 +1,34 @@
+namespace JavaScriptRuntime;
+
+/// <summary>
+/// Base class for JavaScript function values implemented as runtime objects.
+/// </summary>
+public abstract class JsFunctionObject : JsObject
+{
+    protected JsFunctionObject()
+    {
+        PrototypeChain.InitializePrototype(this, Function.Prototype);
+    }
+
+    /// <summary>
+    /// Gets whether this function implements ECMAScript [[Construct]].
+    /// </summary>
+    public virtual bool IsConstructor => false;
+
+    internal object? InvokeCall(object? thisArgument, object?[] arguments)
+        => CallCore(thisArgument, arguments);
+
+    internal object? InvokeConstruct(object?[] arguments, object? newTarget)
+        => ConstructCore(arguments, newTarget);
+
+    /// <summary>
+    /// Implements ECMAScript [[Call]] for this function object.
+    /// </summary>
+    protected abstract object? CallCore(object? thisArgument, object?[] arguments);
+
+    /// <summary>
+    /// Implements ECMAScript [[Construct]] for constructable function objects.
+    /// </summary>
+    protected virtual object? ConstructCore(object?[] arguments, object? newTarget)
+        => throw new TypeError("Value is not a constructor");
+}

--- a/src/JavaScriptRuntime/LegacyDelegateFunctionAdapter.cs
+++ b/src/JavaScriptRuntime/LegacyDelegateFunctionAdapter.cs
@@ -1,0 +1,43 @@
+namespace JavaScriptRuntime;
+
+/// <summary>
+/// Transitional adapter for delegate-backed JavaScript functions.
+/// </summary>
+public sealed class LegacyDelegateFunctionAdapter : JsFunctionObject
+{
+    private readonly object[] _scopes;
+
+    public LegacyDelegateFunctionAdapter(Delegate target, object[]? scopes = null)
+    {
+        Target = target ?? throw new ArgumentNullException(nameof(target));
+        _scopes = scopes ?? RuntimeServices.EmptyScopes;
+    }
+
+    public Delegate Target { get; }
+
+    public override bool IsConstructor => ObjectRuntime.IsConstructibleValue(Target);
+
+    protected override object? CallCore(object? thisArgument, object?[] arguments)
+        => Invoke(Target, _scopes, thisArgument, arguments);
+
+    protected override object? ConstructCore(object?[] arguments, object? newTarget)
+        => Function.Construct(Target, arguments, newTarget);
+
+    internal static object? Invoke(
+        Delegate target,
+        object[] scopes,
+        object? thisArgument,
+        object?[] arguments)
+    {
+        var effectiveThis = Function.GetEffectiveThisArg(target, thisArgument);
+        var previousThis = RuntimeServices.SetCurrentThis(effectiveThis);
+        try
+        {
+            return Closure.InvokeWithArgs(target, scopes, arguments);
+        }
+        finally
+        {
+            RuntimeServices.SetCurrentThis(previousThis);
+        }
+    }
+}

--- a/src/JavaScriptRuntime/ObjectRuntime.Operations.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.Operations.cs
@@ -312,7 +312,7 @@ namespace JavaScriptRuntime
             if (descriptor.HasGet)
             {
                 descriptor.Get = GetProperty(attributes, "get");
-                if (descriptor.Get is not null && descriptor.Get is not Delegate)
+                if (descriptor.Get is not null && !CallableOperations.IsCallable(descriptor.Get))
                 {
                     throw new TypeError("Getter must be a function");
                 }
@@ -321,7 +321,7 @@ namespace JavaScriptRuntime
             if (descriptor.HasSet)
             {
                 descriptor.Set = GetProperty(attributes, "set");
-                if (descriptor.Set is not null && descriptor.Set is not Delegate)
+                if (descriptor.Set is not null && !CallableOperations.IsCallable(descriptor.Set))
                 {
                     throw new TypeError("Setter must be a function");
                 }
@@ -1983,7 +1983,7 @@ namespace JavaScriptRuntime
             if (thisVal is string) return "[object String]";
             if (thisVal is bool) return "[object Boolean]";
             if (thisVal is double or float or int or long) return "[object Number]";
-            if (thisVal is Delegate) return "[object Function]";
+            if (thisVal is Delegate or JsFunctionObject) return "[object Function]";
             if (thisVal is JavaScriptRuntime.RegExp) return "[object RegExp]";
             if (thisVal is GeneratorObject) return "[object Generator]";
             if (thisVal is AsyncGeneratorObject) return "[object AsyncGenerator]";
@@ -2001,7 +2001,7 @@ namespace JavaScriptRuntime
             var target = GetCurrentThisObjectOrThrow();
             var prop = args != null && args.Length > 0 ? args[0] : null;
             var getter = args != null && args.Length > 1 ? args[1] : null;
-            if (getter is null || getter is JsNull || getter is not Delegate)
+            if (getter is null || getter is JsNull || !CallableOperations.IsCallable(getter))
             {
                 throw new TypeError("Getter must be a function");
             }
@@ -2056,7 +2056,7 @@ namespace JavaScriptRuntime
             var target = GetCurrentThisObjectOrThrow();
             var prop = args != null && args.Length > 0 ? args[0] : null;
             var setter = args != null && args.Length > 1 ? args[1] : null;
-            if (setter is null || setter is JsNull || setter is not Delegate)
+            if (setter is null || setter is JsNull || !CallableOperations.IsCallable(setter))
             {
                 throw new TypeError("Setter must be a function");
             }
@@ -2261,6 +2261,11 @@ namespace JavaScriptRuntime
                 return IsConstructibleValue(proxy.GetTarget("construct"));
             }
 
+            if (constructor is JsFunctionObject functionObject)
+            {
+                return functionObject.IsConstructor;
+            }
+
             if (constructor is Type type)
             {
                 return !(type.IsAbstract && type.IsSealed);
@@ -2338,6 +2343,11 @@ namespace JavaScriptRuntime
             if (constructor is ClassConstructorValue classConstructor)
             {
                 return ConstructTypeValue(classConstructor.Type, callArgs, classConstructor.Scopes, classConstructor);
+            }
+
+            if (constructor is JsFunctionObject functionObject)
+            {
+                return CallableOperations.Construct(functionObject, callArgs, newTarget);
             }
 
             object? ConstructTypeValue(Type type, object[] callArgs, object[] scopes, object? prototypeOwner = null)
@@ -3635,17 +3645,9 @@ namespace JavaScriptRuntime
                 return null;
             }
 
-            if (callable is Delegate)
+            if (CallableOperations.IsCallable(callable))
             {
-                var previousThis = RuntimeServices.SetCurrentThis(thisArg);
-                try
-                {
-                    return Closure.InvokeWithArgs(callable, System.Array.Empty<object>(), args);
-                }
-                finally
-                {
-                    RuntimeServices.SetCurrentThis(previousThis);
-                }
+                return CallableOperations.Call(callable, thisArg, args);
             }
 
             throw new TypeError("Property accessor is not a function");

--- a/src/JavaScriptRuntime/ObjectRuntime.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.cs
@@ -285,12 +285,12 @@ namespace JavaScriptRuntime
                 throw new TypeError("Cannot convert undefined or null to object");
             }
 
-            if (getter is not null && getter is not JsNull && getter is not Delegate)
+            if (getter is not null && getter is not JsNull && !CallableOperations.IsCallable(getter))
             {
                 throw new TypeError("Getter must be a function");
             }
 
-            if (setter is not null && setter is not JsNull && setter is not Delegate)
+            if (setter is not null && setter is not JsNull && !CallableOperations.IsCallable(setter))
             {
                 throw new TypeError("Setter must be a function");
             }

--- a/src/JavaScriptRuntime/Proxy.cs
+++ b/src/JavaScriptRuntime/Proxy.cs
@@ -22,14 +22,7 @@ namespace JavaScriptRuntime
         }
 
         internal static bool IsCallableValue(object? value)
-        {
-            if (value is JavaScriptRuntime.Proxy proxy)
-            {
-                return proxy.IsCallableTarget;
-            }
-
-            return value is Delegate or ClassConstructorValue;
-        }
+            => CallableOperations.IsCallable(value);
 
         public Proxy(object? target, object? handler)
         {

--- a/src/JavaScriptRuntime/TypeUtilities.cs
+++ b/src/JavaScriptRuntime/TypeUtilities.cs
@@ -100,6 +100,7 @@ namespace JavaScriptRuntime
                 case JavaScriptRuntime.Proxy proxy:
                     return proxy.IsCallableTarget ? "function" : "object";
             }
+            if (value is JsFunctionObject) return "function";
             if (value is JsObject) return "object";
             if (value is Array) return "object";
             // Functions are delegates in our model; detect common delegate base

--- a/tests/Jroc.Tests/Function/JsFunctionObjectRuntimeTests.cs
+++ b/tests/Jroc.Tests/Function/JsFunctionObjectRuntimeTests.cs
@@ -1,0 +1,326 @@
+using JavaScriptRuntime;
+
+namespace Jroc.Tests.Function;
+
+public sealed class JsFunctionObjectRuntimeTests
+{
+    [Fact]
+    public void FunctionObjects_HaveOrdinaryObjectSemantics()
+    {
+        var runtime = RuntimeServices.BuildServiceProvider();
+        try
+        {
+            GlobalThis.ServiceProvider = runtime;
+            PrototypeChain.Enable();
+
+            var function = new RecordingFunction();
+            var otherFunction = new RecordingFunction();
+            var symbol = new Symbol("function-state");
+
+            Assert.NotSame(function, otherFunction);
+            Assert.Equal("function", TypeUtilities.Typeof(function));
+            Assert.Same(JavaScriptRuntime.Function.Prototype, JavaScriptRuntime.Object.getPrototypeOf(function));
+
+            ObjectRuntime.SetProperty(function, "custom", 42d);
+            ObjectRuntime.SetItem(function, symbol, "symbol-value");
+            Assert.Equal(42d, ObjectRuntime.GetProperty(function, "custom"));
+            Assert.Equal("symbol-value", ObjectRuntime.GetItem(function, symbol));
+
+            var descriptor = new JsObject
+            {
+                ["value"] = "fixed",
+                ["writable"] = false,
+                ["enumerable"] = false,
+                ["configurable"] = true
+            };
+            JavaScriptRuntime.Object.defineProperty(function, "fixed", descriptor);
+
+            var actualDescriptor = Assert.IsType<JsObject>(
+                JavaScriptRuntime.Object.getOwnPropertyDescriptor(function, "fixed"));
+            Assert.Equal("fixed", actualDescriptor["value"]);
+            Assert.False(Assert.IsType<bool>(actualDescriptor["writable"]));
+            Assert.False(Assert.IsType<bool>(actualDescriptor["enumerable"]));
+            Assert.True(Assert.IsType<bool>(actualDescriptor["configurable"]));
+
+            object? setterThis = null;
+            object? setterValue = null;
+            var getter = new LambdaFunction((thisArgument, _) =>
+            {
+                Assert.Same(function, thisArgument);
+                return "accessor-value";
+            });
+            var setter = new LambdaFunction((thisArgument, arguments) =>
+            {
+                setterThis = thisArgument;
+                setterValue = arguments[0];
+                return null;
+            });
+            JavaScriptRuntime.Object.defineProperty(function, "accessor", new JsObject
+            {
+                ["get"] = getter,
+                ["set"] = setter,
+                ["enumerable"] = true,
+                ["configurable"] = true
+            });
+
+            Assert.Equal("accessor-value", ObjectRuntime.GetProperty(function, "accessor"));
+            ObjectRuntime.SetProperty(function, "accessor", "updated");
+            Assert.Same(function, setterThis);
+            Assert.Equal("updated", setterValue);
+
+            Assert.True(ObjectRuntime.DeleteProperty(function, "custom"));
+            Assert.False(JavaScriptRuntime.Object.hasOwn(function, "custom"));
+
+            JavaScriptRuntime.Object.preventExtensions(function);
+            Assert.False(JavaScriptRuntime.Object.isExtensible(function));
+            Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(function, "newProperty", 1d));
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void CallableOperations_CallRestoresNestedInvocationContext()
+    {
+        var function = new ReentrantFunction();
+        var previousThis = RuntimeServices.SetCurrentThis("original-this");
+        var previousArguments = RuntimeServices.SetCurrentArguments(new object?[] { "original-argument" });
+        var previousCallee = RuntimeServices.SetCurrentCallee("original-callee");
+        var previousNewTarget = RuntimeServices.SetCurrentNewTarget("original-new-target");
+        try
+        {
+            var result = Assert.IsType<NestedCallSnapshot>(
+                CallableOperations.Call(function, "outer-this", new object?[] { "outer" }));
+            var functionPrototypeResult = Assert.IsType<CallSnapshot>(
+                JavaScriptRuntime.Function.Call(
+                    function,
+                    "prototype-call-this",
+                    new object?[] { "prototype-call" }));
+
+            Assert.Equal("inner-this", result.Inner.ThisArgument);
+            Assert.Equal("inner", result.Inner.Argument);
+            Assert.Same(function, result.Inner.Callee);
+            Assert.Null(result.Inner.NewTarget);
+
+            Assert.Equal("outer-this", result.OuterAfterInner.ThisArgument);
+            Assert.Equal("outer", result.OuterAfterInner.Argument);
+            Assert.Same(function, result.OuterAfterInner.Callee);
+            Assert.Null(result.OuterAfterInner.NewTarget);
+
+            Assert.Equal("prototype-call-this", functionPrototypeResult.ThisArgument);
+            Assert.Equal("prototype-call", functionPrototypeResult.Argument);
+
+            Assert.Equal("original-this", RuntimeServices.GetCurrentThis());
+            Assert.Equal("original-argument", Assert.Single(RuntimeServices.GetCurrentArguments()!));
+            Assert.Equal("original-callee", RuntimeServices.GetCurrentCallee());
+            Assert.Equal("original-new-target", RuntimeServices.GetCurrentNewTarget());
+        }
+        finally
+        {
+            RuntimeServices.SetCurrentNewTarget(previousNewTarget);
+            RuntimeServices.SetCurrentCallee(previousCallee);
+            RuntimeServices.SetCurrentArguments(previousArguments);
+            RuntimeServices.SetCurrentThis(previousThis);
+        }
+    }
+
+    [Fact]
+    public async Task CallableOperations_ConcurrentCallsKeepReceiverAndArgumentsIsolated()
+    {
+        using var barrier = new Barrier(2);
+        var function = new ConcurrentFunction(barrier);
+
+        var firstTask = Task.Run(() =>
+            Assert.IsType<CallSnapshot>(
+                CallableOperations.Call(function, "first-this", new object?[] { "first" })));
+        var secondTask = Task.Run(() =>
+            Assert.IsType<CallSnapshot>(
+                CallableOperations.Call(function, "second-this", new object?[] { "second" })));
+
+        var results = await Task.WhenAll(firstTask, secondTask);
+
+        Assert.Contains(results, result =>
+            Equals(result.ThisArgument, "first-this") && Equals(result.Argument, "first"));
+        Assert.Contains(results, result =>
+            Equals(result.ThisArgument, "second-this") && Equals(result.Argument, "second"));
+        Assert.All(results, result => Assert.Same(function, result.Callee));
+    }
+
+    [Fact]
+    public void CallableOperations_ConstructsOnlyConstructableFunctionObjects()
+    {
+        var constructor = new ConstructableFunction();
+        var arrow = new RecordingFunction();
+        var explicitNewTarget = new JsObject();
+
+        Assert.True(CallableOperations.IsCallable(constructor));
+        Assert.True(CallableOperations.IsConstructor(constructor));
+        Assert.False(CallableOperations.IsConstructor(arrow));
+
+        var defaultResult = Assert.IsType<ConstructSnapshot>(
+            CallableOperations.Construct(constructor, new object?[] { 1d }));
+        Assert.Equal(1d, defaultResult.Argument);
+        Assert.Same(constructor, defaultResult.NewTarget);
+        Assert.Same(constructor, defaultResult.Callee);
+
+        var explicitResult = Assert.IsType<ConstructSnapshot>(
+            CallableOperations.Construct(constructor, new object?[] { 2d }, explicitNewTarget));
+        Assert.Equal(2d, explicitResult.Argument);
+        Assert.Same(explicitNewTarget, explicitResult.NewTarget);
+
+        var error = Assert.Throws<TypeError>(
+            () => CallableOperations.Construct(arrow, System.Array.Empty<object?>()));
+        Assert.Equal("Value is not a constructor", error.Message);
+    }
+
+    [Fact]
+    public void CallableOperations_RejectsNonCallableValuesConsistently()
+    {
+        var value = new JsObject();
+
+        Assert.False(CallableOperations.IsCallable(value));
+        Assert.False(CallableOperations.IsConstructor(value));
+
+        var callError = Assert.Throws<TypeError>(
+            () => CallableOperations.Call(value, null, System.Array.Empty<object?>()));
+        var constructError = Assert.Throws<TypeError>(
+            () => CallableOperations.Construct(value, System.Array.Empty<object?>()));
+
+        Assert.Equal("Value is not callable", callError.Message);
+        Assert.Equal("Value is not a constructor", constructError.Message);
+    }
+
+    [Fact]
+    public void LegacyDelegateAdapterSupportsIncrementalMigration()
+    {
+        var runtime = RuntimeServices.BuildServiceProvider();
+        try
+        {
+            GlobalThis.ServiceProvider = runtime;
+            Func<object[], object?[]?, object?> legacyCall = static (_, args) =>
+                new CallSnapshot(
+                    RuntimeServices.GetCurrentThis(),
+                    args![0],
+                    RuntimeServices.GetCurrentCallee(),
+                    RuntimeServices.GetCurrentNewTarget());
+            JavaScriptRuntime.Function.InitializeFunctionInstance(
+                legacyCall,
+                1d,
+                "legacyCall",
+                requiresInvocationContext: true);
+
+            var adapter = new LegacyDelegateFunctionAdapter(legacyCall);
+
+            Assert.True(CallableOperations.IsCallable(legacyCall));
+            Assert.True(CallableOperations.IsCallable(adapter));
+            Assert.Equal("function", TypeUtilities.Typeof(adapter));
+
+            var rawResult = Assert.IsType<CallSnapshot>(
+                CallableOperations.Call(legacyCall, "raw-this", new object?[] { "raw" }));
+            var adapterResult = Assert.IsType<CallSnapshot>(
+                CallableOperations.Call(adapter, "adapter-this", new object?[] { "adapter" }));
+
+            Assert.Equal("raw-this", rawResult.ThisArgument);
+            Assert.Equal("raw", rawResult.Argument);
+            Assert.Same(legacyCall, rawResult.Callee);
+
+            Assert.Equal("adapter-this", adapterResult.ThisArgument);
+            Assert.Equal("adapter", adapterResult.Argument);
+            Assert.Same(legacyCall, adapterResult.Callee);
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void CallableProxyDispatchesToFunctionObject()
+    {
+        var target = new RecordingFunction();
+        var proxy = new JavaScriptRuntime.Proxy(target, new JsObject());
+
+        Assert.True(CallableOperations.IsCallable(proxy));
+
+        var result = Assert.IsType<CallSnapshot>(
+            CallableOperations.Call(proxy, "proxy-this", new object?[] { "proxy-argument" }));
+
+        Assert.Equal("proxy-this", result.ThisArgument);
+        Assert.Equal("proxy-argument", result.Argument);
+        Assert.Same(target, result.Callee);
+    }
+
+    private sealed class RecordingFunction : JsFunctionObject
+    {
+        protected override object? CallCore(object? thisArgument, object?[] arguments)
+            => Capture(arguments);
+    }
+
+    private sealed class LambdaFunction(Func<object?, object?[], object?> implementation) : JsFunctionObject
+    {
+        protected override object? CallCore(object? thisArgument, object?[] arguments)
+            => implementation(thisArgument, arguments);
+    }
+
+    private sealed class ReentrantFunction : JsFunctionObject
+    {
+        protected override object? CallCore(object? thisArgument, object?[] arguments)
+        {
+            if (Equals(arguments[0], "outer"))
+            {
+                var inner = Assert.IsType<CallSnapshot>(
+                    CallableOperations.Call(this, "inner-this", new object?[] { "inner" }));
+                return new NestedCallSnapshot(inner, Capture(arguments));
+            }
+
+            return Capture(arguments);
+        }
+    }
+
+    private sealed class ConcurrentFunction(Barrier barrier) : JsFunctionObject
+    {
+        protected override object? CallCore(object? thisArgument, object?[] arguments)
+        {
+            barrier.SignalAndWait(TimeSpan.FromSeconds(10));
+            return Capture(arguments);
+        }
+    }
+
+    private sealed class ConstructableFunction : JsFunctionObject
+    {
+        public override bool IsConstructor => true;
+
+        protected override object? CallCore(object? thisArgument, object?[] arguments)
+            => Capture(arguments);
+
+        protected override object? ConstructCore(object?[] arguments, object? newTarget)
+            => new ConstructSnapshot(
+                arguments[0],
+                newTarget,
+                RuntimeServices.GetCurrentCallee());
+    }
+
+    private static CallSnapshot Capture(object?[] arguments)
+        => new(
+            RuntimeServices.GetCurrentThis(),
+            arguments[0],
+            RuntimeServices.GetCurrentCallee(),
+            RuntimeServices.GetCurrentNewTarget());
+
+    private sealed record CallSnapshot(
+        object? ThisArgument,
+        object? Argument,
+        object? Callee,
+        object? NewTarget);
+
+    private sealed record NestedCallSnapshot(
+        CallSnapshot Inner,
+        CallSnapshot OuterAfterInner);
+
+    private sealed record ConstructSnapshot(
+        object? Argument,
+        object? NewTarget,
+        object? Callee);
+}


### PR DESCRIPTION
Closes #1709

## Summary

- add the abstract `JsFunctionObject : JsObject` runtime foundation with
  ordinary object identity, prototype, property, descriptor, symbol, deletion,
  and integrity behavior
- centralize `IsCallable`, `Call`, `IsConstructor`, and `Construct` in
  `CallableOperations`, with explicit per-invocation receiver, arguments,
  callee, and `newTarget` context
- add the visibly transitional `LegacyDelegateFunctionAdapter` and bridge
  existing generic call, construction, proxy, accessor, `Function.call/apply`,
  and `typeof` paths without selecting the final #1710 argument ABI
- document the runtime boundary and add focused coverage for nested,
  concurrent, proxy, accessor, construction, error, and legacy-adapter behavior

## Validation

- `dotnet build --no-restore --nologo --verbosity:minimal`
- 7 new `JsFunctionObjectRuntimeTests`
- 64 affected Function, object, descriptor, prototype, proxy, and callable
  inventory regression tests

The full `Jroc.Tests` invocation was also attempted, but its existing test host
stalled without failure output after more than 19 minutes; the focused groups
above and the full solution build completed successfully.
