### PR TITLE
perf(runtime): define JsFunctionObject invocation ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   delegate-backed functions. Function objects now share ordinary object,
   descriptor, prototype, proxy, and integrity behavior without storing mutable
   per-invocation receiver or argument state.
+- runtime/perf: define the `JsFunctionObject` dynamic invocation ABI with
+  inline arities 0-5, array-backed arbitrary/spread arguments, lazy
+  `arguments` materialization, separate construction entry points, and a
+  context-free generated-adapter path. Add arity analysis and allocation
+  benchmarks comparing the new ABI with `Closure.InvokeWithArgs`.
 
 ## v0.12.3 - 2026-08-05
 

--- a/docs/runtime/JsFunctionObjectInvocationAbi.md
+++ b/docs/runtime/JsFunctionObjectInvocationAbi.md
@@ -1,0 +1,135 @@
+# JsFunctionObject invocation ABI
+
+This document defines the compiler/runtime boundary for dynamic calls to
+object-backed JavaScript functions. It complements the typed direct-call path:
+when the compiler knows the exact callable and inferred CLR signature, it
+continues to call that typed implementation directly.
+
+## Argument transport
+
+`JsCallArguments` is a readonly, non-`ref struct` value carrier:
+
+- arities 0 through 5 use inline fields and allocate no argument array;
+- arbitrary and spread calls use an already-materialized `object?[]`;
+- `Count` preserves the distinction between missing and present arguments;
+- `GetArgument(index)` returns JavaScript `undefined` (CLR `null`) when the
+  index is outside the supplied argument count;
+- `ToArray()` returns existing arbitrary storage or materializes inline
+  storage only when array semantics are requested.
+
+The arbitrary array is invocation-owned storage. Compiler spread lowering
+creates it after evaluating the iterable, and host adapters must not mutate or
+reuse it while the call can observe or retain an `arguments` object.
+
+The carrier is deliberately not stack-only. It can safely cross async storage
+boundaries, unlike a `Span<T>` or `ref struct`, and it never uses pooled mutable
+arrays that could be corrupted by recursion, reentrancy, or retained
+`arguments` objects.
+
+`CallableOperations` exposes `Call0` through `Call5` for common arities and
+`Call` for an arbitrary array. Construction is separate through `Construct0`
+through `Construct5` and `Construct`; fixed construction entry points carry
+`newTarget` explicitly.
+
+## Invocation context
+
+Every `JsFunctionObject` receives `this`, `JsCallArguments`, and (for
+construction) `newTarget` explicitly. Generated adapters override
+`RequiresInvocationContext` with `false` when the callable does not read
+ambient call state. That path installs no `AsyncLocal` values and performs no
+argument materialization.
+
+Callables that use `arguments`, reflective callee state, or another runtime
+feature that requires ambient invocation state retain the default value of
+`true`. `CallableOperations` then installs receiver, packed arguments, callee,
+and `newTarget` for the duration of the call and restores outer state in a
+`finally` block. `RuntimeServices.GetCurrentArguments()` lazily materializes
+inline arguments on first observation and returns the same array for the
+remainder of that invocation.
+
+## Generated adapter contract
+
+A generated callee-shaped type keeps its inferred typed implementation as the
+canonical method:
+
+```csharp
+public double __js_call_typed(double value) => value + 1d;
+
+protected override object? CallCore(
+    object? thisArgument,
+    in JsCallArguments arguments)
+{
+    var value = TypeUtilities.ToNumber(arguments.GetArgument(0));
+    return __js_call_typed(value);
+}
+```
+
+The adapter performs missing/default/rest handling and conversion at the
+dynamic boundary, then boxes the return only when re-entering generic
+JavaScript value flow. Materializing a function object does not widen the
+typed implementation. Additional call-site-specialized methods use the same
+generated object type and identity.
+
+Constructor adapters apply ECMAScript constructor-return rules separately.
+Async and generator adapters return their JavaScript-visible Promise or
+iterator object rather than exposing an internal state-machine result.
+
+Legacy delegates remain supported through
+`LegacyDelegateFunctionAdapter`. They materialize arguments when their current
+delegate ABI requires an array; this is an explicit migration path, not the
+generated function-object ABI.
+
+## Arity evidence
+
+Run the checked-in analyzer:
+
+```bash
+dotnet run --project tests/performance/Benchmarks/Benchmarks.csproj -- \
+  --callable-arity-analysis
+```
+
+The 2026-08-05 analysis covered all 26 checked-in benchmark scenarios:
+
+| Arity | Call expressions | Construct expressions |
+| ---: | ---: | ---: |
+| 0 | 441 (23.52%) | 45 (12.71%) |
+| 1 | 983 (52.43%) | 161 (45.48%) |
+| 2 | 410 (21.87%) | 30 (8.47%) |
+| 3 | 29 (1.55%) | 99 (27.97%) |
+| 4 | 12 (0.64%) | 7 (1.98%) |
+| 5 | 0 | 2 (0.56%) |
+| 6+ | 0 | 10 (2.82%) |
+
+Thus arities 0 through 2 cover 97.82% of lexical benchmark calls, and 0
+through 5 cover every benchmark call plus 97.18% of constructions. This is a
+static call-site distribution, not execution-frequency weighting.
+
+The same analyzer found 86 current runtime callback-dispatch references:
+4 each at fixed arities 0 and 1, 5 at arity 2, 3 at arity 3, and 70 using the
+arbitrary delegate dispatcher. This identifies later callback migrations where
+fixed entry points can remove existing arrays.
+
+## Allocation benchmark
+
+Run:
+
+```bash
+dotnet run -c Release \
+  --project tests/performance/Benchmarks/Benchmarks.csproj -- \
+  --callable-abi --filter "*"
+```
+
+The local .NET 10 ShortRun on 2026-08-05 produced:
+
+| Path | Mean | Allocated |
+| --- | ---: | ---: |
+| `JsFunctionObject` fixed arity 3 | 1.537 ns | 0 B |
+| `JsFunctionObject` pre-materialized arbitrary arguments | 1.572 ns | 0 B |
+| `JsFunctionObject` spread materialization | 12.161 ns | 48 B |
+| legacy `Closure.InvokeWithArgs3` | 18.774 ns | 48 B |
+| `JsFunctionObject` ambient-context fixed arity 3 | 325.786 ns | 304 B |
+
+These microbenchmarks guard the ABI shape; end-to-end benchmark results remain
+the authority for application performance. The ambient-context result also
+makes planner classification important: generated adapters should opt into
+ambient state only when their semantics require it.

--- a/docs/runtime/OrdinaryObjectRepresentation.md
+++ b/docs/runtime/OrdinaryObjectRepresentation.md
@@ -105,9 +105,9 @@ reentrancy, and concurrent calls remain isolated.
 
 `LegacyDelegateFunctionAdapter` keeps existing delegate-backed compiled
 functions available during the staged migration. New object-backed callables
-derive from `JsFunctionObject`; the final fixed-arity and arbitrary-argument ABI
-and compiler-generated subclasses are tracked separately under
-[#1710](https://github.com/tomacox74/js2il/issues/1710) and
+derive from `JsFunctionObject` and use the
+[fixed-arity/arbitrary invocation ABI](JsFunctionObjectInvocationAbi.md).
+Compiler-generated subclasses are tracked under
 [#1711](https://github.com/tomacox74/js2il/issues/1711).
 
 ## Host boundary

--- a/src/JavaScriptRuntime/CallableOperations.cs
+++ b/src/JavaScriptRuntime/CallableOperations.cs
@@ -19,20 +19,71 @@ public static class CallableOperations
 
     public static object? Call(object? target, object? thisArgument, object?[]? arguments)
     {
-        var callArguments = arguments ?? System.Array.Empty<object?>();
+        var callArguments = JsCallArguments.FromArray(arguments);
+        return CallCore(target, thisArgument, callArguments);
+    }
 
-        return target switch
-        {
-            JsFunctionObject functionObject => CallFunctionObject(functionObject, thisArgument, callArguments),
-            Delegate legacyDelegate => LegacyDelegateFunctionAdapter.Invoke(
-                legacyDelegate,
-                RuntimeServices.EmptyScopes,
-                thisArgument,
-                callArguments),
-            Proxy proxy when proxy.IsCallableTarget => CallProxy(proxy, thisArgument, callArguments),
-            ClassConstructorValue => throw new TypeError("Class constructor cannot be invoked without 'new'"),
-            _ => throw new TypeError("Value is not callable")
-        };
+    public static object? Call0(object? target, object? thisArgument)
+    {
+        var arguments = JsCallArguments.Empty;
+        return CallCore(target, thisArgument, arguments);
+    }
+
+    public static object? Call1(object? target, object? thisArgument, object? argument0)
+    {
+        var arguments = JsCallArguments.From(argument0);
+        return CallCore(target, thisArgument, arguments);
+    }
+
+    public static object? Call2(
+        object? target,
+        object? thisArgument,
+        object? argument0,
+        object? argument1)
+    {
+        var arguments = JsCallArguments.From(argument0, argument1);
+        return CallCore(target, thisArgument, arguments);
+    }
+
+    public static object? Call3(
+        object? target,
+        object? thisArgument,
+        object? argument0,
+        object? argument1,
+        object? argument2)
+    {
+        var arguments = JsCallArguments.From(argument0, argument1, argument2);
+        return CallCore(target, thisArgument, arguments);
+    }
+
+    public static object? Call4(
+        object? target,
+        object? thisArgument,
+        object? argument0,
+        object? argument1,
+        object? argument2,
+        object? argument3)
+    {
+        var arguments = JsCallArguments.From(argument0, argument1, argument2, argument3);
+        return CallCore(target, thisArgument, arguments);
+    }
+
+    public static object? Call5(
+        object? target,
+        object? thisArgument,
+        object? argument0,
+        object? argument1,
+        object? argument2,
+        object? argument3,
+        object? argument4)
+    {
+        var arguments = JsCallArguments.From(
+            argument0,
+            argument1,
+            argument2,
+            argument3,
+            argument4);
+        return CallCore(target, thisArgument, arguments);
     }
 
     public static bool IsConstructor(object? value)
@@ -49,8 +100,106 @@ public static class CallableOperations
 
     public static object? Construct(object? target, object?[]? arguments, object? newTarget)
     {
-        var constructArguments = arguments ?? System.Array.Empty<object?>();
+        var constructArguments = JsCallArguments.FromArray(arguments);
+        return ConstructCore(target, newTarget, constructArguments);
+    }
 
+    public static object? Construct0(object? target, object? newTarget)
+    {
+        var arguments = JsCallArguments.Empty;
+        return ConstructCore(target, newTarget, arguments);
+    }
+
+    public static object? Construct1(
+        object? target,
+        object? newTarget,
+        object? argument0)
+    {
+        var arguments = JsCallArguments.From(argument0);
+        return ConstructCore(target, newTarget, arguments);
+    }
+
+    public static object? Construct2(
+        object? target,
+        object? newTarget,
+        object? argument0,
+        object? argument1)
+    {
+        var arguments = JsCallArguments.From(argument0, argument1);
+        return ConstructCore(target, newTarget, arguments);
+    }
+
+    public static object? Construct3(
+        object? target,
+        object? newTarget,
+        object? argument0,
+        object? argument1,
+        object? argument2)
+    {
+        var arguments = JsCallArguments.From(argument0, argument1, argument2);
+        return ConstructCore(target, newTarget, arguments);
+    }
+
+    public static object? Construct4(
+        object? target,
+        object? newTarget,
+        object? argument0,
+        object? argument1,
+        object? argument2,
+        object? argument3)
+    {
+        var arguments = JsCallArguments.From(argument0, argument1, argument2, argument3);
+        return ConstructCore(target, newTarget, arguments);
+    }
+
+    public static object? Construct5(
+        object? target,
+        object? newTarget,
+        object? argument0,
+        object? argument1,
+        object? argument2,
+        object? argument3,
+        object? argument4)
+    {
+        var arguments = JsCallArguments.From(
+            argument0,
+            argument1,
+            argument2,
+            argument3,
+            argument4);
+        return ConstructCore(target, newTarget, arguments);
+    }
+
+    private static object? CallCore(
+        object? target,
+        object? thisArgument,
+        in JsCallArguments arguments)
+    {
+        return target switch
+        {
+            JsFunctionObject functionObject => CallFunctionObject(
+                functionObject,
+                thisArgument,
+                arguments),
+            Delegate legacyDelegate => LegacyDelegateFunctionAdapter.Invoke(
+                legacyDelegate,
+                RuntimeServices.EmptyScopes,
+                thisArgument,
+                arguments.ToArray()),
+            Proxy proxy when proxy.IsCallableTarget => CallProxy(
+                proxy,
+                thisArgument,
+                arguments.ToArray()),
+            ClassConstructorValue => throw new TypeError("Class constructor cannot be invoked without 'new'"),
+            _ => throw new TypeError("Value is not callable")
+        };
+    }
+
+    private static object? ConstructCore(
+        object? target,
+        object? newTarget,
+        in JsCallArguments arguments)
+    {
         if (target is JsFunctionObject functionObject)
         {
             if (!functionObject.IsConstructor)
@@ -58,7 +207,7 @@ public static class CallableOperations
                 throw new TypeError("Value is not a constructor");
             }
 
-            return ConstructFunctionObject(functionObject, constructArguments, newTarget);
+            return ConstructFunctionObject(functionObject, arguments, newTarget);
         }
 
         if (!ObjectRuntime.IsConstructibleValue(target))
@@ -66,17 +215,24 @@ public static class CallableOperations
             throw new TypeError("Value is not a constructor");
         }
 
-        var legacyArguments = System.Array.ConvertAll(constructArguments, static argument => argument!);
+        var legacyArguments = System.Array.ConvertAll(
+            arguments.ToArray(),
+            static argument => argument!);
         return ObjectRuntime.ConstructValue(target!, legacyArguments, newTarget);
     }
 
     private static object? CallFunctionObject(
         JsFunctionObject functionObject,
         object? thisArgument,
-        object?[] arguments)
+        in JsCallArguments arguments)
     {
+        if (!functionObject.RequiresInvocationContext)
+        {
+            return functionObject.InvokeCall(thisArgument, arguments);
+        }
+
         var previousThis = RuntimeServices.SetCurrentThis(thisArgument);
-        var previousArguments = RuntimeServices.SetCurrentArguments(arguments);
+        var previousArguments = RuntimeServices.SetCurrentCallArguments(arguments);
         var previousCallee = RuntimeServices.SetCurrentCallee(functionObject);
         var previousNewTarget = RuntimeServices.SetCurrentNewTarget(null);
         try
@@ -87,17 +243,22 @@ public static class CallableOperations
         {
             RuntimeServices.SetCurrentNewTarget(previousNewTarget);
             RuntimeServices.SetCurrentCallee(previousCallee);
-            RuntimeServices.SetCurrentArguments(previousArguments);
+            RuntimeServices.RestoreCurrentCallArguments(previousArguments);
             RuntimeServices.SetCurrentThis(previousThis);
         }
     }
 
     private static object? ConstructFunctionObject(
         JsFunctionObject functionObject,
-        object?[] arguments,
+        in JsCallArguments arguments,
         object? newTarget)
     {
-        var previousArguments = RuntimeServices.SetCurrentArguments(arguments);
+        if (!functionObject.RequiresInvocationContext)
+        {
+            return functionObject.InvokeConstruct(arguments, newTarget);
+        }
+
+        var previousArguments = RuntimeServices.SetCurrentCallArguments(arguments);
         var previousCallee = RuntimeServices.SetCurrentCallee(functionObject);
         var previousNewTarget = RuntimeServices.SetCurrentNewTarget(newTarget);
         try
@@ -108,7 +269,7 @@ public static class CallableOperations
         {
             RuntimeServices.SetCurrentNewTarget(previousNewTarget);
             RuntimeServices.SetCurrentCallee(previousCallee);
-            RuntimeServices.SetCurrentArguments(previousArguments);
+            RuntimeServices.RestoreCurrentCallArguments(previousArguments);
         }
     }
 

--- a/src/JavaScriptRuntime/Closure.cs
+++ b/src/JavaScriptRuntime/Closure.cs
@@ -703,6 +703,14 @@ namespace JavaScriptRuntime
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (scopes == null) throw new ArgumentNullException(nameof(scopes));
 
+            if (target is JsFunctionObject functionObject)
+            {
+                return CallableOperations.Call(
+                    functionObject,
+                    RuntimeServices.GetCurrentThis(),
+                    args)!;
+            }
+
             if (target is Delegate fastDelegate
                 && !Function.RequiresInvocationContext(fastDelegate)
                 && !Function.HasBoundWithObject(fastDelegate))
@@ -744,14 +752,6 @@ namespace JavaScriptRuntime
                     }
 
                     return InvokeWithArgsCore(proxyTarget, scopes, newTarget, args);
-                }
-
-                if (target is JsFunctionObject functionObject)
-                {
-                    return CallableOperations.Call(
-                        functionObject,
-                        RuntimeServices.GetCurrentThis(),
-                        args)!;
                 }
 
                 // CommonJS require(...) is passed into scripts as a RequireDelegate, which does not include
@@ -953,6 +953,11 @@ namespace JavaScriptRuntime
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (scopes == null) throw new ArgumentNullException(nameof(scopes));
 
+            if (target is JsFunctionObject)
+            {
+                return CallableOperations.Call0(target, RuntimeServices.GetCurrentThis())!;
+            }
+
             if (TryInvokeProxyCallFastPath(target, scopes, System.Array.Empty<object>(), out var proxyResult))
             {
                 return proxyResult;
@@ -1003,6 +1008,11 @@ namespace JavaScriptRuntime
         {
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (scopes == null) throw new ArgumentNullException(nameof(scopes));
+
+            if (target is JsFunctionObject)
+            {
+                return CallableOperations.Call1(target, RuntimeServices.GetCurrentThis(), a0)!;
+            }
 
             var args = new object?[] { a0 };
 
@@ -1063,6 +1073,15 @@ namespace JavaScriptRuntime
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (scopes == null) throw new ArgumentNullException(nameof(scopes));
 
+            if (target is JsFunctionObject)
+            {
+                return CallableOperations.Call2(
+                    target,
+                    RuntimeServices.GetCurrentThis(),
+                    a0,
+                    a1)!;
+            }
+
             var args = new object?[] { a0, a1 };
 
             if (TryInvokeProxyCallFastPath(target, scopes, args, out var proxyResult))
@@ -1121,6 +1140,16 @@ namespace JavaScriptRuntime
         {
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (scopes == null) throw new ArgumentNullException(nameof(scopes));
+
+            if (target is JsFunctionObject)
+            {
+                return CallableOperations.Call3(
+                    target,
+                    RuntimeServices.GetCurrentThis(),
+                    a0,
+                    a1,
+                    a2)!;
+            }
 
             var args = new object?[] { a0, a1, a2 };
 
@@ -1181,6 +1210,17 @@ namespace JavaScriptRuntime
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (scopes == null) throw new ArgumentNullException(nameof(scopes));
 
+            if (target is JsFunctionObject)
+            {
+                return CallableOperations.Call4(
+                    target,
+                    RuntimeServices.GetCurrentThis(),
+                    a0,
+                    a1,
+                    a2,
+                    a3)!;
+            }
+
             var args = new object?[] { a0, a1, a2, a3 };
 
             if (TryInvokeProxyCallFastPath(target, scopes, args, out var proxyResult))
@@ -1239,6 +1279,18 @@ namespace JavaScriptRuntime
         {
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (scopes == null) throw new ArgumentNullException(nameof(scopes));
+
+            if (target is JsFunctionObject)
+            {
+                return CallableOperations.Call5(
+                    target,
+                    RuntimeServices.GetCurrentThis(),
+                    a0,
+                    a1,
+                    a2,
+                    a3,
+                    a4)!;
+            }
 
             var args = new object?[] { a0, a1, a2, a3, a4 };
 

--- a/src/JavaScriptRuntime/JsCallArguments.cs
+++ b/src/JavaScriptRuntime/JsCallArguments.cs
@@ -1,0 +1,123 @@
+namespace JavaScriptRuntime;
+
+/// <summary>
+/// Allocation-conscious JavaScript argument transport for dynamic calls.
+/// </summary>
+public readonly struct JsCallArguments
+{
+    private readonly object?[]? _array;
+    private readonly object? _argument0;
+    private readonly object? _argument1;
+    private readonly object? _argument2;
+    private readonly object? _argument3;
+    private readonly object? _argument4;
+    private readonly byte _inlineCount;
+
+    private JsCallArguments(
+        byte inlineCount,
+        object? argument0 = null,
+        object? argument1 = null,
+        object? argument2 = null,
+        object? argument3 = null,
+        object? argument4 = null)
+    {
+        _array = null;
+        _argument0 = argument0;
+        _argument1 = argument1;
+        _argument2 = argument2;
+        _argument3 = argument3;
+        _argument4 = argument4;
+        _inlineCount = inlineCount;
+    }
+
+    private JsCallArguments(object?[] arguments)
+    {
+        _array = arguments;
+        _argument0 = null;
+        _argument1 = null;
+        _argument2 = null;
+        _argument3 = null;
+        _argument4 = null;
+        _inlineCount = 0;
+    }
+
+    public static JsCallArguments Empty => default;
+
+    public int Count => _array?.Length ?? _inlineCount;
+
+    public bool UsesArrayStorage => _array is not null;
+
+    public static JsCallArguments From(object? argument0)
+        => new(1, argument0);
+
+    public static JsCallArguments From(object? argument0, object? argument1)
+        => new(2, argument0, argument1);
+
+    public static JsCallArguments From(object? argument0, object? argument1, object? argument2)
+        => new(3, argument0, argument1, argument2);
+
+    public static JsCallArguments From(
+        object? argument0,
+        object? argument1,
+        object? argument2,
+        object? argument3)
+        => new(4, argument0, argument1, argument2, argument3);
+
+    public static JsCallArguments From(
+        object? argument0,
+        object? argument1,
+        object? argument2,
+        object? argument3,
+        object? argument4)
+        => new(5, argument0, argument1, argument2, argument3, argument4);
+
+    public static JsCallArguments FromArray(object?[]? arguments)
+        => arguments is null || arguments.Length == 0
+            ? Empty
+            : new JsCallArguments(arguments);
+
+    public object? GetArgument(int index)
+    {
+        if ((uint)index >= (uint)Count)
+        {
+            return null;
+        }
+
+        if (_array is not null)
+        {
+            return _array[index];
+        }
+
+        return index switch
+        {
+            0 => _argument0,
+            1 => _argument1,
+            2 => _argument2,
+            3 => _argument3,
+            4 => _argument4,
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Returns the existing arbitrary-argument array or materializes inline arguments.
+    /// </summary>
+    public object?[] ToArray()
+    {
+        if (_array is not null)
+        {
+            return _array;
+        }
+
+        return _inlineCount switch
+        {
+            0 => System.Array.Empty<object?>(),
+            1 => [_argument0],
+            2 => [_argument0, _argument1],
+            3 => [_argument0, _argument1, _argument2],
+            4 => [_argument0, _argument1, _argument2, _argument3],
+            5 => [_argument0, _argument1, _argument2, _argument3, _argument4],
+            _ => throw new InvalidOperationException("Invalid inline JavaScript argument count.")
+        };
+    }
+}

--- a/src/JavaScriptRuntime/JsFunctionObject.cs
+++ b/src/JavaScriptRuntime/JsFunctionObject.cs
@@ -15,20 +15,25 @@ public abstract class JsFunctionObject : JsObject
     /// </summary>
     public virtual bool IsConstructor => false;
 
-    internal object? InvokeCall(object? thisArgument, object?[] arguments)
+    /// <summary>
+    /// Gets whether invocation must populate ambient runtime call state.
+    /// </summary>
+    public virtual bool RequiresInvocationContext => true;
+
+    internal object? InvokeCall(object? thisArgument, in JsCallArguments arguments)
         => CallCore(thisArgument, arguments);
 
-    internal object? InvokeConstruct(object?[] arguments, object? newTarget)
+    internal object? InvokeConstruct(in JsCallArguments arguments, object? newTarget)
         => ConstructCore(arguments, newTarget);
 
     /// <summary>
     /// Implements ECMAScript [[Call]] for this function object.
     /// </summary>
-    protected abstract object? CallCore(object? thisArgument, object?[] arguments);
+    protected abstract object? CallCore(object? thisArgument, in JsCallArguments arguments);
 
     /// <summary>
     /// Implements ECMAScript [[Construct]] for constructable function objects.
     /// </summary>
-    protected virtual object? ConstructCore(object?[] arguments, object? newTarget)
+    protected virtual object? ConstructCore(in JsCallArguments arguments, object? newTarget)
         => throw new TypeError("Value is not a constructor");
 }

--- a/src/JavaScriptRuntime/LegacyDelegateFunctionAdapter.cs
+++ b/src/JavaScriptRuntime/LegacyDelegateFunctionAdapter.cs
@@ -17,11 +17,11 @@ public sealed class LegacyDelegateFunctionAdapter : JsFunctionObject
 
     public override bool IsConstructor => ObjectRuntime.IsConstructibleValue(Target);
 
-    protected override object? CallCore(object? thisArgument, object?[] arguments)
-        => Invoke(Target, _scopes, thisArgument, arguments);
+    protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
+        => Invoke(Target, _scopes, thisArgument, arguments.ToArray());
 
-    protected override object? ConstructCore(object?[] arguments, object? newTarget)
-        => Function.Construct(Target, arguments, newTarget);
+    protected override object? ConstructCore(in JsCallArguments arguments, object? newTarget)
+        => Function.Construct(Target, arguments.ToArray(), newTarget);
 
     internal static object? Invoke(
         Delegate target,

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -15,6 +15,7 @@ public class RuntimeServices
     private static readonly System.Threading.AsyncLocal<object?> _currentLexicalSuperReceiver = new();
     private static readonly System.Threading.AsyncLocal<object[]?> _currentLexicalSuperScopes = new();
     private static readonly System.Threading.AsyncLocal<object?[]?> _currentArguments = new();
+    private static readonly System.Threading.AsyncLocal<JsCallArguments?> _currentCallArguments = new();
     private static readonly System.Threading.AsyncLocal<object?> _currentNewTarget = new();
     private static readonly System.Threading.AsyncLocal<object?> _currentCallee = new();
     [ThreadStatic] private static Stack<object?[]?>? _constructorArgStack;
@@ -942,7 +943,19 @@ public class RuntimeServices
 
     public static object?[]? GetCurrentArguments()
     {
-        return _currentArguments.Value;
+        if (_currentArguments.Value is { } materializedArguments)
+        {
+            return materializedArguments;
+        }
+
+        if (_currentCallArguments.Value is not { } callArguments)
+        {
+            return null;
+        }
+
+        materializedArguments = callArguments.ToArray();
+        _currentArguments.Value = materializedArguments;
+        return materializedArguments;
     }
 
     public static object?[]? SetCurrentArguments(object?[]? value)
@@ -951,6 +964,26 @@ public class RuntimeServices
         _currentArguments.Value = value;
         return previous;
     }
+
+    internal static CurrentCallArgumentsState SetCurrentCallArguments(in JsCallArguments value)
+    {
+        var previous = new CurrentCallArgumentsState(
+            _currentArguments.Value,
+            _currentCallArguments.Value);
+        _currentArguments.Value = null;
+        _currentCallArguments.Value = value;
+        return previous;
+    }
+
+    internal static void RestoreCurrentCallArguments(CurrentCallArgumentsState state)
+    {
+        _currentCallArguments.Value = state.PackedArguments;
+        _currentArguments.Value = state.MaterializedArguments;
+    }
+
+    internal readonly record struct CurrentCallArgumentsState(
+        object?[]? MaterializedArguments,
+        JsCallArguments? PackedArguments);
 
     /// <summary>
     /// Saves the current arguments onto a thread-local stack and sets new arguments.

--- a/tests/Jroc.Tests/Function/JsCallArgumentsRuntimeTests.cs
+++ b/tests/Jroc.Tests/Function/JsCallArgumentsRuntimeTests.cs
@@ -1,0 +1,333 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using JavaScriptRuntime;
+
+namespace Jroc.Tests.Function;
+
+public sealed class JsCallArgumentsRuntimeTests
+{
+    [Fact]
+    public void FixedArityCallsUseInlineArgumentStorage()
+    {
+        var function = new InspectArgumentsFunction();
+
+        for (var arity = 0; arity <= 5; arity++)
+        {
+            var result = Assert.IsType<ArgumentsSnapshot>(arity switch
+            {
+                0 => CallableOperations.Call0(function, "receiver"),
+                1 => CallableOperations.Call1(function, "receiver", "a0"),
+                2 => CallableOperations.Call2(function, "receiver", "a0", "a1"),
+                3 => CallableOperations.Call3(function, "receiver", "a0", "a1", "a2"),
+                4 => CallableOperations.Call4(function, "receiver", "a0", "a1", "a2", "a3"),
+                5 => CallableOperations.Call5(function, "receiver", "a0", "a1", "a2", "a3", "a4"),
+                _ => throw new InvalidOperationException()
+            });
+
+            Assert.Equal(arity, result.Count);
+            Assert.False(result.UsesArrayStorage);
+            Assert.Equal("receiver", result.ThisArgument);
+        }
+    }
+
+    [Fact]
+    public void ContextFreeAdapterUsesOnlyExplicitInvocationState()
+    {
+        var function = new ContextFreeFunction();
+        var previousThis = RuntimeServices.SetCurrentThis("ambient-this");
+        var previousArguments = RuntimeServices.SetCurrentArguments(
+            new object?[] { "ambient-argument" });
+        try
+        {
+            var result = Assert.IsType<ContextFreeSnapshot>(
+                CallableOperations.Call1(function, "explicit-this", "explicit-argument"));
+            var genericBridgeResult = Assert.IsType<ContextFreeSnapshot>(
+                Closure.InvokeWithArgs(
+                    function,
+                    RuntimeServices.EmptyScopes,
+                    new object?[] { "generic-argument" }));
+
+            Assert.Equal("explicit-this", result.ThisArgument);
+            Assert.Equal("explicit-argument", result.Argument);
+            Assert.Equal("ambient-this", genericBridgeResult.ThisArgument);
+            Assert.Equal("generic-argument", genericBridgeResult.Argument);
+            Assert.Equal("ambient-this", RuntimeServices.GetCurrentThis());
+            Assert.Equal(
+                "ambient-argument",
+                Assert.Single(RuntimeServices.GetCurrentArguments()!));
+        }
+        finally
+        {
+            RuntimeServices.SetCurrentArguments(previousArguments);
+            RuntimeServices.SetCurrentThis(previousThis);
+        }
+    }
+
+    [Fact]
+    public void LegacyFixedDispatchersBridgeWithoutMaterializingArguments()
+    {
+        var function = new InspectArgumentsFunction();
+        var previousThis = RuntimeServices.SetCurrentThis("legacy-receiver");
+        try
+        {
+            var one = Assert.IsType<ArgumentsSnapshot>(
+                Closure.InvokeWithArgs1(
+                    function,
+                    RuntimeServices.EmptyScopes,
+                    "a0"));
+            var three = Assert.IsType<ArgumentsSnapshot>(
+                Closure.InvokeWithArgs3(
+                    function,
+                    RuntimeServices.EmptyScopes,
+                    "a0",
+                    "a1",
+                    "a2"));
+            var five = Assert.IsType<ArgumentsSnapshot>(
+                Closure.InvokeWithArgs5(
+                    function,
+                    RuntimeServices.EmptyScopes,
+                    "a0",
+                    "a1",
+                    "a2",
+                    "a3",
+                    "a4"));
+
+            Assert.Equal(new[] { 1, 3, 5 }, new[] { one.Count, three.Count, five.Count });
+            Assert.False(one.UsesArrayStorage);
+            Assert.False(three.UsesArrayStorage);
+            Assert.False(five.UsesArrayStorage);
+            Assert.Equal("legacy-receiver", five.ThisArgument);
+        }
+        finally
+        {
+            RuntimeServices.SetCurrentThis(previousThis);
+        }
+    }
+
+    [Fact]
+    public void ArbitraryAndSpreadArgumentsRetainArrayStorage()
+    {
+        var function = new InspectArgumentsFunction();
+        object?[] spreadArguments = ["a0", null, 3d, true, "a4", "a5", "a6"];
+
+        var result = Assert.IsType<ArgumentsSnapshot>(
+            CallableOperations.Call(function, "receiver", spreadArguments));
+
+        Assert.Equal(spreadArguments.Length, result.Count);
+        Assert.True(result.UsesArrayStorage);
+        Assert.Same(spreadArguments, result.MaterializedArguments);
+        Assert.Null(result.MissingArgument);
+    }
+
+    [Fact]
+    public void ArgumentsArrayMaterializesLazilyAndRemainsStableWithinCall()
+    {
+        var function = new MaterializeArgumentsFunction();
+
+        var result = Assert.IsType<MaterializedArgumentsSnapshot>(
+            CallableOperations.Call3(function, null, "first", null, "third"));
+
+        Assert.False(result.UsedArrayStorageBeforeMaterialization);
+        Assert.Same(result.FirstRead, result.SecondRead);
+        Assert.Equal(new object?[] { "first", null, "third" }, result.FirstRead);
+    }
+
+    [Fact]
+    public void MissingExtraDefaultAndRestSemanticsUseArgumentCount()
+    {
+        var function = new DefaultsAndRestFunction();
+
+        var missing = Assert.IsType<DefaultsAndRestSnapshot>(
+            CallableOperations.Call0(function, null));
+        var extra = Assert.IsType<DefaultsAndRestSnapshot>(
+            CallableOperations.Call4(function, null, "value", 1d, 2d, 3d));
+
+        Assert.Equal("default", missing.First);
+        Assert.Empty(missing.Rest);
+        Assert.Equal("value", extra.First);
+        Assert.Equal(new object?[] { 1d, 2d, 3d }, extra.Rest);
+    }
+
+    [Fact]
+    public void FixedArityConstructionCarriesNewTargetWithoutArrayStorage()
+    {
+        var constructor = new InspectConstructorFunction();
+        var newTarget = new JsObject();
+
+        var result = Assert.IsType<ConstructArgumentsSnapshot>(
+            CallableOperations.Construct2(constructor, newTarget, "first", "second"));
+
+        Assert.Equal(2, result.Count);
+        Assert.False(result.UsesArrayStorage);
+        Assert.Same(newTarget, result.NewTarget);
+        Assert.Same(constructor, result.Callee);
+    }
+
+    [Fact]
+    public void AbruptCompletionRestoresOuterPackedArguments()
+    {
+        var function = new CatchingFunction();
+
+        var result = Assert.IsType<object?[]>(
+            CallableOperations.Call1(function, null, "outer"));
+
+        Assert.Equal(new object?[] { "outer" }, result);
+        Assert.Null(RuntimeServices.GetCurrentArguments());
+    }
+
+    [Fact]
+    public void TypedImplementationRemainsTypedBehindGenericAdapter()
+    {
+        var function = new TypedAdapterFunction();
+        var type = typeof(TypedAdapterFunction);
+        var numberMethod = type.GetMethod(nameof(TypedAdapterFunction.InvokeNumber))!;
+        var booleanMethod = type.GetMethod(nameof(TypedAdapterFunction.InvokeBoolean))!;
+        var stringMethod = type.GetMethod(nameof(TypedAdapterFunction.InvokeString))!;
+        var adapterMethod = type.GetMethod(
+            "CallCore",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        Assert.Equal(typeof(double), numberMethod.ReturnType);
+        Assert.Equal(typeof(double), Assert.Single(numberMethod.GetParameters()).ParameterType);
+        Assert.Equal(typeof(bool), booleanMethod.ReturnType);
+        Assert.Equal(typeof(bool), Assert.Single(booleanMethod.GetParameters()).ParameterType);
+        Assert.Equal(typeof(string), stringMethod.ReturnType);
+        Assert.Equal(typeof(string), Assert.Single(stringMethod.GetParameters()).ParameterType);
+
+        Assert.Equal(typeof(object), adapterMethod.ReturnType);
+        var adapterArgumentsParameter = adapterMethod.GetParameters()[1];
+        Assert.Equal(typeof(JsCallArguments).MakeByRefType(), adapterArgumentsParameter.ParameterType);
+        Assert.True(adapterArgumentsParameter.IsIn);
+
+        Assert.DoesNotContain(
+            unchecked((byte)OpCodes.Box.Value),
+            numberMethod.GetMethodBody()!.GetILAsByteArray()!);
+        Assert.Contains(
+            unchecked((byte)OpCodes.Box.Value),
+            adapterMethod.GetMethodBody()!.GetILAsByteArray()!);
+
+        Assert.Equal(3d, CallableOperations.Call1(function, null, 2d));
+        Assert.Same(function, function.Identity);
+        Assert.False(typeof(JsCallArguments).IsByRefLike);
+    }
+
+    private sealed class InspectArgumentsFunction : JsFunctionObject
+    {
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
+            => new ArgumentsSnapshot(
+                arguments.Count,
+                arguments.UsesArrayStorage,
+                thisArgument,
+                arguments.ToArray(),
+                arguments.GetArgument(arguments.Count + 1));
+    }
+
+    private sealed class ContextFreeFunction : JsFunctionObject
+    {
+        public override bool RequiresInvocationContext => false;
+
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
+            => new ContextFreeSnapshot(thisArgument, arguments.GetArgument(0));
+    }
+
+    private sealed class MaterializeArgumentsFunction : JsFunctionObject
+    {
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
+        {
+            var usedArrayStorage = arguments.UsesArrayStorage;
+            var firstRead = RuntimeServices.GetCurrentArguments()!;
+            var secondRead = RuntimeServices.GetCurrentArguments()!;
+            return new MaterializedArgumentsSnapshot(usedArrayStorage, firstRead, secondRead);
+        }
+    }
+
+    private sealed class DefaultsAndRestFunction : JsFunctionObject
+    {
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
+        {
+            var first = arguments.GetArgument(0) ?? "default";
+            var rest = new object?[System.Math.Max(arguments.Count - 1, 0)];
+            for (var index = 1; index < arguments.Count; index++)
+            {
+                rest[index - 1] = arguments.GetArgument(index);
+            }
+
+            return new DefaultsAndRestSnapshot(first, rest);
+        }
+    }
+
+    private sealed class InspectConstructorFunction : JsFunctionObject
+    {
+        public override bool IsConstructor => true;
+
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
+            => null;
+
+        protected override object? ConstructCore(
+            in JsCallArguments arguments,
+            object? newTarget)
+            => new ConstructArgumentsSnapshot(
+                arguments.Count,
+                arguments.UsesArrayStorage,
+                newTarget,
+                RuntimeServices.GetCurrentCallee());
+    }
+
+    private sealed class CatchingFunction : JsFunctionObject
+    {
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
+        {
+            try
+            {
+                CallableOperations.Call0(new ThrowingFunction(), null);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            return RuntimeServices.GetCurrentArguments();
+        }
+    }
+
+    private sealed class ThrowingFunction : JsFunctionObject
+    {
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
+            => throw new InvalidOperationException("abrupt completion");
+    }
+
+    private sealed class TypedAdapterFunction : JsFunctionObject
+    {
+        public JsFunctionObject Identity => this;
+
+        public double InvokeNumber(double value) => value + 1d;
+
+        public bool InvokeBoolean(bool value) => !value;
+
+        public string InvokeString(string value) => value + "!";
+
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
+            => InvokeNumber(TypeUtilities.ToNumber(arguments.GetArgument(0)));
+    }
+
+    private sealed record ArgumentsSnapshot(
+        int Count,
+        bool UsesArrayStorage,
+        object? ThisArgument,
+        object?[] MaterializedArguments,
+        object? MissingArgument);
+
+    private sealed record MaterializedArgumentsSnapshot(
+        bool UsedArrayStorageBeforeMaterialization,
+        object?[] FirstRead,
+        object?[] SecondRead);
+
+    private sealed record ContextFreeSnapshot(object? ThisArgument, object? Argument);
+
+    private sealed record DefaultsAndRestSnapshot(object? First, object?[] Rest);
+
+    private sealed record ConstructArgumentsSnapshot(
+        int Count,
+        bool UsesArrayStorage,
+        object? NewTarget,
+        object? Callee);
+}

--- a/tests/Jroc.Tests/Function/JsFunctionObjectRuntimeTests.cs
+++ b/tests/Jroc.Tests/Function/JsFunctionObjectRuntimeTests.cs
@@ -52,7 +52,7 @@ public sealed class JsFunctionObjectRuntimeTests
             var setter = new LambdaFunction((thisArgument, arguments) =>
             {
                 setterThis = thisArgument;
-                setterValue = arguments[0];
+                setterValue = arguments.GetArgument(0);
                 return null;
             });
             JavaScriptRuntime.Object.defineProperty(function, "accessor", new JsObject
@@ -254,21 +254,21 @@ public sealed class JsFunctionObjectRuntimeTests
 
     private sealed class RecordingFunction : JsFunctionObject
     {
-        protected override object? CallCore(object? thisArgument, object?[] arguments)
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
             => Capture(arguments);
     }
 
-    private sealed class LambdaFunction(Func<object?, object?[], object?> implementation) : JsFunctionObject
+    private sealed class LambdaFunction(Func<object?, JsCallArguments, object?> implementation) : JsFunctionObject
     {
-        protected override object? CallCore(object? thisArgument, object?[] arguments)
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
             => implementation(thisArgument, arguments);
     }
 
     private sealed class ReentrantFunction : JsFunctionObject
     {
-        protected override object? CallCore(object? thisArgument, object?[] arguments)
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
         {
-            if (Equals(arguments[0], "outer"))
+            if (Equals(arguments.GetArgument(0), "outer"))
             {
                 var inner = Assert.IsType<CallSnapshot>(
                     CallableOperations.Call(this, "inner-this", new object?[] { "inner" }));
@@ -281,7 +281,7 @@ public sealed class JsFunctionObjectRuntimeTests
 
     private sealed class ConcurrentFunction(Barrier barrier) : JsFunctionObject
     {
-        protected override object? CallCore(object? thisArgument, object?[] arguments)
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
         {
             barrier.SignalAndWait(TimeSpan.FromSeconds(10));
             return Capture(arguments);
@@ -292,20 +292,20 @@ public sealed class JsFunctionObjectRuntimeTests
     {
         public override bool IsConstructor => true;
 
-        protected override object? CallCore(object? thisArgument, object?[] arguments)
+        protected override object? CallCore(object? thisArgument, in JsCallArguments arguments)
             => Capture(arguments);
 
-        protected override object? ConstructCore(object?[] arguments, object? newTarget)
+        protected override object? ConstructCore(in JsCallArguments arguments, object? newTarget)
             => new ConstructSnapshot(
-                arguments[0],
+                arguments.GetArgument(0),
                 newTarget,
                 RuntimeServices.GetCurrentCallee());
     }
 
-    private static CallSnapshot Capture(object?[] arguments)
+    private static CallSnapshot Capture(in JsCallArguments arguments)
         => new(
             RuntimeServices.GetCurrentThis(),
-            arguments[0],
+            arguments.GetArgument(0),
             RuntimeServices.GetCurrentCallee(),
             RuntimeServices.GetCurrentNewTarget());
 

--- a/tests/performance/Benchmarks/CallableArityAnalysis.cs
+++ b/tests/performance/Benchmarks/CallableArityAnalysis.cs
@@ -1,0 +1,150 @@
+using System.Text.RegularExpressions;
+using Acornima.Ast;
+using Jroc.Services;
+
+namespace Benchmarks;
+
+internal static partial class CallableArityAnalysis
+{
+    public static int Run()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var scenarioRoot = Path.Combine(
+            repositoryRoot,
+            "tests",
+            "performance",
+            "Benchmarks",
+            "Scenarios");
+        var parser = new JavaScriptParser();
+        var callArities = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        var constructArities = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        var scenarioCount = 0;
+
+        foreach (var path in Directory.EnumerateFiles(
+                     scenarioRoot,
+                     "*.js",
+                     SearchOption.AllDirectories).Order())
+        {
+            scenarioCount++;
+            var ast = parser.ParseJavaScript(File.ReadAllText(path), path);
+            parser.VisitAst(ast, node =>
+            {
+                switch (node)
+                {
+                    case CallExpression call:
+                        Increment(
+                            callArities,
+                            DescribeArguments(call.Arguments));
+                        break;
+                    case NewExpression construct:
+                        Increment(
+                            constructArities,
+                            DescribeArguments(construct.Arguments));
+                        break;
+                }
+            });
+        }
+
+        var runtimeArities = AnalyzeRuntimeCallbackDispatch(repositoryRoot);
+
+        Console.WriteLine($"Scenarios analyzed: {scenarioCount}");
+        WriteDistribution("Benchmark call expressions", callArities);
+        WriteDistribution("Benchmark construct expressions", constructArities);
+        WriteDistribution("Runtime fixed dispatcher references", runtimeArities);
+        return 0;
+    }
+
+    private static SortedDictionary<string, int> AnalyzeRuntimeCallbackDispatch(
+        string repositoryRoot)
+    {
+        var runtimeRoot = Path.Combine(repositoryRoot, "src", "JavaScriptRuntime");
+        var distribution = new SortedDictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var path in Directory.EnumerateFiles(
+                     runtimeRoot,
+                     "*.cs",
+                     SearchOption.AllDirectories))
+        {
+            if (string.Equals(
+                    Path.GetFileName(path),
+                    "Closure.cs",
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var source = File.ReadAllText(path);
+            foreach (Match match in FixedDispatcherRegex().Matches(source))
+            {
+                Increment(distribution, match.Groups["arity"].Value);
+            }
+
+            var arbitraryCount = ArbitraryDispatcherRegex().Matches(source).Count;
+            if (arbitraryCount > 0)
+            {
+                distribution["arbitrary"] =
+                    distribution.GetValueOrDefault("arbitrary") + arbitraryCount;
+            }
+        }
+
+        return distribution;
+    }
+
+    private static string DescribeArguments(NodeList<Expression> arguments)
+    {
+        if (arguments.Any(static argument => argument is SpreadElement))
+        {
+            return "spread";
+        }
+
+        return arguments.Count <= 5
+            ? arguments.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : "6+";
+    }
+
+    private static void Increment(IDictionary<string, int> distribution, string key)
+    {
+        distribution.TryGetValue(key, out var count);
+        distribution[key] = count + 1;
+    }
+
+    private static void WriteDistribution(
+        string title,
+        IReadOnlyDictionary<string, int> distribution)
+    {
+        var total = distribution.Values.Sum();
+        Console.WriteLine();
+        Console.WriteLine($"{title} (total {total}):");
+        foreach (var (arity, count) in distribution)
+        {
+            var percentage = total == 0 ? 0d : count * 100d / total;
+            Console.WriteLine($"  {arity,9}: {count,5} ({percentage,6:F2}%)");
+        }
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        foreach (var start in new[] { Directory.GetCurrentDirectory(), AppContext.BaseDirectory })
+        {
+            var current = new DirectoryInfo(start);
+            while (current is not null)
+            {
+                if (File.Exists(Path.Combine(current.FullName, "package.json"))
+                    && Directory.Exists(Path.Combine(current.FullName, "src", "JavaScriptRuntime")))
+                {
+                    return current.FullName;
+                }
+
+                current = current.Parent;
+            }
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the JROC repository root.");
+    }
+
+    [GeneratedRegex(@"Closure\.InvokeWithArgs(?<arity>[0-5])\s*\(")]
+    private static partial Regex FixedDispatcherRegex();
+
+    [GeneratedRegex(@"Closure\.InvokeWithArgs\s*\(")]
+    private static partial Regex ArbitraryDispatcherRegex();
+}

--- a/tests/performance/Benchmarks/JsFunctionObjectInvocationBenchmarks.cs
+++ b/tests/performance/Benchmarks/JsFunctionObjectInvocationBenchmarks.cs
@@ -1,0 +1,94 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Order;
+using JavaScriptRuntime;
+
+namespace Benchmarks;
+
+/// <summary>
+/// Compares the function-object ABI with the transitional delegate dispatcher.
+/// </summary>
+[MemoryDiagnoser]
+[ShortRunJob]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[HideColumns("Error", "StdDev")]
+public class JsFunctionObjectInvocationBenchmarks
+{
+    private static readonly object Argument0 = new();
+    private static readonly object Argument1 = new();
+    private static readonly object Argument2 = new();
+    private static readonly object?[] ArbitraryArguments = [Argument0, Argument1, Argument2];
+
+    private readonly BenchmarkFunction _functionObject = new();
+    private readonly ContextualBenchmarkFunction _contextualFunctionObject = new();
+    private readonly JsFuncNoScopes3 _legacyDelegate =
+        static (_, _, _, argument2) => argument2;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Function.InitializeFunctionInstance(
+            _legacyDelegate,
+            3d,
+            "legacy",
+            requiresInvocationContext: false);
+    }
+
+    [Benchmark(Baseline = true, Description = "Legacy Closure.InvokeWithArgs3")]
+    public object LegacyDelegateFixed3()
+        => Closure.InvokeWithArgs3(
+            _legacyDelegate,
+            RuntimeServices.EmptyScopes,
+            Argument0,
+            Argument1,
+            Argument2);
+
+    [Benchmark(Description = "JsFunctionObject fixed arity 3")]
+    public object FunctionObjectFixed3()
+        => CallableOperations.Call3(
+            _functionObject,
+            null,
+            Argument0,
+            Argument1,
+            Argument2)!;
+
+    [Benchmark(Description = "JsFunctionObject pre-materialized arbitrary args")]
+    public object FunctionObjectArbitrary()
+        => CallableOperations.Call(_functionObject, null, ArbitraryArguments)!;
+
+    [Benchmark(Description = "JsFunctionObject ambient-context fixed arity 3")]
+    public object FunctionObjectAmbientContextFixed3()
+        => CallableOperations.Call3(
+            _contextualFunctionObject,
+            null,
+            Argument0,
+            Argument1,
+            Argument2)!;
+
+    [Benchmark(Description = "JsFunctionObject spread materialization")]
+    public object FunctionObjectSpreadMaterialization()
+        => CallableOperations.Call(
+            _functionObject,
+            null,
+            new object?[] { Argument0, Argument1, Argument2 })!;
+
+    private sealed class BenchmarkFunction : JsFunctionObject
+    {
+        public override bool RequiresInvocationContext => false;
+
+        protected override object? CallCore(
+            object? thisArgument,
+            in JsCallArguments arguments)
+            => arguments.GetArgument(2);
+    }
+
+    private sealed class ContextualBenchmarkFunction : JsFunctionObject
+    {
+        protected override object? CallCore(
+            object? thisArgument,
+            in JsCallArguments arguments)
+            => arguments.GetArgument(2);
+    }
+}

--- a/tests/performance/Benchmarks/Program.cs
+++ b/tests/performance/Benchmarks/Program.cs
@@ -14,7 +14,11 @@ if (programArgs.Length > 0 && programArgs[0] == "--validate")
 }
 else
 {
-    if (programArgs.Length > 0 && programArgs[0] == "--dispatch")
+    if (programArgs.Length > 0 && programArgs[0] == "--callable-arity-analysis")
+    {
+        Environment.ExitCode = CallableArityAnalysis.Run();
+    }
+    else if (programArgs.Length > 0 && programArgs[0] == "--dispatch")
     {
         // Run the focused late-bound dispatch microbenchmarks without interactive benchmark selection.
         var summary = BenchmarkRunner.Run<LateBoundDispatchBenchmarks>(args: programArgs.Skip(1).ToArray());
@@ -43,6 +47,11 @@ else
     else if (programArgs.Length > 0 && programArgs[0] == "--callable-baselines")
     {
         var summary = BenchmarkRunner.Run<CallableArchitectureBenchmarks>(args: programArgs.Skip(1).ToArray());
+        SetExitCodeFromSummaries([summary]);
+    }
+    else if (programArgs.Length > 0 && programArgs[0] == "--callable-abi")
+    {
+        var summary = BenchmarkRunner.Run<JsFunctionObjectInvocationBenchmarks>(args: programArgs.Skip(1).ToArray());
         SetExitCodeFromSummaries([summary]);
     }
 #if SOURCE_JROC_PROJECTS
@@ -122,6 +131,8 @@ Console.WriteLine("  dotnet run -c Release --descriptor-storage # Run inline des
 Console.WriteLine("  dotnet run -c Release --array-operations # Run dense-array operation microbenchmarks");
 Console.WriteLine("  dotnet run -c Release --prototype-storage # Run prototype storage allocation microbenchmarks");
 Console.WriteLine("  dotnet run -c Release --callable-baselines # Run callable materialization and steady-state baselines");
+Console.WriteLine("  dotnet run -c Release --callable-abi # Compare function-object and legacy invocation ABIs");
+Console.WriteLine("  dotnet run -c Release --callable-arity-analysis # Measure benchmark/runtime call-site arities");
 Console.WriteLine("  dotnet run -c Release -- --dromaeo # Run Dromaeo execution benchmarks");
 Console.WriteLine("  dotnet run -c Release -- --kracken --scenario audio-oscillator # Run one Kraken scenario");
 Console.WriteLine("  dotnet run -c Release -- --prime-execute # Run the one-pass Prime sieve execution benchmark");


### PR DESCRIPTION
Closes #1710

## Summary

- define `JsCallArguments` with inline arities 0-5 and invocation-owned array
  storage for arbitrary/spread calls
- add fixed-arity `Call0`-`Call5` and `Construct0`-`Construct5` operations,
  with receiver and `newTarget` carried explicitly
- lazily materialize `arguments` only when observed and preserve nested,
  recursive, concurrent, and abrupt-completion context restoration
- let generated adapters opt out of expensive ambient `AsyncLocal` state when
  they consume only explicit invocation parameters
- preserve inferred typed implementation signatures behind generic adapter
  thunks and keep specialized methods on one function-object identity
- bridge the existing generic/fixed `Closure` dispatchers and document legacy
  delegate, proxy, constructor, async, and generator adaptation rules
- add a repeatable benchmark-scenario/runtime arity analyzer and BenchmarkDotNet
  allocation comparison

## Measurements

The analyzer covered all 26 checked-in performance scenarios. Arity 0-2 covers
97.82% of lexical calls; arity 0-5 covers every call and 97.18% of constructor
sites.

Local .NET 10 BenchmarkDotNet ShortRun results:

| Path | Mean | Allocated |
| --- | ---: | ---: |
| function object fixed arity 3 | 1.537 ns | 0 B |
| pre-materialized arbitrary arguments | 1.572 ns | 0 B |
| spread materialization | 12.161 ns | 48 B |
| legacy `Closure.InvokeWithArgs3` | 18.774 ns | 48 B |
| ambient-context fixed arity 3 | 325.786 ns | 304 B |

The ambient-context result is intentionally visible: #1711 planning should set
`RequiresInvocationContext` only for callables whose semantics need ambient
state.

## Validation

- `dotnet build --no-restore --nologo --verbosity:minimal`
- 80 focused function-object, callable ABI, Function, object, descriptor,
  prototype, proxy, and architecture inventory tests
- `dotnet run --project tests/performance/Benchmarks/Benchmarks.csproj --no-build -- --callable-arity-analysis`
- `dotnet run -c Release --project tests/performance/Benchmarks/Benchmarks.csproj -- --callable-abi --filter "*"`
