### PR TITLE
perf(il): deduplicate class constructor initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- compiler/IL: reuse the class type throughout straight-line class element
+  initialization, eliminating redundant `RunClassConstructor` calls for
+  private accessors and method metadata.
 - compiler/IL: nest generated function-object wrappers under their canonical
   callable or class owner type, eliminating detached `FunctionObjects.*`
   namespaces for ordinary functions and class methods.

--- a/src/Compiler/IR/LIR/HIRToLIRLower.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLower.cs
@@ -102,9 +102,9 @@ public sealed partial class HIRToLIRLowerer
 
     private readonly Stack<TempVariable> _activeWithObjects = new();
 
-    // Class method property initialization needs the class Type as the method owner; class constructor
-    // value creation immediately afterward can reuse that temp instead of re-emitting RunClassConstructor.
-    private readonly Dictionary<string, TempVariable> _classMethodOwnerTempsByRegistryName = new(StringComparer.Ordinal);
+    // Class element initialization needs the class Type as its owner. Reuse it for every element
+    // and for class-constructor value creation, rather than repeatedly running the CLR initializer.
+    private readonly Dictionary<string, TempVariable> _classInitializationOwnerTempsByRegistryName = new(StringComparer.Ordinal);
     private readonly Dictionary<string, TempVariable> _classMethodScopesTempsByRegistryName = new(StringComparer.Ordinal);
 
     // Flow-sensitive numeric type refinement: maps a binding to the last proven unboxed-double

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.ClassDefinitions.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.ClassDefinitions.cs
@@ -104,8 +104,8 @@ public sealed partial class HIRToLIRLowerer
     {
         resultTempVar = default;
 
-        if (!TryLowerExpression(expression.Target, out var targetTemp)
-            || !TryLowerExpression(expression.Owner, out var ownerTemp)
+        if (!TryLowerClassInitializationOwner(expression.Owner, out var ownerTemp)
+            || !TryLowerClassInitializationTarget(expression.Target, expression.Owner, ownerTemp, out var targetTemp)
             || !TryLowerExpression(expression.Key, out var keyTemp))
         {
             return false;
@@ -215,19 +215,18 @@ public sealed partial class HIRToLIRLowerer
             return false;
         }
 
-        if (!TryLowerExpression(expression.Owner, out var ownerTemp))
+        if (!TryLowerClassInitializationOwner(expression.Owner, out var ownerTemp))
         {
             return false;
         }
 
-        if (!TryLowerExpression(expression.Prototype, out var prototypeTemp))
+        if (!TryLowerClassInitializationTarget(
+                expression.Prototype,
+                expression.Owner,
+                ownerTemp,
+                out var prototypeTemp))
         {
             return false;
-        }
-
-        if (expression.Owner is HIRUserClassTypeExpression ownerClassType)
-        {
-            _classMethodOwnerTempsByRegistryName[ownerClassType.RegistryClassName] = ownerTemp;
         }
 
         var scopesTemp = CreateTempVariable();
@@ -364,6 +363,63 @@ public sealed partial class HIRToLIRLowerer
 
         return classScope.Children.FirstOrDefault(scope =>
             ReferenceEquals(scope.AstNode, methodDefinition.Value));
+    }
+
+    private bool TryLowerClassInitializationOwner(
+        HIRExpression owner,
+        out TempVariable ownerTemp)
+    {
+        if (owner is HIRUserClassTypeExpression classType
+            && _classInitializationOwnerTempsByRegistryName.TryGetValue(
+                classType.RegistryClassName,
+                out ownerTemp))
+        {
+            return true;
+        }
+
+        if (!TryLowerExpression(owner, out ownerTemp))
+        {
+            return false;
+        }
+
+        if (owner is HIRUserClassTypeExpression initializedClassType)
+        {
+            _classInitializationOwnerTempsByRegistryName[
+                initializedClassType.RegistryClassName] = ownerTemp;
+        }
+
+        return true;
+    }
+
+    private bool TryLowerClassInitializationTarget(
+        HIRExpression target,
+        HIRExpression owner,
+        TempVariable ownerTemp,
+        out TempVariable targetTemp)
+    {
+        if (target is HIRPropertyAccessExpression
+            {
+                Object: HIRUserClassTypeExpression targetClassType,
+                PropertyName: "prototype"
+            }
+            && owner is HIRUserClassTypeExpression ownerClassType
+            && string.Equals(
+                targetClassType.RegistryClassName,
+                ownerClassType.RegistryClassName,
+                StringComparison.Ordinal))
+        {
+            var prototypeKeyTemp = CreateStringConstant("prototype");
+            targetTemp = CreateTempVariable();
+            _methodBodyIR.Instructions.Add(new LIRGetItem(
+                EnsureObject(ownerTemp),
+                EnsureObject(prototypeKeyTemp),
+                targetTemp));
+            DefineTempStorage(
+                targetTemp,
+                new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+            return true;
+        }
+        return TryLowerExpression(target, out targetTemp);
     }
 
     private TempVariable CreateStringConstant(string value)

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
@@ -1096,7 +1096,7 @@ public sealed partial class HIRToLIRLowerer
             DefineTempStorage(scopesTemp, new ValueStorage(ValueStorageKind.Reference, typeof(object[])));
         }
 
-        if (!_classMethodOwnerTempsByRegistryName.Remove(registryClassName, out var typeTemp))
+        if (!_classInitializationOwnerTempsByRegistryName.Remove(registryClassName, out var typeTemp))
         {
             typeTemp = CreateTempVariable();
             _methodBodyIR.Instructions.Add(new LIRGetUserClassType(registryClassName, typeTemp));

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalSuper_MethodAndConstructor.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalSuper_MethodAndConstructor.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2461
+				// Method begins at RVA 0x2435
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,7 +47,7 @@
 					object[] capture2
 				) cil managed 
 			{
-				// Method begins at RVA 0x255f
+				// Method begins at RVA 0x2533
 				// Header size: 1
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -69,7 +69,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x257c
+				// Method begins at RVA 0x2550
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -81,7 +81,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x257f
+				// Method begins at RVA 0x2553
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -95,7 +95,7 @@
 					object thisArgument
 				) cil managed 
 			{
-				// Method begins at RVA 0x2582
+				// Method begins at RVA 0x2556
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -108,7 +108,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x258a
+				// Method begins at RVA 0x255e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -121,7 +121,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x2592
+				// Method begins at RVA 0x2566
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -137,7 +137,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x259a
+				// Method begins at RVA 0x256e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -159,7 +159,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22f4
+			// Method begins at RVA 0x22c8
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -188,7 +188,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2473
+				// Method begins at RVA 0x2447
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -217,7 +217,7 @@
 					object[] capture2
 				) cil managed 
 			{
-				// Method begins at RVA 0x25a2
+				// Method begins at RVA 0x2576
 				// Header size: 1
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x25bf
+				// Method begins at RVA 0x2593
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -251,7 +251,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x25c2
+				// Method begins at RVA 0x2596
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -265,7 +265,7 @@
 					object thisArgument
 				) cil managed 
 			{
-				// Method begins at RVA 0x25c5
+				// Method begins at RVA 0x2599
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -278,7 +278,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x25cd
+				// Method begins at RVA 0x25a1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -291,7 +291,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x25d5
+				// Method begins at RVA 0x25a9
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -307,7 +307,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x25dd
+				// Method begins at RVA 0x25b1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -329,7 +329,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2314
+			// Method begins at RVA 0x22e8
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -358,7 +358,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2434
+				// Method begins at RVA 0x2408
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -378,7 +378,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243d
+				// Method begins at RVA 0x2411
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -398,7 +398,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2446
+				// Method begins at RVA 0x241a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -423,7 +423,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x247c
+				// Method begins at RVA 0x2450
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -439,7 +439,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x248b
+				// Method begins at RVA 0x245f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -451,7 +451,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x248e
+				// Method begins at RVA 0x2462
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -466,7 +466,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2491
+				// Method begins at RVA 0x2465
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -482,7 +482,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x249d
+				// Method begins at RVA 0x2471
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -501,7 +501,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a9
+				// Method begins at RVA 0x247d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -514,7 +514,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24b1
+				// Method begins at RVA 0x2485
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -526,7 +526,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24b4
+				// Method begins at RVA 0x2488
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -541,7 +541,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x24b7
+				// Method begins at RVA 0x248b
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -574,7 +574,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2332
+			// Method begins at RVA 0x2306
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -593,7 +593,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23e5
+			// Method begins at RVA 0x23b9
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -616,7 +616,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x244f
+				// Method begins at RVA 0x2423
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -636,7 +636,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2458
+				// Method begins at RVA 0x242c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -656,7 +656,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x246a
+				// Method begins at RVA 0x243e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -685,7 +685,7 @@
 					object[] capture2
 				) cil managed 
 			{
-				// Method begins at RVA 0x24db
+				// Method begins at RVA 0x24af
 				// Header size: 1
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -707,7 +707,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24f8
+				// Method begins at RVA 0x24cc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -719,7 +719,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24fb
+				// Method begins at RVA 0x24cf
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -731,7 +731,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x24fe
+				// Method begins at RVA 0x24d2
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -744,7 +744,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x2506
+				// Method begins at RVA 0x24da
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -760,7 +760,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x250e
+				// Method begins at RVA 0x24e2
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -776,7 +776,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x251a
+				// Method begins at RVA 0x24ee
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -800,7 +800,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2526
+				// Method begins at RVA 0x24fa
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -816,7 +816,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2535
+				// Method begins at RVA 0x2509
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -828,7 +828,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2538
+				// Method begins at RVA 0x250c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -843,7 +843,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x253b
+				// Method begins at RVA 0x250f
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -878,7 +878,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2344
+			// Method begins at RVA 0x2318
 			// Header size: 12
 			// Code size: 149 (0x95)
 			.maxstack 8
@@ -956,7 +956,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f0
+			// Method begins at RVA 0x23c4
 			// Header size: 12
 			// Code size: 47 (0x2f)
 			.maxstack 8
@@ -996,7 +996,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x242b
+			// Method begins at RVA 0x23ff
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1022,7 +1022,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 661 (0x295)
+		// Code size: 617 (0x269)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Scope,
@@ -1032,13 +1032,12 @@
 			[4] object,
 			[5] object,
 			[6] class [System.Runtime]System.Type,
-			[7] class [System.Runtime]System.Type,
-			[8] object,
-			[9] object[],
-			[10] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read,
-			[11] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader,
-			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[13] object
+			[7] object,
+			[8] object[],
+			[9] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read,
+			[10] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader,
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[12] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Scope::.ctor()
@@ -1049,199 +1048,189 @@
 		IL_0011: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.s 6
-		IL_001d: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base
-		IL_0022: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0027: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base
-		IL_002c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0031: stloc.s 7
-		IL_0033: ldloc.s 7
-		IL_0035: ldstr "prototype"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003f: stloc.s 8
-		IL_0041: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0046: stloc.s 9
-		IL_0048: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read::.ctor()
-		IL_004d: ldc.i4.0
-		IL_004e: conv.r8
-		IL_004f: ldstr "read"
-		IL_0054: ldc.i4.1
-		IL_0055: ldc.i4.1
-		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0, float64, string, bool, bool)
-		IL_005b: stloc.s 10
-		IL_005d: ldloc.s 10
-		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0)
-		IL_0064: stloc.s 10
-		IL_0066: ldloc.s 8
-		IL_0068: ldstr "read"
-		IL_006d: ldloc.s 10
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0074: pop
-		IL_0075: ldc.i4.1
-		IL_0076: newarr [System.Runtime]System.Object
-		IL_007b: dup
-		IL_007c: ldc.i4.0
-		IL_007d: ldloc.0
-		IL_007e: stelem.ref
-		IL_007f: stloc.s 9
-		IL_0081: ldloc.s 6
-		IL_0083: ldloc.s 9
-		IL_0085: ldc.r8 1
-		IL_008e: box [System.Runtime]System.Double
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0098: stloc.s 8
-		IL_009a: ldloc.s 8
-		IL_009c: stloc.1
-		IL_009d: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_00a2: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00a7: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_00ac: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00b1: stloc.s 6
-		IL_00b3: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_00b8: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00bd: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_00c2: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00c7: stloc.s 7
-		IL_00c9: ldloc.s 7
-		IL_00cb: ldstr "prototype"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d5: stloc.s 8
-		IL_00d7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00dc: stloc.s 9
-		IL_00de: ldloc.s 9
-		IL_00e0: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader::.ctor(object[])
-		IL_00e5: ldc.i4.0
-		IL_00e6: conv.r8
-		IL_00e7: ldstr "makeReader"
-		IL_00ec: ldc.i4.0
-		IL_00ed: ldc.i4.1
-		IL_00ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0, float64, string, bool, bool)
-		IL_00f3: stloc.s 11
-		IL_00f5: ldloc.s 11
-		IL_00f7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0)
-		IL_00fc: stloc.s 11
-		IL_00fe: ldloc.s 8
-		IL_0100: ldstr "makeReader"
-		IL_0105: ldloc.s 11
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_010c: pop
-		IL_010d: ldc.i4.1
-		IL_010e: newarr [System.Runtime]System.Object
-		IL_0113: dup
-		IL_0114: ldc.i4.0
-		IL_0115: ldloc.0
-		IL_0116: stelem.ref
-		IL_0117: stloc.s 9
-		IL_0119: ldloc.s 6
-		IL_011b: ldloc.s 9
-		IL_011d: ldc.r8 1
-		IL_0126: box [System.Runtime]System.Double
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0130: stloc.s 8
-		IL_0132: ldloc.s 8
-		IL_0134: ldloc.1
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_013a: stloc.s 8
-		IL_013c: ldloc.s 8
-		IL_013e: stloc.2
-		IL_013f: ldc.i4.1
-		IL_0140: newarr [System.Runtime]System.Object
-		IL_0145: dup
-		IL_0146: ldc.i4.0
-		IL_0147: ldloc.0
-		IL_0148: stelem.ref
-		IL_0149: stloc.s 9
-		IL_014b: ldloc.s 9
-		IL_014d: ldc.i4.1
-		IL_014e: newarr [System.Runtime]System.Object
-		IL_0153: dup
-		IL_0154: ldc.i4.0
-		IL_0155: ldc.r8 11
-		IL_015e: box [System.Runtime]System.Double
-		IL_0163: stelem.ref
-		IL_0164: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0169: ldloc.2
-		IL_016a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_016f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0174: ldc.r8 11
-		IL_017d: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::.ctor(object[], float64)
-		IL_0182: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_0187: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_018c: dup
-		IL_018d: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_0192: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0197: ldstr "prototype"
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_01a1: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_01a6: stloc.3
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_01b1: stloc.3
-		IL_01b2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_01b7: ldloc.3
-		IL_01b8: ldstr "fromConstructor"
-		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c2: stloc.s 4
-		IL_01c4: ldloc.3
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ca: stloc.s 8
-		IL_01cc: ldloc.s 8
-		IL_01ce: isinst Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_01d3: dup
-		IL_01d4: brfalse IL_01e5
+		IL_001d: ldloc.s 6
+		IL_001f: ldstr "prototype"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0029: stloc.s 7
+		IL_002b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0030: stloc.s 8
+		IL_0032: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read::.ctor()
+		IL_0037: ldc.i4.0
+		IL_0038: conv.r8
+		IL_0039: ldstr "read"
+		IL_003e: ldc.i4.1
+		IL_003f: ldc.i4.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.s 9
+		IL_0047: ldloc.s 9
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0)
+		IL_004e: stloc.s 9
+		IL_0050: ldloc.s 7
+		IL_0052: ldstr "read"
+		IL_0057: ldloc.s 9
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005e: pop
+		IL_005f: ldc.i4.1
+		IL_0060: newarr [System.Runtime]System.Object
+		IL_0065: dup
+		IL_0066: ldc.i4.0
+		IL_0067: ldloc.0
+		IL_0068: stelem.ref
+		IL_0069: stloc.s 8
+		IL_006b: ldloc.s 6
+		IL_006d: ldloc.s 8
+		IL_006f: ldc.r8 1
+		IL_0078: box [System.Runtime]System.Double
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0082: stloc.s 7
+		IL_0084: ldloc.s 7
+		IL_0086: stloc.1
+		IL_0087: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+		IL_008c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0091: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+		IL_0096: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_009b: stloc.s 6
+		IL_009d: ldloc.s 6
+		IL_009f: ldstr "prototype"
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a9: stloc.s 7
+		IL_00ab: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00b0: stloc.s 8
+		IL_00b2: ldloc.s 8
+		IL_00b4: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader::.ctor(object[])
+		IL_00b9: ldc.i4.0
+		IL_00ba: conv.r8
+		IL_00bb: ldstr "makeReader"
+		IL_00c0: ldc.i4.0
+		IL_00c1: ldc.i4.1
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0, float64, string, bool, bool)
+		IL_00c7: stloc.s 10
+		IL_00c9: ldloc.s 10
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0)
+		IL_00d0: stloc.s 10
+		IL_00d2: ldloc.s 7
+		IL_00d4: ldstr "makeReader"
+		IL_00d9: ldloc.s 10
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00e0: pop
+		IL_00e1: ldc.i4.1
+		IL_00e2: newarr [System.Runtime]System.Object
+		IL_00e7: dup
+		IL_00e8: ldc.i4.0
+		IL_00e9: ldloc.0
+		IL_00ea: stelem.ref
+		IL_00eb: stloc.s 8
+		IL_00ed: ldloc.s 6
+		IL_00ef: ldloc.s 8
+		IL_00f1: ldc.r8 1
+		IL_00fa: box [System.Runtime]System.Double
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0104: stloc.s 7
+		IL_0106: ldloc.s 7
+		IL_0108: ldloc.1
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_010e: stloc.s 7
+		IL_0110: ldloc.s 7
+		IL_0112: stloc.2
+		IL_0113: ldc.i4.1
+		IL_0114: newarr [System.Runtime]System.Object
+		IL_0119: dup
+		IL_011a: ldc.i4.0
+		IL_011b: ldloc.0
+		IL_011c: stelem.ref
+		IL_011d: stloc.s 8
+		IL_011f: ldloc.s 8
+		IL_0121: ldc.i4.1
+		IL_0122: newarr [System.Runtime]System.Object
+		IL_0127: dup
+		IL_0128: ldc.i4.0
+		IL_0129: ldc.r8 11
+		IL_0132: box [System.Runtime]System.Double
+		IL_0137: stelem.ref
+		IL_0138: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_013d: ldloc.2
+		IL_013e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0143: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0148: ldc.r8 11
+		IL_0151: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::.ctor(object[], float64)
+		IL_0156: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_015b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0160: dup
+		IL_0161: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+		IL_0166: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_016b: ldstr "prototype"
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0175: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_017a: stloc.3
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0185: stloc.3
+		IL_0186: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_018b: ldloc.3
+		IL_018c: ldstr "fromConstructor"
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0196: stloc.s 4
+		IL_0198: ldloc.3
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019e: stloc.s 7
+		IL_01a0: ldloc.s 7
+		IL_01a2: isinst Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+		IL_01a7: dup
+		IL_01a8: brfalse IL_01b9
 
-		IL_01d9: callvirt instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::makeReader()
-		IL_01de: stloc.s 5
-		IL_01e0: br IL_01f4
+		IL_01ad: callvirt instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::makeReader()
+		IL_01b2: stloc.s 5
+		IL_01b4: br IL_01c8
 
-		IL_01e5: pop
-		IL_01e6: ldloc.s 8
-		IL_01e8: ldstr "makeReader"
-		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01f2: stloc.s 5
+		IL_01b9: pop
+		IL_01ba: ldloc.s 7
+		IL_01bc: ldstr "makeReader"
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01c6: stloc.s 5
 
-		IL_01f4: ldstr "console"
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0203: stloc.s 8
-		IL_0205: ldloc.s 4
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0211: dup
-		IL_0212: ldstr "value"
-		IL_0217: ldc.r8 99
-		IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0225: stloc.s 12
-		IL_0227: ldstr "call"
-		IL_022c: ldloc.s 12
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0233: stloc.s 13
-		IL_0235: ldloc.s 8
-		IL_0237: ldstr "log"
-		IL_023c: ldloc.s 13
-		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0243: pop
-		IL_0244: ldstr "console"
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0253: stloc.s 13
-		IL_0255: ldloc.s 5
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0261: dup
-		IL_0262: ldstr "value"
-		IL_0267: ldc.r8 99
-		IL_0270: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0275: stloc.s 12
-		IL_0277: ldstr "call"
-		IL_027c: ldloc.s 12
-		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0283: stloc.s 8
-		IL_0285: ldloc.s 13
-		IL_0287: ldstr "log"
-		IL_028c: ldloc.s 8
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0293: pop
-		IL_0294: ret
+		IL_01c8: ldstr "console"
+		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d7: stloc.s 7
+		IL_01d9: ldloc.s 4
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01e5: dup
+		IL_01e6: ldstr "value"
+		IL_01eb: ldc.r8 99
+		IL_01f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_01f9: stloc.s 11
+		IL_01fb: ldstr "call"
+		IL_0200: ldloc.s 11
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0207: stloc.s 12
+		IL_0209: ldloc.s 7
+		IL_020b: ldstr "log"
+		IL_0210: ldloc.s 12
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0217: pop
+		IL_0218: ldstr "console"
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0227: stloc.s 12
+		IL_0229: ldloc.s 5
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0230: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0235: dup
+		IL_0236: ldstr "value"
+		IL_023b: ldc.r8 99
+		IL_0244: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0249: stloc.s 11
+		IL_024b: ldstr "call"
+		IL_0250: ldloc.s 11
+		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0257: stloc.s 7
+		IL_0259: ldloc.s 12
+		IL_025b: ldstr "log"
+		IL_0260: ldloc.s 7
+		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0267: pop
+		IL_0268: ret
 	} // end of method ArrowFunction_LexicalSuper_MethodAndConstructor::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor
@@ -1253,7 +1242,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25e5
+		// Method begins at RVA 0x25b9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_CallsOtherAsync.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_CallsOtherAsync.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a3
+				// Method begins at RVA 0x248f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x253d
+				// Method begins at RVA 0x2529
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2545
+				// Method begins at RVA 0x2531
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2548
+				// Method begins at RVA 0x2534
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -85,7 +85,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x254b
+				// Method begins at RVA 0x2537
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2221
+			// Method begins at RVA 0x220a
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2488
+				// Method begins at RVA 0x2474
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -171,7 +171,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2491
+				// Method begins at RVA 0x247d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -202,7 +202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x249a
+				// Method begins at RVA 0x2486
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -227,7 +227,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x24ac
+				// Method begins at RVA 0x2498
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -243,7 +243,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24bb
+				// Method begins at RVA 0x24a7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -255,7 +255,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24be
+				// Method begins at RVA 0x24aa
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -270,7 +270,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x24c1
+				// Method begins at RVA 0x24ad
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -286,7 +286,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x24cd
+				// Method begins at RVA 0x24b9
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -305,7 +305,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d9
+				// Method begins at RVA 0x24c5
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -318,7 +318,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24e1
+				// Method begins at RVA 0x24cd
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -330,7 +330,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24e4
+				// Method begins at RVA 0x24d0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -345,7 +345,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x24e7
+				// Method begins at RVA 0x24d3
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -372,7 +372,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x250b
+				// Method begins at RVA 0x24f7
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -385,7 +385,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2513
+				// Method begins at RVA 0x24ff
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -397,7 +397,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2516
+				// Method begins at RVA 0x2502
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -412,7 +412,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2519
+				// Method begins at RVA 0x2505
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -440,7 +440,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2244
+			// Method begins at RVA 0x222d
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -459,7 +459,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x224c
+			// Method begins at RVA 0x2238
 			// Header size: 12
 			// Code size: 244 (0xf4)
 			.maxstack 8
@@ -578,7 +578,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x234c
+			// Method begins at RVA 0x2338
 			// Header size: 12
 			// Code size: 295 (0x127)
 			.maxstack 8
@@ -735,7 +735,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x247f
+			// Method begins at RVA 0x246b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -761,18 +761,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 453 (0x1c5)
+		// Code size: 430 (0x1ae)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Async_ClassMethod_CallsOtherAsync/Scope,
 			[1] object,
 			[2] class Modules.Async_ClassMethod_CallsOtherAsync/Service,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object[],
-			[6] object,
-			[7] class Modules.Async_ClassMethod_CallsOtherAsync/Service,
-			[8] class Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28/FunctionObject
+			[4] object[],
+			[5] object,
+			[6] class Modules.Async_ClassMethod_CallsOtherAsync/Service,
+			[7] class Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Async_ClassMethod_CallsOtherAsync/Scope::.ctor()
@@ -783,185 +782,180 @@
 		IL_0011: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: pop
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.0
-		IL_0048: stelem.ref
-		IL_0049: stloc.s 5
-		IL_004b: ldc.i4.s 10
-		IL_004d: newarr [System.Runtime]System.Object
-		IL_0052: dup
-		IL_0053: ldc.i4.0
-		IL_0054: ldloc.3
-		IL_0055: stelem.ref
-		IL_0056: dup
-		IL_0057: ldc.i4.1
-		IL_0058: ldstr "fetchData"
-		IL_005d: stelem.ref
-		IL_005e: dup
-		IL_005f: ldc.i4.2
-		IL_0060: ldstr "fetchData"
-		IL_0065: stelem.ref
-		IL_0066: dup
-		IL_0067: ldc.i4.3
-		IL_0068: ldc.r8 0.0
-		IL_0071: box [System.Runtime]System.Double
-		IL_0076: stelem.ref
-		IL_0077: dup
-		IL_0078: ldc.i4.4
-		IL_0079: ldstr "fetchData"
-		IL_007e: stelem.ref
-		IL_007f: dup
-		IL_0080: ldc.i4.5
-		IL_0081: ldc.i4.0
-		IL_0082: box [System.Runtime]System.Boolean
-		IL_0087: stelem.ref
-		IL_0088: dup
-		IL_0089: ldc.i4.6
-		IL_008a: ldc.i4.0
-		IL_008b: box [System.Runtime]System.Boolean
-		IL_0090: stelem.ref
-		IL_0091: dup
-		IL_0092: ldc.i4.7
-		IL_0093: ldc.i4.0
-		IL_0094: box [System.Runtime]System.Boolean
-		IL_0099: stelem.ref
-		IL_009a: dup
-		IL_009b: ldc.i4.8
-		IL_009c: ldc.i4.1
-		IL_009d: box [System.Runtime]System.Boolean
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: pop
+		IL_0028: ldc.i4.1
+		IL_0029: newarr [System.Runtime]System.Object
+		IL_002e: dup
+		IL_002f: ldc.i4.0
+		IL_0030: ldloc.0
+		IL_0031: stelem.ref
+		IL_0032: stloc.s 4
+		IL_0034: ldc.i4.s 10
+		IL_0036: newarr [System.Runtime]System.Object
+		IL_003b: dup
+		IL_003c: ldc.i4.0
+		IL_003d: ldloc.3
+		IL_003e: stelem.ref
+		IL_003f: dup
+		IL_0040: ldc.i4.1
+		IL_0041: ldstr "fetchData"
+		IL_0046: stelem.ref
+		IL_0047: dup
+		IL_0048: ldc.i4.2
+		IL_0049: ldstr "fetchData"
+		IL_004e: stelem.ref
+		IL_004f: dup
+		IL_0050: ldc.i4.3
+		IL_0051: ldc.r8 0.0
+		IL_005a: box [System.Runtime]System.Double
+		IL_005f: stelem.ref
+		IL_0060: dup
+		IL_0061: ldc.i4.4
+		IL_0062: ldstr "fetchData"
+		IL_0067: stelem.ref
+		IL_0068: dup
+		IL_0069: ldc.i4.5
+		IL_006a: ldc.i4.0
+		IL_006b: box [System.Runtime]System.Boolean
+		IL_0070: stelem.ref
+		IL_0071: dup
+		IL_0072: ldc.i4.6
+		IL_0073: ldc.i4.0
+		IL_0074: box [System.Runtime]System.Boolean
+		IL_0079: stelem.ref
+		IL_007a: dup
+		IL_007b: ldc.i4.7
+		IL_007c: ldc.i4.0
+		IL_007d: box [System.Runtime]System.Boolean
+		IL_0082: stelem.ref
+		IL_0083: dup
+		IL_0084: ldc.i4.8
+		IL_0085: ldc.i4.1
+		IL_0086: box [System.Runtime]System.Boolean
+		IL_008b: stelem.ref
+		IL_008c: dup
+		IL_008d: ldc.i4.s 9
+		IL_008f: ldloc.s 4
+		IL_0091: stelem.ref
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0097: pop
+		IL_0098: ldc.i4.s 10
+		IL_009a: newarr [System.Runtime]System.Object
+		IL_009f: dup
+		IL_00a0: ldc.i4.0
+		IL_00a1: ldloc.3
 		IL_00a2: stelem.ref
 		IL_00a3: dup
-		IL_00a4: ldc.i4.s 9
-		IL_00a6: ldloc.s 5
-		IL_00a8: stelem.ref
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00ae: pop
-		IL_00af: ldc.i4.s 10
-		IL_00b1: newarr [System.Runtime]System.Object
-		IL_00b6: dup
-		IL_00b7: ldc.i4.0
-		IL_00b8: ldloc.3
-		IL_00b9: stelem.ref
-		IL_00ba: dup
-		IL_00bb: ldc.i4.1
-		IL_00bc: ldstr "processData"
-		IL_00c1: stelem.ref
-		IL_00c2: dup
-		IL_00c3: ldc.i4.2
-		IL_00c4: ldstr "processData"
-		IL_00c9: stelem.ref
-		IL_00ca: dup
-		IL_00cb: ldc.i4.3
-		IL_00cc: ldc.r8 0.0
-		IL_00d5: box [System.Runtime]System.Double
-		IL_00da: stelem.ref
-		IL_00db: dup
-		IL_00dc: ldc.i4.4
-		IL_00dd: ldstr "processData"
-		IL_00e2: stelem.ref
-		IL_00e3: dup
-		IL_00e4: ldc.i4.5
-		IL_00e5: ldc.i4.0
-		IL_00e6: box [System.Runtime]System.Boolean
-		IL_00eb: stelem.ref
-		IL_00ec: dup
-		IL_00ed: ldc.i4.6
-		IL_00ee: ldc.i4.0
-		IL_00ef: box [System.Runtime]System.Boolean
-		IL_00f4: stelem.ref
-		IL_00f5: dup
-		IL_00f6: ldc.i4.7
-		IL_00f7: ldc.i4.0
-		IL_00f8: box [System.Runtime]System.Boolean
-		IL_00fd: stelem.ref
-		IL_00fe: dup
-		IL_00ff: ldc.i4.8
-		IL_0100: ldc.i4.1
-		IL_0101: box [System.Runtime]System.Boolean
-		IL_0106: stelem.ref
-		IL_0107: dup
-		IL_0108: ldc.i4.s 9
-		IL_010a: ldloc.s 5
-		IL_010c: stelem.ref
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0112: pop
-		IL_0113: ldc.i4.1
-		IL_0114: newarr [System.Runtime]System.Object
-		IL_0119: dup
-		IL_011a: ldc.i4.0
-		IL_011b: ldloc.0
-		IL_011c: stelem.ref
-		IL_011d: stloc.s 5
-		IL_011f: ldloc.3
+		IL_00a4: ldc.i4.1
+		IL_00a5: ldstr "processData"
+		IL_00aa: stelem.ref
+		IL_00ab: dup
+		IL_00ac: ldc.i4.2
+		IL_00ad: ldstr "processData"
+		IL_00b2: stelem.ref
+		IL_00b3: dup
+		IL_00b4: ldc.i4.3
+		IL_00b5: ldc.r8 0.0
+		IL_00be: box [System.Runtime]System.Double
+		IL_00c3: stelem.ref
+		IL_00c4: dup
+		IL_00c5: ldc.i4.4
+		IL_00c6: ldstr "processData"
+		IL_00cb: stelem.ref
+		IL_00cc: dup
+		IL_00cd: ldc.i4.5
+		IL_00ce: ldc.i4.0
+		IL_00cf: box [System.Runtime]System.Boolean
+		IL_00d4: stelem.ref
+		IL_00d5: dup
+		IL_00d6: ldc.i4.6
+		IL_00d7: ldc.i4.0
+		IL_00d8: box [System.Runtime]System.Boolean
+		IL_00dd: stelem.ref
+		IL_00de: dup
+		IL_00df: ldc.i4.7
+		IL_00e0: ldc.i4.0
+		IL_00e1: box [System.Runtime]System.Boolean
+		IL_00e6: stelem.ref
+		IL_00e7: dup
+		IL_00e8: ldc.i4.8
+		IL_00e9: ldc.i4.1
+		IL_00ea: box [System.Runtime]System.Boolean
+		IL_00ef: stelem.ref
+		IL_00f0: dup
+		IL_00f1: ldc.i4.s 9
+		IL_00f3: ldloc.s 4
+		IL_00f5: stelem.ref
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_00fb: pop
+		IL_00fc: ldc.i4.1
+		IL_00fd: newarr [System.Runtime]System.Object
+		IL_0102: dup
+		IL_0103: ldc.i4.0
+		IL_0104: ldloc.0
+		IL_0105: stelem.ref
+		IL_0106: stloc.s 4
+		IL_0108: ldloc.3
+		IL_0109: ldloc.s 4
+		IL_010b: ldc.r8 0.0
+		IL_0114: box [System.Runtime]System.Double
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_011e: stloc.s 5
 		IL_0120: ldloc.s 5
-		IL_0122: ldc.r8 0.0
-		IL_012b: box [System.Runtime]System.Double
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0135: stloc.s 6
-		IL_0137: ldloc.s 6
-		IL_0139: stloc.1
-		IL_013a: ldc.i4.0
-		IL_013b: newarr [System.Runtime]System.Object
-		IL_0140: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0145: newobj instance void Modules.Async_ClassMethod_CallsOtherAsync/Service::.ctor()
-		IL_014a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_014f: stloc.2
-		IL_0150: ldloc.2
-		IL_0151: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service
-		IL_0156: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_015b: ldstr "prototype"
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0165: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_016a: ldloc.2
-		IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Async_ClassMethod_CallsOtherAsync/Service>(!!0)
-		IL_0170: stloc.s 7
-		IL_0172: ldloc.s 7
-		IL_0174: ldc.i4.1
-		IL_0175: newarr [System.Runtime]System.Object
-		IL_017a: dup
-		IL_017b: ldc.i4.0
-		IL_017c: ldloc.0
-		IL_017d: stelem.ref
-		IL_017e: ldnull
-		IL_017f: callvirt instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::processData(object[], object)
-		IL_0184: stloc.s 6
-		IL_0186: ldloc.s 6
-		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018d: stloc.s 6
-		IL_018f: ldc.i4.1
-		IL_0190: newarr [System.Runtime]System.Object
-		IL_0195: dup
-		IL_0196: ldc.i4.0
-		IL_0197: ldloc.0
-		IL_0198: stelem.ref
-		IL_0199: stloc.s 5
-		IL_019b: newobj instance void Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28/FunctionObject::.ctor()
-		IL_01a0: ldc.i4.1
-		IL_01a1: conv.r8
-		IL_01a2: ldstr ""
-		IL_01a7: ldc.i4.0
-		IL_01a8: ldc.i4.0
-		IL_01a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28/FunctionObject>(!!0)
-		IL_01b3: stloc.s 8
-		IL_01b5: ldloc.s 6
-		IL_01b7: ldstr "then"
-		IL_01bc: ldloc.s 8
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c3: pop
-		IL_01c4: ret
+		IL_0122: stloc.1
+		IL_0123: ldc.i4.0
+		IL_0124: newarr [System.Runtime]System.Object
+		IL_0129: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_012e: newobj instance void Modules.Async_ClassMethod_CallsOtherAsync/Service::.ctor()
+		IL_0133: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0138: stloc.2
+		IL_0139: ldloc.2
+		IL_013a: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service
+		IL_013f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0144: ldstr "prototype"
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_014e: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0153: ldloc.2
+		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Async_ClassMethod_CallsOtherAsync/Service>(!!0)
+		IL_0159: stloc.s 6
+		IL_015b: ldloc.s 6
+		IL_015d: ldc.i4.1
+		IL_015e: newarr [System.Runtime]System.Object
+		IL_0163: dup
+		IL_0164: ldc.i4.0
+		IL_0165: ldloc.0
+		IL_0166: stelem.ref
+		IL_0167: ldnull
+		IL_0168: callvirt instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::processData(object[], object)
+		IL_016d: stloc.s 5
+		IL_016f: ldloc.s 5
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0176: stloc.s 5
+		IL_0178: ldc.i4.1
+		IL_0179: newarr [System.Runtime]System.Object
+		IL_017e: dup
+		IL_017f: ldc.i4.0
+		IL_0180: ldloc.0
+		IL_0181: stelem.ref
+		IL_0182: stloc.s 4
+		IL_0184: newobj instance void Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28/FunctionObject::.ctor()
+		IL_0189: ldc.i4.1
+		IL_018a: conv.r8
+		IL_018b: ldstr ""
+		IL_0190: ldc.i4.0
+		IL_0191: ldc.i4.0
+		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0197: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28/FunctionObject>(!!0)
+		IL_019c: stloc.s 7
+		IL_019e: ldloc.s 5
+		IL_01a0: ldstr "then"
+		IL_01a5: ldloc.s 7
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ac: pop
+		IL_01ad: ret
 	} // end of method Async_ClassMethod_CallsOtherAsync::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_CallsOtherAsync
@@ -973,7 +967,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x255a
+		// Method begins at RVA 0x2546
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_MultipleAwaits.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_MultipleAwaits.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b8
+				// Method begins at RVA 0x23a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2427
+				// Method begins at RVA 0x2413
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x242f
+				// Method begins at RVA 0x241b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2432
+				// Method begins at RVA 0x241e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -85,7 +85,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2435
+				// Method begins at RVA 0x2421
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21e5
+			// Method begins at RVA 0x21ce
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a6
+				// Method begins at RVA 0x2392
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -176,7 +176,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23af
+				// Method begins at RVA 0x239b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -201,7 +201,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x23c1
+				// Method begins at RVA 0x23ad
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -217,7 +217,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23d0
+				// Method begins at RVA 0x23bc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -229,7 +229,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23d3
+				// Method begins at RVA 0x23bf
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -244,7 +244,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23d6
+				// Method begins at RVA 0x23c2
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -260,7 +260,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x23e2
+				// Method begins at RVA 0x23ce
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -279,7 +279,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ee
+				// Method begins at RVA 0x23da
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -292,7 +292,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23f6
+				// Method begins at RVA 0x23e2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -304,7 +304,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23f9
+				// Method begins at RVA 0x23e5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -319,7 +319,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23fc
+				// Method begins at RVA 0x23e8
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -350,7 +350,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2208
+			// Method begins at RVA 0x21f1
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -370,7 +370,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2210
+			// Method begins at RVA 0x21fc
 			// Header size: 12
 			// Code size: 385 (0x181)
 			.maxstack 8
@@ -573,7 +573,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x239d
+			// Method begins at RVA 0x2389
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -599,19 +599,18 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 393 (0x189)
+		// Code size: 370 (0x172)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Async_ClassMethod_MultipleAwaits/Scope,
 			[1] object,
 			[2] class Modules.Async_ClassMethod_MultipleAwaits/Processor,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object[],
-			[6] object,
-			[7] class Modules.Async_ClassMethod_MultipleAwaits/Processor,
-			[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[9] class Modules.Async_ClassMethod_MultipleAwaits/ArrowFunction_L12C34/FunctionObject
+			[4] object[],
+			[5] object,
+			[6] class Modules.Async_ClassMethod_MultipleAwaits/Processor,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[8] class Modules.Async_ClassMethod_MultipleAwaits/ArrowFunction_L12C34/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Async_ClassMethod_MultipleAwaits/Scope::.ctor()
@@ -622,146 +621,141 @@
 		IL_0011: ldtoken Modules.Async_ClassMethod_MultipleAwaits/Processor
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.Async_ClassMethod_MultipleAwaits/Processor
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Async_ClassMethod_MultipleAwaits/Processor
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: pop
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.0
-		IL_0048: stelem.ref
-		IL_0049: stloc.s 5
-		IL_004b: ldc.i4.s 10
-		IL_004d: newarr [System.Runtime]System.Object
-		IL_0052: dup
-		IL_0053: ldc.i4.0
-		IL_0054: ldloc.3
-		IL_0055: stelem.ref
-		IL_0056: dup
-		IL_0057: ldc.i4.1
-		IL_0058: ldstr "process"
-		IL_005d: stelem.ref
-		IL_005e: dup
-		IL_005f: ldc.i4.2
-		IL_0060: ldstr "process"
-		IL_0065: stelem.ref
-		IL_0066: dup
-		IL_0067: ldc.i4.3
-		IL_0068: ldc.r8 1
-		IL_0071: box [System.Runtime]System.Double
-		IL_0076: stelem.ref
-		IL_0077: dup
-		IL_0078: ldc.i4.4
-		IL_0079: ldstr "process"
-		IL_007e: stelem.ref
-		IL_007f: dup
-		IL_0080: ldc.i4.5
-		IL_0081: ldc.i4.0
-		IL_0082: box [System.Runtime]System.Boolean
-		IL_0087: stelem.ref
-		IL_0088: dup
-		IL_0089: ldc.i4.6
-		IL_008a: ldc.i4.0
-		IL_008b: box [System.Runtime]System.Boolean
-		IL_0090: stelem.ref
-		IL_0091: dup
-		IL_0092: ldc.i4.7
-		IL_0093: ldc.i4.0
-		IL_0094: box [System.Runtime]System.Boolean
-		IL_0099: stelem.ref
-		IL_009a: dup
-		IL_009b: ldc.i4.8
-		IL_009c: ldc.i4.1
-		IL_009d: box [System.Runtime]System.Boolean
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.s 9
-		IL_00a6: ldloc.s 5
-		IL_00a8: stelem.ref
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00ae: pop
-		IL_00af: ldc.i4.1
-		IL_00b0: newarr [System.Runtime]System.Object
-		IL_00b5: dup
-		IL_00b6: ldc.i4.0
-		IL_00b7: ldloc.0
-		IL_00b8: stelem.ref
-		IL_00b9: stloc.s 5
-		IL_00bb: ldloc.3
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: pop
+		IL_0028: ldc.i4.1
+		IL_0029: newarr [System.Runtime]System.Object
+		IL_002e: dup
+		IL_002f: ldc.i4.0
+		IL_0030: ldloc.0
+		IL_0031: stelem.ref
+		IL_0032: stloc.s 4
+		IL_0034: ldc.i4.s 10
+		IL_0036: newarr [System.Runtime]System.Object
+		IL_003b: dup
+		IL_003c: ldc.i4.0
+		IL_003d: ldloc.3
+		IL_003e: stelem.ref
+		IL_003f: dup
+		IL_0040: ldc.i4.1
+		IL_0041: ldstr "process"
+		IL_0046: stelem.ref
+		IL_0047: dup
+		IL_0048: ldc.i4.2
+		IL_0049: ldstr "process"
+		IL_004e: stelem.ref
+		IL_004f: dup
+		IL_0050: ldc.i4.3
+		IL_0051: ldc.r8 1
+		IL_005a: box [System.Runtime]System.Double
+		IL_005f: stelem.ref
+		IL_0060: dup
+		IL_0061: ldc.i4.4
+		IL_0062: ldstr "process"
+		IL_0067: stelem.ref
+		IL_0068: dup
+		IL_0069: ldc.i4.5
+		IL_006a: ldc.i4.0
+		IL_006b: box [System.Runtime]System.Boolean
+		IL_0070: stelem.ref
+		IL_0071: dup
+		IL_0072: ldc.i4.6
+		IL_0073: ldc.i4.0
+		IL_0074: box [System.Runtime]System.Boolean
+		IL_0079: stelem.ref
+		IL_007a: dup
+		IL_007b: ldc.i4.7
+		IL_007c: ldc.i4.0
+		IL_007d: box [System.Runtime]System.Boolean
+		IL_0082: stelem.ref
+		IL_0083: dup
+		IL_0084: ldc.i4.8
+		IL_0085: ldc.i4.1
+		IL_0086: box [System.Runtime]System.Boolean
+		IL_008b: stelem.ref
+		IL_008c: dup
+		IL_008d: ldc.i4.s 9
+		IL_008f: ldloc.s 4
+		IL_0091: stelem.ref
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0097: pop
+		IL_0098: ldc.i4.1
+		IL_0099: newarr [System.Runtime]System.Object
+		IL_009e: dup
+		IL_009f: ldc.i4.0
+		IL_00a0: ldloc.0
+		IL_00a1: stelem.ref
+		IL_00a2: stloc.s 4
+		IL_00a4: ldloc.3
+		IL_00a5: ldloc.s 4
+		IL_00a7: ldc.r8 0.0
+		IL_00b0: box [System.Runtime]System.Double
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00ba: stloc.s 5
 		IL_00bc: ldloc.s 5
-		IL_00be: ldc.r8 0.0
-		IL_00c7: box [System.Runtime]System.Double
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00d1: stloc.s 6
-		IL_00d3: ldloc.s 6
-		IL_00d5: stloc.1
-		IL_00d6: ldc.i4.0
-		IL_00d7: newarr [System.Runtime]System.Object
-		IL_00dc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00e1: newobj instance void Modules.Async_ClassMethod_MultipleAwaits/Processor::.ctor()
-		IL_00e6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00eb: stloc.2
-		IL_00ec: ldloc.2
-		IL_00ed: ldtoken Modules.Async_ClassMethod_MultipleAwaits/Processor
-		IL_00f2: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00f7: ldstr "prototype"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0101: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0106: ldloc.2
-		IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Async_ClassMethod_MultipleAwaits/Processor>(!!0)
-		IL_010c: stloc.s 7
-		IL_010e: ldc.i4.2
-		IL_010f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0114: dup
-		IL_0115: ldc.r8 10
-		IL_011e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0123: dup
-		IL_0124: ldc.r8 32
-		IL_012d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0132: stloc.s 8
-		IL_0134: ldloc.s 7
-		IL_0136: ldc.i4.1
-		IL_0137: newarr [System.Runtime]System.Object
-		IL_013c: dup
-		IL_013d: ldc.i4.0
-		IL_013e: ldloc.0
-		IL_013f: stelem.ref
-		IL_0140: ldnull
-		IL_0141: ldloc.s 8
-		IL_0143: callvirt instance object Modules.Async_ClassMethod_MultipleAwaits/Processor::process(object[], object, object)
-		IL_0148: stloc.s 6
-		IL_014a: ldloc.s 6
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0151: stloc.s 6
-		IL_0153: ldc.i4.1
-		IL_0154: newarr [System.Runtime]System.Object
-		IL_0159: dup
-		IL_015a: ldc.i4.0
-		IL_015b: ldloc.0
-		IL_015c: stelem.ref
-		IL_015d: stloc.s 5
-		IL_015f: newobj instance void Modules.Async_ClassMethod_MultipleAwaits/ArrowFunction_L12C34/FunctionObject::.ctor()
-		IL_0164: ldc.i4.1
-		IL_0165: conv.r8
-		IL_0166: ldstr ""
-		IL_016b: ldc.i4.0
-		IL_016c: ldc.i4.0
-		IL_016d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ClassMethod_MultipleAwaits/ArrowFunction_L12C34/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0172: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ClassMethod_MultipleAwaits/ArrowFunction_L12C34/FunctionObject>(!!0)
-		IL_0177: stloc.s 9
-		IL_0179: ldloc.s 6
-		IL_017b: ldstr "then"
-		IL_0180: ldloc.s 9
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0187: pop
-		IL_0188: ret
+		IL_00be: stloc.1
+		IL_00bf: ldc.i4.0
+		IL_00c0: newarr [System.Runtime]System.Object
+		IL_00c5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00ca: newobj instance void Modules.Async_ClassMethod_MultipleAwaits/Processor::.ctor()
+		IL_00cf: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00d4: stloc.2
+		IL_00d5: ldloc.2
+		IL_00d6: ldtoken Modules.Async_ClassMethod_MultipleAwaits/Processor
+		IL_00db: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00e0: ldstr "prototype"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00ea: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00ef: ldloc.2
+		IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Async_ClassMethod_MultipleAwaits/Processor>(!!0)
+		IL_00f5: stloc.s 6
+		IL_00f7: ldc.i4.2
+		IL_00f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00fd: dup
+		IL_00fe: ldc.r8 10
+		IL_0107: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_010c: dup
+		IL_010d: ldc.r8 32
+		IL_0116: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_011b: stloc.s 7
+		IL_011d: ldloc.s 6
+		IL_011f: ldc.i4.1
+		IL_0120: newarr [System.Runtime]System.Object
+		IL_0125: dup
+		IL_0126: ldc.i4.0
+		IL_0127: ldloc.0
+		IL_0128: stelem.ref
+		IL_0129: ldnull
+		IL_012a: ldloc.s 7
+		IL_012c: callvirt instance object Modules.Async_ClassMethod_MultipleAwaits/Processor::process(object[], object, object)
+		IL_0131: stloc.s 5
+		IL_0133: ldloc.s 5
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013a: stloc.s 5
+		IL_013c: ldc.i4.1
+		IL_013d: newarr [System.Runtime]System.Object
+		IL_0142: dup
+		IL_0143: ldc.i4.0
+		IL_0144: ldloc.0
+		IL_0145: stelem.ref
+		IL_0146: stloc.s 4
+		IL_0148: newobj instance void Modules.Async_ClassMethod_MultipleAwaits/ArrowFunction_L12C34/FunctionObject::.ctor()
+		IL_014d: ldc.i4.1
+		IL_014e: conv.r8
+		IL_014f: ldstr ""
+		IL_0154: ldc.i4.0
+		IL_0155: ldc.i4.0
+		IL_0156: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ClassMethod_MultipleAwaits/ArrowFunction_L12C34/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_015b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ClassMethod_MultipleAwaits/ArrowFunction_L12C34/FunctionObject>(!!0)
+		IL_0160: stloc.s 8
+		IL_0162: ldloc.s 5
+		IL_0164: ldstr "then"
+		IL_0169: ldloc.s 8
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0170: pop
+		IL_0171: ret
 	} // end of method Async_ClassMethod_MultipleAwaits::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_MultipleAwaits
@@ -773,7 +767,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2444
+		// Method begins at RVA 0x2430
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_SimpleAwait.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2332
+				// Method begins at RVA 0x231e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a8
+				// Method begins at RVA 0x2394
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23b0
+				// Method begins at RVA 0x239c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23b3
+				// Method begins at RVA 0x239f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -85,7 +85,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23b6
+				// Method begins at RVA 0x23a2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d9
+			// Method begins at RVA 0x21c2
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2320
+				// Method begins at RVA 0x230c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -171,7 +171,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2329
+				// Method begins at RVA 0x2315
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +196,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x233b
+				// Method begins at RVA 0x2327
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -212,7 +212,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x234a
+				// Method begins at RVA 0x2336
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -224,7 +224,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x234d
+				// Method begins at RVA 0x2339
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -239,7 +239,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2350
+				// Method begins at RVA 0x233c
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -255,7 +255,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x235c
+				// Method begins at RVA 0x2348
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -274,7 +274,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2368
+				// Method begins at RVA 0x2354
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -287,7 +287,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2370
+				// Method begins at RVA 0x235c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -299,7 +299,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2373
+				// Method begins at RVA 0x235f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -314,7 +314,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2376
+				// Method begins at RVA 0x2362
 				// Header size: 1
 				// Code size: 49 (0x31)
 				.maxstack 8
@@ -348,7 +348,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21fc
+			// Method begins at RVA 0x21e5
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -369,7 +369,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2204
+			// Method begins at RVA 0x21f0
 			// Header size: 12
 			// Code size: 263 (0x107)
 			.maxstack 8
@@ -510,7 +510,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2317
+			// Method begins at RVA 0x2303
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -536,18 +536,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 381 (0x17d)
+		// Code size: 358 (0x166)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Async_ClassMethod_SimpleAwait/Scope,
 			[1] object,
 			[2] class Modules.Async_ClassMethod_SimpleAwait/Calculator,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object[],
-			[6] object,
-			[7] class Modules.Async_ClassMethod_SimpleAwait/Calculator,
-			[8] class Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21/FunctionObject
+			[4] object[],
+			[5] object,
+			[6] class Modules.Async_ClassMethod_SimpleAwait/Calculator,
+			[7] class Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Async_ClassMethod_SimpleAwait/Scope::.ctor()
@@ -558,140 +557,135 @@
 		IL_0011: ldtoken Modules.Async_ClassMethod_SimpleAwait/Calculator
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.Async_ClassMethod_SimpleAwait/Calculator
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Async_ClassMethod_SimpleAwait/Calculator
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: pop
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.0
-		IL_0048: stelem.ref
-		IL_0049: stloc.s 5
-		IL_004b: ldc.i4.s 10
-		IL_004d: newarr [System.Runtime]System.Object
-		IL_0052: dup
-		IL_0053: ldc.i4.0
-		IL_0054: ldloc.3
-		IL_0055: stelem.ref
-		IL_0056: dup
-		IL_0057: ldc.i4.1
-		IL_0058: ldstr "add"
-		IL_005d: stelem.ref
-		IL_005e: dup
-		IL_005f: ldc.i4.2
-		IL_0060: ldstr "add"
-		IL_0065: stelem.ref
-		IL_0066: dup
-		IL_0067: ldc.i4.3
-		IL_0068: ldc.r8 2
-		IL_0071: box [System.Runtime]System.Double
-		IL_0076: stelem.ref
-		IL_0077: dup
-		IL_0078: ldc.i4.4
-		IL_0079: ldstr "add"
-		IL_007e: stelem.ref
-		IL_007f: dup
-		IL_0080: ldc.i4.5
-		IL_0081: ldc.i4.0
-		IL_0082: box [System.Runtime]System.Boolean
-		IL_0087: stelem.ref
-		IL_0088: dup
-		IL_0089: ldc.i4.6
-		IL_008a: ldc.i4.0
-		IL_008b: box [System.Runtime]System.Boolean
-		IL_0090: stelem.ref
-		IL_0091: dup
-		IL_0092: ldc.i4.7
-		IL_0093: ldc.i4.0
-		IL_0094: box [System.Runtime]System.Boolean
-		IL_0099: stelem.ref
-		IL_009a: dup
-		IL_009b: ldc.i4.8
-		IL_009c: ldc.i4.1
-		IL_009d: box [System.Runtime]System.Boolean
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.s 9
-		IL_00a6: ldloc.s 5
-		IL_00a8: stelem.ref
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00ae: pop
-		IL_00af: ldc.i4.1
-		IL_00b0: newarr [System.Runtime]System.Object
-		IL_00b5: dup
-		IL_00b6: ldc.i4.0
-		IL_00b7: ldloc.0
-		IL_00b8: stelem.ref
-		IL_00b9: stloc.s 5
-		IL_00bb: ldloc.3
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: pop
+		IL_0028: ldc.i4.1
+		IL_0029: newarr [System.Runtime]System.Object
+		IL_002e: dup
+		IL_002f: ldc.i4.0
+		IL_0030: ldloc.0
+		IL_0031: stelem.ref
+		IL_0032: stloc.s 4
+		IL_0034: ldc.i4.s 10
+		IL_0036: newarr [System.Runtime]System.Object
+		IL_003b: dup
+		IL_003c: ldc.i4.0
+		IL_003d: ldloc.3
+		IL_003e: stelem.ref
+		IL_003f: dup
+		IL_0040: ldc.i4.1
+		IL_0041: ldstr "add"
+		IL_0046: stelem.ref
+		IL_0047: dup
+		IL_0048: ldc.i4.2
+		IL_0049: ldstr "add"
+		IL_004e: stelem.ref
+		IL_004f: dup
+		IL_0050: ldc.i4.3
+		IL_0051: ldc.r8 2
+		IL_005a: box [System.Runtime]System.Double
+		IL_005f: stelem.ref
+		IL_0060: dup
+		IL_0061: ldc.i4.4
+		IL_0062: ldstr "add"
+		IL_0067: stelem.ref
+		IL_0068: dup
+		IL_0069: ldc.i4.5
+		IL_006a: ldc.i4.0
+		IL_006b: box [System.Runtime]System.Boolean
+		IL_0070: stelem.ref
+		IL_0071: dup
+		IL_0072: ldc.i4.6
+		IL_0073: ldc.i4.0
+		IL_0074: box [System.Runtime]System.Boolean
+		IL_0079: stelem.ref
+		IL_007a: dup
+		IL_007b: ldc.i4.7
+		IL_007c: ldc.i4.0
+		IL_007d: box [System.Runtime]System.Boolean
+		IL_0082: stelem.ref
+		IL_0083: dup
+		IL_0084: ldc.i4.8
+		IL_0085: ldc.i4.1
+		IL_0086: box [System.Runtime]System.Boolean
+		IL_008b: stelem.ref
+		IL_008c: dup
+		IL_008d: ldc.i4.s 9
+		IL_008f: ldloc.s 4
+		IL_0091: stelem.ref
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0097: pop
+		IL_0098: ldc.i4.1
+		IL_0099: newarr [System.Runtime]System.Object
+		IL_009e: dup
+		IL_009f: ldc.i4.0
+		IL_00a0: ldloc.0
+		IL_00a1: stelem.ref
+		IL_00a2: stloc.s 4
+		IL_00a4: ldloc.3
+		IL_00a5: ldloc.s 4
+		IL_00a7: ldc.r8 0.0
+		IL_00b0: box [System.Runtime]System.Double
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00ba: stloc.s 5
 		IL_00bc: ldloc.s 5
-		IL_00be: ldc.r8 0.0
-		IL_00c7: box [System.Runtime]System.Double
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00d1: stloc.s 6
-		IL_00d3: ldloc.s 6
-		IL_00d5: stloc.1
-		IL_00d6: ldc.i4.0
-		IL_00d7: newarr [System.Runtime]System.Object
-		IL_00dc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00e1: newobj instance void Modules.Async_ClassMethod_SimpleAwait/Calculator::.ctor()
-		IL_00e6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00eb: stloc.2
-		IL_00ec: ldloc.2
-		IL_00ed: ldtoken Modules.Async_ClassMethod_SimpleAwait/Calculator
-		IL_00f2: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00f7: ldstr "prototype"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0101: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0106: ldloc.2
-		IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Async_ClassMethod_SimpleAwait/Calculator>(!!0)
-		IL_010c: stloc.s 7
-		IL_010e: ldloc.s 7
-		IL_0110: ldc.i4.1
-		IL_0111: newarr [System.Runtime]System.Object
-		IL_0116: dup
-		IL_0117: ldc.i4.0
-		IL_0118: ldloc.0
-		IL_0119: stelem.ref
-		IL_011a: ldnull
-		IL_011b: ldc.r8 2
-		IL_0124: box [System.Runtime]System.Double
-		IL_0129: ldc.r8 3
-		IL_0132: box [System.Runtime]System.Double
-		IL_0137: callvirt instance object Modules.Async_ClassMethod_SimpleAwait/Calculator::'add'(object[], object, object, object)
-		IL_013c: stloc.s 6
-		IL_013e: ldloc.s 6
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0145: stloc.s 6
-		IL_0147: ldc.i4.1
-		IL_0148: newarr [System.Runtime]System.Object
-		IL_014d: dup
-		IL_014e: ldc.i4.0
-		IL_014f: ldloc.0
-		IL_0150: stelem.ref
-		IL_0151: stloc.s 5
-		IL_0153: newobj instance void Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21/FunctionObject::.ctor()
-		IL_0158: ldc.i4.1
-		IL_0159: conv.r8
-		IL_015a: ldstr ""
-		IL_015f: ldc.i4.0
-		IL_0160: ldc.i4.0
-		IL_0161: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21/FunctionObject>(!!0)
-		IL_016b: stloc.s 8
-		IL_016d: ldloc.s 6
-		IL_016f: ldstr "then"
-		IL_0174: ldloc.s 8
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017b: pop
-		IL_017c: ret
+		IL_00be: stloc.1
+		IL_00bf: ldc.i4.0
+		IL_00c0: newarr [System.Runtime]System.Object
+		IL_00c5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00ca: newobj instance void Modules.Async_ClassMethod_SimpleAwait/Calculator::.ctor()
+		IL_00cf: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00d4: stloc.2
+		IL_00d5: ldloc.2
+		IL_00d6: ldtoken Modules.Async_ClassMethod_SimpleAwait/Calculator
+		IL_00db: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00e0: ldstr "prototype"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00ea: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00ef: ldloc.2
+		IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Async_ClassMethod_SimpleAwait/Calculator>(!!0)
+		IL_00f5: stloc.s 6
+		IL_00f7: ldloc.s 6
+		IL_00f9: ldc.i4.1
+		IL_00fa: newarr [System.Runtime]System.Object
+		IL_00ff: dup
+		IL_0100: ldc.i4.0
+		IL_0101: ldloc.0
+		IL_0102: stelem.ref
+		IL_0103: ldnull
+		IL_0104: ldc.r8 2
+		IL_010d: box [System.Runtime]System.Double
+		IL_0112: ldc.r8 3
+		IL_011b: box [System.Runtime]System.Double
+		IL_0120: callvirt instance object Modules.Async_ClassMethod_SimpleAwait/Calculator::'add'(object[], object, object, object)
+		IL_0125: stloc.s 5
+		IL_0127: ldloc.s 5
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012e: stloc.s 5
+		IL_0130: ldc.i4.1
+		IL_0131: newarr [System.Runtime]System.Object
+		IL_0136: dup
+		IL_0137: ldc.i4.0
+		IL_0138: ldloc.0
+		IL_0139: stelem.ref
+		IL_013a: stloc.s 4
+		IL_013c: newobj instance void Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21/FunctionObject::.ctor()
+		IL_0141: ldc.i4.1
+		IL_0142: conv.r8
+		IL_0143: ldstr ""
+		IL_0148: ldc.i4.0
+		IL_0149: ldc.i4.0
+		IL_014a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_014f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21/FunctionObject>(!!0)
+		IL_0154: stloc.s 7
+		IL_0156: ldloc.s 5
+		IL_0158: ldstr "then"
+		IL_015d: ldloc.s 7
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0164: pop
+		IL_0165: ret
 	} // end of method Async_ClassMethod_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_SimpleAwait
@@ -703,7 +697,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23c5
+		// Method begins at RVA 0x23b1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_WithThis.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_WithThis.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2326
+				// Method begins at RVA 0x230e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x238e
+				// Method begins at RVA 0x2376
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2396
+				// Method begins at RVA 0x237e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2399
+				// Method begins at RVA 0x2381
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -85,7 +85,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x239c
+				// Method begins at RVA 0x2384
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21bd
+			// Method begins at RVA 0x21a6
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230b
+				// Method begins at RVA 0x22f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2314
+				// Method begins at RVA 0x22fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x231d
+				// Method begins at RVA 0x2305
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -216,7 +216,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x232f
+				// Method begins at RVA 0x2317
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -232,7 +232,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x233e
+				// Method begins at RVA 0x2326
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -244,7 +244,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2341
+				// Method begins at RVA 0x2329
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -259,7 +259,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2344
+				// Method begins at RVA 0x232c
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -275,7 +275,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2350
+				// Method begins at RVA 0x2338
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -294,7 +294,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x235c
+				// Method begins at RVA 0x2344
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -307,7 +307,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2364
+				// Method begins at RVA 0x234c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -319,7 +319,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2367
+				// Method begins at RVA 0x234f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -334,7 +334,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x236a
+				// Method begins at RVA 0x2352
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -365,7 +365,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21e0
+			// Method begins at RVA 0x21c9
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -387,7 +387,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f8
+			// Method begins at RVA 0x21e0
 			// Header size: 12
 			// Code size: 254 (0xfe)
 			.maxstack 8
@@ -508,7 +508,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2302
+			// Method begins at RVA 0x22ea
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -534,18 +534,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 353 (0x161)
+		// Code size: 330 (0x14a)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Async_ClassMethod_WithThis/Scope,
 			[1] object,
 			[2] class Modules.Async_ClassMethod_WithThis/Counter,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object[],
-			[6] object,
-			[7] class Modules.Async_ClassMethod_WithThis/Counter,
-			[8] class Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25/FunctionObject
+			[4] object[],
+			[5] object,
+			[6] class Modules.Async_ClassMethod_WithThis/Counter,
+			[7] class Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Async_ClassMethod_WithThis/Scope::.ctor()
@@ -556,136 +555,131 @@
 		IL_0011: ldtoken Modules.Async_ClassMethod_WithThis/Counter
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.Async_ClassMethod_WithThis/Counter
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Async_ClassMethod_WithThis/Counter
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: pop
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.0
-		IL_0048: stelem.ref
-		IL_0049: stloc.s 5
-		IL_004b: ldc.i4.s 10
-		IL_004d: newarr [System.Runtime]System.Object
-		IL_0052: dup
-		IL_0053: ldc.i4.0
-		IL_0054: ldloc.3
-		IL_0055: stelem.ref
-		IL_0056: dup
-		IL_0057: ldc.i4.1
-		IL_0058: ldstr "getCount"
-		IL_005d: stelem.ref
-		IL_005e: dup
-		IL_005f: ldc.i4.2
-		IL_0060: ldstr "getCount"
-		IL_0065: stelem.ref
-		IL_0066: dup
-		IL_0067: ldc.i4.3
-		IL_0068: ldc.r8 0.0
-		IL_0071: box [System.Runtime]System.Double
-		IL_0076: stelem.ref
-		IL_0077: dup
-		IL_0078: ldc.i4.4
-		IL_0079: ldstr "getCount"
-		IL_007e: stelem.ref
-		IL_007f: dup
-		IL_0080: ldc.i4.5
-		IL_0081: ldc.i4.0
-		IL_0082: box [System.Runtime]System.Boolean
-		IL_0087: stelem.ref
-		IL_0088: dup
-		IL_0089: ldc.i4.6
-		IL_008a: ldc.i4.0
-		IL_008b: box [System.Runtime]System.Boolean
-		IL_0090: stelem.ref
-		IL_0091: dup
-		IL_0092: ldc.i4.7
-		IL_0093: ldc.i4.0
-		IL_0094: box [System.Runtime]System.Boolean
-		IL_0099: stelem.ref
-		IL_009a: dup
-		IL_009b: ldc.i4.8
-		IL_009c: ldc.i4.1
-		IL_009d: box [System.Runtime]System.Boolean
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.s 9
-		IL_00a6: ldloc.s 5
-		IL_00a8: stelem.ref
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00ae: pop
-		IL_00af: ldc.i4.1
-		IL_00b0: newarr [System.Runtime]System.Object
-		IL_00b5: dup
-		IL_00b6: ldc.i4.0
-		IL_00b7: ldloc.0
-		IL_00b8: stelem.ref
-		IL_00b9: stloc.s 5
-		IL_00bb: ldloc.3
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: pop
+		IL_0028: ldc.i4.1
+		IL_0029: newarr [System.Runtime]System.Object
+		IL_002e: dup
+		IL_002f: ldc.i4.0
+		IL_0030: ldloc.0
+		IL_0031: stelem.ref
+		IL_0032: stloc.s 4
+		IL_0034: ldc.i4.s 10
+		IL_0036: newarr [System.Runtime]System.Object
+		IL_003b: dup
+		IL_003c: ldc.i4.0
+		IL_003d: ldloc.3
+		IL_003e: stelem.ref
+		IL_003f: dup
+		IL_0040: ldc.i4.1
+		IL_0041: ldstr "getCount"
+		IL_0046: stelem.ref
+		IL_0047: dup
+		IL_0048: ldc.i4.2
+		IL_0049: ldstr "getCount"
+		IL_004e: stelem.ref
+		IL_004f: dup
+		IL_0050: ldc.i4.3
+		IL_0051: ldc.r8 0.0
+		IL_005a: box [System.Runtime]System.Double
+		IL_005f: stelem.ref
+		IL_0060: dup
+		IL_0061: ldc.i4.4
+		IL_0062: ldstr "getCount"
+		IL_0067: stelem.ref
+		IL_0068: dup
+		IL_0069: ldc.i4.5
+		IL_006a: ldc.i4.0
+		IL_006b: box [System.Runtime]System.Boolean
+		IL_0070: stelem.ref
+		IL_0071: dup
+		IL_0072: ldc.i4.6
+		IL_0073: ldc.i4.0
+		IL_0074: box [System.Runtime]System.Boolean
+		IL_0079: stelem.ref
+		IL_007a: dup
+		IL_007b: ldc.i4.7
+		IL_007c: ldc.i4.0
+		IL_007d: box [System.Runtime]System.Boolean
+		IL_0082: stelem.ref
+		IL_0083: dup
+		IL_0084: ldc.i4.8
+		IL_0085: ldc.i4.1
+		IL_0086: box [System.Runtime]System.Boolean
+		IL_008b: stelem.ref
+		IL_008c: dup
+		IL_008d: ldc.i4.s 9
+		IL_008f: ldloc.s 4
+		IL_0091: stelem.ref
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0097: pop
+		IL_0098: ldc.i4.1
+		IL_0099: newarr [System.Runtime]System.Object
+		IL_009e: dup
+		IL_009f: ldc.i4.0
+		IL_00a0: ldloc.0
+		IL_00a1: stelem.ref
+		IL_00a2: stloc.s 4
+		IL_00a4: ldloc.3
+		IL_00a5: ldloc.s 4
+		IL_00a7: ldc.r8 0.0
+		IL_00b0: box [System.Runtime]System.Double
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00ba: stloc.s 5
 		IL_00bc: ldloc.s 5
-		IL_00be: ldc.r8 0.0
-		IL_00c7: box [System.Runtime]System.Double
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00d1: stloc.s 6
-		IL_00d3: ldloc.s 6
-		IL_00d5: stloc.1
-		IL_00d6: ldc.i4.0
-		IL_00d7: newarr [System.Runtime]System.Object
-		IL_00dc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00e1: newobj instance void Modules.Async_ClassMethod_WithThis/Counter::.ctor()
-		IL_00e6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00eb: stloc.2
-		IL_00ec: ldloc.2
-		IL_00ed: ldtoken Modules.Async_ClassMethod_WithThis/Counter
-		IL_00f2: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00f7: ldstr "prototype"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0101: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0106: ldloc.2
-		IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Async_ClassMethod_WithThis/Counter>(!!0)
-		IL_010c: stloc.s 7
-		IL_010e: ldloc.s 7
-		IL_0110: ldc.i4.1
-		IL_0111: newarr [System.Runtime]System.Object
-		IL_0116: dup
-		IL_0117: ldc.i4.0
-		IL_0118: ldloc.0
-		IL_0119: stelem.ref
-		IL_011a: ldnull
-		IL_011b: callvirt instance object Modules.Async_ClassMethod_WithThis/Counter::getCount(object[], object)
-		IL_0120: stloc.s 6
-		IL_0122: ldloc.s 6
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0129: stloc.s 6
-		IL_012b: ldc.i4.1
-		IL_012c: newarr [System.Runtime]System.Object
-		IL_0131: dup
-		IL_0132: ldc.i4.0
-		IL_0133: ldloc.0
-		IL_0134: stelem.ref
-		IL_0135: stloc.s 5
-		IL_0137: newobj instance void Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25/FunctionObject::.ctor()
-		IL_013c: ldc.i4.1
-		IL_013d: conv.r8
-		IL_013e: ldstr ""
-		IL_0143: ldc.i4.0
-		IL_0144: ldc.i4.0
-		IL_0145: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_014a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25/FunctionObject>(!!0)
-		IL_014f: stloc.s 8
-		IL_0151: ldloc.s 6
-		IL_0153: ldstr "then"
-		IL_0158: ldloc.s 8
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015f: pop
-		IL_0160: ret
+		IL_00be: stloc.1
+		IL_00bf: ldc.i4.0
+		IL_00c0: newarr [System.Runtime]System.Object
+		IL_00c5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00ca: newobj instance void Modules.Async_ClassMethod_WithThis/Counter::.ctor()
+		IL_00cf: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00d4: stloc.2
+		IL_00d5: ldloc.2
+		IL_00d6: ldtoken Modules.Async_ClassMethod_WithThis/Counter
+		IL_00db: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00e0: ldstr "prototype"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00ea: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00ef: ldloc.2
+		IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Async_ClassMethod_WithThis/Counter>(!!0)
+		IL_00f5: stloc.s 6
+		IL_00f7: ldloc.s 6
+		IL_00f9: ldc.i4.1
+		IL_00fa: newarr [System.Runtime]System.Object
+		IL_00ff: dup
+		IL_0100: ldc.i4.0
+		IL_0101: ldloc.0
+		IL_0102: stelem.ref
+		IL_0103: ldnull
+		IL_0104: callvirt instance object Modules.Async_ClassMethod_WithThis/Counter::getCount(object[], object)
+		IL_0109: stloc.s 5
+		IL_010b: ldloc.s 5
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0112: stloc.s 5
+		IL_0114: ldc.i4.1
+		IL_0115: newarr [System.Runtime]System.Object
+		IL_011a: dup
+		IL_011b: ldc.i4.0
+		IL_011c: ldloc.0
+		IL_011d: stelem.ref
+		IL_011e: stloc.s 4
+		IL_0120: newobj instance void Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25/FunctionObject::.ctor()
+		IL_0125: ldc.i4.1
+		IL_0126: conv.r8
+		IL_0127: ldstr ""
+		IL_012c: ldc.i4.0
+		IL_012d: ldc.i4.0
+		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0133: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25/FunctionObject>(!!0)
+		IL_0138: stloc.s 7
+		IL_013a: ldloc.s 5
+		IL_013c: ldstr "then"
+		IL_0141: ldloc.s 7
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0148: pop
+		IL_0149: ret
 	} // end of method Async_ClassMethod_WithThis::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_WithThis
@@ -697,7 +691,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23ab
+		// Method begins at RVA 0x2393
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Inheritance_SuperAsyncMethod.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Inheritance_SuperAsyncMethod.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x255c
+				// Method begins at RVA 0x252c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2648
+				// Method begins at RVA 0x2618
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2650
+				// Method begins at RVA 0x2620
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2653
+				// Method begins at RVA 0x2623
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -85,7 +85,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2656
+				// Method begins at RVA 0x2626
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22d8
+			// Method begins at RVA 0x22aa
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2538
+				// Method begins at RVA 0x2508
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -171,7 +171,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2541
+				// Method begins at RVA 0x2511
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +196,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2565
+				// Method begins at RVA 0x2535
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -212,7 +212,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2574
+				// Method begins at RVA 0x2544
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -224,7 +224,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2577
+				// Method begins at RVA 0x2547
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -239,7 +239,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x257a
+				// Method begins at RVA 0x254a
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -255,7 +255,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2586
+				// Method begins at RVA 0x2556
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -274,7 +274,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2592
+				// Method begins at RVA 0x2562
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -287,7 +287,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x259a
+				// Method begins at RVA 0x256a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -299,7 +299,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x259d
+				// Method begins at RVA 0x256d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -314,7 +314,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x25a0
+				// Method begins at RVA 0x2570
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -345,7 +345,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22fb
+			// Method begins at RVA 0x22cd
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -365,7 +365,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2314
+			// Method begins at RVA 0x22e4
 			// Header size: 12
 			// Code size: 265 (0x109)
 			.maxstack 8
@@ -506,7 +506,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x254a
+				// Method begins at RVA 0x251a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -536,7 +536,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2553
+				// Method begins at RVA 0x2523
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -561,7 +561,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x25cb
+				// Method begins at RVA 0x259b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -577,7 +577,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x25da
+				// Method begins at RVA 0x25aa
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -589,7 +589,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x25dd
+				// Method begins at RVA 0x25ad
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -604,7 +604,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x25e0
+				// Method begins at RVA 0x25b0
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -620,7 +620,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x25ec
+				// Method begins at RVA 0x25bc
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -646,7 +646,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x25f8
+				// Method begins at RVA 0x25c8
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -665,7 +665,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x260e
+				// Method begins at RVA 0x25de
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -677,7 +677,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2611
+				// Method begins at RVA 0x25e1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -689,7 +689,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x2614
+				// Method begins at RVA 0x25e4
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -702,7 +702,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x261c
+				// Method begins at RVA 0x25ec
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -718,7 +718,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2624
+				// Method begins at RVA 0x25f4
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -746,7 +746,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2303
+			// Method begins at RVA 0x22d5
 			// Header size: 1
 			// Code size: 13 (0xd)
 			.maxstack 8
@@ -767,7 +767,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x242c
+			// Method begins at RVA 0x23fc
 			// Header size: 12
 			// Code size: 247 (0xf7)
 			.maxstack 8
@@ -889,7 +889,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x252f
+			// Method begins at RVA 0x24ff
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -915,17 +915,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 636 (0x27c)
+		// Code size: 590 (0x24e)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Async_Inheritance_SuperAsyncMethod/Scope,
 			[1] object,
 			[2] object,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object[],
-			[6] object,
-			[7] class Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26/FunctionObject
+			[4] object[],
+			[5] object,
+			[6] class Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Async_Inheritance_SuperAsyncMethod/Scope::.ctor()
@@ -936,245 +935,235 @@
 		IL_0011: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Base
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Base
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Base
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: pop
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.0
-		IL_0048: stelem.ref
-		IL_0049: stloc.s 5
-		IL_004b: ldc.i4.s 10
-		IL_004d: newarr [System.Runtime]System.Object
-		IL_0052: dup
-		IL_0053: ldc.i4.0
-		IL_0054: ldloc.3
-		IL_0055: stelem.ref
-		IL_0056: dup
-		IL_0057: ldc.i4.1
-		IL_0058: ldstr "inc"
-		IL_005d: stelem.ref
-		IL_005e: dup
-		IL_005f: ldc.i4.2
-		IL_0060: ldstr "inc"
-		IL_0065: stelem.ref
-		IL_0066: dup
-		IL_0067: ldc.i4.3
-		IL_0068: ldc.r8 1
-		IL_0071: box [System.Runtime]System.Double
-		IL_0076: stelem.ref
-		IL_0077: dup
-		IL_0078: ldc.i4.4
-		IL_0079: ldstr "inc"
-		IL_007e: stelem.ref
-		IL_007f: dup
-		IL_0080: ldc.i4.5
-		IL_0081: ldc.i4.0
-		IL_0082: box [System.Runtime]System.Boolean
-		IL_0087: stelem.ref
-		IL_0088: dup
-		IL_0089: ldc.i4.6
-		IL_008a: ldc.i4.0
-		IL_008b: box [System.Runtime]System.Boolean
-		IL_0090: stelem.ref
-		IL_0091: dup
-		IL_0092: ldc.i4.7
-		IL_0093: ldc.i4.0
-		IL_0094: box [System.Runtime]System.Boolean
-		IL_0099: stelem.ref
-		IL_009a: dup
-		IL_009b: ldc.i4.8
-		IL_009c: ldc.i4.1
-		IL_009d: box [System.Runtime]System.Boolean
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.s 9
-		IL_00a6: ldloc.s 5
-		IL_00a8: stelem.ref
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00ae: pop
-		IL_00af: ldc.i4.1
-		IL_00b0: newarr [System.Runtime]System.Object
-		IL_00b5: dup
-		IL_00b6: ldc.i4.0
-		IL_00b7: ldloc.0
-		IL_00b8: stelem.ref
-		IL_00b9: stloc.s 5
-		IL_00bb: ldloc.3
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: pop
+		IL_0028: ldc.i4.1
+		IL_0029: newarr [System.Runtime]System.Object
+		IL_002e: dup
+		IL_002f: ldc.i4.0
+		IL_0030: ldloc.0
+		IL_0031: stelem.ref
+		IL_0032: stloc.s 4
+		IL_0034: ldc.i4.s 10
+		IL_0036: newarr [System.Runtime]System.Object
+		IL_003b: dup
+		IL_003c: ldc.i4.0
+		IL_003d: ldloc.3
+		IL_003e: stelem.ref
+		IL_003f: dup
+		IL_0040: ldc.i4.1
+		IL_0041: ldstr "inc"
+		IL_0046: stelem.ref
+		IL_0047: dup
+		IL_0048: ldc.i4.2
+		IL_0049: ldstr "inc"
+		IL_004e: stelem.ref
+		IL_004f: dup
+		IL_0050: ldc.i4.3
+		IL_0051: ldc.r8 1
+		IL_005a: box [System.Runtime]System.Double
+		IL_005f: stelem.ref
+		IL_0060: dup
+		IL_0061: ldc.i4.4
+		IL_0062: ldstr "inc"
+		IL_0067: stelem.ref
+		IL_0068: dup
+		IL_0069: ldc.i4.5
+		IL_006a: ldc.i4.0
+		IL_006b: box [System.Runtime]System.Boolean
+		IL_0070: stelem.ref
+		IL_0071: dup
+		IL_0072: ldc.i4.6
+		IL_0073: ldc.i4.0
+		IL_0074: box [System.Runtime]System.Boolean
+		IL_0079: stelem.ref
+		IL_007a: dup
+		IL_007b: ldc.i4.7
+		IL_007c: ldc.i4.0
+		IL_007d: box [System.Runtime]System.Boolean
+		IL_0082: stelem.ref
+		IL_0083: dup
+		IL_0084: ldc.i4.8
+		IL_0085: ldc.i4.1
+		IL_0086: box [System.Runtime]System.Boolean
+		IL_008b: stelem.ref
+		IL_008c: dup
+		IL_008d: ldc.i4.s 9
+		IL_008f: ldloc.s 4
+		IL_0091: stelem.ref
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0097: pop
+		IL_0098: ldc.i4.1
+		IL_0099: newarr [System.Runtime]System.Object
+		IL_009e: dup
+		IL_009f: ldc.i4.0
+		IL_00a0: ldloc.0
+		IL_00a1: stelem.ref
+		IL_00a2: stloc.s 4
+		IL_00a4: ldloc.3
+		IL_00a5: ldloc.s 4
+		IL_00a7: ldc.r8 0.0
+		IL_00b0: box [System.Runtime]System.Double
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00ba: stloc.s 5
 		IL_00bc: ldloc.s 5
-		IL_00be: ldc.r8 0.0
-		IL_00c7: box [System.Runtime]System.Double
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00d1: stloc.s 6
-		IL_00d3: ldloc.s 6
-		IL_00d5: stloc.1
-		IL_00d6: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Derived
-		IL_00db: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00e0: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Derived
-		IL_00e5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00ea: stloc.3
-		IL_00eb: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Derived
-		IL_00f0: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00f5: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Derived
-		IL_00fa: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00ff: stloc.s 4
-		IL_0101: ldloc.s 4
-		IL_0103: ldstr "prototype"
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010d: pop
-		IL_010e: ldc.i4.1
-		IL_010f: newarr [System.Runtime]System.Object
-		IL_0114: dup
-		IL_0115: ldc.i4.0
-		IL_0116: ldloc.0
+		IL_00be: stloc.1
+		IL_00bf: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Derived
+		IL_00c4: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00c9: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Derived
+		IL_00ce: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00d3: stloc.3
+		IL_00d4: ldloc.3
+		IL_00d5: ldstr "prototype"
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00df: pop
+		IL_00e0: ldc.i4.1
+		IL_00e1: newarr [System.Runtime]System.Object
+		IL_00e6: dup
+		IL_00e7: ldc.i4.0
+		IL_00e8: ldloc.0
+		IL_00e9: stelem.ref
+		IL_00ea: stloc.s 4
+		IL_00ec: ldc.i4.s 10
+		IL_00ee: newarr [System.Runtime]System.Object
+		IL_00f3: dup
+		IL_00f4: ldc.i4.0
+		IL_00f5: ldloc.3
+		IL_00f6: stelem.ref
+		IL_00f7: dup
+		IL_00f8: ldc.i4.1
+		IL_00f9: ldstr "run"
+		IL_00fe: stelem.ref
+		IL_00ff: dup
+		IL_0100: ldc.i4.2
+		IL_0101: ldstr "run"
+		IL_0106: stelem.ref
+		IL_0107: dup
+		IL_0108: ldc.i4.3
+		IL_0109: ldc.r8 0.0
+		IL_0112: box [System.Runtime]System.Double
 		IL_0117: stelem.ref
-		IL_0118: stloc.s 5
-		IL_011a: ldc.i4.s 10
-		IL_011c: newarr [System.Runtime]System.Object
-		IL_0121: dup
+		IL_0118: dup
+		IL_0119: ldc.i4.4
+		IL_011a: ldstr "run"
+		IL_011f: stelem.ref
+		IL_0120: dup
+		IL_0121: ldc.i4.5
 		IL_0122: ldc.i4.0
-		IL_0123: ldloc.3
-		IL_0124: stelem.ref
-		IL_0125: dup
-		IL_0126: ldc.i4.1
-		IL_0127: ldstr "run"
-		IL_012c: stelem.ref
-		IL_012d: dup
-		IL_012e: ldc.i4.2
-		IL_012f: ldstr "run"
-		IL_0134: stelem.ref
-		IL_0135: dup
-		IL_0136: ldc.i4.3
-		IL_0137: ldc.r8 0.0
-		IL_0140: box [System.Runtime]System.Double
-		IL_0145: stelem.ref
-		IL_0146: dup
-		IL_0147: ldc.i4.4
-		IL_0148: ldstr "run"
-		IL_014d: stelem.ref
-		IL_014e: dup
-		IL_014f: ldc.i4.5
-		IL_0150: ldc.i4.0
-		IL_0151: box [System.Runtime]System.Boolean
-		IL_0156: stelem.ref
-		IL_0157: dup
-		IL_0158: ldc.i4.6
-		IL_0159: ldc.i4.0
-		IL_015a: box [System.Runtime]System.Boolean
-		IL_015f: stelem.ref
-		IL_0160: dup
-		IL_0161: ldc.i4.7
-		IL_0162: ldc.i4.0
-		IL_0163: box [System.Runtime]System.Boolean
-		IL_0168: stelem.ref
-		IL_0169: dup
-		IL_016a: ldc.i4.8
-		IL_016b: ldc.i4.1
-		IL_016c: box [System.Runtime]System.Boolean
-		IL_0171: stelem.ref
-		IL_0172: dup
-		IL_0173: ldc.i4.s 9
-		IL_0175: ldloc.s 5
-		IL_0177: stelem.ref
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_017d: pop
-		IL_017e: ldc.i4.1
-		IL_017f: newarr [System.Runtime]System.Object
-		IL_0184: dup
-		IL_0185: ldc.i4.0
-		IL_0186: ldloc.0
-		IL_0187: stelem.ref
-		IL_0188: stloc.s 5
-		IL_018a: ldloc.3
-		IL_018b: ldloc.s 5
-		IL_018d: ldc.r8 0.0
-		IL_0196: box [System.Runtime]System.Double
-		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_01a0: stloc.s 6
-		IL_01a2: ldloc.s 6
-		IL_01a4: ldloc.1
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_01aa: stloc.s 6
-		IL_01ac: ldloc.s 6
-		IL_01ae: stloc.2
-		IL_01af: ldc.i4.0
-		IL_01b0: newarr [System.Runtime]System.Object
-		IL_01b5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_01ba: ldloc.2
-		IL_01bb: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_01c0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_01c5: newobj instance void Modules.Async_Inheritance_SuperAsyncMethod/Derived::.ctor()
-		IL_01ca: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_01cf: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_01d4: dup
-		IL_01d5: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Derived
-		IL_01da: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01df: ldstr "prototype"
-		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_01e9: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_01ee: stloc.s 6
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_01fa: stloc.s 6
-		IL_01fc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_0201: ldloc.s 6
-		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0208: stloc.s 6
-		IL_020a: ldloc.s 6
-		IL_020c: isinst Modules.Async_Inheritance_SuperAsyncMethod/Derived
-		IL_0211: dup
-		IL_0212: brfalse IL_022e
+		IL_0123: box [System.Runtime]System.Boolean
+		IL_0128: stelem.ref
+		IL_0129: dup
+		IL_012a: ldc.i4.6
+		IL_012b: ldc.i4.0
+		IL_012c: box [System.Runtime]System.Boolean
+		IL_0131: stelem.ref
+		IL_0132: dup
+		IL_0133: ldc.i4.7
+		IL_0134: ldc.i4.0
+		IL_0135: box [System.Runtime]System.Boolean
+		IL_013a: stelem.ref
+		IL_013b: dup
+		IL_013c: ldc.i4.8
+		IL_013d: ldc.i4.1
+		IL_013e: box [System.Runtime]System.Boolean
+		IL_0143: stelem.ref
+		IL_0144: dup
+		IL_0145: ldc.i4.s 9
+		IL_0147: ldloc.s 4
+		IL_0149: stelem.ref
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_014f: pop
+		IL_0150: ldc.i4.1
+		IL_0151: newarr [System.Runtime]System.Object
+		IL_0156: dup
+		IL_0157: ldc.i4.0
+		IL_0158: ldloc.0
+		IL_0159: stelem.ref
+		IL_015a: stloc.s 4
+		IL_015c: ldloc.3
+		IL_015d: ldloc.s 4
+		IL_015f: ldc.r8 0.0
+		IL_0168: box [System.Runtime]System.Double
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0172: stloc.s 5
+		IL_0174: ldloc.s 5
+		IL_0176: ldloc.1
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_017c: stloc.s 5
+		IL_017e: ldloc.s 5
+		IL_0180: stloc.2
+		IL_0181: ldc.i4.0
+		IL_0182: newarr [System.Runtime]System.Object
+		IL_0187: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_018c: ldloc.2
+		IL_018d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0192: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0197: newobj instance void Modules.Async_Inheritance_SuperAsyncMethod/Derived::.ctor()
+		IL_019c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_01a1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_01a6: dup
+		IL_01a7: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Derived
+		IL_01ac: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_01b1: ldstr "prototype"
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_01bb: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_01c0: stloc.s 5
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_01cc: stloc.s 5
+		IL_01ce: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_01d3: ldloc.s 5
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01da: stloc.s 5
+		IL_01dc: ldloc.s 5
+		IL_01de: isinst Modules.Async_Inheritance_SuperAsyncMethod/Derived
+		IL_01e3: dup
+		IL_01e4: brfalse IL_0200
 
-		IL_0217: ldc.i4.1
-		IL_0218: newarr [System.Runtime]System.Object
-		IL_021d: dup
-		IL_021e: ldc.i4.0
-		IL_021f: ldloc.0
-		IL_0220: stelem.ref
-		IL_0221: ldnull
-		IL_0222: callvirt instance object Modules.Async_Inheritance_SuperAsyncMethod/Derived::run(object[], object)
-		IL_0227: stloc.s 6
-		IL_0229: br IL_023d
+		IL_01e9: ldc.i4.1
+		IL_01ea: newarr [System.Runtime]System.Object
+		IL_01ef: dup
+		IL_01f0: ldc.i4.0
+		IL_01f1: ldloc.0
+		IL_01f2: stelem.ref
+		IL_01f3: ldnull
+		IL_01f4: callvirt instance object Modules.Async_Inheritance_SuperAsyncMethod/Derived::run(object[], object)
+		IL_01f9: stloc.s 5
+		IL_01fb: br IL_020f
 
-		IL_022e: pop
-		IL_022f: ldloc.s 6
-		IL_0231: ldstr "run"
-		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_023b: stloc.s 6
+		IL_0200: pop
+		IL_0201: ldloc.s 5
+		IL_0203: ldstr "run"
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_020d: stloc.s 5
 
-		IL_023d: ldloc.s 6
-		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0244: stloc.s 6
-		IL_0246: ldc.i4.1
-		IL_0247: newarr [System.Runtime]System.Object
-		IL_024c: dup
-		IL_024d: ldc.i4.0
-		IL_024e: ldloc.0
-		IL_024f: stelem.ref
-		IL_0250: stloc.s 5
-		IL_0252: newobj instance void Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26/FunctionObject::.ctor()
-		IL_0257: ldc.i4.1
-		IL_0258: conv.r8
-		IL_0259: ldstr ""
-		IL_025e: ldc.i4.0
-		IL_025f: ldc.i4.0
-		IL_0260: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0265: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26/FunctionObject>(!!0)
-		IL_026a: stloc.s 7
-		IL_026c: ldloc.s 6
-		IL_026e: ldstr "then"
-		IL_0273: ldloc.s 7
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027a: pop
-		IL_027b: ret
+		IL_020f: ldloc.s 5
+		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0216: stloc.s 5
+		IL_0218: ldc.i4.1
+		IL_0219: newarr [System.Runtime]System.Object
+		IL_021e: dup
+		IL_021f: ldc.i4.0
+		IL_0220: ldloc.0
+		IL_0221: stelem.ref
+		IL_0222: stloc.s 4
+		IL_0224: newobj instance void Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26/FunctionObject::.ctor()
+		IL_0229: ldc.i4.1
+		IL_022a: conv.r8
+		IL_022b: ldstr ""
+		IL_0230: ldc.i4.0
+		IL_0231: ldc.i4.0
+		IL_0232: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0237: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26/FunctionObject>(!!0)
+		IL_023c: stloc.s 6
+		IL_023e: ldloc.s 5
+		IL_0240: ldstr "then"
+		IL_0245: ldloc.s 6
+		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024c: pop
+		IL_024d: ret
 	} // end of method Async_Inheritance_SuperAsyncMethod::__js_module_init__
 
 } // end of class Modules.Async_Inheritance_SuperAsyncMethod
@@ -1186,7 +1175,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2665
+		// Method begins at RVA 0x2635
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_StaticMethod_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_StaticMethod_SimpleAwait.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f2
+				// Method begins at RVA 0x22d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x233d
+				// Method begins at RVA 0x2321
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2345
+				// Method begins at RVA 0x2329
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2348
+				// Method begins at RVA 0x232c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -85,7 +85,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x234b
+				// Method begins at RVA 0x232f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2188
+			// Method begins at RVA 0x216c
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -151,7 +151,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e0
+				// Method begins at RVA 0x22c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -181,7 +181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e9
+				// Method begins at RVA 0x22cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -206,7 +206,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22fb
+				// Method begins at RVA 0x22df
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -222,7 +222,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x230a
+				// Method begins at RVA 0x22ee
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -234,7 +234,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x230d
+				// Method begins at RVA 0x22f1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -249,7 +249,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2310
+				// Method begins at RVA 0x22f4
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -265,7 +265,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x231c
+				// Method begins at RVA 0x2300
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -284,7 +284,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2328
+				// Method begins at RVA 0x230c
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -297,7 +297,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2330
+				// Method begins at RVA 0x2314
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -309,7 +309,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2333
+				// Method begins at RVA 0x2317
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -324,7 +324,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2336
+				// Method begins at RVA 0x231a
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -343,7 +343,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21a8
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -362,7 +362,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21cc
+			// Method begins at RVA 0x21b0
 			// Header size: 12
 			// Code size: 255 (0xff)
 			.maxstack 8
@@ -484,7 +484,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22d7
+			// Method begins at RVA 0x22bb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -510,17 +510,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 300 (0x12c)
+		// Code size: 272 (0x110)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Async_StaticMethod_SimpleAwait/Scope,
 			[1] object,
 			[2] class [System.Runtime]System.Type,
-			[3] class [System.Runtime]System.Type,
-			[4] object[],
+			[3] object[],
+			[4] object,
 			[5] object,
-			[6] object,
-			[7] class Modules.Async_StaticMethod_SimpleAwait/ArrowFunction_L9C24/FunctionObject
+			[6] class Modules.Async_StaticMethod_SimpleAwait/ArrowFunction_L9C24/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Async_StaticMethod_SimpleAwait/Scope::.ctor()
@@ -531,120 +530,115 @@
 		IL_0011: ldtoken Modules.Async_StaticMethod_SimpleAwait/Fetcher
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.2
-		IL_001c: ldtoken Modules.Async_StaticMethod_SimpleAwait/Fetcher
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Async_StaticMethod_SimpleAwait/Fetcher
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.3
-		IL_0031: ldloc.3
-		IL_0032: ldstr "prototype"
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003c: pop
-		IL_003d: ldc.i4.1
-		IL_003e: newarr [System.Runtime]System.Object
-		IL_0043: dup
-		IL_0044: ldc.i4.0
-		IL_0045: ldloc.0
-		IL_0046: stelem.ref
-		IL_0047: stloc.s 4
-		IL_0049: ldc.i4.s 10
-		IL_004b: newarr [System.Runtime]System.Object
-		IL_0050: dup
-		IL_0051: ldc.i4.0
-		IL_0052: ldloc.2
-		IL_0053: stelem.ref
-		IL_0054: dup
-		IL_0055: ldc.i4.1
-		IL_0056: ldstr "getData"
-		IL_005b: stelem.ref
-		IL_005c: dup
-		IL_005d: ldc.i4.2
-		IL_005e: ldstr "getData"
-		IL_0063: stelem.ref
-		IL_0064: dup
-		IL_0065: ldc.i4.3
-		IL_0066: ldc.r8 0.0
-		IL_006f: box [System.Runtime]System.Double
-		IL_0074: stelem.ref
-		IL_0075: dup
-		IL_0076: ldc.i4.4
-		IL_0077: ldstr "getData"
-		IL_007c: stelem.ref
-		IL_007d: dup
-		IL_007e: ldc.i4.5
-		IL_007f: ldc.i4.1
-		IL_0080: box [System.Runtime]System.Boolean
-		IL_0085: stelem.ref
-		IL_0086: dup
-		IL_0087: ldc.i4.6
-		IL_0088: ldc.i4.0
-		IL_0089: box [System.Runtime]System.Boolean
-		IL_008e: stelem.ref
-		IL_008f: dup
-		IL_0090: ldc.i4.7
-		IL_0091: ldc.i4.0
-		IL_0092: box [System.Runtime]System.Boolean
-		IL_0097: stelem.ref
-		IL_0098: dup
-		IL_0099: ldc.i4.8
-		IL_009a: ldc.i4.1
-		IL_009b: box [System.Runtime]System.Boolean
-		IL_00a0: stelem.ref
-		IL_00a1: dup
-		IL_00a2: ldc.i4.s 9
-		IL_00a4: ldloc.s 4
-		IL_00a6: stelem.ref
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00ac: pop
-		IL_00ad: ldc.i4.1
-		IL_00ae: newarr [System.Runtime]System.Object
-		IL_00b3: dup
-		IL_00b4: ldc.i4.0
-		IL_00b5: ldloc.0
-		IL_00b6: stelem.ref
-		IL_00b7: stloc.s 4
-		IL_00b9: ldloc.2
-		IL_00ba: ldloc.s 4
-		IL_00bc: ldc.r8 0.0
-		IL_00c5: box [System.Runtime]System.Double
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00cf: stloc.s 5
-		IL_00d1: ldloc.s 5
-		IL_00d3: stloc.1
-		IL_00d4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00d9: stloc.s 4
-		IL_00db: ldloc.1
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_00e1: stloc.s 5
-		IL_00e3: ldloc.s 4
-		IL_00e5: ldnull
-		IL_00e6: call object Modules.Async_StaticMethod_SimpleAwait/Fetcher::getData(object[], object)
-		IL_00eb: stloc.s 6
-		IL_00ed: ldloc.s 6
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f4: stloc.s 6
-		IL_00f6: ldc.i4.1
-		IL_00f7: newarr [System.Runtime]System.Object
-		IL_00fc: dup
-		IL_00fd: ldc.i4.0
-		IL_00fe: ldloc.0
-		IL_00ff: stelem.ref
-		IL_0100: stloc.s 4
-		IL_0102: newobj instance void Modules.Async_StaticMethod_SimpleAwait/ArrowFunction_L9C24/FunctionObject::.ctor()
-		IL_0107: ldc.i4.1
-		IL_0108: conv.r8
-		IL_0109: ldstr ""
-		IL_010e: ldc.i4.0
-		IL_010f: ldc.i4.0
-		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_StaticMethod_SimpleAwait/ArrowFunction_L9C24/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0115: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_StaticMethod_SimpleAwait/ArrowFunction_L9C24/FunctionObject>(!!0)
-		IL_011a: stloc.s 7
-		IL_011c: ldloc.s 6
-		IL_011e: ldstr "then"
-		IL_0123: ldloc.s 7
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012a: pop
-		IL_012b: ret
+		IL_001c: ldloc.2
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: pop
+		IL_0028: ldc.i4.1
+		IL_0029: newarr [System.Runtime]System.Object
+		IL_002e: dup
+		IL_002f: ldc.i4.0
+		IL_0030: ldloc.0
+		IL_0031: stelem.ref
+		IL_0032: stloc.3
+		IL_0033: ldc.i4.s 10
+		IL_0035: newarr [System.Runtime]System.Object
+		IL_003a: dup
+		IL_003b: ldc.i4.0
+		IL_003c: ldloc.2
+		IL_003d: stelem.ref
+		IL_003e: dup
+		IL_003f: ldc.i4.1
+		IL_0040: ldstr "getData"
+		IL_0045: stelem.ref
+		IL_0046: dup
+		IL_0047: ldc.i4.2
+		IL_0048: ldstr "getData"
+		IL_004d: stelem.ref
+		IL_004e: dup
+		IL_004f: ldc.i4.3
+		IL_0050: ldc.r8 0.0
+		IL_0059: box [System.Runtime]System.Double
+		IL_005e: stelem.ref
+		IL_005f: dup
+		IL_0060: ldc.i4.4
+		IL_0061: ldstr "getData"
+		IL_0066: stelem.ref
+		IL_0067: dup
+		IL_0068: ldc.i4.5
+		IL_0069: ldc.i4.1
+		IL_006a: box [System.Runtime]System.Boolean
+		IL_006f: stelem.ref
+		IL_0070: dup
+		IL_0071: ldc.i4.6
+		IL_0072: ldc.i4.0
+		IL_0073: box [System.Runtime]System.Boolean
+		IL_0078: stelem.ref
+		IL_0079: dup
+		IL_007a: ldc.i4.7
+		IL_007b: ldc.i4.0
+		IL_007c: box [System.Runtime]System.Boolean
+		IL_0081: stelem.ref
+		IL_0082: dup
+		IL_0083: ldc.i4.8
+		IL_0084: ldc.i4.1
+		IL_0085: box [System.Runtime]System.Boolean
+		IL_008a: stelem.ref
+		IL_008b: dup
+		IL_008c: ldc.i4.s 9
+		IL_008e: ldloc.3
+		IL_008f: stelem.ref
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0095: pop
+		IL_0096: ldc.i4.1
+		IL_0097: newarr [System.Runtime]System.Object
+		IL_009c: dup
+		IL_009d: ldc.i4.0
+		IL_009e: ldloc.0
+		IL_009f: stelem.ref
+		IL_00a0: stloc.3
+		IL_00a1: ldloc.2
+		IL_00a2: ldloc.3
+		IL_00a3: ldc.r8 0.0
+		IL_00ac: box [System.Runtime]System.Double
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00b6: stloc.s 4
+		IL_00b8: ldloc.s 4
+		IL_00ba: stloc.1
+		IL_00bb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00c0: stloc.3
+		IL_00c1: ldloc.1
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_00c7: stloc.s 4
+		IL_00c9: ldloc.3
+		IL_00ca: ldnull
+		IL_00cb: call object Modules.Async_StaticMethod_SimpleAwait/Fetcher::getData(object[], object)
+		IL_00d0: stloc.s 5
+		IL_00d2: ldloc.s 5
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d9: stloc.s 5
+		IL_00db: ldc.i4.1
+		IL_00dc: newarr [System.Runtime]System.Object
+		IL_00e1: dup
+		IL_00e2: ldc.i4.0
+		IL_00e3: ldloc.0
+		IL_00e4: stelem.ref
+		IL_00e5: stloc.3
+		IL_00e6: newobj instance void Modules.Async_StaticMethod_SimpleAwait/ArrowFunction_L9C24/FunctionObject::.ctor()
+		IL_00eb: ldc.i4.1
+		IL_00ec: conv.r8
+		IL_00ed: ldstr ""
+		IL_00f2: ldc.i4.0
+		IL_00f3: ldc.i4.0
+		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_StaticMethod_SimpleAwait/ArrowFunction_L9C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_StaticMethod_SimpleAwait/ArrowFunction_L9C24/FunctionObject>(!!0)
+		IL_00fe: stloc.s 6
+		IL_0100: ldloc.s 5
+		IL_0102: ldstr "then"
+		IL_0107: ldloc.s 6
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010e: pop
+		IL_010f: ret
 	} // end of method Async_StaticMethod_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_StaticMethod_SimpleAwait
@@ -656,7 +650,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x235a
+		// Method begins at RVA 0x233e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_AccessorMethods_InstanceAndStatic.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_AccessorMethods_InstanceAndStatic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x253b
+				// Method begins at RVA 0x249f
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -48,7 +48,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x254f
+				// Method begins at RVA 0x24b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2558
+				// Method begins at RVA 0x24bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2561
+				// Method begins at RVA 0x24c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x256a
+				// Method begins at RVA 0x24ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2573
+				// Method begins at RVA 0x24d7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -149,7 +149,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2582
+				// Method begins at RVA 0x24e6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2585
+				// Method begins at RVA 0x24e9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -176,7 +176,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2588
+				// Method begins at RVA 0x24ec
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -192,7 +192,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2594
+				// Method begins at RVA 0x24f8
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -211,7 +211,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25a0
+				// Method begins at RVA 0x2504
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -224,7 +224,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x25a8
+				// Method begins at RVA 0x250c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -236,7 +236,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x25ab
+				// Method begins at RVA 0x250f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -251,7 +251,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x25ae
+				// Method begins at RVA 0x2512
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -278,7 +278,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25d2
+				// Method begins at RVA 0x2536
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -291,7 +291,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x25da
+				// Method begins at RVA 0x253e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -303,7 +303,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x25dd
+				// Method begins at RVA 0x2541
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -318,7 +318,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x25e0
+				// Method begins at RVA 0x2544
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -348,7 +348,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x260b
+				// Method begins at RVA 0x256f
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -361,7 +361,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2613
+				// Method begins at RVA 0x2577
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -373,7 +373,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2616
+				// Method begins at RVA 0x257a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -388,7 +388,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2619
+				// Method begins at RVA 0x257d
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -420,7 +420,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x263d
+				// Method begins at RVA 0x25a1
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -436,7 +436,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x264c
+				// Method begins at RVA 0x25b0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -448,7 +448,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x264f
+				// Method begins at RVA 0x25b3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -463,7 +463,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2652
+				// Method begins at RVA 0x25b6
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -489,7 +489,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2660
+				// Method begins at RVA 0x25c4
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -505,7 +505,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x266f
+				// Method begins at RVA 0x25d3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -517,7 +517,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2672
+				// Method begins at RVA 0x25d6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -532,7 +532,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2675
+				// Method begins at RVA 0x25d9
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -565,7 +565,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2434
+			// Method begins at RVA 0x2398
 			// Header size: 12
 			// Code size: 23 (0x17)
 			.maxstack 8
@@ -592,7 +592,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2457
+			// Method begins at RVA 0x23bb
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -610,7 +610,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2488
+			// Method begins at RVA 0x23ec
 			// Header size: 12
 			// Code size: 25 (0x19)
 			.maxstack 8
@@ -635,7 +635,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2460
+			// Method begins at RVA 0x23c4
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -665,7 +665,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24b0
+			// Method begins at RVA 0x2414
 			// Header size: 12
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -689,7 +689,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24d8
+			// Method begins at RVA 0x243c
 			// Header size: 12
 			// Code size: 78 (0x4e)
 			.maxstack 8
@@ -731,7 +731,7 @@
 		.method private hidebysig specialname rtspecialname static 
 			void .cctor () cil managed 
 		{
-			// Method begins at RVA 0x24c4
+			// Method begins at RVA 0x2428
 			// Header size: 12
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -753,7 +753,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2532
+			// Method begins at RVA 0x2496
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -779,7 +779,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 981 (0x3d5)
+		// Code size: 827 (0x33b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_AccessorMethods_InstanceAndStatic/Scope,
@@ -832,271 +832,236 @@
 		IL_006e: ldstr "prototype"
 		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0078: stloc.s 5
-		IL_007a: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_007f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0084: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0089: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_008e: stloc.s 4
-		IL_0090: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0095: stloc.3
-		IL_0096: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count::.ctor()
-		IL_009b: ldc.i4.0
-		IL_009c: conv.r8
-		IL_009d: ldstr "get count"
-		IL_00a2: ldc.i4.1
-		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0, float64, string, bool, bool)
-		IL_00a9: stloc.s 6
-		IL_00ab: ldloc.s 6
-		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0)
-		IL_00b2: stloc.s 6
-		IL_00b4: ldloc.s 5
-		IL_00b6: ldstr "count"
-		IL_00bb: ldloc.s 6
-		IL_00bd: ldnull
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_00c3: pop
-		IL_00c4: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_00c9: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00ce: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_00d3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00d8: stloc.s 4
-		IL_00da: ldloc.s 4
-		IL_00dc: ldstr "prototype"
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e6: stloc.s 5
-		IL_00e8: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_00ed: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00f2: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_00f7: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00fc: stloc.s 4
+		IL_007a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_007f: stloc.3
+		IL_0080: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count::.ctor()
+		IL_0085: ldc.i4.0
+		IL_0086: conv.r8
+		IL_0087: ldstr "get count"
+		IL_008c: ldc.i4.1
+		IL_008d: ldc.i4.1
+		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0, float64, string, bool, bool)
+		IL_0093: stloc.s 6
+		IL_0095: ldloc.s 6
+		IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0)
+		IL_009c: stloc.s 6
+		IL_009e: ldloc.s 5
+		IL_00a0: ldstr "count"
+		IL_00a5: ldloc.s 6
+		IL_00a7: ldnull
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_00ad: pop
+		IL_00ae: ldloc.s 4
+		IL_00b0: ldstr "prototype"
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ba: stloc.s 5
+		IL_00bc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00c1: stloc.3
+		IL_00c2: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::.ctor()
+		IL_00c7: ldc.i4.1
+		IL_00c8: conv.r8
+		IL_00c9: ldstr "set count"
+		IL_00ce: ldc.i4.1
+		IL_00cf: ldc.i4.1
+		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0, float64, string, bool, bool)
+		IL_00d5: stloc.s 7
+		IL_00d7: ldloc.s 7
+		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0)
+		IL_00de: stloc.s 7
+		IL_00e0: ldloc.s 5
+		IL_00e2: ldstr "count"
+		IL_00e7: ldnull
+		IL_00e8: ldloc.s 7
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_00ef: pop
+		IL_00f0: ldloc.s 4
+		IL_00f2: ldstr "prototype"
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00fc: stloc.s 5
 		IL_00fe: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0103: stloc.3
-		IL_0104: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::.ctor()
-		IL_0109: ldc.i4.1
+		IL_0104: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label::.ctor()
+		IL_0109: ldc.i4.0
 		IL_010a: conv.r8
-		IL_010b: ldstr "set count"
+		IL_010b: ldstr "get label"
 		IL_0110: ldc.i4.1
 		IL_0111: ldc.i4.1
-		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0, float64, string, bool, bool)
-		IL_0117: stloc.s 7
-		IL_0119: ldloc.s 7
-		IL_011b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0)
-		IL_0120: stloc.s 7
+		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0, float64, string, bool, bool)
+		IL_0117: stloc.s 8
+		IL_0119: ldloc.s 8
+		IL_011b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0)
+		IL_0120: stloc.s 8
 		IL_0122: ldloc.s 5
-		IL_0124: ldstr "count"
-		IL_0129: ldnull
-		IL_012a: ldloc.s 7
+		IL_0124: ldstr "label"
+		IL_0129: ldloc.s 8
+		IL_012b: ldnull
 		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_0131: pop
 		IL_0132: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
 		IL_0137: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_013c: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
 		IL_0141: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0146: stloc.s 4
-		IL_0148: ldloc.s 4
-		IL_014a: ldstr "prototype"
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0154: stloc.s 5
-		IL_0156: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_015b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0160: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0165: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_016a: stloc.s 4
-		IL_016c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0171: stloc.3
-		IL_0172: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label::.ctor()
-		IL_0177: ldc.i4.0
-		IL_0178: conv.r8
-		IL_0179: ldstr "get label"
-		IL_017e: ldc.i4.1
-		IL_017f: ldc.i4.1
-		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0, float64, string, bool, bool)
-		IL_0185: stloc.s 8
-		IL_0187: ldloc.s 8
-		IL_0189: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0)
-		IL_018e: stloc.s 8
-		IL_0190: ldloc.s 5
-		IL_0192: ldstr "label"
-		IL_0197: ldloc.s 8
-		IL_0199: ldnull
-		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_019f: pop
-		IL_01a0: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_01a5: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01aa: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_01af: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01b4: stloc.s 4
-		IL_01b6: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_01bb: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01c0: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_01c5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01ca: stloc.s 9
-		IL_01cc: ldc.i4.1
-		IL_01cd: newarr [System.Runtime]System.Object
-		IL_01d2: dup
-		IL_01d3: ldc.i4.0
-		IL_01d4: ldloc.0
-		IL_01d5: stelem.ref
-		IL_01d6: stloc.3
-		IL_01d7: ldloc.3
-		IL_01d8: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::.ctor(object[])
-		IL_01dd: ldc.i4.0
-		IL_01de: conv.r8
-		IL_01df: ldstr "get total"
-		IL_01e4: ldc.i4.0
-		IL_01e5: ldc.i4.1
-		IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0, float64, string, bool, bool)
-		IL_01eb: stloc.s 10
-		IL_01ed: ldloc.s 10
-		IL_01ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0)
-		IL_01f4: stloc.s 10
-		IL_01f6: ldloc.s 4
-		IL_01f8: ldstr "total"
-		IL_01fd: ldloc.s 10
-		IL_01ff: ldnull
-		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_0205: pop
-		IL_0206: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_020b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0210: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0215: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_021a: stloc.s 4
-		IL_021c: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0221: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0226: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_022b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0230: stloc.s 9
-		IL_0232: ldc.i4.1
-		IL_0233: newarr [System.Runtime]System.Object
-		IL_0238: dup
-		IL_0239: ldc.i4.0
-		IL_023a: ldloc.0
-		IL_023b: stelem.ref
-		IL_023c: stloc.3
-		IL_023d: ldloc.3
-		IL_023e: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::.ctor(object[])
-		IL_0243: ldc.i4.1
-		IL_0244: conv.r8
-		IL_0245: ldstr "set total"
-		IL_024a: ldc.i4.0
-		IL_024b: ldc.i4.1
-		IL_024c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0, float64, string, bool, bool)
-		IL_0251: stloc.s 11
-		IL_0253: ldloc.s 11
-		IL_0255: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0)
-		IL_025a: stloc.s 11
-		IL_025c: ldloc.s 4
-		IL_025e: ldstr "total"
-		IL_0263: ldnull
-		IL_0264: ldloc.s 11
-		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_026b: pop
-		IL_026c: ldc.i4.1
-		IL_026d: newarr [System.Runtime]System.Object
-		IL_0272: dup
-		IL_0273: ldc.i4.0
-		IL_0274: ldloc.0
-		IL_0275: stelem.ref
-		IL_0276: stloc.3
-		IL_0277: ldloc.3
-		IL_0278: ldc.i4.1
-		IL_0279: newarr [System.Runtime]System.Object
-		IL_027e: dup
-		IL_027f: ldc.i4.0
-		IL_0280: ldc.r8 4
-		IL_0289: box [System.Runtime]System.Double
-		IL_028e: stelem.ref
-		IL_028f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0294: ldc.r8 4
-		IL_029d: box [System.Runtime]System.Double
-		IL_02a2: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::.ctor(object[], object)
-		IL_02a7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_02ac: stloc.2
-		IL_02ad: ldloc.2
-		IL_02ae: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_02b3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_02b8: ldstr "prototype"
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_02c2: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_02c7: ldstr "console"
-		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d6: stloc.s 5
-		IL_02d8: ldloc.2
-		IL_02d9: ldstr "count"
-		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e3: stloc.s 12
-		IL_02e5: ldloc.s 5
-		IL_02e7: ldstr "log"
-		IL_02ec: ldloc.s 12
-		IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02f3: pop
-		IL_02f4: ldloc.2
-		IL_02f5: ldstr "count"
-		IL_02fa: ldc.r8 10
-		IL_0303: ldc.i4.1
-		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0309: pop
-		IL_030a: ldstr "console"
-		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0319: stloc.s 12
-		IL_031b: ldloc.2
-		IL_031c: ldstr "count"
-		IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0326: stloc.s 5
-		IL_0328: ldloc.s 12
-		IL_032a: ldstr "log"
-		IL_032f: ldloc.s 5
-		IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0336: pop
-		IL_0337: ldstr "console"
-		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0346: stloc.s 5
-		IL_0348: ldloc.2
-		IL_0349: ldstr "label"
-		IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0353: stloc.s 12
-		IL_0355: ldloc.s 5
-		IL_0357: ldstr "log"
-		IL_035c: ldloc.s 12
-		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0363: pop
-		IL_0364: ldstr "console"
-		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0373: stloc.s 12
-		IL_0375: ldloc.1
-		IL_0376: ldstr "total"
-		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0380: stloc.s 5
-		IL_0382: ldloc.s 12
-		IL_0384: ldstr "log"
-		IL_0389: ldloc.s 5
-		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0390: pop
-		IL_0391: ldloc.1
-		IL_0392: ldstr "total"
-		IL_0397: ldc.r8 5
-		IL_03a0: ldc.i4.1
-		IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_03a6: pop
-		IL_03a7: ldstr "console"
-		IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b6: stloc.s 5
-		IL_03b8: ldloc.1
-		IL_03b9: ldstr "total"
-		IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03c3: stloc.s 12
-		IL_03c5: ldloc.s 5
-		IL_03c7: ldstr "log"
-		IL_03cc: ldloc.s 12
-		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03d3: pop
-		IL_03d4: ret
+		IL_0146: stloc.s 9
+		IL_0148: ldc.i4.1
+		IL_0149: newarr [System.Runtime]System.Object
+		IL_014e: dup
+		IL_014f: ldc.i4.0
+		IL_0150: ldloc.0
+		IL_0151: stelem.ref
+		IL_0152: stloc.3
+		IL_0153: ldloc.3
+		IL_0154: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::.ctor(object[])
+		IL_0159: ldc.i4.0
+		IL_015a: conv.r8
+		IL_015b: ldstr "get total"
+		IL_0160: ldc.i4.0
+		IL_0161: ldc.i4.1
+		IL_0162: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0, float64, string, bool, bool)
+		IL_0167: stloc.s 10
+		IL_0169: ldloc.s 10
+		IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0)
+		IL_0170: stloc.s 10
+		IL_0172: ldloc.s 9
+		IL_0174: ldstr "total"
+		IL_0179: ldloc.s 10
+		IL_017b: ldnull
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0181: pop
+		IL_0182: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_0187: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_018c: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_0191: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0196: stloc.s 9
+		IL_0198: ldc.i4.1
+		IL_0199: newarr [System.Runtime]System.Object
+		IL_019e: dup
+		IL_019f: ldc.i4.0
+		IL_01a0: ldloc.0
+		IL_01a1: stelem.ref
+		IL_01a2: stloc.3
+		IL_01a3: ldloc.3
+		IL_01a4: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::.ctor(object[])
+		IL_01a9: ldc.i4.1
+		IL_01aa: conv.r8
+		IL_01ab: ldstr "set total"
+		IL_01b0: ldc.i4.0
+		IL_01b1: ldc.i4.1
+		IL_01b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0, float64, string, bool, bool)
+		IL_01b7: stloc.s 11
+		IL_01b9: ldloc.s 11
+		IL_01bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0)
+		IL_01c0: stloc.s 11
+		IL_01c2: ldloc.s 9
+		IL_01c4: ldstr "total"
+		IL_01c9: ldnull
+		IL_01ca: ldloc.s 11
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_01d1: pop
+		IL_01d2: ldc.i4.1
+		IL_01d3: newarr [System.Runtime]System.Object
+		IL_01d8: dup
+		IL_01d9: ldc.i4.0
+		IL_01da: ldloc.0
+		IL_01db: stelem.ref
+		IL_01dc: stloc.3
+		IL_01dd: ldloc.3
+		IL_01de: ldc.i4.1
+		IL_01df: newarr [System.Runtime]System.Object
+		IL_01e4: dup
+		IL_01e5: ldc.i4.0
+		IL_01e6: ldc.r8 4
+		IL_01ef: box [System.Runtime]System.Double
+		IL_01f4: stelem.ref
+		IL_01f5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_01fa: ldc.r8 4
+		IL_0203: box [System.Runtime]System.Double
+		IL_0208: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::.ctor(object[], object)
+		IL_020d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0212: stloc.2
+		IL_0213: ldloc.2
+		IL_0214: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_0219: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_021e: ldstr "prototype"
+		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0228: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_022d: ldstr "console"
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_023c: stloc.s 5
+		IL_023e: ldloc.2
+		IL_023f: ldstr "count"
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0249: stloc.s 12
+		IL_024b: ldloc.s 5
+		IL_024d: ldstr "log"
+		IL_0252: ldloc.s 12
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0259: pop
+		IL_025a: ldloc.2
+		IL_025b: ldstr "count"
+		IL_0260: ldc.r8 10
+		IL_0269: ldc.i4.1
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_026f: pop
+		IL_0270: ldstr "console"
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_027f: stloc.s 12
+		IL_0281: ldloc.2
+		IL_0282: ldstr "count"
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_028c: stloc.s 5
+		IL_028e: ldloc.s 12
+		IL_0290: ldstr "log"
+		IL_0295: ldloc.s 5
+		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029c: pop
+		IL_029d: ldstr "console"
+		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ac: stloc.s 5
+		IL_02ae: ldloc.2
+		IL_02af: ldstr "label"
+		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b9: stloc.s 12
+		IL_02bb: ldloc.s 5
+		IL_02bd: ldstr "log"
+		IL_02c2: ldloc.s 12
+		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c9: pop
+		IL_02ca: ldstr "console"
+		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d9: stloc.s 12
+		IL_02db: ldloc.1
+		IL_02dc: ldstr "total"
+		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02e6: stloc.s 5
+		IL_02e8: ldloc.s 12
+		IL_02ea: ldstr "log"
+		IL_02ef: ldloc.s 5
+		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02f6: pop
+		IL_02f7: ldloc.1
+		IL_02f8: ldstr "total"
+		IL_02fd: ldc.r8 5
+		IL_0306: ldc.i4.1
+		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_030c: pop
+		IL_030d: ldstr "console"
+		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_031c: stloc.s 5
+		IL_031e: ldloc.1
+		IL_031f: ldstr "total"
+		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0329: stloc.s 12
+		IL_032b: ldloc.s 5
+		IL_032d: ldstr "log"
+		IL_0332: ldloc.s 12
+		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0339: pop
+		IL_033a: ret
 	} // end of method Classes_AccessorMethods_InstanceAndStatic::__js_module_init__
 
 } // end of class Modules.Classes_AccessorMethods_InstanceAndStatic
@@ -1108,7 +1073,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x268a
+		// Method begins at RVA 0x25ee
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DeclarationOrder.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DeclarationOrder.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ff
+				// Method begins at RVA 0x21eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2208
+				// Method begins at RVA 0x21f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2211
+				// Method begins at RVA 0x21fd
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2220
+				// Method begins at RVA 0x220c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2223
+				// Method begins at RVA 0x220f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2226
+				// Method begins at RVA 0x2212
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2232
+				// Method begins at RVA 0x221e
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x223e
+				// Method begins at RVA 0x222a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2246
+				// Method begins at RVA 0x2232
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2249
+				// Method begins at RVA 0x2235
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x224c
+				// Method begins at RVA 0x2238
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -214,7 +214,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2194
+			// Method begins at RVA 0x2180
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -244,7 +244,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21cc
+			// Method begins at RVA 0x21b8
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -274,7 +274,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21f6
+			// Method begins at RVA 0x21e2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -300,19 +300,18 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 312 (0x138)
+		// Code size: 289 (0x121)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Scope,
 			[1] object,
 			[2] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object,
-			[6] object[],
-			[7] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method,
-			[8] object,
-			[9] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
+			[4] object,
+			[5] object[],
+			[6] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method,
+			[7] object,
+			[8] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Scope::.ctor()
@@ -323,97 +322,92 @@
 		IL_0011: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: stloc.s 5
-		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0045: stloc.s 6
-		IL_0047: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method::.ctor()
-		IL_004c: ldc.i4.0
-		IL_004d: conv.r8
-		IL_004e: ldstr "method"
-		IL_0053: ldc.i4.1
-		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0, float64, string, bool, bool)
-		IL_005a: stloc.s 7
-		IL_005c: ldloc.s 7
-		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0)
-		IL_0063: stloc.s 7
-		IL_0065: ldloc.s 5
-		IL_0067: ldstr "method"
-		IL_006c: ldloc.s 7
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0073: pop
-		IL_0074: ldc.i4.1
-		IL_0075: newarr [System.Runtime]System.Object
-		IL_007a: dup
-		IL_007b: ldc.i4.0
-		IL_007c: ldloc.0
-		IL_007d: stelem.ref
-		IL_007e: stloc.s 6
-		IL_0080: ldloc.3
-		IL_0081: ldloc.s 6
-		IL_0083: ldc.r8 0.0
-		IL_008c: box [System.Runtime]System.Double
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0096: stloc.s 5
-		IL_0098: ldloc.s 5
-		IL_009a: stloc.1
-		IL_009b: ldc.i4.1
-		IL_009c: newarr [System.Runtime]System.Object
-		IL_00a1: dup
-		IL_00a2: ldc.i4.0
-		IL_00a3: ldloc.0
-		IL_00a4: stelem.ref
-		IL_00a5: stloc.s 6
-		IL_00a7: ldloc.s 6
-		IL_00a9: ldc.i4.0
-		IL_00aa: newarr [System.Runtime]System.Object
-		IL_00af: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00b4: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::.ctor(object[])
-		IL_00b9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00be: stloc.2
-		IL_00bf: ldloc.2
-		IL_00c0: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
-		IL_00c5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00ca: ldstr "prototype"
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00d4: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00d9: ldstr "console"
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e8: stloc.s 5
-		IL_00ea: ldloc.2
-		IL_00eb: ldstr "field"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f5: stloc.s 8
-		IL_00f7: ldloc.s 5
-		IL_00f9: ldstr "log"
-		IL_00fe: ldloc.s 8
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0105: pop
-		IL_0106: ldstr "console"
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0115: stloc.s 8
-		IL_0117: ldloc.2
-		IL_0118: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example>(!!0)
-		IL_011d: stloc.s 9
-		IL_011f: ldloc.s 9
-		IL_0121: callvirt instance object Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::'method'()
-		IL_0126: stloc.s 5
-		IL_0128: ldloc.s 8
-		IL_012a: ldstr "log"
-		IL_012f: ldloc.s 5
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0136: pop
-		IL_0137: ret
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: stloc.s 4
+		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002e: stloc.s 5
+		IL_0030: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method::.ctor()
+		IL_0035: ldc.i4.0
+		IL_0036: conv.r8
+		IL_0037: ldstr "method"
+		IL_003c: ldc.i4.1
+		IL_003d: ldc.i4.1
+		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0, float64, string, bool, bool)
+		IL_0043: stloc.s 6
+		IL_0045: ldloc.s 6
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0)
+		IL_004c: stloc.s 6
+		IL_004e: ldloc.s 4
+		IL_0050: ldstr "method"
+		IL_0055: ldloc.s 6
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005c: pop
+		IL_005d: ldc.i4.1
+		IL_005e: newarr [System.Runtime]System.Object
+		IL_0063: dup
+		IL_0064: ldc.i4.0
+		IL_0065: ldloc.0
+		IL_0066: stelem.ref
+		IL_0067: stloc.s 5
+		IL_0069: ldloc.3
+		IL_006a: ldloc.s 5
+		IL_006c: ldc.r8 0.0
+		IL_0075: box [System.Runtime]System.Double
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_007f: stloc.s 4
+		IL_0081: ldloc.s 4
+		IL_0083: stloc.1
+		IL_0084: ldc.i4.1
+		IL_0085: newarr [System.Runtime]System.Object
+		IL_008a: dup
+		IL_008b: ldc.i4.0
+		IL_008c: ldloc.0
+		IL_008d: stelem.ref
+		IL_008e: stloc.s 5
+		IL_0090: ldloc.s 5
+		IL_0092: ldc.i4.0
+		IL_0093: newarr [System.Runtime]System.Object
+		IL_0098: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_009d: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::.ctor(object[])
+		IL_00a2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00a7: stloc.2
+		IL_00a8: ldloc.2
+		IL_00a9: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
+		IL_00ae: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00b3: ldstr "prototype"
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00bd: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00c2: ldstr "console"
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d1: stloc.s 4
+		IL_00d3: ldloc.2
+		IL_00d4: ldstr "field"
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00de: stloc.s 7
+		IL_00e0: ldloc.s 4
+		IL_00e2: ldstr "log"
+		IL_00e7: ldloc.s 7
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ee: pop
+		IL_00ef: ldstr "console"
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fe: stloc.s 7
+		IL_0100: ldloc.2
+		IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example>(!!0)
+		IL_0106: stloc.s 8
+		IL_0108: ldloc.s 8
+		IL_010a: callvirt instance object Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::'method'()
+		IL_010f: stloc.s 4
+		IL_0111: ldloc.s 7
+		IL_0113: ldstr "log"
+		IL_0118: ldloc.s 4
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011f: pop
+		IL_0120: ret
 	} // end of method Classes_ClassComputedFieldAndMethod_DeclarationOrder::__js_module_init__
 
 } // end of class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder
@@ -425,7 +419,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2270
+		// Method begins at RVA 0x225c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassExpression_LazyPrototypeMetadata.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassExpression_LazyPrototypeMetadata.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c0
+				// Method begins at RVA 0x22aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c9
+				// Method begins at RVA 0x22b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22d2
+				// Method begins at RVA 0x22bc
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22e1
+				// Method begins at RVA 0x22cb
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22e4
+				// Method begins at RVA 0x22ce
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22e7
+				// Method begins at RVA 0x22d1
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22f3
+				// Method begins at RVA 0x22dd
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ff
+				// Method begins at RVA 0x22e9
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2307
+				// Method begins at RVA 0x22f1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x230a
+				// Method begins at RVA 0x22f4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x230d
+				// Method begins at RVA 0x22f7
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -209,7 +209,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a8
+			// Method begins at RVA 0x2292
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -225,7 +225,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22b0
+			// Method begins at RVA 0x229a
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -243,7 +243,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22b7
+			// Method begins at RVA 0x22a1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -269,7 +269,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 588 (0x24c)
+		// Code size: 566 (0x236)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassExpression_LazyPrototypeMetadata/Scope,
@@ -277,15 +277,14 @@
 			[2] object,
 			[3] object,
 			[4] class [System.Runtime]System.Type,
-			[5] class [System.Runtime]System.Type,
-			[6] object,
-			[7] object[],
-			[8] class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet,
+			[5] object,
+			[6] object[],
+			[7] class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet,
+			[8] object,
 			[9] object,
-			[10] object,
-			[11] bool,
-			[12] object,
-			[13] string
+			[10] bool,
+			[11] object,
+			[12] string
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -305,167 +304,162 @@
 		IL_0038: ldtoken Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
 		IL_003d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0042: stloc.s 4
-		IL_0044: ldtoken Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
-		IL_0049: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_004e: ldtoken Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
-		IL_0053: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0058: stloc.s 5
-		IL_005a: ldloc.s 5
-		IL_005c: ldstr "prototype"
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0066: stloc.s 6
-		IL_0068: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006d: stloc.s 7
-		IL_006f: newobj instance void Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::.ctor()
-		IL_0074: ldc.i4.0
-		IL_0075: conv.r8
-		IL_0076: ldstr "greet"
-		IL_007b: ldc.i4.0
-		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0, float64, string, bool, bool)
-		IL_0082: stloc.s 8
-		IL_0084: ldloc.s 8
-		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0)
-		IL_008b: stloc.s 8
-		IL_008d: ldloc.s 6
-		IL_008f: ldstr "greet"
-		IL_0094: ldloc.s 8
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_009b: pop
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
-		IL_00a6: stloc.s 7
-		IL_00a8: ldloc.s 4
-		IL_00aa: ldloc.s 7
-		IL_00ac: ldc.r8 0.0
-		IL_00b5: box [System.Runtime]System.Double
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
-		IL_00bf: stloc.s 6
-		IL_00c1: ldloc.s 6
-		IL_00c3: ldstr "Greeter"
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
-		IL_00cd: stloc.s 6
-		IL_00cf: ldloc.s 6
-		IL_00d1: ldstr "Greeter"
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
-		IL_00db: stloc.2
-		IL_00dc: ldloc.2
-		IL_00dd: ldc.i4.0
-		IL_00de: newarr [System.Runtime]System.Object
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_00e8: stloc.3
-		IL_00e9: ldstr "console"
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f8: stloc.s 6
-		IL_00fa: ldloc.3
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0100: stloc.s 9
-		IL_0102: ldloc.s 9
-		IL_0104: isinst Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
-		IL_0109: dup
-		IL_010a: brfalse IL_011b
+		IL_0044: ldloc.s 4
+		IL_0046: ldstr "prototype"
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0050: stloc.s 5
+		IL_0052: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0057: stloc.s 6
+		IL_0059: newobj instance void Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::.ctor()
+		IL_005e: ldc.i4.0
+		IL_005f: conv.r8
+		IL_0060: ldstr "greet"
+		IL_0065: ldc.i4.0
+		IL_0066: ldc.i4.1
+		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0, float64, string, bool, bool)
+		IL_006c: stloc.s 7
+		IL_006e: ldloc.s 7
+		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0)
+		IL_0075: stloc.s 7
+		IL_0077: ldloc.s 5
+		IL_0079: ldstr "greet"
+		IL_007e: ldloc.s 7
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0085: pop
+		IL_0086: ldc.i4.1
+		IL_0087: newarr [System.Runtime]System.Object
+		IL_008c: dup
+		IL_008d: ldc.i4.0
+		IL_008e: ldloc.0
+		IL_008f: stelem.ref
+		IL_0090: stloc.s 6
+		IL_0092: ldloc.s 4
+		IL_0094: ldloc.s 6
+		IL_0096: ldc.r8 0.0
+		IL_009f: box [System.Runtime]System.Double
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
+		IL_00a9: stloc.s 5
+		IL_00ab: ldloc.s 5
+		IL_00ad: ldstr "Greeter"
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
+		IL_00b7: stloc.s 5
+		IL_00b9: ldloc.s 5
+		IL_00bb: ldstr "Greeter"
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
+		IL_00c5: stloc.2
+		IL_00c6: ldloc.2
+		IL_00c7: ldc.i4.0
+		IL_00c8: newarr [System.Runtime]System.Object
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_00d2: stloc.3
+		IL_00d3: ldstr "console"
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e2: stloc.s 5
+		IL_00e4: ldloc.3
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ea: stloc.s 8
+		IL_00ec: ldloc.s 8
+		IL_00ee: isinst Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
+		IL_00f3: dup
+		IL_00f4: brfalse IL_0105
 
-		IL_010f: callvirt instance object Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17::greet()
-		IL_0114: stloc.s 9
-		IL_0116: br IL_012a
+		IL_00f9: callvirt instance object Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17::greet()
+		IL_00fe: stloc.s 8
+		IL_0100: br IL_0114
 
-		IL_011b: pop
-		IL_011c: ldloc.s 9
-		IL_011e: ldstr "greet"
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0128: stloc.s 9
+		IL_0105: pop
+		IL_0106: ldloc.s 8
+		IL_0108: ldstr "greet"
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0112: stloc.s 8
 
-		IL_012a: ldloc.s 6
-		IL_012c: ldstr "log"
-		IL_0131: ldloc.s 9
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0138: pop
-		IL_0139: ldstr "console"
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0148: stloc.s 9
-		IL_014a: ldloc.3
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0150: stloc.s 6
-		IL_0152: ldloc.2
-		IL_0153: ldstr "prototype"
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015d: stloc.s 10
-		IL_015f: ldloc.s 6
-		IL_0161: ldloc.s 10
-		IL_0163: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0168: stloc.s 11
-		IL_016a: ldloc.s 11
-		IL_016c: box [System.Runtime]System.Boolean
-		IL_0171: stloc.s 12
-		IL_0173: ldloc.s 9
-		IL_0175: ldstr "log"
-		IL_017a: ldloc.s 12
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0181: pop
-		IL_0182: ldstr "console"
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0191: stloc.s 9
-		IL_0193: ldloc.2
-		IL_0194: ldstr "prototype"
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_019e: stloc.s 10
-		IL_01a0: ldloc.s 10
-		IL_01a2: ldstr "greet"
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ac: stloc.s 10
-		IL_01ae: ldloc.s 10
-		IL_01b0: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_01b5: stloc.s 13
-		IL_01b7: ldloc.s 9
-		IL_01b9: ldstr "log"
-		IL_01be: ldloc.s 13
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c5: pop
-		IL_01c6: ldstr "console"
-		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d5: stloc.s 9
-		IL_01d7: ldloc.2
-		IL_01d8: ldstr "prototype"
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e2: stloc.s 10
-		IL_01e4: ldloc.s 10
-		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_01eb: ldstr "length"
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01f5: stloc.s 10
-		IL_01f7: ldloc.s 9
-		IL_01f9: ldstr "log"
-		IL_01fe: ldloc.s 10
-		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0205: pop
-		IL_0206: ldstr "console"
-		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0215: stloc.s 10
-		IL_0217: ldloc.2
-		IL_0218: ldstr "prototype"
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0222: stloc.s 9
-		IL_0224: ldloc.s 9
-		IL_0226: ldstr "greet"
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0230: ldstr "enumerable"
-		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_023a: stloc.s 9
-		IL_023c: ldloc.s 10
-		IL_023e: ldstr "log"
-		IL_0243: ldloc.s 9
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024a: pop
-		IL_024b: ret
+		IL_0114: ldloc.s 5
+		IL_0116: ldstr "log"
+		IL_011b: ldloc.s 8
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0122: pop
+		IL_0123: ldstr "console"
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0132: stloc.s 8
+		IL_0134: ldloc.3
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_013a: stloc.s 5
+		IL_013c: ldloc.2
+		IL_013d: ldstr "prototype"
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0147: stloc.s 9
+		IL_0149: ldloc.s 5
+		IL_014b: ldloc.s 9
+		IL_014d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0152: stloc.s 10
+		IL_0154: ldloc.s 10
+		IL_0156: box [System.Runtime]System.Boolean
+		IL_015b: stloc.s 11
+		IL_015d: ldloc.s 8
+		IL_015f: ldstr "log"
+		IL_0164: ldloc.s 11
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016b: pop
+		IL_016c: ldstr "console"
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017b: stloc.s 8
+		IL_017d: ldloc.2
+		IL_017e: ldstr "prototype"
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0188: stloc.s 9
+		IL_018a: ldloc.s 9
+		IL_018c: ldstr "greet"
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0196: stloc.s 9
+		IL_0198: ldloc.s 9
+		IL_019a: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_019f: stloc.s 12
+		IL_01a1: ldloc.s 8
+		IL_01a3: ldstr "log"
+		IL_01a8: ldloc.s 12
+		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01af: pop
+		IL_01b0: ldstr "console"
+		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01bf: stloc.s 8
+		IL_01c1: ldloc.2
+		IL_01c2: ldstr "prototype"
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01cc: stloc.s 9
+		IL_01ce: ldloc.s 9
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_01d5: ldstr "length"
+		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01df: stloc.s 9
+		IL_01e1: ldloc.s 8
+		IL_01e3: ldstr "log"
+		IL_01e8: ldloc.s 9
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ef: pop
+		IL_01f0: ldstr "console"
+		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ff: stloc.s 9
+		IL_0201: ldloc.2
+		IL_0202: ldstr "prototype"
+		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_020c: stloc.s 8
+		IL_020e: ldloc.s 8
+		IL_0210: ldstr "greet"
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_021a: ldstr "enumerable"
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0224: stloc.s 8
+		IL_0226: ldloc.s 9
+		IL_0228: ldstr "log"
+		IL_022d: ldloc.s 8
+		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0234: pop
+		IL_0235: ret
 	} // end of method Classes_ClassExpression_LazyPrototypeMetadata::__js_module_init__
 
 } // end of class Modules.Classes_ClassExpression_LazyPrototypeMetadata
@@ -477,7 +471,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2331
+		// Method begins at RVA 0x231b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassFieldTypeInference_Primitives.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassFieldTypeInference_Primitives.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2227
+				// Method begins at RVA 0x2213
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2230
+				// Method begins at RVA 0x221c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2239
+				// Method begins at RVA 0x2225
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2242
+				// Method begins at RVA 0x222e
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2251
+				// Method begins at RVA 0x223d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2254
+				// Method begins at RVA 0x2240
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2257
+				// Method begins at RVA 0x2243
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -142,7 +142,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2263
+				// Method begins at RVA 0x224f
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x226f
+				// Method begins at RVA 0x225b
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -174,7 +174,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2277
+				// Method begins at RVA 0x2263
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -186,7 +186,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x227a
+				// Method begins at RVA 0x2266
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -201,7 +201,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x227d
+				// Method begins at RVA 0x2269
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -234,7 +234,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21cf
+			// Method begins at RVA 0x21b8
 			// Header size: 1
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -259,7 +259,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f8
+			// Method begins at RVA 0x21e4
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -288,7 +288,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x221e
+			// Method begins at RVA 0x220a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,19 +314,18 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 371 (0x173)
+		// Code size: 348 (0x15c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassFieldTypeInference_Primitives/Scope,
 			[1] object,
 			[2] class Modules.Classes_ClassFieldTypeInference_Primitives/Counter,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object,
-			[6] object[],
-			[7] class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment,
-			[8] class Modules.Classes_ClassFieldTypeInference_Primitives/Counter,
-			[9] object
+			[4] object,
+			[5] object[],
+			[6] class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment,
+			[7] class Modules.Classes_ClassFieldTypeInference_Primitives/Counter,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Scope::.ctor()
@@ -337,112 +336,107 @@
 		IL_0011: ldtoken Modules.Classes_ClassFieldTypeInference_Primitives/Counter
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.Classes_ClassFieldTypeInference_Primitives/Counter
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Classes_ClassFieldTypeInference_Primitives/Counter
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: stloc.s 5
-		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0045: stloc.s 6
-		IL_0047: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment::.ctor()
-		IL_004c: ldc.i4.0
-		IL_004d: conv.r8
-		IL_004e: ldstr "increment"
-		IL_0053: ldc.i4.1
-		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0, float64, string, bool, bool)
-		IL_005a: stloc.s 7
-		IL_005c: ldloc.s 7
-		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0)
-		IL_0063: stloc.s 7
-		IL_0065: ldloc.s 5
-		IL_0067: ldstr "increment"
-		IL_006c: ldloc.s 7
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0073: pop
-		IL_0074: ldc.i4.1
-		IL_0075: newarr [System.Runtime]System.Object
-		IL_007a: dup
-		IL_007b: ldc.i4.0
-		IL_007c: ldloc.0
-		IL_007d: stelem.ref
-		IL_007e: stloc.s 6
-		IL_0080: ldloc.3
-		IL_0081: ldloc.s 6
-		IL_0083: ldc.r8 0.0
-		IL_008c: box [System.Runtime]System.Double
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0096: stloc.s 5
-		IL_0098: ldloc.s 5
-		IL_009a: stloc.1
-		IL_009b: ldc.i4.0
-		IL_009c: newarr [System.Runtime]System.Object
-		IL_00a1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00a6: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter::.ctor()
-		IL_00ab: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00b0: stloc.2
-		IL_00b1: ldloc.2
-		IL_00b2: ldtoken Modules.Classes_ClassFieldTypeInference_Primitives/Counter
-		IL_00b7: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00bc: ldstr "prototype"
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00c6: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00cb: ldloc.2
-		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter>(!!0)
-		IL_00d1: stloc.s 8
-		IL_00d3: ldloc.s 8
-		IL_00d5: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
-		IL_00da: pop
-		IL_00db: ldloc.2
-		IL_00dc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter>(!!0)
-		IL_00e1: stloc.s 8
-		IL_00e3: ldloc.s 8
-		IL_00e5: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
-		IL_00ea: pop
-		IL_00eb: ldstr "console"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fa: stloc.s 5
-		IL_00fc: ldloc.2
-		IL_00fd: ldstr "value"
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0107: stloc.s 9
-		IL_0109: ldloc.s 5
-		IL_010b: ldstr "log"
-		IL_0110: ldloc.s 9
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0117: pop
-		IL_0118: ldstr "console"
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0127: stloc.s 9
-		IL_0129: ldloc.2
-		IL_012a: ldstr "name"
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0134: stloc.s 5
-		IL_0136: ldloc.s 9
-		IL_0138: ldstr "log"
-		IL_013d: ldloc.s 5
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0144: pop
-		IL_0145: ldstr "console"
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0154: stloc.s 5
-		IL_0156: ldloc.2
-		IL_0157: ldstr "active"
-		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0161: stloc.s 9
-		IL_0163: ldloc.s 5
-		IL_0165: ldstr "log"
-		IL_016a: ldloc.s 9
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0171: pop
-		IL_0172: ret
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: stloc.s 4
+		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002e: stloc.s 5
+		IL_0030: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment::.ctor()
+		IL_0035: ldc.i4.0
+		IL_0036: conv.r8
+		IL_0037: ldstr "increment"
+		IL_003c: ldc.i4.1
+		IL_003d: ldc.i4.1
+		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0, float64, string, bool, bool)
+		IL_0043: stloc.s 6
+		IL_0045: ldloc.s 6
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0)
+		IL_004c: stloc.s 6
+		IL_004e: ldloc.s 4
+		IL_0050: ldstr "increment"
+		IL_0055: ldloc.s 6
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005c: pop
+		IL_005d: ldc.i4.1
+		IL_005e: newarr [System.Runtime]System.Object
+		IL_0063: dup
+		IL_0064: ldc.i4.0
+		IL_0065: ldloc.0
+		IL_0066: stelem.ref
+		IL_0067: stloc.s 5
+		IL_0069: ldloc.3
+		IL_006a: ldloc.s 5
+		IL_006c: ldc.r8 0.0
+		IL_0075: box [System.Runtime]System.Double
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_007f: stloc.s 4
+		IL_0081: ldloc.s 4
+		IL_0083: stloc.1
+		IL_0084: ldc.i4.0
+		IL_0085: newarr [System.Runtime]System.Object
+		IL_008a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_008f: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter::.ctor()
+		IL_0094: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0099: stloc.2
+		IL_009a: ldloc.2
+		IL_009b: ldtoken Modules.Classes_ClassFieldTypeInference_Primitives/Counter
+		IL_00a0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00a5: ldstr "prototype"
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00af: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00b4: ldloc.2
+		IL_00b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter>(!!0)
+		IL_00ba: stloc.s 7
+		IL_00bc: ldloc.s 7
+		IL_00be: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
+		IL_00c3: pop
+		IL_00c4: ldloc.2
+		IL_00c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter>(!!0)
+		IL_00ca: stloc.s 7
+		IL_00cc: ldloc.s 7
+		IL_00ce: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
+		IL_00d3: pop
+		IL_00d4: ldstr "console"
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e3: stloc.s 4
+		IL_00e5: ldloc.2
+		IL_00e6: ldstr "value"
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f0: stloc.s 8
+		IL_00f2: ldloc.s 4
+		IL_00f4: ldstr "log"
+		IL_00f9: ldloc.s 8
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0100: pop
+		IL_0101: ldstr "console"
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0110: stloc.s 8
+		IL_0112: ldloc.2
+		IL_0113: ldstr "name"
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011d: stloc.s 4
+		IL_011f: ldloc.s 8
+		IL_0121: ldstr "log"
+		IL_0126: ldloc.s 4
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012d: pop
+		IL_012e: ldstr "console"
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013d: stloc.s 4
+		IL_013f: ldloc.2
+		IL_0140: ldstr "active"
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_014a: stloc.s 8
+		IL_014c: ldloc.s 4
+		IL_014e: ldstr "log"
+		IL_0153: ldloc.s 8
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015a: pop
+		IL_015b: ret
 	} // end of method Classes_ClassFieldTypeInference_Primitives::__js_module_init__
 
 } // end of class Modules.Classes_ClassFieldTypeInference_Primitives
@@ -454,7 +448,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22a1
+		// Method begins at RVA 0x228d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassLocal_ReassignedClass_FallsBack.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassLocal_ReassignedClass_FallsBack.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x221f
+					// Method begins at RVA 0x2207
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2228
+					// Method begins at RVA 0x2210
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2216
+				// Method begins at RVA 0x21fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 					class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2295
+				// Method begins at RVA 0x227d
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -101,7 +101,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22a4
+				// Method begins at RVA 0x228c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -113,7 +113,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22a7
+				// Method begins at RVA 0x228f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -127,7 +127,7 @@
 					object thisArgument
 				) cil managed 
 			{
-				// Method begins at RVA 0x22aa
+				// Method begins at RVA 0x2292
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -143,7 +143,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22b2
+				// Method begins at RVA 0x229a
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -162,7 +162,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22c4
+				// Method begins at RVA 0x22ac
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -180,7 +180,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22d2
+				// Method begins at RVA 0x22ba
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -208,7 +208,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2130
+			// Method begins at RVA 0x2118
 			// Header size: 12
 			// Code size: 154 (0x9a)
 			.maxstack 8
@@ -295,7 +295,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2204
+				// Method begins at RVA 0x21ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -315,7 +315,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x220d
+				// Method begins at RVA 0x21f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -340,7 +340,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2231
+				// Method begins at RVA 0x2219
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -356,7 +356,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2240
+				// Method begins at RVA 0x2228
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -368,7 +368,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2243
+				// Method begins at RVA 0x222b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -383,7 +383,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2246
+				// Method begins at RVA 0x222e
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -399,7 +399,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2252
+				// Method begins at RVA 0x223a
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -418,7 +418,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x225e
+				// Method begins at RVA 0x2246
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -431,7 +431,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2266
+				// Method begins at RVA 0x224e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -443,7 +443,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2269
+				// Method begins at RVA 0x2251
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -458,7 +458,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x226c
+				// Method begins at RVA 0x2254
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -487,7 +487,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f3
+			// Method begins at RVA 0x21db
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -503,7 +503,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21e8
+			// Method begins at RVA 0x21d0
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -529,7 +529,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21fb
+			// Method begins at RVA 0x21e3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -555,16 +555,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 210 (0xd2)
+		// Code size: 187 (0xbb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope,
 			[1] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test,
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object,
-			[6] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read
+			[4] object,
+			[5] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope::.ctor()
@@ -593,56 +592,51 @@
 		IL_0037: ldtoken Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box
 		IL_003c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0041: stloc.3
-		IL_0042: ldtoken Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box
-		IL_0047: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_004c: ldtoken Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box
-		IL_0051: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0056: stloc.s 4
-		IL_0058: ldloc.s 4
-		IL_005a: ldstr "prototype"
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0064: stloc.s 5
-		IL_0066: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006b: stloc.2
-		IL_006c: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read::.ctor()
-		IL_0071: ldc.i4.0
-		IL_0072: conv.r8
-		IL_0073: ldstr "read"
-		IL_0078: ldc.i4.0
-		IL_0079: ldc.i4.1
-		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0, float64, string, bool, bool)
-		IL_007f: stloc.s 6
-		IL_0081: ldloc.s 6
-		IL_0083: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0)
-		IL_0088: stloc.s 6
-		IL_008a: ldloc.s 5
-		IL_008c: ldstr "read"
-		IL_0091: ldloc.s 6
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0098: pop
-		IL_0099: ldc.i4.1
-		IL_009a: newarr [System.Runtime]System.Object
-		IL_009f: dup
-		IL_00a0: ldc.i4.0
-		IL_00a1: ldloc.0
-		IL_00a2: stelem.ref
-		IL_00a3: stloc.2
-		IL_00a4: ldloc.3
-		IL_00a5: ldloc.2
-		IL_00a6: ldc.r8 0.0
-		IL_00af: box [System.Runtime]System.Double
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00b9: stloc.s 5
-		IL_00bb: ldloc.0
-		IL_00bc: ldloc.s 5
-		IL_00be: stfld object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope::Box
-		IL_00c3: nop
-		IL_00c4: ldloc.0
-		IL_00c5: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope
-		IL_00ca: ldnull
-		IL_00cb: call object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test::__js_call__(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope, object)
-		IL_00d0: pop
-		IL_00d1: ret
+		IL_0042: ldloc.3
+		IL_0043: ldstr "prototype"
+		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_004d: stloc.s 4
+		IL_004f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0054: stloc.2
+		IL_0055: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read::.ctor()
+		IL_005a: ldc.i4.0
+		IL_005b: conv.r8
+		IL_005c: ldstr "read"
+		IL_0061: ldc.i4.0
+		IL_0062: ldc.i4.1
+		IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0, float64, string, bool, bool)
+		IL_0068: stloc.s 5
+		IL_006a: ldloc.s 5
+		IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0)
+		IL_0071: stloc.s 5
+		IL_0073: ldloc.s 4
+		IL_0075: ldstr "read"
+		IL_007a: ldloc.s 5
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0081: pop
+		IL_0082: ldc.i4.1
+		IL_0083: newarr [System.Runtime]System.Object
+		IL_0088: dup
+		IL_0089: ldc.i4.0
+		IL_008a: ldloc.0
+		IL_008b: stelem.ref
+		IL_008c: stloc.2
+		IL_008d: ldloc.3
+		IL_008e: ldloc.2
+		IL_008f: ldc.r8 0.0
+		IL_0098: box [System.Runtime]System.Double
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00a2: stloc.s 4
+		IL_00a4: ldloc.0
+		IL_00a5: ldloc.s 4
+		IL_00a7: stfld object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope::Box
+		IL_00ac: nop
+		IL_00ad: ldloc.0
+		IL_00ae: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope
+		IL_00b3: ldnull
+		IL_00b4: call object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test::__js_call__(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope, object)
+		IL_00b9: pop
+		IL_00ba: ret
 	} // end of method Classes_ClassLocal_ReassignedClass_FallsBack::__js_module_init__
 
 } // end of class Modules.Classes_ClassLocal_ReassignedClass_FallsBack
@@ -654,7 +648,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e1
+		// Method begins at RVA 0x22c9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x229c
+				// Method begins at RVA 0x2284
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a5
+				// Method begins at RVA 0x228d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ae
+				// Method begins at RVA 0x2296
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22d2
+				// Method begins at RVA 0x22ba
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22e1
+				// Method begins at RVA 0x22c9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22e4
+				// Method begins at RVA 0x22cc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22e7
+				// Method begins at RVA 0x22cf
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -142,7 +142,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22f3
+				// Method begins at RVA 0x22db
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ff
+				// Method begins at RVA 0x22e7
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -174,7 +174,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2307
+				// Method begins at RVA 0x22ef
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -186,7 +186,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x230a
+				// Method begins at RVA 0x22f2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -201,7 +201,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x230d
+				// Method begins at RVA 0x22f5
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -233,7 +233,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21bf
+			// Method begins at RVA 0x21a7
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -252,7 +252,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2268
+			// Method begins at RVA 0x2250
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -286,7 +286,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b7
+				// Method begins at RVA 0x229f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -306,7 +306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c0
+				// Method begins at RVA 0x22a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -326,7 +326,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c9
+				// Method begins at RVA 0x22b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -353,7 +353,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x2336
+				// Method begins at RVA 0x231e
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -372,7 +372,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x234c
+				// Method begins at RVA 0x2334
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -384,7 +384,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x234f
+				// Method begins at RVA 0x2337
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -399,7 +399,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2352
+				// Method begins at RVA 0x233a
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -415,7 +415,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x235e
+				// Method begins at RVA 0x2346
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -434,7 +434,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x236a
+				// Method begins at RVA 0x2352
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -447,7 +447,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2372
+				// Method begins at RVA 0x235a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -459,7 +459,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2375
+				// Method begins at RVA 0x235d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -474,7 +474,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2378
+				// Method begins at RVA 0x2360
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -509,7 +509,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2198
+			// Method begins at RVA 0x2180
 			// Header size: 12
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -537,7 +537,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21c0
 			// Header size: 12
 			// Code size: 129 (0x81)
 			.maxstack 8
@@ -608,7 +608,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2293
+			// Method begins at RVA 0x227b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -634,19 +634,18 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 314 (0x13a)
+		// Code size: 291 (0x123)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope,
 			[1] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator,
 			[2] object,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object,
-			[6] object[],
-			[7] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext,
-			[8] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator,
-			[9] float64
+			[4] object,
+			[5] object[],
+			[6] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext,
+			[7] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator,
+			[8] float64
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope::.ctor()
@@ -657,100 +656,95 @@
 		IL_0011: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: stloc.s 5
-		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0045: stloc.s 6
-		IL_0047: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext::.ctor()
-		IL_004c: ldc.i4.0
-		IL_004d: conv.r8
-		IL_004e: ldstr "getNext"
-		IL_0053: ldc.i4.1
-		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0, float64, string, bool, bool)
-		IL_005a: stloc.s 7
-		IL_005c: ldloc.s 7
-		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0)
-		IL_0063: stloc.s 7
-		IL_0065: ldloc.s 5
-		IL_0067: ldstr "getNext"
-		IL_006c: ldloc.s 7
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0073: pop
-		IL_0074: ldc.i4.1
-		IL_0075: newarr [System.Runtime]System.Object
-		IL_007a: dup
-		IL_007b: ldc.i4.0
-		IL_007c: ldloc.0
-		IL_007d: stelem.ref
-		IL_007e: stloc.s 6
-		IL_0080: ldloc.3
-		IL_0081: ldloc.s 6
-		IL_0083: ldc.r8 0.0
-		IL_008c: box [System.Runtime]System.Double
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0096: stloc.s 5
-		IL_0098: ldloc.0
-		IL_0099: ldloc.s 5
-		IL_009b: stfld object Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope::Counter
-		IL_00a0: nop
-		IL_00a1: ldc.i4.1
-		IL_00a2: newarr [System.Runtime]System.Object
-		IL_00a7: dup
-		IL_00a8: ldc.i4.0
-		IL_00a9: ldloc.0
-		IL_00aa: stelem.ref
-		IL_00ab: stloc.s 6
-		IL_00ad: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
-		IL_00b2: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00b7: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
-		IL_00bc: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00c1: stloc.3
-		IL_00c2: ldc.i4.1
-		IL_00c3: newarr [System.Runtime]System.Object
-		IL_00c8: dup
-		IL_00c9: ldc.i4.0
-		IL_00ca: ldloc.0
-		IL_00cb: stelem.ref
-		IL_00cc: stloc.s 6
-		IL_00ce: ldloc.s 6
-		IL_00d0: ldc.i4.0
-		IL_00d1: newarr [System.Runtime]System.Object
-		IL_00d6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00db: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::.ctor(object[])
-		IL_00e0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00e5: stloc.1
-		IL_00e6: ldloc.1
-		IL_00e7: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
-		IL_00ec: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00f1: ldstr "prototype"
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00fb: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0100: ldloc.1
-		IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator>(!!0)
-		IL_0106: stloc.s 8
-		IL_0108: ldloc.s 8
-		IL_010a: callvirt instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::compute()
-		IL_010f: stloc.s 9
-		IL_0111: ldloc.s 9
-		IL_0113: box [System.Runtime]System.Double
-		IL_0118: stloc.2
-		IL_0119: ldstr "console"
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0128: ldstr "log"
-		IL_012d: ldstr "final output:"
-		IL_0132: ldloc.2
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0138: pop
-		IL_0139: ret
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: stloc.s 4
+		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002e: stloc.s 5
+		IL_0030: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext::.ctor()
+		IL_0035: ldc.i4.0
+		IL_0036: conv.r8
+		IL_0037: ldstr "getNext"
+		IL_003c: ldc.i4.1
+		IL_003d: ldc.i4.1
+		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0, float64, string, bool, bool)
+		IL_0043: stloc.s 6
+		IL_0045: ldloc.s 6
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0)
+		IL_004c: stloc.s 6
+		IL_004e: ldloc.s 4
+		IL_0050: ldstr "getNext"
+		IL_0055: ldloc.s 6
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005c: pop
+		IL_005d: ldc.i4.1
+		IL_005e: newarr [System.Runtime]System.Object
+		IL_0063: dup
+		IL_0064: ldc.i4.0
+		IL_0065: ldloc.0
+		IL_0066: stelem.ref
+		IL_0067: stloc.s 5
+		IL_0069: ldloc.3
+		IL_006a: ldloc.s 5
+		IL_006c: ldc.r8 0.0
+		IL_0075: box [System.Runtime]System.Double
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_007f: stloc.s 4
+		IL_0081: ldloc.0
+		IL_0082: ldloc.s 4
+		IL_0084: stfld object Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope::Counter
+		IL_0089: nop
+		IL_008a: ldc.i4.1
+		IL_008b: newarr [System.Runtime]System.Object
+		IL_0090: dup
+		IL_0091: ldc.i4.0
+		IL_0092: ldloc.0
+		IL_0093: stelem.ref
+		IL_0094: stloc.s 5
+		IL_0096: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+		IL_009b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00a0: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+		IL_00a5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00aa: stloc.3
+		IL_00ab: ldc.i4.1
+		IL_00ac: newarr [System.Runtime]System.Object
+		IL_00b1: dup
+		IL_00b2: ldc.i4.0
+		IL_00b3: ldloc.0
+		IL_00b4: stelem.ref
+		IL_00b5: stloc.s 5
+		IL_00b7: ldloc.s 5
+		IL_00b9: ldc.i4.0
+		IL_00ba: newarr [System.Runtime]System.Object
+		IL_00bf: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00c4: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::.ctor(object[])
+		IL_00c9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00ce: stloc.1
+		IL_00cf: ldloc.1
+		IL_00d0: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+		IL_00d5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00da: ldstr "prototype"
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00e4: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00e9: ldloc.1
+		IL_00ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator>(!!0)
+		IL_00ef: stloc.s 7
+		IL_00f1: ldloc.s 7
+		IL_00f3: callvirt instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::compute()
+		IL_00f8: stloc.s 8
+		IL_00fa: ldloc.s 8
+		IL_00fc: box [System.Runtime]System.Double
+		IL_0101: stloc.2
+		IL_0102: ldstr "console"
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0111: ldstr "log"
+		IL_0116: ldstr "final output:"
+		IL_011b: ldloc.2
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0121: pop
+		IL_0122: ret
 	} // end of method Classes_ClassMethod_LocalVar_ReassignedFromMethodCall::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall
@@ -762,7 +756,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23a1
+		// Method begins at RVA 0x2389
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MethodValueRequiresMetadata.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MethodValueRequiresMetadata.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ca
+				// Method begins at RVA 0x21b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d3
+				// Method begins at RVA 0x21bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21dc
+				// Method begins at RVA 0x21c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x21e5
+				// Method begins at RVA 0x21cd
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x21f4
+				// Method begins at RVA 0x21dc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x21f7
+				// Method begins at RVA 0x21df
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x21fa
+				// Method begins at RVA 0x21e2
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -142,7 +142,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2206
+				// Method begins at RVA 0x21ee
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2212
+				// Method begins at RVA 0x21fa
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -174,7 +174,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x221a
+				// Method begins at RVA 0x2202
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -186,7 +186,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x221d
+				// Method begins at RVA 0x2205
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -201,7 +201,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2220
+				// Method begins at RVA 0x2208
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -228,7 +228,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2244
+				// Method begins at RVA 0x222c
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -241,7 +241,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x224c
+				// Method begins at RVA 0x2234
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -253,7 +253,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x224f
+				// Method begins at RVA 0x2237
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -268,7 +268,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2252
+				// Method begins at RVA 0x223a
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -296,7 +296,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2195
+			// Method begins at RVA 0x217e
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -312,7 +312,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21ba
+			// Method begins at RVA 0x21a2
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -327,7 +327,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a0
+			// Method begins at RVA 0x2188
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -352,7 +352,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c1
+			// Method begins at RVA 0x21a9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -378,21 +378,20 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 313 (0x139)
+		// Code size: 290 (0x122)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Scope,
 			[1] object,
 			[2] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object,
-			[6] object[],
-			[7] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet,
-			[8] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet,
-			[9] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter,
-			[10] object,
-			[11] string
+			[4] object,
+			[5] object[],
+			[6] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet,
+			[7] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet,
+			[8] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter,
+			[9] object,
+			[10] string
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Scope::.ctor()
@@ -402,97 +401,92 @@
 		IL_0010: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
 		IL_0015: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001a: stloc.3
-		IL_001b: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
-		IL_0020: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0025: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
-		IL_002a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_002f: stloc.s 4
-		IL_0031: ldloc.s 4
-		IL_0033: ldstr "prototype"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003d: stloc.s 5
-		IL_003f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0044: stloc.s 6
-		IL_0046: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet::.ctor()
-		IL_004b: ldc.i4.0
-		IL_004c: conv.r8
-		IL_004d: ldstr "greet"
-		IL_0052: ldc.i4.0
-		IL_0053: ldc.i4.1
-		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0, float64, string, bool, bool)
-		IL_0059: stloc.s 7
-		IL_005b: ldloc.s 7
-		IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0)
-		IL_0062: stloc.s 7
-		IL_0064: ldloc.s 5
-		IL_0066: ldstr "greet"
-		IL_006b: ldloc.s 7
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0072: pop
-		IL_0073: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0078: stloc.s 6
-		IL_007a: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::.ctor()
-		IL_007f: ldc.i4.0
-		IL_0080: conv.r8
-		IL_0081: ldstr "getGreet"
-		IL_0086: ldc.i4.1
-		IL_0087: ldc.i4.1
-		IL_0088: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0, float64, string, bool, bool)
-		IL_008d: stloc.s 8
-		IL_008f: ldloc.s 8
-		IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0)
-		IL_0096: stloc.s 8
-		IL_0098: ldloc.s 5
-		IL_009a: ldstr "getGreet"
-		IL_009f: ldloc.s 8
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00a6: pop
-		IL_00a7: ldc.i4.1
-		IL_00a8: newarr [System.Runtime]System.Object
-		IL_00ad: dup
-		IL_00ae: ldc.i4.0
-		IL_00af: ldloc.0
-		IL_00b0: stelem.ref
-		IL_00b1: stloc.s 6
-		IL_00b3: ldloc.3
-		IL_00b4: ldloc.s 6
-		IL_00b6: ldc.r8 0.0
-		IL_00bf: box [System.Runtime]System.Double
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00c9: stloc.s 5
-		IL_00cb: ldloc.s 5
-		IL_00cd: stloc.1
-		IL_00ce: ldc.i4.0
-		IL_00cf: newarr [System.Runtime]System.Object
-		IL_00d4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00d9: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::.ctor()
-		IL_00de: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00e3: stloc.2
-		IL_00e4: ldloc.2
-		IL_00e5: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
-		IL_00ea: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00ef: ldstr "prototype"
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00f9: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00fe: ldstr "console"
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010d: stloc.s 5
-		IL_010f: ldloc.2
-		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter>(!!0)
-		IL_0115: stloc.s 9
-		IL_0117: ldloc.s 9
-		IL_0119: callvirt instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::getGreet()
-		IL_011e: stloc.s 10
-		IL_0120: ldloc.s 10
-		IL_0122: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0127: stloc.s 11
-		IL_0129: ldloc.s 5
-		IL_012b: ldstr "log"
-		IL_0130: ldloc.s 11
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0137: pop
-		IL_0138: ret
+		IL_001b: ldloc.3
+		IL_001c: ldstr "prototype"
+		IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0026: stloc.s 4
+		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002d: stloc.s 5
+		IL_002f: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet::.ctor()
+		IL_0034: ldc.i4.0
+		IL_0035: conv.r8
+		IL_0036: ldstr "greet"
+		IL_003b: ldc.i4.0
+		IL_003c: ldc.i4.1
+		IL_003d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0, float64, string, bool, bool)
+		IL_0042: stloc.s 6
+		IL_0044: ldloc.s 6
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0)
+		IL_004b: stloc.s 6
+		IL_004d: ldloc.s 4
+		IL_004f: ldstr "greet"
+		IL_0054: ldloc.s 6
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005b: pop
+		IL_005c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0061: stloc.s 5
+		IL_0063: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::.ctor()
+		IL_0068: ldc.i4.0
+		IL_0069: conv.r8
+		IL_006a: ldstr "getGreet"
+		IL_006f: ldc.i4.1
+		IL_0070: ldc.i4.1
+		IL_0071: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0, float64, string, bool, bool)
+		IL_0076: stloc.s 7
+		IL_0078: ldloc.s 7
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0)
+		IL_007f: stloc.s 7
+		IL_0081: ldloc.s 4
+		IL_0083: ldstr "getGreet"
+		IL_0088: ldloc.s 7
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_008f: pop
+		IL_0090: ldc.i4.1
+		IL_0091: newarr [System.Runtime]System.Object
+		IL_0096: dup
+		IL_0097: ldc.i4.0
+		IL_0098: ldloc.0
+		IL_0099: stelem.ref
+		IL_009a: stloc.s 5
+		IL_009c: ldloc.3
+		IL_009d: ldloc.s 5
+		IL_009f: ldc.r8 0.0
+		IL_00a8: box [System.Runtime]System.Double
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00b2: stloc.s 4
+		IL_00b4: ldloc.s 4
+		IL_00b6: stloc.1
+		IL_00b7: ldc.i4.0
+		IL_00b8: newarr [System.Runtime]System.Object
+		IL_00bd: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00c2: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::.ctor()
+		IL_00c7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00cc: stloc.2
+		IL_00cd: ldloc.2
+		IL_00ce: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
+		IL_00d3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00d8: ldstr "prototype"
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00e2: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00e7: ldstr "console"
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f6: stloc.s 4
+		IL_00f8: ldloc.2
+		IL_00f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter>(!!0)
+		IL_00fe: stloc.s 8
+		IL_0100: ldloc.s 8
+		IL_0102: callvirt instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::getGreet()
+		IL_0107: stloc.s 9
+		IL_0109: ldloc.s 9
+		IL_010b: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0110: stloc.s 10
+		IL_0112: ldloc.s 4
+		IL_0114: ldstr "log"
+		IL_0119: ldloc.s 10
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0120: pop
+		IL_0121: ret
 	} // end of method Classes_ClassMethod_MethodValueRequiresMetadata::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_MethodValueRequiresMetadata
@@ -504,7 +498,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2276
+		// Method begins at RVA 0x225e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_ClassExpression_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_ClassExpression_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222e
+				// Method begins at RVA 0x21ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2237
+				// Method begins at RVA 0x21f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2240
+				// Method begins at RVA 0x2200
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 					class [System.Runtime]System.Object capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x2249
+				// Method begins at RVA 0x2209
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -104,7 +104,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x225f
+				// Method begins at RVA 0x221f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -116,7 +116,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2262
+				// Method begins at RVA 0x2222
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -131,7 +131,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2265
+				// Method begins at RVA 0x2225
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -147,7 +147,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2271
+				// Method begins at RVA 0x2231
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x227d
+				// Method begins at RVA 0x223d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -179,7 +179,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2285
+				// Method begins at RVA 0x2245
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2288
+				// Method begins at RVA 0x2248
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -206,7 +206,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x228b
+				// Method begins at RVA 0x224b
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -239,7 +239,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22b4
+				// Method begins at RVA 0x2274
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -255,7 +255,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22c3
+				// Method begins at RVA 0x2283
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -267,7 +267,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22c6
+				// Method begins at RVA 0x2286
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -282,7 +282,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22c9
+				// Method begins at RVA 0x2289
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -311,7 +311,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21db
+			// Method begins at RVA 0x219a
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -327,7 +327,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21e3
+			// Method begins at RVA 0x21a2
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -342,7 +342,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f0
+			// Method begins at RVA 0x21b0
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -374,7 +374,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2225
+			// Method begins at RVA 0x21e5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -400,7 +400,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 383 (0x17f)
+		// Code size: 318 (0x13e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/Scope,
@@ -410,8 +410,7 @@
 			[4] object,
 			[5] object[],
 			[6] class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value,
-			[7] class [System.Runtime]System.Type,
-			[8] class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log
+			[7] class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/Scope::.ctor()
@@ -435,108 +434,93 @@
 		IL_003e: ldstr "prototype"
 		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0048: stloc.s 4
-		IL_004a: ldtoken Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-		IL_004f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0054: ldtoken Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-		IL_0059: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_005e: stloc.3
-		IL_005f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0064: stloc.s 5
-		IL_0066: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::.ctor()
-		IL_006b: ldc.i4.0
-		IL_006c: conv.r8
-		IL_006d: ldstr "get value"
-		IL_0072: ldc.i4.0
-		IL_0073: ldc.i4.1
-		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0, float64, string, bool, bool)
-		IL_0079: stloc.s 6
-		IL_007b: ldloc.s 6
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0)
-		IL_0082: stloc.s 6
-		IL_0084: ldloc.s 4
-		IL_0086: ldstr "value"
-		IL_008b: ldloc.s 6
-		IL_008d: ldnull
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_0093: pop
-		IL_0094: ldtoken Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-		IL_0099: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_009e: ldtoken Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-		IL_00a3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00a8: stloc.3
-		IL_00a9: ldtoken Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-		IL_00ae: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00b3: ldtoken Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-		IL_00b8: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00bd: stloc.s 7
-		IL_00bf: ldloc.s 7
-		IL_00c1: ldstr "prototype"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00cb: stloc.s 4
-		IL_00cd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00d2: stloc.s 5
-		IL_00d4: ldloc.3
-		IL_00d5: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::.ctor(class [System.Runtime]System.Object)
-		IL_00da: ldc.i4.0
-		IL_00db: conv.r8
-		IL_00dc: ldstr "log"
-		IL_00e1: ldc.i4.1
-		IL_00e2: ldc.i4.1
-		IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0, float64, string, bool, bool)
-		IL_00e8: stloc.s 8
-		IL_00ea: ldloc.s 8
-		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0)
-		IL_00f1: stloc.s 8
+		IL_004a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004f: stloc.s 5
+		IL_0051: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::.ctor()
+		IL_0056: ldc.i4.0
+		IL_0057: conv.r8
+		IL_0058: ldstr "get value"
+		IL_005d: ldc.i4.0
+		IL_005e: ldc.i4.1
+		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0, float64, string, bool, bool)
+		IL_0064: stloc.s 6
+		IL_0066: ldloc.s 6
+		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0)
+		IL_006d: stloc.s 6
+		IL_006f: ldloc.s 4
+		IL_0071: ldstr "value"
+		IL_0076: ldloc.s 6
+		IL_0078: ldnull
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_007e: pop
+		IL_007f: ldloc.3
+		IL_0080: ldstr "prototype"
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_008a: stloc.s 4
+		IL_008c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0091: stloc.s 5
+		IL_0093: ldloc.3
+		IL_0094: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::.ctor(class [System.Runtime]System.Object)
+		IL_0099: ldc.i4.0
+		IL_009a: conv.r8
+		IL_009b: ldstr "log"
+		IL_00a0: ldc.i4.1
+		IL_00a1: ldc.i4.1
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0, float64, string, bool, bool)
+		IL_00a7: stloc.s 7
+		IL_00a9: ldloc.s 7
+		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0)
+		IL_00b0: stloc.s 7
+		IL_00b2: ldloc.s 4
+		IL_00b4: ldstr "log"
+		IL_00b9: ldloc.s 7
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00c0: pop
+		IL_00c1: ldc.i4.1
+		IL_00c2: newarr [System.Runtime]System.Object
+		IL_00c7: dup
+		IL_00c8: ldc.i4.0
+		IL_00c9: ldloc.0
+		IL_00ca: stelem.ref
+		IL_00cb: stloc.s 5
+		IL_00cd: ldloc.3
+		IL_00ce: ldloc.s 5
+		IL_00d0: ldc.r8 0.0
+		IL_00d9: box [System.Runtime]System.Double
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
+		IL_00e3: stloc.s 4
+		IL_00e5: ldloc.s 4
+		IL_00e7: ldstr "Counter"
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
+		IL_00f1: stloc.s 4
 		IL_00f3: ldloc.s 4
-		IL_00f5: ldstr "log"
-		IL_00fa: ldloc.s 8
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0101: pop
-		IL_0102: ldc.i4.1
-		IL_0103: newarr [System.Runtime]System.Object
-		IL_0108: dup
-		IL_0109: ldc.i4.0
-		IL_010a: ldloc.0
-		IL_010b: stelem.ref
-		IL_010c: stloc.s 5
-		IL_010e: ldloc.3
-		IL_010f: ldloc.s 5
-		IL_0111: ldc.r8 0.0
-		IL_011a: box [System.Runtime]System.Double
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
-		IL_0124: stloc.s 4
-		IL_0126: ldloc.s 4
-		IL_0128: ldstr "Counter"
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
-		IL_0132: stloc.s 4
-		IL_0134: ldloc.s 4
-		IL_0136: ldstr "Counter"
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
-		IL_0140: stloc.2
-		IL_0141: ldloc.2
-		IL_0142: ldc.i4.0
-		IL_0143: newarr [System.Runtime]System.Object
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_014d: stloc.s 4
-		IL_014f: ldloc.s 4
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0156: stloc.s 4
-		IL_0158: ldloc.s 4
-		IL_015a: isinst Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-		IL_015f: dup
-		IL_0160: brfalse IL_0170
+		IL_00f5: ldstr "Counter"
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
+		IL_00ff: stloc.2
+		IL_0100: ldloc.2
+		IL_0101: ldc.i4.0
+		IL_0102: newarr [System.Runtime]System.Object
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_010c: stloc.s 4
+		IL_010e: ldloc.s 4
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0115: stloc.s 4
+		IL_0117: ldloc.s 4
+		IL_0119: isinst Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
+		IL_011e: dup
+		IL_011f: brfalse IL_012f
 
-		IL_0165: callvirt instance object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::log()
-		IL_016a: pop
-		IL_016b: br IL_017e
+		IL_0124: callvirt instance object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::log()
+		IL_0129: pop
+		IL_012a: br IL_013d
 
-		IL_0170: pop
-		IL_0171: ldloc.s 4
-		IL_0173: ldstr "log"
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_017d: pop
+		IL_012f: pop
+		IL_0130: ldloc.s 4
+		IL_0132: ldstr "log"
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_013c: pop
 
-		IL_017e: ret
+		IL_013d: ret
 	} // end of method Classes_ClassPrivateAccessor_ClassExpression_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log
@@ -548,7 +532,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22f2
+		// Method begins at RVA 0x22b2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b7
+				// Method begins at RVA 0x234b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c0
+				// Method begins at RVA 0x2354
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c9
+				// Method begins at RVA 0x235d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23db
+					// Method begins at RVA 0x236f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23e4
+					// Method begins at RVA 0x2378
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d2
+				// Method begins at RVA 0x2366
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -147,7 +147,7 @@
 					class [System.Runtime]System.Object capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x23ed
+				// Method begins at RVA 0x2381
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2403
+				// Method begins at RVA 0x2397
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -178,7 +178,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2406
+				// Method begins at RVA 0x239a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -193,7 +193,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2409
+				// Method begins at RVA 0x239d
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -209,7 +209,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2415
+				// Method begins at RVA 0x23a9
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -228,7 +228,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2421
+				// Method begins at RVA 0x23b5
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -241,7 +241,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2429
+				// Method begins at RVA 0x23bd
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -253,7 +253,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x242c
+				// Method begins at RVA 0x23c0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -268,7 +268,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x242f
+				// Method begins at RVA 0x23c3
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -296,7 +296,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2458
+				// Method begins at RVA 0x23ec
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -309,7 +309,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2460
+				// Method begins at RVA 0x23f4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -321,7 +321,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2463
+				// Method begins at RVA 0x23f7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -336,7 +336,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2466
+				// Method begins at RVA 0x23fa
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -371,7 +371,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2491
+				// Method begins at RVA 0x2425
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -387,7 +387,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24a0
+				// Method begins at RVA 0x2434
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -399,7 +399,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24a3
+				// Method begins at RVA 0x2437
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -414,7 +414,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x24a6
+				// Method begins at RVA 0x243a
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -446,7 +446,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2227
+			// Method begins at RVA 0x21bc
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -462,7 +462,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x222f
+			// Method begins at RVA 0x21c4
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -479,7 +479,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23a4
+			// Method begins at RVA 0x2338
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -497,7 +497,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x223c
+			// Method begins at RVA 0x21d0
 			// Header size: 12
 			// Code size: 330 (0x14a)
 			.maxstack 8
@@ -638,7 +638,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23ae
+			// Method begins at RVA 0x2342
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -664,7 +664,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 459 (0x1cb)
+		// Code size: 352 (0x160)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/Scope,
@@ -674,9 +674,8 @@
 			[4] object[],
 			[5] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly,
 			[6] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly,
-			[7] class [System.Runtime]System.Type,
-			[8] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log,
-			[9] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+			[7] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log,
+			[8] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/Scope::.ctor()
@@ -691,142 +690,117 @@
 		IL_001d: ldstr "prototype"
 		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0027: stloc.3
-		IL_0028: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_002d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0032: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_0037: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_003c: stloc.2
-		IL_003d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0042: stloc.s 4
-		IL_0044: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::.ctor()
-		IL_0049: ldc.i4.0
-		IL_004a: conv.r8
-		IL_004b: ldstr "get readOnly"
-		IL_0050: ldc.i4.0
-		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0, float64, string, bool, bool)
-		IL_0057: stloc.s 5
-		IL_0059: ldloc.s 5
-		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0)
-		IL_0060: stloc.s 5
-		IL_0062: ldloc.3
-		IL_0063: ldstr "readOnly"
-		IL_0068: ldloc.s 5
-		IL_006a: ldnull
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_0070: pop
-		IL_0071: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_0076: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_007b: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_0080: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0085: stloc.2
-		IL_0086: ldloc.2
-		IL_0087: ldstr "prototype"
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0091: stloc.3
-		IL_0092: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_0097: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_009c: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_00a1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00a6: stloc.2
-		IL_00a7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ac: stloc.s 4
-		IL_00ae: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::.ctor()
-		IL_00b3: ldc.i4.1
-		IL_00b4: conv.r8
-		IL_00b5: ldstr "set writeOnly"
-		IL_00ba: ldc.i4.1
-		IL_00bb: ldc.i4.1
-		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0, float64, string, bool, bool)
-		IL_00c1: stloc.s 6
-		IL_00c3: ldloc.s 6
-		IL_00c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0)
-		IL_00ca: stloc.s 6
-		IL_00cc: ldloc.3
-		IL_00cd: ldstr "writeOnly"
-		IL_00d2: ldnull
-		IL_00d3: ldloc.s 6
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_00da: pop
-		IL_00db: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_00e0: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00e5: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_00ea: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00ef: stloc.2
-		IL_00f0: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_00f5: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00fa: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_00ff: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0104: stloc.s 7
-		IL_0106: ldloc.s 7
-		IL_0108: ldstr "prototype"
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0112: stloc.3
-		IL_0113: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0118: stloc.s 4
-		IL_011a: ldloc.2
-		IL_011b: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log::.ctor(class [System.Runtime]System.Object)
-		IL_0120: ldc.i4.0
-		IL_0121: conv.r8
-		IL_0122: ldstr "log"
-		IL_0127: ldc.i4.1
-		IL_0128: ldc.i4.1
-		IL_0129: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0, float64, string, bool, bool)
-		IL_012e: stloc.s 8
-		IL_0130: ldloc.s 8
-		IL_0132: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0)
-		IL_0137: stloc.s 8
-		IL_0139: ldloc.3
-		IL_013a: ldstr "log"
-		IL_013f: ldloc.s 8
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0146: pop
-		IL_0147: ldc.i4.1
-		IL_0148: newarr [System.Runtime]System.Object
-		IL_014d: dup
-		IL_014e: ldc.i4.0
-		IL_014f: ldloc.0
-		IL_0150: stelem.ref
-		IL_0151: stloc.s 4
-		IL_0153: ldloc.2
-		IL_0154: ldloc.s 4
-		IL_0156: ldc.r8 0.0
-		IL_015f: box [System.Runtime]System.Double
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0169: stloc.3
-		IL_016a: ldloc.3
-		IL_016b: stloc.1
-		IL_016c: ldc.i4.0
-		IL_016d: newarr [System.Runtime]System.Object
-		IL_0172: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0177: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::.ctor()
-		IL_017c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0181: stloc.s 9
-		IL_0183: ldloc.s 9
-		IL_0185: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_018a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_018f: ldstr "prototype"
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0199: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_019e: ldloc.s 9
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a5: stloc.3
-		IL_01a6: ldloc.3
-		IL_01a7: isinst Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_01ac: dup
-		IL_01ad: brfalse IL_01bd
+		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002d: stloc.s 4
+		IL_002f: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::.ctor()
+		IL_0034: ldc.i4.0
+		IL_0035: conv.r8
+		IL_0036: ldstr "get readOnly"
+		IL_003b: ldc.i4.0
+		IL_003c: ldc.i4.1
+		IL_003d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0, float64, string, bool, bool)
+		IL_0042: stloc.s 5
+		IL_0044: ldloc.s 5
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0)
+		IL_004b: stloc.s 5
+		IL_004d: ldloc.3
+		IL_004e: ldstr "readOnly"
+		IL_0053: ldloc.s 5
+		IL_0055: ldnull
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_005b: pop
+		IL_005c: ldloc.2
+		IL_005d: ldstr "prototype"
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0067: stloc.3
+		IL_0068: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006d: stloc.s 4
+		IL_006f: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::.ctor()
+		IL_0074: ldc.i4.1
+		IL_0075: conv.r8
+		IL_0076: ldstr "set writeOnly"
+		IL_007b: ldc.i4.1
+		IL_007c: ldc.i4.1
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0, float64, string, bool, bool)
+		IL_0082: stloc.s 6
+		IL_0084: ldloc.s 6
+		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0)
+		IL_008b: stloc.s 6
+		IL_008d: ldloc.3
+		IL_008e: ldstr "writeOnly"
+		IL_0093: ldnull
+		IL_0094: ldloc.s 6
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_009b: pop
+		IL_009c: ldloc.2
+		IL_009d: ldstr "prototype"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a7: stloc.3
+		IL_00a8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ad: stloc.s 4
+		IL_00af: ldloc.2
+		IL_00b0: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log::.ctor(class [System.Runtime]System.Object)
+		IL_00b5: ldc.i4.0
+		IL_00b6: conv.r8
+		IL_00b7: ldstr "log"
+		IL_00bc: ldc.i4.1
+		IL_00bd: ldc.i4.1
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0, float64, string, bool, bool)
+		IL_00c3: stloc.s 7
+		IL_00c5: ldloc.s 7
+		IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0)
+		IL_00cc: stloc.s 7
+		IL_00ce: ldloc.3
+		IL_00cf: ldstr "log"
+		IL_00d4: ldloc.s 7
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00db: pop
+		IL_00dc: ldc.i4.1
+		IL_00dd: newarr [System.Runtime]System.Object
+		IL_00e2: dup
+		IL_00e3: ldc.i4.0
+		IL_00e4: ldloc.0
+		IL_00e5: stelem.ref
+		IL_00e6: stloc.s 4
+		IL_00e8: ldloc.2
+		IL_00e9: ldloc.s 4
+		IL_00eb: ldc.r8 0.0
+		IL_00f4: box [System.Runtime]System.Double
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00fe: stloc.3
+		IL_00ff: ldloc.3
+		IL_0100: stloc.1
+		IL_0101: ldc.i4.0
+		IL_0102: newarr [System.Runtime]System.Object
+		IL_0107: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_010c: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::.ctor()
+		IL_0111: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0116: stloc.s 8
+		IL_0118: ldloc.s 8
+		IL_011a: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+		IL_011f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0124: ldstr "prototype"
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_012e: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0133: ldloc.s 8
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013a: stloc.3
+		IL_013b: ldloc.3
+		IL_013c: isinst Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+		IL_0141: dup
+		IL_0142: brfalse IL_0152
 
-		IL_01b2: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::log()
-		IL_01b7: pop
-		IL_01b8: br IL_01ca
+		IL_0147: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::log()
+		IL_014c: pop
+		IL_014d: br IL_015f
 
-		IL_01bd: pop
-		IL_01be: ldloc.3
-		IL_01bf: ldstr "log"
-		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01c9: pop
+		IL_0152: pop
+		IL_0153: ldloc.3
+		IL_0154: ldstr "log"
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_015e: pop
 
-		IL_01ca: ret
+		IL_015f: ret
 	} // end of method Classes_ClassPrivateAccessor_EdgeCases_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log
@@ -838,7 +812,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24cf
+		// Method begins at RVA 0x2463
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x219b
+				// Method begins at RVA 0x2183
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a4
+				// Method begins at RVA 0x218c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 					class [System.Runtime]System.Object capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x21ad
+				// Method begins at RVA 0x2195
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -84,7 +84,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x21c3
+				// Method begins at RVA 0x21ab
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -96,7 +96,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x21c6
+				// Method begins at RVA 0x21ae
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -111,7 +111,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x21c9
+				// Method begins at RVA 0x21b1
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -127,7 +127,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x21d5
+				// Method begins at RVA 0x21bd
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -151,7 +151,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x21e1
+				// Method begins at RVA 0x21c9
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -167,7 +167,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x21f0
+				// Method begins at RVA 0x21d8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -179,7 +179,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x21f3
+				// Method begins at RVA 0x21db
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -194,7 +194,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x21f6
+				// Method begins at RVA 0x21de
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -229,7 +229,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2148
+			// Method begins at RVA 0x2130
 			// Header size: 12
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -256,7 +256,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x216f
+			// Method begins at RVA 0x2157
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -282,7 +282,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2192
+			// Method begins at RVA 0x217a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -308,18 +308,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 235 (0xeb)
+		// Code size: 212 (0xd4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Scope,
 			[1] object,
 			[2] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object,
-			[6] object[],
-			[7] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret,
-			[8] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
+			[4] object,
+			[5] object[],
+			[6] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret,
+			[7] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Scope::.ctor()
@@ -330,76 +329,71 @@
 		IL_0011: ldtoken Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: stloc.s 5
-		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0045: stloc.s 6
-		IL_0047: ldloc.3
-		IL_0048: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret::.ctor(class [System.Runtime]System.Object)
-		IL_004d: ldc.i4.0
-		IL_004e: conv.r8
-		IL_004f: ldstr "logSecret"
-		IL_0054: ldc.i4.1
-		IL_0055: ldc.i4.1
-		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0, float64, string, bool, bool)
-		IL_005b: stloc.s 7
-		IL_005d: ldloc.s 7
-		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0)
-		IL_0064: stloc.s 7
-		IL_0066: ldloc.s 5
-		IL_0068: ldstr "logSecret"
-		IL_006d: ldloc.s 7
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0074: pop
-		IL_0075: ldc.i4.1
-		IL_0076: newarr [System.Runtime]System.Object
-		IL_007b: dup
-		IL_007c: ldc.i4.0
-		IL_007d: ldloc.0
-		IL_007e: stelem.ref
-		IL_007f: stloc.s 6
-		IL_0081: ldloc.3
-		IL_0082: ldloc.s 6
-		IL_0084: ldc.r8 0.0
-		IL_008d: box [System.Runtime]System.Double
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0097: stloc.s 5
-		IL_0099: ldloc.s 5
-		IL_009b: stloc.1
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
-		IL_00a6: stloc.s 6
-		IL_00a8: ldloc.s 6
-		IL_00aa: ldc.i4.0
-		IL_00ab: newarr [System.Runtime]System.Object
-		IL_00b0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00b5: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::.ctor(object[])
-		IL_00ba: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00bf: stloc.2
-		IL_00c0: ldloc.2
-		IL_00c1: ldtoken Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
-		IL_00c6: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00cb: ldstr "prototype"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00d5: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00da: ldloc.2
-		IL_00db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter>(!!0)
-		IL_00e0: stloc.s 8
-		IL_00e2: ldloc.s 8
-		IL_00e4: callvirt instance object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::logSecret()
-		IL_00e9: pop
-		IL_00ea: ret
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: stloc.s 4
+		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002e: stloc.s 5
+		IL_0030: ldloc.3
+		IL_0031: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret::.ctor(class [System.Runtime]System.Object)
+		IL_0036: ldc.i4.0
+		IL_0037: conv.r8
+		IL_0038: ldstr "logSecret"
+		IL_003d: ldc.i4.1
+		IL_003e: ldc.i4.1
+		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0, float64, string, bool, bool)
+		IL_0044: stloc.s 6
+		IL_0046: ldloc.s 6
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0)
+		IL_004d: stloc.s 6
+		IL_004f: ldloc.s 4
+		IL_0051: ldstr "logSecret"
+		IL_0056: ldloc.s 6
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005d: pop
+		IL_005e: ldc.i4.1
+		IL_005f: newarr [System.Runtime]System.Object
+		IL_0064: dup
+		IL_0065: ldc.i4.0
+		IL_0066: ldloc.0
+		IL_0067: stelem.ref
+		IL_0068: stloc.s 5
+		IL_006a: ldloc.3
+		IL_006b: ldloc.s 5
+		IL_006d: ldc.r8 0.0
+		IL_0076: box [System.Runtime]System.Double
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0080: stloc.s 4
+		IL_0082: ldloc.s 4
+		IL_0084: stloc.1
+		IL_0085: ldc.i4.1
+		IL_0086: newarr [System.Runtime]System.Object
+		IL_008b: dup
+		IL_008c: ldc.i4.0
+		IL_008d: ldloc.0
+		IL_008e: stelem.ref
+		IL_008f: stloc.s 5
+		IL_0091: ldloc.s 5
+		IL_0093: ldc.i4.0
+		IL_0094: newarr [System.Runtime]System.Object
+		IL_0099: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_009e: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::.ctor(object[])
+		IL_00a3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00a8: stloc.2
+		IL_00a9: ldloc.2
+		IL_00aa: ldtoken Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
+		IL_00af: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00b4: ldstr "prototype"
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00be: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00c3: ldloc.2
+		IL_00c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter>(!!0)
+		IL_00c9: stloc.s 7
+		IL_00cb: ldloc.s 7
+		IL_00cd: callvirt instance object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::logSecret()
+		IL_00d2: pop
+		IL_00d3: ret
 	} // end of method Classes_ClassPrivateField_HelperMethod_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateField_HelperMethod_Log
@@ -411,7 +405,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x221f
+		// Method begins at RVA 0x2207
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2419
+				// Method begins at RVA 0x2381
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2422
+				// Method begins at RVA 0x238a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x242b
+				// Method begins at RVA 0x2393
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2434
+				// Method begins at RVA 0x239c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243d
+				// Method begins at RVA 0x23a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -125,7 +125,7 @@
 					class [System.Runtime]System.Object capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x2446
+				// Method begins at RVA 0x23ae
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -144,7 +144,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x245c
+				// Method begins at RVA 0x23c4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -156,7 +156,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x245f
+				// Method begins at RVA 0x23c7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -171,7 +171,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2462
+				// Method begins at RVA 0x23ca
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -187,7 +187,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x246e
+				// Method begins at RVA 0x23d6
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -211,7 +211,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x247a
+				// Method begins at RVA 0x23e2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -227,7 +227,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2489
+				// Method begins at RVA 0x23f1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x248c
+				// Method begins at RVA 0x23f4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -254,7 +254,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x248f
+				// Method begins at RVA 0x23f7
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -287,7 +287,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x24b8
+				// Method begins at RVA 0x2420
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -303,7 +303,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24c7
+				// Method begins at RVA 0x242f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -315,7 +315,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24ca
+				// Method begins at RVA 0x2432
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -330,7 +330,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x24cd
+				// Method begins at RVA 0x2435
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -363,7 +363,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x24f6
+				// Method begins at RVA 0x245e
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -379,7 +379,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2505
+				// Method begins at RVA 0x246d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -391,7 +391,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2508
+				// Method begins at RVA 0x2470
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -406,7 +406,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x250b
+				// Method begins at RVA 0x2473
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -442,7 +442,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x253b
+				// Method begins at RVA 0x24a3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -458,7 +458,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x254a
+				// Method begins at RVA 0x24b2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -470,7 +470,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x254d
+				// Method begins at RVA 0x24b5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -485,7 +485,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2550
+				// Method begins at RVA 0x24b8
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -520,7 +520,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2308
+			// Method begins at RVA 0x2270
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -548,7 +548,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x236e
+			// Method begins at RVA 0x22d6
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -568,7 +568,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2338
+			// Method begins at RVA 0x22a0
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -601,7 +601,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2406
+			// Method begins at RVA 0x236e
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -619,7 +619,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x238c
+			// Method begins at RVA 0x22f4
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -673,7 +673,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2410
+			// Method begins at RVA 0x2378
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -699,22 +699,21 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 683 (0x2ab)
+		// Code size: 532 (0x214)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Scope,
 			[1] object,
 			[2] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object,
-			[6] object[],
-			[7] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double,
-			[8] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret,
-			[9] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret,
-			[10] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log,
-			[11] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter,
-			[12] object
+			[4] object,
+			[5] object[],
+			[6] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double,
+			[7] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret,
+			[8] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret,
+			[9] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log,
+			[10] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter,
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Scope::.ctor()
@@ -725,209 +724,174 @@
 		IL_0011: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: stloc.s 5
-		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0045: stloc.s 6
-		IL_0047: ldloc.3
-		IL_0048: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::.ctor(class [System.Runtime]System.Object)
-		IL_004d: ldc.i4.0
-		IL_004e: conv.r8
-		IL_004f: ldstr "#double"
-		IL_0054: ldc.i4.1
-		IL_0055: ldc.i4.1
-		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0, float64, string, bool, bool)
-		IL_005b: stloc.s 7
-		IL_005d: ldloc.s 7
-		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0)
-		IL_0064: stloc.s 7
-		IL_0066: ldloc.s 5
-		IL_0068: ldstr "__jroc_priv_method_double"
-		IL_006d: ldloc.s 7
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0074: pop
-		IL_0075: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_007a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_007f: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_0084: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0089: stloc.3
-		IL_008a: ldloc.3
-		IL_008b: ldstr "prototype"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0095: stloc.s 5
-		IL_0097: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_009c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00a1: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_00a6: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00ab: stloc.3
-		IL_00ac: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00b1: stloc.s 6
-		IL_00b3: ldloc.3
-		IL_00b4: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::.ctor(class [System.Runtime]System.Object)
-		IL_00b9: ldc.i4.0
-		IL_00ba: conv.r8
-		IL_00bb: ldstr "get secret"
-		IL_00c0: ldc.i4.1
-		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0, float64, string, bool, bool)
-		IL_00c7: stloc.s 8
-		IL_00c9: ldloc.s 8
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0)
-		IL_00d0: stloc.s 8
-		IL_00d2: ldloc.s 5
-		IL_00d4: ldstr "secret"
-		IL_00d9: ldloc.s 8
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: stloc.s 4
+		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002e: stloc.s 5
+		IL_0030: ldloc.3
+		IL_0031: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::.ctor(class [System.Runtime]System.Object)
+		IL_0036: ldc.i4.0
+		IL_0037: conv.r8
+		IL_0038: ldstr "#double"
+		IL_003d: ldc.i4.1
+		IL_003e: ldc.i4.1
+		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0, float64, string, bool, bool)
+		IL_0044: stloc.s 6
+		IL_0046: ldloc.s 6
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0)
+		IL_004d: stloc.s 6
+		IL_004f: ldloc.s 4
+		IL_0051: ldstr "__jroc_priv_method_double"
+		IL_0056: ldloc.s 6
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005d: pop
+		IL_005e: ldloc.3
+		IL_005f: ldstr "prototype"
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0069: stloc.s 4
+		IL_006b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0070: stloc.s 5
+		IL_0072: ldloc.3
+		IL_0073: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::.ctor(class [System.Runtime]System.Object)
+		IL_0078: ldc.i4.0
+		IL_0079: conv.r8
+		IL_007a: ldstr "get secret"
+		IL_007f: ldc.i4.1
+		IL_0080: ldc.i4.1
+		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0, float64, string, bool, bool)
+		IL_0086: stloc.s 7
+		IL_0088: ldloc.s 7
+		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0)
+		IL_008f: stloc.s 7
+		IL_0091: ldloc.s 4
+		IL_0093: ldstr "secret"
+		IL_0098: ldloc.s 7
+		IL_009a: ldnull
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_00a0: pop
+		IL_00a1: ldloc.3
+		IL_00a2: ldstr "prototype"
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ac: stloc.s 4
+		IL_00ae: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00b3: stloc.s 5
+		IL_00b5: ldloc.3
+		IL_00b6: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::.ctor(class [System.Runtime]System.Object)
+		IL_00bb: ldc.i4.1
+		IL_00bc: conv.r8
+		IL_00bd: ldstr "set secret"
+		IL_00c2: ldc.i4.1
+		IL_00c3: ldc.i4.1
+		IL_00c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0, float64, string, bool, bool)
+		IL_00c9: stloc.s 8
+		IL_00cb: ldloc.s 8
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0)
+		IL_00d2: stloc.s 8
+		IL_00d4: ldloc.s 4
+		IL_00d6: ldstr "secret"
 		IL_00db: ldnull
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_00e1: pop
-		IL_00e2: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_00e7: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00ec: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_00f1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00f6: stloc.3
-		IL_00f7: ldloc.3
-		IL_00f8: ldstr "prototype"
-		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0102: stloc.s 5
-		IL_0104: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_0109: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_010e: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_0113: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0118: stloc.3
-		IL_0119: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_011e: stloc.s 6
-		IL_0120: ldloc.3
-		IL_0121: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::.ctor(class [System.Runtime]System.Object)
+		IL_00dc: ldloc.s 8
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_00e3: pop
+		IL_00e4: ldloc.3
+		IL_00e5: ldstr "prototype"
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ef: stloc.s 4
+		IL_00f1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00f6: stloc.s 5
+		IL_00f8: ldloc.3
+		IL_00f9: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log::.ctor(class [System.Runtime]System.Object)
+		IL_00fe: ldc.i4.0
+		IL_00ff: conv.r8
+		IL_0100: ldstr "log"
+		IL_0105: ldc.i4.1
+		IL_0106: ldc.i4.1
+		IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0, float64, string, bool, bool)
+		IL_010c: stloc.s 9
+		IL_010e: ldloc.s 9
+		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0)
+		IL_0115: stloc.s 9
+		IL_0117: ldloc.s 4
+		IL_0119: ldstr "log"
+		IL_011e: ldloc.s 9
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0125: pop
 		IL_0126: ldc.i4.1
-		IL_0127: conv.r8
-		IL_0128: ldstr "set secret"
-		IL_012d: ldc.i4.1
-		IL_012e: ldc.i4.1
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0, float64, string, bool, bool)
-		IL_0134: stloc.s 9
-		IL_0136: ldloc.s 9
-		IL_0138: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0)
-		IL_013d: stloc.s 9
-		IL_013f: ldloc.s 5
-		IL_0141: ldstr "secret"
-		IL_0146: ldnull
-		IL_0147: ldloc.s 9
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_014e: pop
-		IL_014f: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_0154: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0159: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_015e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0163: stloc.3
-		IL_0164: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_0169: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_016e: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_0173: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0178: stloc.s 4
-		IL_017a: ldloc.s 4
+		IL_0127: newarr [System.Runtime]System.Object
+		IL_012c: dup
+		IL_012d: ldc.i4.0
+		IL_012e: ldloc.0
+		IL_012f: stelem.ref
+		IL_0130: stloc.s 5
+		IL_0132: ldloc.3
+		IL_0133: ldloc.s 5
+		IL_0135: ldc.r8 0.0
+		IL_013e: box [System.Runtime]System.Double
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0148: stloc.s 4
+		IL_014a: ldloc.s 4
+		IL_014c: stloc.1
+		IL_014d: ldc.i4.1
+		IL_014e: newarr [System.Runtime]System.Object
+		IL_0153: dup
+		IL_0154: ldc.i4.0
+		IL_0155: ldloc.0
+		IL_0156: stelem.ref
+		IL_0157: stloc.s 5
+		IL_0159: ldloc.s 5
+		IL_015b: ldc.i4.0
+		IL_015c: newarr [System.Runtime]System.Object
+		IL_0161: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0166: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::.ctor(object[])
+		IL_016b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0170: stloc.2
+		IL_0171: ldloc.2
+		IL_0172: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+		IL_0177: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_017c: ldstr "prototype"
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0186: stloc.s 5
-		IL_0188: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_018d: stloc.s 6
-		IL_018f: ldloc.3
-		IL_0190: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log::.ctor(class [System.Runtime]System.Object)
-		IL_0195: ldc.i4.0
-		IL_0196: conv.r8
-		IL_0197: ldstr "log"
-		IL_019c: ldc.i4.1
-		IL_019d: ldc.i4.1
-		IL_019e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0, float64, string, bool, bool)
-		IL_01a3: stloc.s 10
-		IL_01a5: ldloc.s 10
-		IL_01a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0)
-		IL_01ac: stloc.s 10
-		IL_01ae: ldloc.s 5
-		IL_01b0: ldstr "log"
-		IL_01b5: ldloc.s 10
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01bc: pop
-		IL_01bd: ldc.i4.1
-		IL_01be: newarr [System.Runtime]System.Object
-		IL_01c3: dup
-		IL_01c4: ldc.i4.0
-		IL_01c5: ldloc.0
-		IL_01c6: stelem.ref
-		IL_01c7: stloc.s 6
-		IL_01c9: ldloc.3
-		IL_01ca: ldloc.s 6
-		IL_01cc: ldc.r8 0.0
-		IL_01d5: box [System.Runtime]System.Double
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_01df: stloc.s 5
-		IL_01e1: ldloc.s 5
-		IL_01e3: stloc.1
-		IL_01e4: ldc.i4.1
-		IL_01e5: newarr [System.Runtime]System.Object
-		IL_01ea: dup
-		IL_01eb: ldc.i4.0
-		IL_01ec: ldloc.0
-		IL_01ed: stelem.ref
-		IL_01ee: stloc.s 6
-		IL_01f0: ldloc.s 6
-		IL_01f2: ldc.i4.0
-		IL_01f3: newarr [System.Runtime]System.Object
-		IL_01f8: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_01fd: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::.ctor(object[])
-		IL_0202: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0207: stloc.2
-		IL_0208: ldloc.2
-		IL_0209: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_020e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0213: ldstr "prototype"
-		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_021d: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0222: ldloc.2
-		IL_0223: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter>(!!0)
-		IL_0228: stloc.s 11
-		IL_022a: ldloc.s 11
-		IL_022c: callvirt instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::log()
-		IL_0231: pop
-		IL_0232: ldstr "console"
-		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0241: stloc.s 5
-		IL_0243: ldloc.2
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024e: ldstr "includes"
-		IL_0253: ldstr "#double"
-		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025d: stloc.s 12
-		IL_025f: ldloc.s 5
-		IL_0261: ldstr "log"
-		IL_0266: ldloc.s 12
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026d: pop
-		IL_026e: ldstr "console"
-		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027d: stloc.s 12
-		IL_027f: ldloc.2
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028a: ldstr "includes"
-		IL_028f: ldstr "#secret"
-		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0299: stloc.s 5
-		IL_029b: ldloc.s 12
-		IL_029d: ldstr "log"
-		IL_02a2: ldloc.s 5
-		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a9: pop
-		IL_02aa: ret
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0186: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_018b: ldloc.2
+		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter>(!!0)
+		IL_0191: stloc.s 10
+		IL_0193: ldloc.s 10
+		IL_0195: callvirt instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::log()
+		IL_019a: pop
+		IL_019b: ldstr "console"
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01aa: stloc.s 4
+		IL_01ac: ldloc.2
+		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b7: ldstr "includes"
+		IL_01bc: ldstr "#double"
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c6: stloc.s 11
+		IL_01c8: ldloc.s 4
+		IL_01ca: ldstr "log"
+		IL_01cf: ldloc.s 11
+		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d6: pop
+		IL_01d7: ldstr "console"
+		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e6: stloc.s 11
+		IL_01e8: ldloc.2
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f3: ldstr "includes"
+		IL_01f8: ldstr "#secret"
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0202: stloc.s 4
+		IL_0204: ldloc.s 11
+		IL_0206: ldstr "log"
+		IL_020b: ldloc.s 4
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0212: pop
+		IL_0213: ret
 	} // end of method Classes_ClassPrivateMethodAndAccessor_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateMethodAndAccessor_Log
@@ -939,7 +903,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2579
+		// Method begins at RVA 0x24e1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticMethod_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticMethod_HelloWorld.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2135
+				// Method begins at RVA 0x211d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x213e
+				// Method begins at RVA 0x2126
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2147
+				// Method begins at RVA 0x212f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2156
+				// Method begins at RVA 0x213e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2159
+				// Method begins at RVA 0x2141
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x215c
+				// Method begins at RVA 0x2144
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2168
+				// Method begins at RVA 0x2150
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2174
+				// Method begins at RVA 0x215c
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x217c
+				// Method begins at RVA 0x2164
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x217f
+				// Method begins at RVA 0x2167
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2182
+				// Method begins at RVA 0x216a
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -200,7 +200,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2102
+			// Method begins at RVA 0x20ea
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -216,7 +216,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x210a
+			// Method begins at RVA 0x20f2
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -241,7 +241,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x212c
+			// Method begins at RVA 0x2114
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -267,16 +267,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 166 (0xa6)
+		// Code size: 142 (0x8e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassWithStaticMethod_HelloWorld/Scope,
 			[1] object,
 			[2] class [System.Runtime]System.Type,
-			[3] class [System.Runtime]System.Type,
-			[4] object[],
-			[5] class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld,
-			[6] object
+			[3] object[],
+			[4] class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassWithStaticMethod_HelloWorld/Scope::.ctor()
@@ -287,54 +286,49 @@
 		IL_0011: ldtoken Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.2
-		IL_001c: ldtoken Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.3
-		IL_0031: ldloc.3
-		IL_0032: ldstr "prototype"
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003c: pop
-		IL_003d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0042: stloc.s 4
-		IL_0044: newobj instance void Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::.ctor()
-		IL_0049: ldc.i4.0
-		IL_004a: conv.r8
-		IL_004b: ldstr "helloWorld"
-		IL_0050: ldc.i4.0
-		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0, float64, string, bool, bool)
-		IL_0057: stloc.s 5
-		IL_0059: ldloc.s 5
-		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0)
-		IL_0060: stloc.s 5
-		IL_0062: ldloc.2
-		IL_0063: ldstr "helloWorld"
-		IL_0068: ldloc.s 5
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_006f: pop
-		IL_0070: ldc.i4.1
-		IL_0071: newarr [System.Runtime]System.Object
-		IL_0076: dup
-		IL_0077: ldc.i4.0
-		IL_0078: ldloc.0
-		IL_0079: stelem.ref
-		IL_007a: stloc.s 4
-		IL_007c: ldloc.2
-		IL_007d: ldloc.s 4
-		IL_007f: ldc.r8 0.0
-		IL_0088: box [System.Runtime]System.Double
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0092: stloc.s 6
-		IL_0094: ldloc.s 6
-		IL_0096: stloc.1
-		IL_0097: ldloc.1
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_009d: stloc.s 6
-		IL_009f: call object Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter::helloWorld()
-		IL_00a4: pop
-		IL_00a5: ret
+		IL_001c: ldloc.2
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: pop
+		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002d: stloc.3
+		IL_002e: newobj instance void Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::.ctor()
+		IL_0033: ldc.i4.0
+		IL_0034: conv.r8
+		IL_0035: ldstr "helloWorld"
+		IL_003a: ldc.i4.0
+		IL_003b: ldc.i4.1
+		IL_003c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0, float64, string, bool, bool)
+		IL_0041: stloc.s 4
+		IL_0043: ldloc.s 4
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0)
+		IL_004a: stloc.s 4
+		IL_004c: ldloc.2
+		IL_004d: ldstr "helloWorld"
+		IL_0052: ldloc.s 4
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0059: pop
+		IL_005a: ldc.i4.1
+		IL_005b: newarr [System.Runtime]System.Object
+		IL_0060: dup
+		IL_0061: ldc.i4.0
+		IL_0062: ldloc.0
+		IL_0063: stelem.ref
+		IL_0064: stloc.3
+		IL_0065: ldloc.2
+		IL_0066: ldloc.3
+		IL_0067: ldc.r8 0.0
+		IL_0070: box [System.Runtime]System.Double
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_007a: stloc.s 5
+		IL_007c: ldloc.s 5
+		IL_007e: stloc.1
+		IL_007f: ldloc.1
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_0085: stloc.s 5
+		IL_0087: call object Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter::helloWorld()
+		IL_008c: pop
+		IL_008d: ret
 	} // end of method Classes_ClassWithStaticMethod_HelloWorld::__js_module_init__
 
 } // end of class Modules.Classes_ClassWithStaticMethod_HelloWorld
@@ -346,7 +340,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2189
+		// Method begins at RVA 0x2171
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x318f
+					// Method begins at RVA 0x3097
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3198
+					// Method begins at RVA 0x30a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 						object[] capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x3426
+					// Method begins at RVA 0x332e
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -83,7 +83,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x3435
+					// Method begins at RVA 0x333d
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -95,7 +95,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x3438
+					// Method begins at RVA 0x3340
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -110,7 +110,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x343b
+					// Method begins at RVA 0x3343
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -126,7 +126,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x3447
+					// Method begins at RVA 0x334f
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -145,7 +145,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3453
+					// Method begins at RVA 0x335b
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -158,7 +158,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x345b
+					// Method begins at RVA 0x3363
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -170,7 +170,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x345e
+					// Method begins at RVA 0x3366
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -185,7 +185,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x3461
+					// Method begins at RVA 0x3369
 					// Header size: 1
 					// Code size: 40 (0x28)
 					.maxstack 8
@@ -214,7 +214,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x306b
+				// Method begins at RVA 0x2f73
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -230,7 +230,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3073
+				// Method begins at RVA 0x2f7b
 				// Header size: 1
 				// Code size: 10 (0xa)
 				.maxstack 8
@@ -248,7 +248,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3186
+				// Method begins at RVA 0x308e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -268,7 +268,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33f5
+				// Method begins at RVA 0x32fd
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -281,7 +281,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x33fd
+				// Method begins at RVA 0x3305
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -293,7 +293,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3400
+				// Method begins at RVA 0x3308
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -308,7 +308,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3403
+				// Method begins at RVA 0x330b
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -325,7 +325,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x340f
+				// Method begins at RVA 0x3317
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -341,7 +341,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3417
+				// Method begins at RVA 0x331f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -366,17 +366,16 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2dd8
+			// Method begins at RVA 0x2d10
 			// Header size: 12
-			// Code size: 143 (0x8f)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/Scope,
 				[1] class [System.Runtime]System.Type,
-				[2] class [System.Runtime]System.Type,
-				[3] object,
-				[4] object[],
-				[5] class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method
+				[2] object,
+				[3] object[],
+				[4] class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method
 			)
 
 			IL_0000: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/Scope::.ctor()
@@ -386,43 +385,38 @@
 			IL_0010: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12
 			IL_0015: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_001a: stloc.1
-			IL_001b: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12
-			IL_0020: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0025: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12
-			IL_002a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_002f: stloc.2
-			IL_0030: ldloc.2
-			IL_0031: ldstr "prototype"
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003b: stloc.3
-			IL_003c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0041: stloc.s 4
-			IL_0043: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method::.ctor()
-			IL_0048: ldc.i4.0
-			IL_0049: conv.r8
-			IL_004a: ldstr "method"
-			IL_004f: ldc.i4.0
-			IL_0050: ldc.i4.1
-			IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0, float64, string, bool, bool)
-			IL_0056: stloc.s 5
-			IL_0058: ldloc.s 5
-			IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0)
-			IL_005f: stloc.s 5
-			IL_0061: ldloc.3
-			IL_0062: ldstr "method"
-			IL_0067: ldloc.s 5
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_006e: pop
-			IL_006f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0074: stloc.s 4
-			IL_0076: ldloc.1
-			IL_0077: ldloc.s 4
-			IL_0079: ldc.r8 0.0
-			IL_0082: box [System.Runtime]System.Double
-			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
-			IL_008c: stloc.3
-			IL_008d: ldloc.3
-			IL_008e: ret
+			IL_001b: ldloc.1
+			IL_001c: ldstr "prototype"
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0026: stloc.2
+			IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_002c: stloc.3
+			IL_002d: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method::.ctor()
+			IL_0032: ldc.i4.0
+			IL_0033: conv.r8
+			IL_0034: ldstr "method"
+			IL_0039: ldc.i4.0
+			IL_003a: ldc.i4.1
+			IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0, float64, string, bool, bool)
+			IL_0040: stloc.s 4
+			IL_0042: ldloc.s 4
+			IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0)
+			IL_0049: stloc.s 4
+			IL_004b: ldloc.2
+			IL_004c: ldstr "method"
+			IL_0051: ldloc.s 4
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_0058: pop
+			IL_0059: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_005e: stloc.3
+			IL_005f: ldloc.1
+			IL_0060: ldloc.3
+			IL_0061: ldc.r8 0.0
+			IL_006a: box [System.Runtime]System.Double
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
+			IL_0074: stloc.2
+			IL_0075: ldloc.2
+			IL_0076: ret
 		} // end of method makeClass::__js_call__
 
 	} // end of class makeClass
@@ -442,7 +436,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31aa
+					// Method begins at RVA 0x30b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -462,7 +456,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31b3
+					// Method begins at RVA 0x30bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -482,7 +476,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31bc
+					// Method begins at RVA 0x30c4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -502,7 +496,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31c5
+					// Method begins at RVA 0x30cd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -522,7 +516,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31ce
+					// Method begins at RVA 0x30d6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -549,7 +543,7 @@
 						class [System.Runtime]System.Object capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x34bb
+					// Method begins at RVA 0x33c3
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -568,7 +562,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x34d1
+					// Method begins at RVA 0x33d9
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -580,7 +574,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x34d4
+					// Method begins at RVA 0x33dc
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -595,7 +589,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x34d7
+					// Method begins at RVA 0x33df
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -611,7 +605,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x34e3
+					// Method begins at RVA 0x33eb
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -635,7 +629,7 @@
 						class [System.Runtime]System.Object capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x34ef
+					// Method begins at RVA 0x33f7
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -651,7 +645,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x34fe
+					// Method begins at RVA 0x3406
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -663,7 +657,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x3501
+					// Method begins at RVA 0x3409
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -678,7 +672,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x3504
+					// Method begins at RVA 0x340c
 					// Header size: 1
 					// Code size: 40 (0x28)
 					.maxstack 8
@@ -706,7 +700,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x352d
+					// Method begins at RVA 0x3435
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -719,7 +713,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x3535
+					// Method begins at RVA 0x343d
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -731,7 +725,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x3538
+					// Method begins at RVA 0x3440
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -746,7 +740,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x353b
+					// Method begins at RVA 0x3443
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -770,7 +764,7 @@
 						class [System.Runtime]System.Object capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x3547
+					// Method begins at RVA 0x344f
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -786,7 +780,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x3556
+					// Method begins at RVA 0x345e
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -798,7 +792,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x3559
+					// Method begins at RVA 0x3461
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -813,7 +807,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x355c
+					// Method begins at RVA 0x3464
 					// Header size: 1
 					// Code size: 30 (0x1e)
 					.maxstack 8
@@ -847,7 +841,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3080
+				// Method begins at RVA 0x2f88
 				// Header size: 12
 				// Code size: 30 (0x1e)
 				.maxstack 8
@@ -877,7 +871,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x30aa
+				// Method begins at RVA 0x2fb2
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -893,7 +887,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x30b2
+				// Method begins at RVA 0x2fba
 				// Header size: 1
 				// Code size: 10 (0xa)
 				.maxstack 8
@@ -908,7 +902,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x30c0
+				// Method begins at RVA 0x2fc8
 				// Header size: 12
 				// Code size: 51 (0x33)
 				.maxstack 8
@@ -943,7 +937,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31a1
+				// Method begins at RVA 0x30a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -963,7 +957,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x348a
+				// Method begins at RVA 0x3392
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -976,7 +970,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3492
+				// Method begins at RVA 0x339a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -988,7 +982,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3495
+				// Method begins at RVA 0x339d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1003,7 +997,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3498
+				// Method begins at RVA 0x33a0
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1020,7 +1014,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x34a4
+				// Method begins at RVA 0x33ac
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1036,7 +1030,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x34ac
+				// Method begins at RVA 0x33b4
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1061,20 +1055,19 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e74
+			// Method begins at RVA 0x2d94
 			// Header size: 12
-			// Code size: 247 (0xf7)
+			// Code size: 224 (0xe0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/Scope,
 				[1] class [System.Runtime]System.Type,
-				[2] class [System.Runtime]System.Type,
-				[3] object,
+				[2] object,
+				[3] object[],
 				[4] object[],
-				[5] object[],
-				[6] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read,
-				[7] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden,
-				[8] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic
+				[5] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read,
+				[6] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden,
+				[7] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic
 			)
 
 			IL_0000: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/Scope::.ctor()
@@ -1084,81 +1077,76 @@
 			IL_0010: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12
 			IL_0015: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_001a: stloc.1
-			IL_001b: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12
-			IL_0020: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0025: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12
-			IL_002a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_002f: stloc.2
-			IL_0030: ldloc.2
-			IL_0031: ldstr "prototype"
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003b: stloc.3
-			IL_003c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0041: stloc.s 4
-			IL_0043: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_001b: ldloc.1
+			IL_001c: ldstr "prototype"
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0026: stloc.2
+			IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_002c: stloc.3
+			IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0032: stloc.s 4
+			IL_0034: ldloc.1
+			IL_0035: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read::.ctor(class [System.Runtime]System.Object)
+			IL_003a: ldc.i4.0
+			IL_003b: conv.r8
+			IL_003c: ldstr "read"
+			IL_0041: ldc.i4.1
+			IL_0042: ldc.i4.1
+			IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0, float64, string, bool, bool)
 			IL_0048: stloc.s 5
-			IL_004a: ldloc.1
-			IL_004b: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read::.ctor(class [System.Runtime]System.Object)
-			IL_0050: ldc.i4.0
-			IL_0051: conv.r8
-			IL_0052: ldstr "read"
-			IL_0057: ldc.i4.1
-			IL_0058: ldc.i4.1
-			IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0, float64, string, bool, bool)
-			IL_005e: stloc.s 6
-			IL_0060: ldloc.s 6
-			IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0)
-			IL_0067: stloc.s 6
-			IL_0069: ldloc.3
-			IL_006a: ldstr "read"
-			IL_006f: ldloc.s 6
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_0076: pop
-			IL_0077: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_007c: stloc.s 5
-			IL_007e: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden::.ctor()
-			IL_0083: ldc.i4.0
-			IL_0084: conv.r8
-			IL_0085: ldstr "#hidden"
-			IL_008a: ldc.i4.0
-			IL_008b: ldc.i4.1
-			IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0, float64, string, bool, bool)
-			IL_0091: stloc.s 7
-			IL_0093: ldloc.s 7
-			IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0)
-			IL_009a: stloc.s 7
-			IL_009c: ldloc.1
-			IL_009d: ldstr "__jroc_priv_method_hidden"
-			IL_00a2: ldloc.s 7
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_00a9: pop
-			IL_00aa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_00af: stloc.s 5
-			IL_00b1: ldloc.1
-			IL_00b2: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::.ctor(class [System.Runtime]System.Object)
-			IL_00b7: ldc.i4.0
-			IL_00b8: conv.r8
-			IL_00b9: ldstr "readStatic"
-			IL_00be: ldc.i4.1
-			IL_00bf: ldc.i4.1
-			IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0, float64, string, bool, bool)
-			IL_00c5: stloc.s 8
-			IL_00c7: ldloc.s 8
-			IL_00c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0)
-			IL_00ce: stloc.s 8
-			IL_00d0: ldloc.1
-			IL_00d1: ldstr "readStatic"
-			IL_00d6: ldloc.s 8
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_00dd: pop
-			IL_00de: ldloc.1
-			IL_00df: ldloc.s 4
-			IL_00e1: ldc.r8 1
-			IL_00ea: box [System.Runtime]System.Double
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
-			IL_00f4: stloc.3
-			IL_00f5: ldloc.3
-			IL_00f6: ret
+			IL_004a: ldloc.s 5
+			IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0)
+			IL_0051: stloc.s 5
+			IL_0053: ldloc.2
+			IL_0054: ldstr "read"
+			IL_0059: ldloc.s 5
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_0060: pop
+			IL_0061: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0066: stloc.s 4
+			IL_0068: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden::.ctor()
+			IL_006d: ldc.i4.0
+			IL_006e: conv.r8
+			IL_006f: ldstr "#hidden"
+			IL_0074: ldc.i4.0
+			IL_0075: ldc.i4.1
+			IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0, float64, string, bool, bool)
+			IL_007b: stloc.s 6
+			IL_007d: ldloc.s 6
+			IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0)
+			IL_0084: stloc.s 6
+			IL_0086: ldloc.1
+			IL_0087: ldstr "__jroc_priv_method_hidden"
+			IL_008c: ldloc.s 6
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_0093: pop
+			IL_0094: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0099: stloc.s 4
+			IL_009b: ldloc.1
+			IL_009c: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::.ctor(class [System.Runtime]System.Object)
+			IL_00a1: ldc.i4.0
+			IL_00a2: conv.r8
+			IL_00a3: ldstr "readStatic"
+			IL_00a8: ldc.i4.1
+			IL_00a9: ldc.i4.1
+			IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0, float64, string, bool, bool)
+			IL_00af: stloc.s 7
+			IL_00b1: ldloc.s 7
+			IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0)
+			IL_00b8: stloc.s 7
+			IL_00ba: ldloc.1
+			IL_00bb: ldstr "readStatic"
+			IL_00c0: ldloc.s 7
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_00c7: pop
+			IL_00c8: ldloc.1
+			IL_00c9: ldloc.3
+			IL_00ca: ldc.r8 1
+			IL_00d3: box [System.Runtime]System.Double
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
+			IL_00dd: stloc.2
+			IL_00de: ldloc.2
+			IL_00df: ret
 		} // end of method makeSecretClass::__js_call__
 
 	} // end of class makeSecretClass
@@ -1174,7 +1162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3108
+				// Method begins at RVA 0x3010
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1194,7 +1182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3111
+				// Method begins at RVA 0x3019
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1219,7 +1207,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x31fb
+				// Method begins at RVA 0x3103
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1235,7 +1223,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x320a
+				// Method begins at RVA 0x3112
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1247,7 +1235,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x320d
+				// Method begins at RVA 0x3115
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1262,7 +1250,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3210
+				// Method begins at RVA 0x3118
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1278,7 +1266,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x321c
+				// Method begins at RVA 0x3124
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1297,7 +1285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3228
+				// Method begins at RVA 0x3130
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1310,7 +1298,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3230
+				// Method begins at RVA 0x3138
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1322,7 +1310,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3233
+				// Method begins at RVA 0x313b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1337,7 +1325,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3236
+				// Method begins at RVA 0x313e
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -1365,7 +1353,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f77
+			// Method begins at RVA 0x2e80
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1381,7 +1369,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3026
+			// Method begins at RVA 0x2f2e
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -1403,7 +1391,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x311a
+				// Method begins at RVA 0x3022
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1423,7 +1411,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3123
+				// Method begins at RVA 0x302b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1443,7 +1431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x312c
+				// Method begins at RVA 0x3034
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1463,7 +1451,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3135
+				// Method begins at RVA 0x303d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1483,7 +1471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x313e
+				// Method begins at RVA 0x3046
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1512,7 +1500,7 @@
 					object[] capture2
 				) cil managed 
 			{
-				// Method begins at RVA 0x325a
+				// Method begins at RVA 0x3162
 				// Header size: 1
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -1534,7 +1522,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3277
+				// Method begins at RVA 0x317f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1546,7 +1534,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x327a
+				// Method begins at RVA 0x3182
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1558,7 +1546,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x327d
+				// Method begins at RVA 0x3185
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1571,7 +1559,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x3285
+				// Method begins at RVA 0x318d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1587,7 +1575,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x328d
+				// Method begins at RVA 0x3195
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1603,7 +1591,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3299
+				// Method begins at RVA 0x31a1
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1629,7 +1617,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x32a5
+				// Method begins at RVA 0x31ad
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -1648,7 +1636,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x32bb
+				// Method begins at RVA 0x31c3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1660,7 +1648,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x32be
+				// Method begins at RVA 0x31c6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1672,7 +1660,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x32c1
+				// Method begins at RVA 0x31c9
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1685,7 +1673,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x32c9
+				// Method begins at RVA 0x31d1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1701,7 +1689,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x32d1
+				// Method begins at RVA 0x31d9
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -1731,7 +1719,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32fc
+				// Method begins at RVA 0x3204
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1744,7 +1732,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3304
+				// Method begins at RVA 0x320c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1756,7 +1744,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3307
+				// Method begins at RVA 0x320f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1771,7 +1759,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x330a
+				// Method begins at RVA 0x3212
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -1798,7 +1786,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x332e
+				// Method begins at RVA 0x3236
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1811,7 +1799,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3336
+				// Method begins at RVA 0x323e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1823,7 +1811,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3339
+				// Method begins at RVA 0x3241
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1838,7 +1826,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x333c
+				// Method begins at RVA 0x3244
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -1868,7 +1856,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3367
+				// Method begins at RVA 0x326f
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1881,7 +1869,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x336f
+				// Method begins at RVA 0x3277
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1893,7 +1881,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3372
+				// Method begins at RVA 0x327a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1908,7 +1896,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3375
+				// Method begins at RVA 0x327d
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1935,7 +1923,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f7f
+			// Method begins at RVA 0x2e88
 			// Header size: 1
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -1971,7 +1959,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ff0
+			// Method begins at RVA 0x2ef8
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -2007,7 +1995,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fe6
+			// Method begins at RVA 0x2eee
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -2025,7 +2013,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3035
+			// Method begins at RVA 0x2f3d
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -2045,7 +2033,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3040
+			// Method begins at RVA 0x2f48
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -2080,7 +2068,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3159
+				// Method begins at RVA 0x3061
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2100,7 +2088,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3162
+				// Method begins at RVA 0x306a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2120,7 +2108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x316b
+				// Method begins at RVA 0x3073
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2147,7 +2135,7 @@
 					class [System.Runtime]System.Object capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x3383
+				// Method begins at RVA 0x328b
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -2166,7 +2154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3399
+				// Method begins at RVA 0x32a1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2178,7 +2166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x339c
+				// Method begins at RVA 0x32a4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2193,7 +2181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x339f
+				// Method begins at RVA 0x32a7
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -2209,7 +2197,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x33ab
+				// Method begins at RVA 0x32b3
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -2233,7 +2221,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x33b7
+				// Method begins at RVA 0x32bf
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2249,7 +2237,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x33c6
+				// Method begins at RVA 0x32ce
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2261,7 +2249,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x33c9
+				// Method begins at RVA 0x32d1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2276,7 +2264,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x33cc
+				// Method begins at RVA 0x32d4
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -2312,7 +2300,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fbc
+			// Method begins at RVA 0x2ec4
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -2342,7 +2330,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x302d
+			// Method begins at RVA 0x2f35
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -2372,7 +2360,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3147
+				// Method begins at RVA 0x304f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2392,7 +2380,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3150
+				// Method begins at RVA 0x3058
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2412,7 +2400,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3174
+				// Method begins at RVA 0x307c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2432,7 +2420,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x317d
+				// Method begins at RVA 0x3085
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2452,7 +2440,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31d7
+				// Method begins at RVA 0x30df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2472,7 +2460,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e0
+				// Method begins at RVA 0x30e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2492,7 +2480,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e9
+				// Method begins at RVA 0x30f1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2512,7 +2500,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31f2
+				// Method begins at RVA 0x30fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2534,7 +2522,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x30ff
+			// Method begins at RVA 0x3007
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2560,7 +2548,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 3398 (0xd46)
+		// Code size: 3200 (0xc80)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Classes_GeneratedMethodFunctionObjects/Scope,
@@ -2600,25 +2588,24 @@
 			[34] object,
 			[35] object[],
 			[36] class [System.Runtime]System.Type,
-			[37] class [System.Runtime]System.Type,
-			[38] object,
-			[39] class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label,
-			[40] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add,
-			[41] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current,
-			[42] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current,
-			[43] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify,
+			[37] object,
+			[38] class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label,
+			[39] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add,
+			[40] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current,
+			[41] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current,
+			[42] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify,
+			[43] object,
 			[44] object,
 			[45] object,
 			[46] object,
 			[47] object,
-			[48] object,
-			[49] bool,
+			[48] bool,
+			[49] object,
 			[50] object,
 			[51] object,
-			[52] object,
-			[53] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[54] class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read,
-			[55] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[52] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[53] class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read,
+			[54] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
 		IL_0000: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Scope::.ctor()
@@ -2659,1090 +2646,1045 @@
 		IL_0051: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Base
 		IL_0056: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_005b: stloc.s 36
-		IL_005d: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Base
-		IL_0062: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0067: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Base
-		IL_006c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0071: stloc.s 37
-		IL_0073: ldloc.s 37
-		IL_0075: ldstr "prototype"
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_007f: stloc.s 38
-		IL_0081: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0086: stloc.s 35
-		IL_0088: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label::.ctor()
-		IL_008d: ldc.i4.0
-		IL_008e: conv.r8
-		IL_008f: ldstr "label"
-		IL_0094: ldc.i4.0
-		IL_0095: ldc.i4.1
-		IL_0096: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0, float64, string, bool, bool)
-		IL_009b: stloc.s 39
-		IL_009d: ldloc.s 39
-		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0)
-		IL_00a4: stloc.s 39
-		IL_00a6: ldloc.s 38
-		IL_00a8: ldstr "label"
-		IL_00ad: ldloc.s 39
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00b4: pop
-		IL_00b5: ldc.i4.1
-		IL_00b6: newarr [System.Runtime]System.Object
-		IL_00bb: dup
-		IL_00bc: ldc.i4.0
-		IL_00bd: ldloc.0
-		IL_00be: stelem.ref
-		IL_00bf: stloc.s 35
-		IL_00c1: ldloc.s 36
-		IL_00c3: ldloc.s 35
-		IL_00c5: ldc.r8 0.0
-		IL_00ce: box [System.Runtime]System.Double
-		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00d8: stloc.s 38
-		IL_00da: ldloc.s 38
-		IL_00dc: stloc.3
-		IL_00dd: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_00e2: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00e7: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_00ec: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00f1: stloc.s 36
-		IL_00f3: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_00f8: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00fd: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_0102: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0107: stloc.s 37
-		IL_0109: ldloc.s 37
-		IL_010b: ldstr "prototype"
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0115: stloc.s 38
-		IL_0117: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_011c: stloc.s 35
-		IL_011e: ldloc.s 38
-		IL_0120: ldloc.s 35
-		IL_0122: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add::.ctor(class [System.Runtime]System.Object, object[])
-		IL_0127: ldc.i4.1
-		IL_0128: conv.r8
-		IL_0129: ldstr "add"
-		IL_012e: ldc.i4.1
-		IL_012f: ldc.i4.1
-		IL_0130: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0, float64, string, bool, bool)
-		IL_0135: stloc.s 40
-		IL_0137: ldloc.s 40
-		IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0)
-		IL_013e: stloc.s 40
-		IL_0140: ldloc.s 38
-		IL_0142: ldstr "add"
-		IL_0147: ldloc.s 40
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_014e: pop
-		IL_014f: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_0154: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0159: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_015e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0163: stloc.s 36
-		IL_0165: ldloc.s 36
-		IL_0167: ldstr "prototype"
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0171: stloc.s 38
-		IL_0173: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_0178: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_017d: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_0182: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0187: stloc.s 36
-		IL_0189: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_018e: stloc.s 35
-		IL_0190: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current::.ctor()
-		IL_0195: ldc.i4.0
-		IL_0196: conv.r8
-		IL_0197: ldstr "get current"
-		IL_019c: ldc.i4.1
-		IL_019d: ldc.i4.1
-		IL_019e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0, float64, string, bool, bool)
-		IL_01a3: stloc.s 41
-		IL_01a5: ldloc.s 41
-		IL_01a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0)
-		IL_01ac: stloc.s 41
-		IL_01ae: ldloc.s 38
-		IL_01b0: ldstr "current"
-		IL_01b5: ldloc.s 41
-		IL_01b7: ldnull
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_01bd: pop
-		IL_01be: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_01c3: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01c8: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_01cd: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01d2: stloc.s 36
-		IL_01d4: ldloc.s 36
-		IL_01d6: ldstr "prototype"
-		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e0: stloc.s 38
-		IL_01e2: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_01e7: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01ec: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_01f1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01f6: stloc.s 36
-		IL_01f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01fd: stloc.s 35
-		IL_01ff: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current::.ctor()
-		IL_0204: ldc.i4.1
-		IL_0205: conv.r8
-		IL_0206: ldstr "set current"
-		IL_020b: ldc.i4.1
-		IL_020c: ldc.i4.1
-		IL_020d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0, float64, string, bool, bool)
-		IL_0212: stloc.s 42
-		IL_0214: ldloc.s 42
-		IL_0216: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0)
-		IL_021b: stloc.s 42
-		IL_021d: ldloc.s 38
-		IL_021f: ldstr "current"
-		IL_0224: ldnull
-		IL_0225: ldloc.s 42
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_022c: pop
-		IL_022d: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_0232: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0237: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_023c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0241: stloc.s 36
-		IL_0243: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_0248: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_024d: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_0252: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0257: stloc.s 37
-		IL_0259: ldloc.s 37
-		IL_025b: ldstr "prototype"
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0265: pop
-		IL_0266: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_026b: stloc.s 35
-		IL_026d: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify::.ctor()
-		IL_0272: ldc.i4.1
-		IL_0273: conv.r8
-		IL_0274: ldstr "identify"
-		IL_0279: ldc.i4.1
-		IL_027a: ldc.i4.1
-		IL_027b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0, float64, string, bool, bool)
-		IL_0280: stloc.s 43
-		IL_0282: ldloc.s 43
-		IL_0284: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0)
-		IL_0289: stloc.s 43
-		IL_028b: ldloc.s 36
-		IL_028d: ldstr "identify"
-		IL_0292: ldloc.s 43
-		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0299: pop
-		IL_029a: ldc.i4.1
-		IL_029b: newarr [System.Runtime]System.Object
-		IL_02a0: dup
-		IL_02a1: ldc.i4.0
-		IL_02a2: ldloc.0
-		IL_02a3: stelem.ref
-		IL_02a4: stloc.s 35
-		IL_02a6: ldloc.s 36
-		IL_02a8: ldloc.s 35
-		IL_02aa: ldc.r8 1
-		IL_02b3: box [System.Runtime]System.Double
-		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_02bd: stloc.s 38
-		IL_02bf: ldloc.s 38
-		IL_02c1: ldloc.3
-		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_02c7: stloc.s 38
-		IL_02c9: ldloc.s 38
-		IL_02cb: stloc.s 4
-		IL_02cd: ldloc.s 4
-		IL_02cf: ldstr "prefix"
-		IL_02d4: ldstr "static:"
-		IL_02d9: ldc.i4.1
-		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_02df: pop
-		IL_02e0: ldc.i4.1
-		IL_02e1: newarr [System.Runtime]System.Object
-		IL_02e6: dup
-		IL_02e7: ldc.i4.0
-		IL_02e8: ldc.r8 3
-		IL_02f1: box [System.Runtime]System.Double
-		IL_02f6: stelem.ref
-		IL_02f7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_02fc: ldloc.s 4
-		IL_02fe: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_0303: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0308: ldc.r8 3
-		IL_0311: box [System.Runtime]System.Double
-		IL_0316: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example::.ctor(object)
-		IL_031b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_0320: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0325: dup
-		IL_0326: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_032b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0330: ldstr "prototype"
-		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_033a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_033f: stloc.s 5
-		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_034b: stloc.s 5
-		IL_034d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_0352: ldloc.s 4
-		IL_0354: ldstr "prototype"
-		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_035e: stloc.s 38
-		IL_0360: ldloc.s 38
-		IL_0362: ldstr "add"
-		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_036c: stloc.s 6
-		IL_036e: ldloc.s 4
-		IL_0370: ldstr "prototype"
-		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_037a: stloc.s 38
-		IL_037c: ldloc.s 38
-		IL_037e: ldstr "current"
-		IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0388: stloc.s 7
-		IL_038a: ldloc.s 4
-		IL_038c: ldstr "identify"
-		IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0396: stloc.s 8
-		IL_0398: ldstr "console"
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03a7: stloc.s 38
-		IL_03a9: ldloc.s 5
-		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b0: stloc.s 44
-		IL_03b2: ldloc.s 44
-		IL_03b4: isinst Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_03b9: dup
-		IL_03ba: brfalse IL_03d9
+		IL_005d: ldloc.s 36
+		IL_005f: ldstr "prototype"
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0069: stloc.s 37
+		IL_006b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0070: stloc.s 35
+		IL_0072: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label::.ctor()
+		IL_0077: ldc.i4.0
+		IL_0078: conv.r8
+		IL_0079: ldstr "label"
+		IL_007e: ldc.i4.0
+		IL_007f: ldc.i4.1
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0, float64, string, bool, bool)
+		IL_0085: stloc.s 38
+		IL_0087: ldloc.s 38
+		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0)
+		IL_008e: stloc.s 38
+		IL_0090: ldloc.s 37
+		IL_0092: ldstr "label"
+		IL_0097: ldloc.s 38
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_009e: pop
+		IL_009f: ldc.i4.1
+		IL_00a0: newarr [System.Runtime]System.Object
+		IL_00a5: dup
+		IL_00a6: ldc.i4.0
+		IL_00a7: ldloc.0
+		IL_00a8: stelem.ref
+		IL_00a9: stloc.s 35
+		IL_00ab: ldloc.s 36
+		IL_00ad: ldloc.s 35
+		IL_00af: ldc.r8 0.0
+		IL_00b8: box [System.Runtime]System.Double
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00c2: stloc.s 37
+		IL_00c4: ldloc.s 37
+		IL_00c6: stloc.3
+		IL_00c7: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
+		IL_00cc: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00d1: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
+		IL_00d6: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00db: stloc.s 36
+		IL_00dd: ldloc.s 36
+		IL_00df: ldstr "prototype"
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e9: stloc.s 37
+		IL_00eb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00f0: stloc.s 35
+		IL_00f2: ldloc.s 37
+		IL_00f4: ldloc.s 35
+		IL_00f6: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add::.ctor(class [System.Runtime]System.Object, object[])
+		IL_00fb: ldc.i4.1
+		IL_00fc: conv.r8
+		IL_00fd: ldstr "add"
+		IL_0102: ldc.i4.1
+		IL_0103: ldc.i4.1
+		IL_0104: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0, float64, string, bool, bool)
+		IL_0109: stloc.s 39
+		IL_010b: ldloc.s 39
+		IL_010d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0)
+		IL_0112: stloc.s 39
+		IL_0114: ldloc.s 37
+		IL_0116: ldstr "add"
+		IL_011b: ldloc.s 39
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0122: pop
+		IL_0123: ldloc.s 36
+		IL_0125: ldstr "prototype"
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012f: stloc.s 37
+		IL_0131: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0136: stloc.s 35
+		IL_0138: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current::.ctor()
+		IL_013d: ldc.i4.0
+		IL_013e: conv.r8
+		IL_013f: ldstr "get current"
+		IL_0144: ldc.i4.1
+		IL_0145: ldc.i4.1
+		IL_0146: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0, float64, string, bool, bool)
+		IL_014b: stloc.s 40
+		IL_014d: ldloc.s 40
+		IL_014f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0)
+		IL_0154: stloc.s 40
+		IL_0156: ldloc.s 37
+		IL_0158: ldstr "current"
+		IL_015d: ldloc.s 40
+		IL_015f: ldnull
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0165: pop
+		IL_0166: ldloc.s 36
+		IL_0168: ldstr "prototype"
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0172: stloc.s 37
+		IL_0174: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0179: stloc.s 35
+		IL_017b: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current::.ctor()
+		IL_0180: ldc.i4.1
+		IL_0181: conv.r8
+		IL_0182: ldstr "set current"
+		IL_0187: ldc.i4.1
+		IL_0188: ldc.i4.1
+		IL_0189: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0, float64, string, bool, bool)
+		IL_018e: stloc.s 41
+		IL_0190: ldloc.s 41
+		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0)
+		IL_0197: stloc.s 41
+		IL_0199: ldloc.s 37
+		IL_019b: ldstr "current"
+		IL_01a0: ldnull
+		IL_01a1: ldloc.s 41
+		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_01a8: pop
+		IL_01a9: ldloc.s 36
+		IL_01ab: ldstr "prototype"
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01b5: pop
+		IL_01b6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01bb: stloc.s 35
+		IL_01bd: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify::.ctor()
+		IL_01c2: ldc.i4.1
+		IL_01c3: conv.r8
+		IL_01c4: ldstr "identify"
+		IL_01c9: ldc.i4.1
+		IL_01ca: ldc.i4.1
+		IL_01cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0, float64, string, bool, bool)
+		IL_01d0: stloc.s 42
+		IL_01d2: ldloc.s 42
+		IL_01d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0)
+		IL_01d9: stloc.s 42
+		IL_01db: ldloc.s 36
+		IL_01dd: ldstr "identify"
+		IL_01e2: ldloc.s 42
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01e9: pop
+		IL_01ea: ldc.i4.1
+		IL_01eb: newarr [System.Runtime]System.Object
+		IL_01f0: dup
+		IL_01f1: ldc.i4.0
+		IL_01f2: ldloc.0
+		IL_01f3: stelem.ref
+		IL_01f4: stloc.s 35
+		IL_01f6: ldloc.s 36
+		IL_01f8: ldloc.s 35
+		IL_01fa: ldc.r8 1
+		IL_0203: box [System.Runtime]System.Double
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_020d: stloc.s 37
+		IL_020f: ldloc.s 37
+		IL_0211: ldloc.3
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_0217: stloc.s 37
+		IL_0219: ldloc.s 37
+		IL_021b: stloc.s 4
+		IL_021d: ldloc.s 4
+		IL_021f: ldstr "prefix"
+		IL_0224: ldstr "static:"
+		IL_0229: ldc.i4.1
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_022f: pop
+		IL_0230: ldc.i4.1
+		IL_0231: newarr [System.Runtime]System.Object
+		IL_0236: dup
+		IL_0237: ldc.i4.0
+		IL_0238: ldc.r8 3
+		IL_0241: box [System.Runtime]System.Double
+		IL_0246: stelem.ref
+		IL_0247: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_024c: ldloc.s 4
+		IL_024e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0253: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0258: ldc.r8 3
+		IL_0261: box [System.Runtime]System.Double
+		IL_0266: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example::.ctor(object)
+		IL_026b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_0270: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0275: dup
+		IL_0276: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
+		IL_027b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0280: ldstr "prototype"
+		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_028a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_028f: stloc.s 5
+		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_029b: stloc.s 5
+		IL_029d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_02a2: ldloc.s 4
+		IL_02a4: ldstr "prototype"
+		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ae: stloc.s 37
+		IL_02b0: ldloc.s 37
+		IL_02b2: ldstr "add"
+		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_02bc: stloc.s 6
+		IL_02be: ldloc.s 4
+		IL_02c0: ldstr "prototype"
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ca: stloc.s 37
+		IL_02cc: ldloc.s 37
+		IL_02ce: ldstr "current"
+		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_02d8: stloc.s 7
+		IL_02da: ldloc.s 4
+		IL_02dc: ldstr "identify"
+		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_02e6: stloc.s 8
+		IL_02e8: ldstr "console"
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f7: stloc.s 37
+		IL_02f9: ldloc.s 5
+		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0300: stloc.s 43
+		IL_0302: ldloc.s 43
+		IL_0304: isinst Modules.Classes_GeneratedMethodFunctionObjects/Example
+		IL_0309: dup
+		IL_030a: brfalse IL_0329
 
-		IL_03bf: ldc.r8 4
-		IL_03c8: box [System.Runtime]System.Double
-		IL_03cd: callvirt instance object Modules.Classes_GeneratedMethodFunctionObjects/Example::'add'(object)
-		IL_03d2: stloc.s 44
-		IL_03d4: br IL_03f6
+		IL_030f: ldc.r8 4
+		IL_0318: box [System.Runtime]System.Double
+		IL_031d: callvirt instance object Modules.Classes_GeneratedMethodFunctionObjects/Example::'add'(object)
+		IL_0322: stloc.s 43
+		IL_0324: br IL_0346
 
-		IL_03d9: pop
-		IL_03da: ldloc.s 44
-		IL_03dc: ldstr "add"
-		IL_03e1: ldc.r8 4
-		IL_03ea: box [System.Runtime]System.Double
-		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03f4: stloc.s 44
+		IL_0329: pop
+		IL_032a: ldloc.s 43
+		IL_032c: ldstr "add"
+		IL_0331: ldc.r8 4
+		IL_033a: box [System.Runtime]System.Double
+		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0344: stloc.s 43
 
-		IL_03f6: ldloc.s 6
-		IL_03f8: ldstr "value"
-		IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0402: stloc.s 45
-		IL_0404: ldloc.s 45
-		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_040b: ldstr "call"
-		IL_0410: ldloc.s 5
-		IL_0412: ldc.r8 5
-		IL_041b: box [System.Runtime]System.Double
-		IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0425: stloc.s 45
-		IL_0427: ldloc.s 38
-		IL_0429: ldstr "log"
-		IL_042e: ldstr "calls"
-		IL_0433: ldloc.s 44
-		IL_0435: ldloc.s 45
-		IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_043c: pop
+		IL_0346: ldloc.s 6
+		IL_0348: ldstr "value"
+		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0352: stloc.s 44
+		IL_0354: ldloc.s 44
+		IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_035b: ldstr "call"
+		IL_0360: ldloc.s 5
+		IL_0362: ldc.r8 5
+		IL_036b: box [System.Runtime]System.Double
+		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0375: stloc.s 44
+		IL_0377: ldloc.s 37
+		IL_0379: ldstr "log"
+		IL_037e: ldstr "calls"
+		IL_0383: ldloc.s 43
+		IL_0385: ldloc.s 44
+		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_038c: pop
+		IL_038d: ldloc.s 5
+		IL_038f: ldstr "current"
+		IL_0394: ldc.r8 9
+		IL_039d: ldc.i4.1
+		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_03a3: pop
+		IL_03a4: ldstr "console"
+		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03b3: stloc.s 44
+		IL_03b5: ldloc.s 5
+		IL_03b7: ldstr "current"
+		IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03c1: stloc.s 43
+		IL_03c3: ldloc.s 7
+		IL_03c5: ldstr "get"
+		IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03cf: stloc.s 37
+		IL_03d1: ldloc.s 37
+		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03d8: ldstr "call"
+		IL_03dd: ldloc.s 5
+		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03e4: stloc.s 37
+		IL_03e6: ldloc.s 44
+		IL_03e8: ldstr "log"
+		IL_03ed: ldstr "accessors"
+		IL_03f2: ldloc.s 43
+		IL_03f4: ldloc.s 37
+		IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_03fb: pop
+		IL_03fc: ldloc.s 7
+		IL_03fe: ldstr "set"
+		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0408: stloc.s 37
+		IL_040a: ldloc.s 37
+		IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0411: ldstr "call"
+		IL_0416: ldloc.s 5
+		IL_0418: ldc.r8 11
+		IL_0421: box [System.Runtime]System.Double
+		IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_042b: pop
+		IL_042c: ldstr "console"
+		IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_043b: stloc.s 37
 		IL_043d: ldloc.s 5
 		IL_043f: ldstr "current"
-		IL_0444: ldc.r8 9
-		IL_044d: ldc.i4.1
-		IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0453: pop
-		IL_0454: ldstr "console"
-		IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0463: stloc.s 45
-		IL_0465: ldloc.s 5
-		IL_0467: ldstr "current"
-		IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0471: stloc.s 44
-		IL_0473: ldloc.s 7
-		IL_0475: ldstr "get"
-		IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_047f: stloc.s 38
-		IL_0481: ldloc.s 38
-		IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0488: ldstr "call"
-		IL_048d: ldloc.s 5
-		IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0494: stloc.s 38
-		IL_0496: ldloc.s 45
-		IL_0498: ldstr "log"
-		IL_049d: ldstr "accessors"
-		IL_04a2: ldloc.s 44
-		IL_04a4: ldloc.s 38
-		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_04ab: pop
-		IL_04ac: ldloc.s 7
-		IL_04ae: ldstr "set"
-		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04b8: stloc.s 38
-		IL_04ba: ldloc.s 38
-		IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04c1: ldstr "call"
-		IL_04c6: ldloc.s 5
-		IL_04c8: ldc.r8 11
-		IL_04d1: box [System.Runtime]System.Double
-		IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04db: pop
-		IL_04dc: ldstr "console"
-		IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04eb: stloc.s 38
-		IL_04ed: ldloc.s 5
-		IL_04ef: ldstr "current"
-		IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04f9: stloc.s 44
-		IL_04fb: ldloc.s 38
-		IL_04fd: ldstr "log"
-		IL_0502: ldstr "setter"
-		IL_0507: ldloc.s 44
-		IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_050e: pop
-		IL_050f: ldstr "console"
-		IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_051e: stloc.s 44
-		IL_0520: ldloc.s 4
-		IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_0527: stloc.s 38
-		IL_0529: ldstr "ok"
-		IL_052e: call object Modules.Classes_GeneratedMethodFunctionObjects/Example::identify(object)
-		IL_0533: stloc.s 45
-		IL_0535: ldloc.s 8
-		IL_0537: ldstr "value"
-		IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0541: stloc.s 38
-		IL_0543: ldloc.s 38
-		IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_054a: ldstr "call"
-		IL_054f: ldloc.s 4
-		IL_0551: ldstr "call"
-		IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_055b: stloc.s 38
-		IL_055d: ldloc.s 44
-		IL_055f: ldstr "log"
-		IL_0564: ldstr "static"
-		IL_0569: ldloc.s 45
-		IL_056b: ldloc.s 38
-		IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0572: pop
-		IL_0573: ldstr "console"
-		IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0582: stloc.s 38
-		IL_0584: ldloc.s 6
-		IL_0586: ldstr "value"
-		IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0590: stloc.s 45
-		IL_0592: ldloc.s 45
-		IL_0594: ldstr "name"
-		IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_059e: stloc.s 45
-		IL_05a0: ldloc.s 6
-		IL_05a2: ldstr "value"
-		IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05ac: stloc.s 44
-		IL_05ae: ldloc.s 44
-		IL_05b0: ldstr "length"
-		IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05ba: stloc.s 44
-		IL_05bc: ldloc.s 7
-		IL_05be: ldstr "get"
-		IL_05c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05c8: stloc.s 46
-		IL_05ca: ldloc.s 46
-		IL_05cc: ldstr "name"
-		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05d6: stloc.s 46
-		IL_05d8: ldloc.s 7
-		IL_05da: ldstr "set"
-		IL_05df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05e4: stloc.s 47
-		IL_05e6: ldloc.s 47
-		IL_05e8: ldstr "name"
-		IL_05ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05f2: stloc.s 47
-		IL_05f4: ldloc.s 8
-		IL_05f6: ldstr "value"
-		IL_05fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0600: stloc.s 48
-		IL_0602: ldloc.s 48
-		IL_0604: ldstr "name"
-		IL_0609: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_060e: stloc.s 48
-		IL_0610: ldloc.s 38
-		IL_0612: ldstr "log"
-		IL_0617: ldc.i4.6
-		IL_0618: newarr [System.Runtime]System.Object
-		IL_061d: dup
-		IL_061e: ldc.i4.0
-		IL_061f: ldstr "metadata"
-		IL_0624: stelem.ref
-		IL_0625: dup
-		IL_0626: ldc.i4.1
-		IL_0627: ldloc.s 45
-		IL_0629: stelem.ref
-		IL_062a: dup
-		IL_062b: ldc.i4.2
-		IL_062c: ldloc.s 44
-		IL_062e: stelem.ref
-		IL_062f: dup
-		IL_0630: ldc.i4.3
-		IL_0631: ldloc.s 46
-		IL_0633: stelem.ref
-		IL_0634: dup
-		IL_0635: ldc.i4.4
-		IL_0636: ldloc.s 47
-		IL_0638: stelem.ref
-		IL_0639: dup
-		IL_063a: ldc.i4.5
-		IL_063b: ldloc.s 48
-		IL_063d: stelem.ref
-		IL_063e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0643: pop
-		IL_0644: ldstr "console"
-		IL_0649: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0653: stloc.s 38
-		IL_0655: ldloc.s 6
-		IL_0657: ldstr "value"
-		IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0661: stloc.s 48
-		IL_0663: ldloc.s 4
-		IL_0665: ldstr "prototype"
-		IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_066f: stloc.s 47
-		IL_0671: ldloc.s 47
-		IL_0673: ldstr "add"
-		IL_0678: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_067d: stloc.s 47
-		IL_067f: ldloc.s 48
-		IL_0681: ldloc.s 47
-		IL_0683: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0688: stloc.s 49
-		IL_068a: ldloc.s 49
-		IL_068c: box [System.Runtime]System.Boolean
-		IL_0691: stloc.s 50
-		IL_0693: ldloc.s 7
-		IL_0695: ldstr "get"
-		IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_069f: stloc.s 47
-		IL_06a1: ldloc.s 4
-		IL_06a3: ldstr "prototype"
-		IL_06a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06ad: stloc.s 48
-		IL_06af: ldloc.s 48
-		IL_06b1: ldstr "current"
-		IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_06bb: ldstr "get"
-		IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06c5: stloc.s 48
-		IL_06c7: ldloc.s 47
-		IL_06c9: ldloc.s 48
-		IL_06cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_06d0: stloc.s 49
-		IL_06d2: ldloc.s 49
-		IL_06d4: box [System.Runtime]System.Boolean
-		IL_06d9: stloc.s 51
-		IL_06db: ldloc.s 6
-		IL_06dd: ldstr "value"
-		IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06e7: stloc.s 48
-		IL_06e9: ldloc.s 48
-		IL_06eb: ldstr "prototype"
-		IL_06f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_06f5: box [System.Runtime]System.Boolean
-		IL_06fa: stloc.s 52
-		IL_06fc: ldloc.s 38
-		IL_06fe: ldstr "log"
-		IL_0703: ldc.i4.4
-		IL_0704: newarr [System.Runtime]System.Object
-		IL_0709: dup
-		IL_070a: ldc.i4.0
-		IL_070b: ldstr "descriptors"
-		IL_0710: stelem.ref
-		IL_0711: dup
-		IL_0712: ldc.i4.1
-		IL_0713: ldloc.s 50
-		IL_0715: stelem.ref
-		IL_0716: dup
-		IL_0717: ldc.i4.2
-		IL_0718: ldloc.s 51
-		IL_071a: stelem.ref
-		IL_071b: dup
-		IL_071c: ldc.i4.3
-		IL_071d: ldloc.s 52
-		IL_071f: stelem.ref
-		IL_0720: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0725: pop
-		IL_0726: ldc.i4.0
-		IL_0727: box [System.Runtime]System.Boolean
-		IL_072c: stloc.s 9
+		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0449: stloc.s 43
+		IL_044b: ldloc.s 37
+		IL_044d: ldstr "log"
+		IL_0452: ldstr "setter"
+		IL_0457: ldloc.s 43
+		IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_045e: pop
+		IL_045f: ldstr "console"
+		IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_046e: stloc.s 43
+		IL_0470: ldloc.s 4
+		IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_0477: stloc.s 37
+		IL_0479: ldstr "ok"
+		IL_047e: call object Modules.Classes_GeneratedMethodFunctionObjects/Example::identify(object)
+		IL_0483: stloc.s 44
+		IL_0485: ldloc.s 8
+		IL_0487: ldstr "value"
+		IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0491: stloc.s 37
+		IL_0493: ldloc.s 37
+		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_049a: ldstr "call"
+		IL_049f: ldloc.s 4
+		IL_04a1: ldstr "call"
+		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04ab: stloc.s 37
+		IL_04ad: ldloc.s 43
+		IL_04af: ldstr "log"
+		IL_04b4: ldstr "static"
+		IL_04b9: ldloc.s 44
+		IL_04bb: ldloc.s 37
+		IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_04c2: pop
+		IL_04c3: ldstr "console"
+		IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04d2: stloc.s 37
+		IL_04d4: ldloc.s 6
+		IL_04d6: ldstr "value"
+		IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04e0: stloc.s 44
+		IL_04e2: ldloc.s 44
+		IL_04e4: ldstr "name"
+		IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04ee: stloc.s 44
+		IL_04f0: ldloc.s 6
+		IL_04f2: ldstr "value"
+		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04fc: stloc.s 43
+		IL_04fe: ldloc.s 43
+		IL_0500: ldstr "length"
+		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_050a: stloc.s 43
+		IL_050c: ldloc.s 7
+		IL_050e: ldstr "get"
+		IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0518: stloc.s 45
+		IL_051a: ldloc.s 45
+		IL_051c: ldstr "name"
+		IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0526: stloc.s 45
+		IL_0528: ldloc.s 7
+		IL_052a: ldstr "set"
+		IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0534: stloc.s 46
+		IL_0536: ldloc.s 46
+		IL_0538: ldstr "name"
+		IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0542: stloc.s 46
+		IL_0544: ldloc.s 8
+		IL_0546: ldstr "value"
+		IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0550: stloc.s 47
+		IL_0552: ldloc.s 47
+		IL_0554: ldstr "name"
+		IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_055e: stloc.s 47
+		IL_0560: ldloc.s 37
+		IL_0562: ldstr "log"
+		IL_0567: ldc.i4.6
+		IL_0568: newarr [System.Runtime]System.Object
+		IL_056d: dup
+		IL_056e: ldc.i4.0
+		IL_056f: ldstr "metadata"
+		IL_0574: stelem.ref
+		IL_0575: dup
+		IL_0576: ldc.i4.1
+		IL_0577: ldloc.s 44
+		IL_0579: stelem.ref
+		IL_057a: dup
+		IL_057b: ldc.i4.2
+		IL_057c: ldloc.s 43
+		IL_057e: stelem.ref
+		IL_057f: dup
+		IL_0580: ldc.i4.3
+		IL_0581: ldloc.s 45
+		IL_0583: stelem.ref
+		IL_0584: dup
+		IL_0585: ldc.i4.4
+		IL_0586: ldloc.s 46
+		IL_0588: stelem.ref
+		IL_0589: dup
+		IL_058a: ldc.i4.5
+		IL_058b: ldloc.s 47
+		IL_058d: stelem.ref
+		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0593: pop
+		IL_0594: ldstr "console"
+		IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05a3: stloc.s 37
+		IL_05a5: ldloc.s 6
+		IL_05a7: ldstr "value"
+		IL_05ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05b1: stloc.s 47
+		IL_05b3: ldloc.s 4
+		IL_05b5: ldstr "prototype"
+		IL_05ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05bf: stloc.s 46
+		IL_05c1: ldloc.s 46
+		IL_05c3: ldstr "add"
+		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05cd: stloc.s 46
+		IL_05cf: ldloc.s 47
+		IL_05d1: ldloc.s 46
+		IL_05d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05d8: stloc.s 48
+		IL_05da: ldloc.s 48
+		IL_05dc: box [System.Runtime]System.Boolean
+		IL_05e1: stloc.s 49
+		IL_05e3: ldloc.s 7
+		IL_05e5: ldstr "get"
+		IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ef: stloc.s 46
+		IL_05f1: ldloc.s 4
+		IL_05f3: ldstr "prototype"
+		IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05fd: stloc.s 47
+		IL_05ff: ldloc.s 47
+		IL_0601: ldstr "current"
+		IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_060b: ldstr "get"
+		IL_0610: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0615: stloc.s 47
+		IL_0617: ldloc.s 46
+		IL_0619: ldloc.s 47
+		IL_061b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0620: stloc.s 48
+		IL_0622: ldloc.s 48
+		IL_0624: box [System.Runtime]System.Boolean
+		IL_0629: stloc.s 50
+		IL_062b: ldloc.s 6
+		IL_062d: ldstr "value"
+		IL_0632: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0637: stloc.s 47
+		IL_0639: ldloc.s 47
+		IL_063b: ldstr "prototype"
+		IL_0640: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0645: box [System.Runtime]System.Boolean
+		IL_064a: stloc.s 51
+		IL_064c: ldloc.s 37
+		IL_064e: ldstr "log"
+		IL_0653: ldc.i4.4
+		IL_0654: newarr [System.Runtime]System.Object
+		IL_0659: dup
+		IL_065a: ldc.i4.0
+		IL_065b: ldstr "descriptors"
+		IL_0660: stelem.ref
+		IL_0661: dup
+		IL_0662: ldc.i4.1
+		IL_0663: ldloc.s 49
+		IL_0665: stelem.ref
+		IL_0666: dup
+		IL_0667: ldc.i4.2
+		IL_0668: ldloc.s 50
+		IL_066a: stelem.ref
+		IL_066b: dup
+		IL_066c: ldc.i4.3
+		IL_066d: ldloc.s 51
+		IL_066f: stelem.ref
+		IL_0670: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0675: pop
+		IL_0676: ldc.i4.0
+		IL_0677: box [System.Runtime]System.Boolean
+		IL_067c: stloc.s 9
 		.try
 		{
-			IL_072e: nop
-			IL_072f: ldstr "Reflect"
-			IL_0734: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_073e: stloc.s 38
-			IL_0740: ldloc.s 6
-			IL_0742: ldstr "value"
-			IL_0747: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_074c: stloc.s 48
-			IL_074e: ldc.i4.0
-			IL_074f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0754: stloc.s 53
-			IL_0756: ldloc.s 38
-			IL_0758: ldstr "construct"
-			IL_075d: ldloc.s 48
-			IL_075f: ldloc.s 53
-			IL_0761: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0766: pop
-			IL_0767: leave IL_07cb
+			IL_067e: nop
+			IL_067f: ldstr "Reflect"
+			IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_068e: stloc.s 37
+			IL_0690: ldloc.s 6
+			IL_0692: ldstr "value"
+			IL_0697: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_069c: stloc.s 47
+			IL_069e: ldc.i4.0
+			IL_069f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_06a4: stloc.s 52
+			IL_06a6: ldloc.s 37
+			IL_06a8: ldstr "construct"
+			IL_06ad: ldloc.s 47
+			IL_06af: ldloc.s 52
+			IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_06b6: pop
+			IL_06b7: leave IL_071b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_076c: stloc.s 10
-			IL_076e: ldloc.s 10
-			IL_0770: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0775: dup
-			IL_0776: brtrue IL_078c
+			IL_06bc: stloc.s 10
+			IL_06be: ldloc.s 10
+			IL_06c0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_06c5: dup
+			IL_06c6: brtrue IL_06dc
 
-			IL_077b: pop
-			IL_077c: ldloc.s 10
-			IL_077e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0783: dup
-			IL_0784: brtrue IL_0798
+			IL_06cb: pop
+			IL_06cc: ldloc.s 10
+			IL_06ce: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_06d3: dup
+			IL_06d4: brtrue IL_06e8
 
-			IL_0789: pop
-			IL_078a: rethrow
+			IL_06d9: pop
+			IL_06da: rethrow
 
-			IL_078c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0791: stloc.s 11
-			IL_0793: br IL_079a
+			IL_06dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_06e1: stloc.s 11
+			IL_06e3: br IL_06ea
 
-			IL_0798: stloc.s 11
+			IL_06e8: stloc.s 11
 
-			IL_079a: ldloc.s 11
-			IL_079c: stloc.s 12
-			IL_079e: ldloc.s 12
-			IL_07a0: stloc.s 48
-			IL_07a2: ldstr "TypeError"
-			IL_07a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07ac: stloc.s 38
-			IL_07ae: ldloc.s 48
-			IL_07b0: ldloc.s 38
-			IL_07b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_07b7: stloc.s 49
-			IL_07b9: ldloc.s 49
-			IL_07bb: box [System.Runtime]System.Boolean
-			IL_07c0: stloc.s 52
-			IL_07c2: ldloc.s 52
-			IL_07c4: stloc.s 9
-			IL_07c6: leave IL_07cb
+			IL_06ea: ldloc.s 11
+			IL_06ec: stloc.s 12
+			IL_06ee: ldloc.s 12
+			IL_06f0: stloc.s 47
+			IL_06f2: ldstr "TypeError"
+			IL_06f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06fc: stloc.s 37
+			IL_06fe: ldloc.s 47
+			IL_0700: ldloc.s 37
+			IL_0702: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0707: stloc.s 48
+			IL_0709: ldloc.s 48
+			IL_070b: box [System.Runtime]System.Boolean
+			IL_0710: stloc.s 51
+			IL_0712: ldloc.s 51
+			IL_0714: stloc.s 9
+			IL_0716: leave IL_071b
 		} // end handler
 
-		IL_07cb: ldstr "console"
-		IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07da: ldstr "log"
-		IL_07df: ldstr "nonconstructor"
-		IL_07e4: ldloc.s 9
-		IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_07eb: pop
-		IL_07ec: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_07f1: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_07f6: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_07fb: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0800: stloc.s 36
-		IL_0802: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_0807: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_080c: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_0811: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0816: stloc.s 37
-		IL_0818: ldloc.s 37
-		IL_081a: ldstr "prototype"
-		IL_081f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0824: stloc.s 38
-		IL_0826: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_082b: stloc.s 35
-		IL_082d: ldloc.s 36
-		IL_082f: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read::.ctor(class [System.Runtime]System.Object)
-		IL_0834: ldc.i4.0
-		IL_0835: conv.r8
-		IL_0836: ldstr "read"
-		IL_083b: ldc.i4.1
-		IL_083c: ldc.i4.1
-		IL_083d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0, float64, string, bool, bool)
-		IL_0842: stloc.s 54
-		IL_0844: ldloc.s 54
-		IL_0846: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0)
-		IL_084b: stloc.s 54
-		IL_084d: ldloc.s 38
-		IL_084f: ldstr "read"
-		IL_0854: ldloc.s 54
-		IL_0856: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_085b: pop
-		IL_085c: ldc.i4.1
-		IL_085d: newarr [System.Runtime]System.Object
-		IL_0862: dup
-		IL_0863: ldc.i4.0
-		IL_0864: ldloc.0
-		IL_0865: stelem.ref
-		IL_0866: stloc.s 35
-		IL_0868: ldloc.s 36
-		IL_086a: ldloc.s 35
-		IL_086c: ldc.r8 1
-		IL_0875: box [System.Runtime]System.Double
-		IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_087f: stloc.s 38
-		IL_0881: ldloc.s 38
-		IL_0883: stloc.s 13
-		IL_0885: ldc.i4.1
-		IL_0886: newarr [System.Runtime]System.Object
-		IL_088b: dup
-		IL_088c: ldc.i4.0
-		IL_088d: ldloc.0
-		IL_088e: stelem.ref
-		IL_088f: stloc.s 35
-		IL_0891: ldloc.s 35
-		IL_0893: ldc.i4.1
-		IL_0894: newarr [System.Runtime]System.Object
-		IL_0899: dup
-		IL_089a: ldc.i4.0
-		IL_089b: ldc.r8 17
-		IL_08a4: box [System.Runtime]System.Double
-		IL_08a9: stelem.ref
-		IL_08aa: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_08af: ldc.r8 17
-		IL_08b8: box [System.Runtime]System.Double
-		IL_08bd: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret::.ctor(object[], object)
-		IL_08c2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_08c7: stloc.s 14
-		IL_08c9: ldloc.s 14
-		IL_08cb: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_08d0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_08d5: ldstr "prototype"
-		IL_08da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_08df: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_08e4: ldloc.s 13
-		IL_08e6: ldstr "prototype"
-		IL_08eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08f0: stloc.s 38
-		IL_08f2: ldloc.s 38
-		IL_08f4: ldstr "read"
-		IL_08f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08fe: stloc.s 15
-		IL_0900: ldc.i4.0
-		IL_0901: box [System.Runtime]System.Boolean
-		IL_0906: stloc.s 16
+		IL_071b: ldstr "console"
+		IL_0720: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0725: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_072a: ldstr "log"
+		IL_072f: ldstr "nonconstructor"
+		IL_0734: ldloc.s 9
+		IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_073b: pop
+		IL_073c: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+		IL_0741: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0746: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+		IL_074b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0750: stloc.s 36
+		IL_0752: ldloc.s 36
+		IL_0754: ldstr "prototype"
+		IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_075e: stloc.s 37
+		IL_0760: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0765: stloc.s 35
+		IL_0767: ldloc.s 36
+		IL_0769: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read::.ctor(class [System.Runtime]System.Object)
+		IL_076e: ldc.i4.0
+		IL_076f: conv.r8
+		IL_0770: ldstr "read"
+		IL_0775: ldc.i4.1
+		IL_0776: ldc.i4.1
+		IL_0777: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0, float64, string, bool, bool)
+		IL_077c: stloc.s 53
+		IL_077e: ldloc.s 53
+		IL_0780: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0)
+		IL_0785: stloc.s 53
+		IL_0787: ldloc.s 37
+		IL_0789: ldstr "read"
+		IL_078e: ldloc.s 53
+		IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0795: pop
+		IL_0796: ldc.i4.1
+		IL_0797: newarr [System.Runtime]System.Object
+		IL_079c: dup
+		IL_079d: ldc.i4.0
+		IL_079e: ldloc.0
+		IL_079f: stelem.ref
+		IL_07a0: stloc.s 35
+		IL_07a2: ldloc.s 36
+		IL_07a4: ldloc.s 35
+		IL_07a6: ldc.r8 1
+		IL_07af: box [System.Runtime]System.Double
+		IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_07b9: stloc.s 37
+		IL_07bb: ldloc.s 37
+		IL_07bd: stloc.s 13
+		IL_07bf: ldc.i4.1
+		IL_07c0: newarr [System.Runtime]System.Object
+		IL_07c5: dup
+		IL_07c6: ldc.i4.0
+		IL_07c7: ldloc.0
+		IL_07c8: stelem.ref
+		IL_07c9: stloc.s 35
+		IL_07cb: ldloc.s 35
+		IL_07cd: ldc.i4.1
+		IL_07ce: newarr [System.Runtime]System.Object
+		IL_07d3: dup
+		IL_07d4: ldc.i4.0
+		IL_07d5: ldc.r8 17
+		IL_07de: box [System.Runtime]System.Double
+		IL_07e3: stelem.ref
+		IL_07e4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_07e9: ldc.r8 17
+		IL_07f2: box [System.Runtime]System.Double
+		IL_07f7: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret::.ctor(object[], object)
+		IL_07fc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0801: stloc.s 14
+		IL_0803: ldloc.s 14
+		IL_0805: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+		IL_080a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_080f: ldstr "prototype"
+		IL_0814: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0819: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_081e: ldloc.s 13
+		IL_0820: ldstr "prototype"
+		IL_0825: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_082a: stloc.s 37
+		IL_082c: ldloc.s 37
+		IL_082e: ldstr "read"
+		IL_0833: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0838: stloc.s 15
+		IL_083a: ldc.i4.0
+		IL_083b: box [System.Runtime]System.Boolean
+		IL_0840: stloc.s 16
 		.try
 		{
-			IL_0908: nop
-			IL_0909: ldloc.s 15
-			IL_090b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0910: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0915: stloc.s 55
-			IL_0917: ldstr "call"
-			IL_091c: ldloc.s 55
-			IL_091e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0923: pop
-			IL_0924: leave IL_0988
+			IL_0842: nop
+			IL_0843: ldloc.s 15
+			IL_0845: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_084a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_084f: stloc.s 54
+			IL_0851: ldstr "call"
+			IL_0856: ldloc.s 54
+			IL_0858: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_085d: pop
+			IL_085e: leave IL_08c2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0929: stloc.s 17
-			IL_092b: ldloc.s 17
-			IL_092d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0932: dup
-			IL_0933: brtrue IL_0949
+			IL_0863: stloc.s 17
+			IL_0865: ldloc.s 17
+			IL_0867: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_086c: dup
+			IL_086d: brtrue IL_0883
 
-			IL_0938: pop
-			IL_0939: ldloc.s 17
-			IL_093b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0940: dup
-			IL_0941: brtrue IL_0955
+			IL_0872: pop
+			IL_0873: ldloc.s 17
+			IL_0875: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_087a: dup
+			IL_087b: brtrue IL_088f
 
-			IL_0946: pop
-			IL_0947: rethrow
+			IL_0880: pop
+			IL_0881: rethrow
 
-			IL_0949: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_094e: stloc.s 18
-			IL_0950: br IL_0957
+			IL_0883: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0888: stloc.s 18
+			IL_088a: br IL_0891
 
-			IL_0955: stloc.s 18
+			IL_088f: stloc.s 18
 
-			IL_0957: ldloc.s 18
-			IL_0959: stloc.s 19
-			IL_095b: ldloc.s 19
-			IL_095d: stloc.s 38
-			IL_095f: ldstr "TypeError"
-			IL_0964: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0969: stloc.s 48
-			IL_096b: ldloc.s 38
-			IL_096d: ldloc.s 48
-			IL_096f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0974: stloc.s 49
-			IL_0976: ldloc.s 49
-			IL_0978: box [System.Runtime]System.Boolean
-			IL_097d: stloc.s 52
-			IL_097f: ldloc.s 52
-			IL_0981: stloc.s 16
-			IL_0983: leave IL_0988
+			IL_0891: ldloc.s 18
+			IL_0893: stloc.s 19
+			IL_0895: ldloc.s 19
+			IL_0897: stloc.s 37
+			IL_0899: ldstr "TypeError"
+			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08a3: stloc.s 47
+			IL_08a5: ldloc.s 37
+			IL_08a7: ldloc.s 47
+			IL_08a9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_08ae: stloc.s 48
+			IL_08b0: ldloc.s 48
+			IL_08b2: box [System.Runtime]System.Boolean
+			IL_08b7: stloc.s 51
+			IL_08b9: ldloc.s 51
+			IL_08bb: stloc.s 16
+			IL_08bd: leave IL_08c2
 		} // end handler
 
-		IL_0988: ldstr "console"
-		IL_098d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0992: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0997: stloc.s 48
-		IL_0999: ldloc.s 15
-		IL_099b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_09a0: ldstr "call"
-		IL_09a5: ldloc.s 14
-		IL_09a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_09ac: stloc.s 38
-		IL_09ae: ldloc.s 48
-		IL_09b0: ldstr "log"
-		IL_09b5: ldstr "private"
-		IL_09ba: ldloc.s 38
-		IL_09bc: ldloc.s 16
-		IL_09be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_09c3: pop
-		IL_09c4: nop
-		IL_09c5: ldloc.1
-		IL_09c6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_09cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_09d0: stloc.s 20
-		IL_09d2: ldloc.1
-		IL_09d3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_09d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_09dd: stloc.s 21
-		IL_09df: ldstr "console"
-		IL_09e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_09e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_09ee: stloc.s 38
-		IL_09f0: ldloc.s 20
-		IL_09f2: ldstr "prototype"
-		IL_09f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09fc: stloc.s 48
-		IL_09fe: ldloc.s 48
-		IL_0a00: ldstr "method"
-		IL_0a05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a0a: stloc.s 48
-		IL_0a0c: ldloc.s 21
-		IL_0a0e: ldstr "prototype"
-		IL_0a13: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a18: stloc.s 47
-		IL_0a1a: ldloc.s 47
-		IL_0a1c: ldstr "method"
-		IL_0a21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a26: stloc.s 47
-		IL_0a28: ldloc.s 48
-		IL_0a2a: ldloc.s 47
-		IL_0a2c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0a31: stloc.s 49
-		IL_0a33: ldloc.s 49
-		IL_0a35: box [System.Runtime]System.Boolean
-		IL_0a3a: stloc.s 52
-		IL_0a3c: ldloc.s 38
-		IL_0a3e: ldstr "log"
-		IL_0a43: ldstr "identity"
-		IL_0a48: ldloc.s 52
-		IL_0a4a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0a4f: pop
-		IL_0a50: nop
-		IL_0a51: ldloc.2
-		IL_0a52: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0a57: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0a5c: stloc.s 22
-		IL_0a5e: ldloc.2
-		IL_0a5f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0a64: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0a69: stloc.s 23
-		IL_0a6b: ldloc.s 22
-		IL_0a6d: ldc.i4.1
-		IL_0a6e: newarr [System.Runtime]System.Object
-		IL_0a73: dup
-		IL_0a74: ldc.i4.0
-		IL_0a75: ldc.r8 1
-		IL_0a7e: box [System.Runtime]System.Double
-		IL_0a83: stelem.ref
-		IL_0a84: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_0a89: stloc.s 24
-		IL_0a8b: ldloc.s 23
-		IL_0a8d: ldc.i4.1
-		IL_0a8e: newarr [System.Runtime]System.Object
-		IL_0a93: dup
-		IL_0a94: ldc.i4.0
-		IL_0a95: ldc.r8 2
-		IL_0a9e: box [System.Runtime]System.Double
-		IL_0aa3: stelem.ref
-		IL_0aa4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_0aa9: stloc.s 25
-		IL_0aab: ldc.i4.0
-		IL_0aac: box [System.Runtime]System.Boolean
-		IL_0ab1: stloc.s 26
+		IL_08c2: ldstr "console"
+		IL_08c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08d1: stloc.s 47
+		IL_08d3: ldloc.s 15
+		IL_08d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08da: ldstr "call"
+		IL_08df: ldloc.s 14
+		IL_08e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_08e6: stloc.s 37
+		IL_08e8: ldloc.s 47
+		IL_08ea: ldstr "log"
+		IL_08ef: ldstr "private"
+		IL_08f4: ldloc.s 37
+		IL_08f6: ldloc.s 16
+		IL_08f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_08fd: pop
+		IL_08fe: nop
+		IL_08ff: ldloc.1
+		IL_0900: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0905: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_090a: stloc.s 20
+		IL_090c: ldloc.1
+		IL_090d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0912: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0917: stloc.s 21
+		IL_0919: ldstr "console"
+		IL_091e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0923: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0928: stloc.s 37
+		IL_092a: ldloc.s 20
+		IL_092c: ldstr "prototype"
+		IL_0931: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0936: stloc.s 47
+		IL_0938: ldloc.s 47
+		IL_093a: ldstr "method"
+		IL_093f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0944: stloc.s 47
+		IL_0946: ldloc.s 21
+		IL_0948: ldstr "prototype"
+		IL_094d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0952: stloc.s 46
+		IL_0954: ldloc.s 46
+		IL_0956: ldstr "method"
+		IL_095b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0960: stloc.s 46
+		IL_0962: ldloc.s 47
+		IL_0964: ldloc.s 46
+		IL_0966: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_096b: stloc.s 48
+		IL_096d: ldloc.s 48
+		IL_096f: box [System.Runtime]System.Boolean
+		IL_0974: stloc.s 51
+		IL_0976: ldloc.s 37
+		IL_0978: ldstr "log"
+		IL_097d: ldstr "identity"
+		IL_0982: ldloc.s 51
+		IL_0984: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0989: pop
+		IL_098a: nop
+		IL_098b: ldloc.2
+		IL_098c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0991: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0996: stloc.s 22
+		IL_0998: ldloc.2
+		IL_0999: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_099e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_09a3: stloc.s 23
+		IL_09a5: ldloc.s 22
+		IL_09a7: ldc.i4.1
+		IL_09a8: newarr [System.Runtime]System.Object
+		IL_09ad: dup
+		IL_09ae: ldc.i4.0
+		IL_09af: ldc.r8 1
+		IL_09b8: box [System.Runtime]System.Double
+		IL_09bd: stelem.ref
+		IL_09be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_09c3: stloc.s 24
+		IL_09c5: ldloc.s 23
+		IL_09c7: ldc.i4.1
+		IL_09c8: newarr [System.Runtime]System.Object
+		IL_09cd: dup
+		IL_09ce: ldc.i4.0
+		IL_09cf: ldc.r8 2
+		IL_09d8: box [System.Runtime]System.Double
+		IL_09dd: stelem.ref
+		IL_09de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_09e3: stloc.s 25
+		IL_09e5: ldc.i4.0
+		IL_09e6: box [System.Runtime]System.Boolean
+		IL_09eb: stloc.s 26
 		.try
 		{
-			IL_0ab3: nop
-			IL_0ab4: ldloc.s 22
-			IL_0ab6: ldstr "prototype"
-			IL_0abb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ac0: stloc.s 38
-			IL_0ac2: ldloc.s 38
-			IL_0ac4: ldstr "read"
-			IL_0ac9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ace: stloc.s 38
-			IL_0ad0: ldloc.s 38
-			IL_0ad2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0ad7: ldstr "call"
-			IL_0adc: ldloc.s 25
-			IL_0ade: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0ae3: pop
-			IL_0ae4: leave IL_0b48
+			IL_09ed: nop
+			IL_09ee: ldloc.s 22
+			IL_09f0: ldstr "prototype"
+			IL_09f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09fa: stloc.s 37
+			IL_09fc: ldloc.s 37
+			IL_09fe: ldstr "read"
+			IL_0a03: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a08: stloc.s 37
+			IL_0a0a: ldloc.s 37
+			IL_0a0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a11: ldstr "call"
+			IL_0a16: ldloc.s 25
+			IL_0a18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0a1d: pop
+			IL_0a1e: leave IL_0a82
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0ae9: stloc.s 27
-			IL_0aeb: ldloc.s 27
-			IL_0aed: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0af2: dup
-			IL_0af3: brtrue IL_0b09
+			IL_0a23: stloc.s 27
+			IL_0a25: ldloc.s 27
+			IL_0a27: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0a2c: dup
+			IL_0a2d: brtrue IL_0a43
 
-			IL_0af8: pop
-			IL_0af9: ldloc.s 27
-			IL_0afb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0b00: dup
-			IL_0b01: brtrue IL_0b15
+			IL_0a32: pop
+			IL_0a33: ldloc.s 27
+			IL_0a35: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0a3a: dup
+			IL_0a3b: brtrue IL_0a4f
 
-			IL_0b06: pop
-			IL_0b07: rethrow
+			IL_0a40: pop
+			IL_0a41: rethrow
 
-			IL_0b09: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0b0e: stloc.s 28
-			IL_0b10: br IL_0b17
+			IL_0a43: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0a48: stloc.s 28
+			IL_0a4a: br IL_0a51
 
-			IL_0b15: stloc.s 28
+			IL_0a4f: stloc.s 28
 
-			IL_0b17: ldloc.s 28
-			IL_0b19: stloc.s 29
-			IL_0b1b: ldloc.s 29
-			IL_0b1d: stloc.s 38
-			IL_0b1f: ldstr "TypeError"
-			IL_0b24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b29: stloc.s 47
-			IL_0b2b: ldloc.s 38
-			IL_0b2d: ldloc.s 47
-			IL_0b2f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0b34: stloc.s 49
-			IL_0b36: ldloc.s 49
-			IL_0b38: box [System.Runtime]System.Boolean
-			IL_0b3d: stloc.s 52
-			IL_0b3f: ldloc.s 52
-			IL_0b41: stloc.s 26
-			IL_0b43: leave IL_0b48
+			IL_0a51: ldloc.s 28
+			IL_0a53: stloc.s 29
+			IL_0a55: ldloc.s 29
+			IL_0a57: stloc.s 37
+			IL_0a59: ldstr "TypeError"
+			IL_0a5e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a63: stloc.s 46
+			IL_0a65: ldloc.s 37
+			IL_0a67: ldloc.s 46
+			IL_0a69: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0a6e: stloc.s 48
+			IL_0a70: ldloc.s 48
+			IL_0a72: box [System.Runtime]System.Boolean
+			IL_0a77: stloc.s 51
+			IL_0a79: ldloc.s 51
+			IL_0a7b: stloc.s 26
+			IL_0a7d: leave IL_0a82
 		} // end handler
 
-		IL_0b48: ldstr "console"
-		IL_0b4d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0b52: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0b57: stloc.s 47
-		IL_0b59: ldloc.s 22
-		IL_0b5b: ldstr "prototype"
-		IL_0b60: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b65: stloc.s 38
-		IL_0b67: ldloc.s 23
-		IL_0b69: ldstr "prototype"
-		IL_0b6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b73: stloc.s 48
-		IL_0b75: ldloc.s 38
-		IL_0b77: ldloc.s 48
-		IL_0b79: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0b7e: stloc.s 49
-		IL_0b80: ldloc.s 49
-		IL_0b82: box [System.Runtime]System.Boolean
-		IL_0b87: stloc.s 52
-		IL_0b89: ldloc.s 22
-		IL_0b8b: ldstr "prototype"
-		IL_0b90: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b95: stloc.s 48
-		IL_0b97: ldloc.s 48
-		IL_0b99: ldstr "read"
-		IL_0b9e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ba3: stloc.s 48
-		IL_0ba5: ldloc.s 23
-		IL_0ba7: ldstr "prototype"
-		IL_0bac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0bb1: stloc.s 38
-		IL_0bb3: ldloc.s 38
-		IL_0bb5: ldstr "read"
-		IL_0bba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0bbf: stloc.s 38
-		IL_0bc1: ldloc.s 48
-		IL_0bc3: ldloc.s 38
-		IL_0bc5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0bca: stloc.s 49
-		IL_0bcc: ldloc.s 49
-		IL_0bce: box [System.Runtime]System.Boolean
-		IL_0bd3: stloc.s 51
-		IL_0bd5: ldloc.s 22
-		IL_0bd7: ldstr "prototype"
-		IL_0bdc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0be1: stloc.s 38
-		IL_0be3: ldloc.s 38
-		IL_0be5: ldstr "read"
-		IL_0bea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0bef: stloc.s 38
-		IL_0bf1: ldloc.s 38
-		IL_0bf3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0bf8: ldstr "call"
-		IL_0bfd: ldloc.s 24
-		IL_0bff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0c04: stloc.s 38
-		IL_0c06: ldloc.s 47
-		IL_0c08: ldstr "log"
-		IL_0c0d: ldc.i4.5
-		IL_0c0e: newarr [System.Runtime]System.Object
-		IL_0c13: dup
-		IL_0c14: ldc.i4.0
-		IL_0c15: ldstr "privateIdentity"
-		IL_0c1a: stelem.ref
-		IL_0c1b: dup
-		IL_0c1c: ldc.i4.1
-		IL_0c1d: ldloc.s 52
-		IL_0c1f: stelem.ref
-		IL_0c20: dup
-		IL_0c21: ldc.i4.2
-		IL_0c22: ldloc.s 51
-		IL_0c24: stelem.ref
-		IL_0c25: dup
-		IL_0c26: ldc.i4.3
-		IL_0c27: ldloc.s 38
-		IL_0c29: stelem.ref
-		IL_0c2a: dup
-		IL_0c2b: ldc.i4.4
-		IL_0c2c: ldloc.s 26
-		IL_0c2e: stelem.ref
-		IL_0c2f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0c34: pop
-		IL_0c35: ldc.i4.0
-		IL_0c36: box [System.Runtime]System.Boolean
-		IL_0c3b: stloc.s 30
+		IL_0a82: ldstr "console"
+		IL_0a87: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0a8c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0a91: stloc.s 46
+		IL_0a93: ldloc.s 22
+		IL_0a95: ldstr "prototype"
+		IL_0a9a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a9f: stloc.s 37
+		IL_0aa1: ldloc.s 23
+		IL_0aa3: ldstr "prototype"
+		IL_0aa8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0aad: stloc.s 47
+		IL_0aaf: ldloc.s 37
+		IL_0ab1: ldloc.s 47
+		IL_0ab3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0ab8: stloc.s 48
+		IL_0aba: ldloc.s 48
+		IL_0abc: box [System.Runtime]System.Boolean
+		IL_0ac1: stloc.s 51
+		IL_0ac3: ldloc.s 22
+		IL_0ac5: ldstr "prototype"
+		IL_0aca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0acf: stloc.s 47
+		IL_0ad1: ldloc.s 47
+		IL_0ad3: ldstr "read"
+		IL_0ad8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0add: stloc.s 47
+		IL_0adf: ldloc.s 23
+		IL_0ae1: ldstr "prototype"
+		IL_0ae6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0aeb: stloc.s 37
+		IL_0aed: ldloc.s 37
+		IL_0aef: ldstr "read"
+		IL_0af4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0af9: stloc.s 37
+		IL_0afb: ldloc.s 47
+		IL_0afd: ldloc.s 37
+		IL_0aff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0b04: stloc.s 48
+		IL_0b06: ldloc.s 48
+		IL_0b08: box [System.Runtime]System.Boolean
+		IL_0b0d: stloc.s 50
+		IL_0b0f: ldloc.s 22
+		IL_0b11: ldstr "prototype"
+		IL_0b16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b1b: stloc.s 37
+		IL_0b1d: ldloc.s 37
+		IL_0b1f: ldstr "read"
+		IL_0b24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b29: stloc.s 37
+		IL_0b2b: ldloc.s 37
+		IL_0b2d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0b32: ldstr "call"
+		IL_0b37: ldloc.s 24
+		IL_0b39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0b3e: stloc.s 37
+		IL_0b40: ldloc.s 46
+		IL_0b42: ldstr "log"
+		IL_0b47: ldc.i4.5
+		IL_0b48: newarr [System.Runtime]System.Object
+		IL_0b4d: dup
+		IL_0b4e: ldc.i4.0
+		IL_0b4f: ldstr "privateIdentity"
+		IL_0b54: stelem.ref
+		IL_0b55: dup
+		IL_0b56: ldc.i4.1
+		IL_0b57: ldloc.s 51
+		IL_0b59: stelem.ref
+		IL_0b5a: dup
+		IL_0b5b: ldc.i4.2
+		IL_0b5c: ldloc.s 50
+		IL_0b5e: stelem.ref
+		IL_0b5f: dup
+		IL_0b60: ldc.i4.3
+		IL_0b61: ldloc.s 37
+		IL_0b63: stelem.ref
+		IL_0b64: dup
+		IL_0b65: ldc.i4.4
+		IL_0b66: ldloc.s 26
+		IL_0b68: stelem.ref
+		IL_0b69: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0b6e: pop
+		IL_0b6f: ldc.i4.0
+		IL_0b70: box [System.Runtime]System.Boolean
+		IL_0b75: stloc.s 30
 		.try
 		{
-			IL_0c3d: nop
-			IL_0c3e: ldloc.s 22
-			IL_0c40: ldstr "readStatic"
-			IL_0c45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c4a: stloc.s 47
-			IL_0c4c: ldloc.s 47
-			IL_0c4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0c53: ldstr "call"
-			IL_0c58: ldloc.s 23
-			IL_0c5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0c5f: pop
-			IL_0c60: leave IL_0cc4
+			IL_0b77: nop
+			IL_0b78: ldloc.s 22
+			IL_0b7a: ldstr "readStatic"
+			IL_0b7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b84: stloc.s 46
+			IL_0b86: ldloc.s 46
+			IL_0b88: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b8d: ldstr "call"
+			IL_0b92: ldloc.s 23
+			IL_0b94: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0b99: pop
+			IL_0b9a: leave IL_0bfe
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0c65: stloc.s 31
-			IL_0c67: ldloc.s 31
-			IL_0c69: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0c6e: dup
-			IL_0c6f: brtrue IL_0c85
+			IL_0b9f: stloc.s 31
+			IL_0ba1: ldloc.s 31
+			IL_0ba3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0ba8: dup
+			IL_0ba9: brtrue IL_0bbf
 
-			IL_0c74: pop
-			IL_0c75: ldloc.s 31
-			IL_0c77: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0c7c: dup
-			IL_0c7d: brtrue IL_0c91
+			IL_0bae: pop
+			IL_0baf: ldloc.s 31
+			IL_0bb1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0bb6: dup
+			IL_0bb7: brtrue IL_0bcb
 
-			IL_0c82: pop
-			IL_0c83: rethrow
+			IL_0bbc: pop
+			IL_0bbd: rethrow
 
-			IL_0c85: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0c8a: stloc.s 32
-			IL_0c8c: br IL_0c93
+			IL_0bbf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0bc4: stloc.s 32
+			IL_0bc6: br IL_0bcd
 
-			IL_0c91: stloc.s 32
+			IL_0bcb: stloc.s 32
 
-			IL_0c93: ldloc.s 32
-			IL_0c95: stloc.s 33
-			IL_0c97: ldloc.s 33
-			IL_0c99: stloc.s 47
-			IL_0c9b: ldstr "TypeError"
-			IL_0ca0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ca5: stloc.s 38
-			IL_0ca7: ldloc.s 47
-			IL_0ca9: ldloc.s 38
-			IL_0cab: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0cb0: stloc.s 49
-			IL_0cb2: ldloc.s 49
-			IL_0cb4: box [System.Runtime]System.Boolean
-			IL_0cb9: stloc.s 51
-			IL_0cbb: ldloc.s 51
-			IL_0cbd: stloc.s 30
-			IL_0cbf: leave IL_0cc4
+			IL_0bcd: ldloc.s 32
+			IL_0bcf: stloc.s 33
+			IL_0bd1: ldloc.s 33
+			IL_0bd3: stloc.s 46
+			IL_0bd5: ldstr "TypeError"
+			IL_0bda: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0bdf: stloc.s 37
+			IL_0be1: ldloc.s 46
+			IL_0be3: ldloc.s 37
+			IL_0be5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0bea: stloc.s 48
+			IL_0bec: ldloc.s 48
+			IL_0bee: box [System.Runtime]System.Boolean
+			IL_0bf3: stloc.s 50
+			IL_0bf5: ldloc.s 50
+			IL_0bf7: stloc.s 30
+			IL_0bf9: leave IL_0bfe
 		} // end handler
 
-		IL_0cc4: ldstr "console"
-		IL_0cc9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0cce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0cd3: stloc.s 38
-		IL_0cd5: ldloc.s 22
-		IL_0cd7: ldstr "readStatic"
-		IL_0cdc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ce1: stloc.s 47
-		IL_0ce3: ldloc.s 23
-		IL_0ce5: ldstr "readStatic"
-		IL_0cea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0cef: stloc.s 48
-		IL_0cf1: ldloc.s 47
-		IL_0cf3: ldloc.s 48
-		IL_0cf5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0cfa: stloc.s 49
-		IL_0cfc: ldloc.s 49
-		IL_0cfe: box [System.Runtime]System.Boolean
-		IL_0d03: stloc.s 51
-		IL_0d05: ldloc.s 22
-		IL_0d07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0d0c: ldstr "readStatic"
-		IL_0d11: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0d16: stloc.s 48
-		IL_0d18: ldloc.s 38
-		IL_0d1a: ldstr "log"
-		IL_0d1f: ldc.i4.4
-		IL_0d20: newarr [System.Runtime]System.Object
-		IL_0d25: dup
-		IL_0d26: ldc.i4.0
-		IL_0d27: ldstr "staticPrivateIdentity"
-		IL_0d2c: stelem.ref
-		IL_0d2d: dup
-		IL_0d2e: ldc.i4.1
-		IL_0d2f: ldloc.s 51
-		IL_0d31: stelem.ref
-		IL_0d32: dup
-		IL_0d33: ldc.i4.2
-		IL_0d34: ldloc.s 48
-		IL_0d36: stelem.ref
-		IL_0d37: dup
-		IL_0d38: ldc.i4.3
-		IL_0d39: ldloc.s 30
-		IL_0d3b: stelem.ref
-		IL_0d3c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0d41: pop
-		IL_0d42: ldnull
-		IL_0d43: stloc.s 34
-		IL_0d45: ret
+		IL_0bfe: ldstr "console"
+		IL_0c03: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0c08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0c0d: stloc.s 37
+		IL_0c0f: ldloc.s 22
+		IL_0c11: ldstr "readStatic"
+		IL_0c16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0c1b: stloc.s 46
+		IL_0c1d: ldloc.s 23
+		IL_0c1f: ldstr "readStatic"
+		IL_0c24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0c29: stloc.s 47
+		IL_0c2b: ldloc.s 46
+		IL_0c2d: ldloc.s 47
+		IL_0c2f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0c34: stloc.s 48
+		IL_0c36: ldloc.s 48
+		IL_0c38: box [System.Runtime]System.Boolean
+		IL_0c3d: stloc.s 50
+		IL_0c3f: ldloc.s 22
+		IL_0c41: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0c46: ldstr "readStatic"
+		IL_0c4b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0c50: stloc.s 47
+		IL_0c52: ldloc.s 37
+		IL_0c54: ldstr "log"
+		IL_0c59: ldc.i4.4
+		IL_0c5a: newarr [System.Runtime]System.Object
+		IL_0c5f: dup
+		IL_0c60: ldc.i4.0
+		IL_0c61: ldstr "staticPrivateIdentity"
+		IL_0c66: stelem.ref
+		IL_0c67: dup
+		IL_0c68: ldc.i4.1
+		IL_0c69: ldloc.s 50
+		IL_0c6b: stelem.ref
+		IL_0c6c: dup
+		IL_0c6d: ldc.i4.2
+		IL_0c6e: ldloc.s 47
+		IL_0c70: stelem.ref
+		IL_0c71: dup
+		IL_0c72: ldc.i4.3
+		IL_0c73: ldloc.s 30
+		IL_0c75: stelem.ref
+		IL_0c76: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0c7b: pop
+		IL_0c7c: ldnull
+		IL_0c7d: stloc.s 34
+		IL_0c7f: ret
 	} // end of method Classes_GeneratedMethodFunctionObjects::__js_module_init__
 
 } // end of class Modules.Classes_GeneratedMethodFunctionObjects
@@ -3754,7 +3696,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x357b
+		// Method begins at RVA 0x3483
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2317
+					// Method begins at RVA 0x22df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2320
+					// Method begins at RVA 0x22e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 						object[] capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x23be
+					// Method begins at RVA 0x2386
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -83,7 +83,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x23cd
+					// Method begins at RVA 0x2395
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -95,7 +95,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x23d0
+					// Method begins at RVA 0x2398
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -110,7 +110,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x23d3
+					// Method begins at RVA 0x239b
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -126,7 +126,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x23df
+					// Method begins at RVA 0x23a7
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -152,7 +152,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x23eb
+					// Method begins at RVA 0x23b3
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -171,7 +171,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2401
+					// Method begins at RVA 0x23c9
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -183,7 +183,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2404
+					// Method begins at RVA 0x23cc
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -195,7 +195,7 @@
 				.method family hidebysig virtual 
 					instance object GetLexicalSuperReceiverCore () cil managed 
 				{
-					// Method begins at RVA 0x2407
+					// Method begins at RVA 0x23cf
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -208,7 +208,7 @@
 				.method family hidebysig virtual 
 					instance object[] GetLexicalSuperScopesCore () cil managed 
 				{
-					// Method begins at RVA 0x240f
+					// Method begins at RVA 0x23d7
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -224,7 +224,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2417
+					// Method begins at RVA 0x23df
 					// Header size: 1
 					// Code size: 35 (0x23)
 					.maxstack 8
@@ -252,7 +252,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22b3
+				// Method begins at RVA 0x227c
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -270,7 +270,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22c4
+				// Method begins at RVA 0x228c
 				// Header size: 12
 				// Code size: 24 (0x18)
 				.maxstack 8
@@ -297,7 +297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230e
+				// Method begins at RVA 0x22d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -317,7 +317,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x238d
+				// Method begins at RVA 0x2355
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -330,7 +330,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2395
+				// Method begins at RVA 0x235d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -342,7 +342,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2398
+				// Method begins at RVA 0x2360
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -357,7 +357,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x239b
+				// Method begins at RVA 0x2363
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -374,7 +374,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x23a7
+				// Method begins at RVA 0x236f
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -390,7 +390,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x23af
+				// Method begins at RVA 0x2377
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -415,19 +415,18 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2124
+			// Method begins at RVA 0x2110
 			// Header size: 12
-			// Code size: 379 (0x17b)
+			// Code size: 344 (0x158)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/Scope,
 				[1] object,
 				[2] class [System.Runtime]System.Type,
-				[3] class [System.Runtime]System.Type,
-				[4] object,
-				[5] object[],
-				[6] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n,
-				[7] object
+				[3] object,
+				[4] object[],
+				[5] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n,
+				[6] object
 			)
 
 			IL_0000: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/Scope::.ctor()
@@ -437,111 +436,106 @@
 			IL_0010: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
 			IL_0015: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_001a: stloc.2
-			IL_001b: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
-			IL_0020: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0025: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
-			IL_002a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_002f: stloc.3
-			IL_0030: ldloc.3
-			IL_0031: ldstr "prototype"
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003b: stloc.s 4
-			IL_003d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0042: stloc.s 5
-			IL_0044: ldloc.s 4
+			IL_001b: ldloc.2
+			IL_001c: ldstr "prototype"
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0026: stloc.3
+			IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_002c: stloc.s 4
+			IL_002e: ldloc.3
+			IL_002f: ldloc.s 4
+			IL_0031: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::.ctor(class [System.Runtime]System.Object, object[])
+			IL_0036: ldc.i4.0
+			IL_0037: conv.r8
+			IL_0038: ldstr "n"
+			IL_003d: ldc.i4.1
+			IL_003e: ldc.i4.1
+			IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0, float64, string, bool, bool)
+			IL_0044: stloc.s 5
 			IL_0046: ldloc.s 5
-			IL_0048: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::.ctor(class [System.Runtime]System.Object, object[])
-			IL_004d: ldc.i4.0
-			IL_004e: conv.r8
-			IL_004f: ldstr "n"
-			IL_0054: ldc.i4.1
-			IL_0055: ldc.i4.1
-			IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0, float64, string, bool, bool)
-			IL_005b: stloc.s 6
-			IL_005d: ldloc.s 6
-			IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0)
-			IL_0064: stloc.s 6
-			IL_0066: ldloc.s 4
-			IL_0068: ldstr "n"
-			IL_006d: ldloc.s 6
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_0074: pop
-			IL_0075: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_007a: stloc.s 5
-			IL_007c: ldloc.2
-			IL_007d: ldloc.s 5
-			IL_007f: ldc.r8 0.0
-			IL_0088: box [System.Runtime]System.Double
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_0092: stloc.s 4
-			IL_0094: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0099: stloc.s 5
-			IL_009b: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
-			IL_00a0: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00a5: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
-			IL_00aa: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00af: stloc.2
-			IL_00b0: ldloc.2
-			IL_00b1: ldloc.s 5
-			IL_00b3: ldc.r8 0.0
-			IL_00bc: box [System.Runtime]System.Double
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_00c6: stloc.s 7
-			IL_00c8: ldloc.s 4
-			IL_00ca: ldloc.s 7
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-			IL_00d1: stloc.s 7
-			IL_00d3: ldloc.s 7
-			IL_00d5: stloc.1
-			IL_00d6: ldstr "console"
-			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e5: stloc.s 7
-			IL_00e7: ldc.i4.0
-			IL_00e8: newarr [System.Runtime]System.Object
-			IL_00ed: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_00f2: ldloc.1
-			IL_00f3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-			IL_00f8: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-			IL_00fd: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::.ctor()
-			IL_0102: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-			IL_0107: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_010c: dup
-			IL_010d: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
-			IL_0112: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0117: ldstr "prototype"
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_0121: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0126: stloc.s 4
-			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_0132: stloc.s 4
-			IL_0134: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-			IL_0139: ldloc.s 4
-			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0140: stloc.s 4
-			IL_0142: ldloc.s 4
-			IL_0144: isinst Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
-			IL_0149: dup
-			IL_014a: brfalse IL_015b
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0)
+			IL_004d: stloc.s 5
+			IL_004f: ldloc.3
+			IL_0050: ldstr "n"
+			IL_0055: ldloc.s 5
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_005c: pop
+			IL_005d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0062: stloc.s 4
+			IL_0064: ldloc.2
+			IL_0065: ldloc.s 4
+			IL_0067: ldc.r8 0.0
+			IL_0070: box [System.Runtime]System.Double
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_007a: stloc.3
+			IL_007b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0080: stloc.s 4
+			IL_0082: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
+			IL_0087: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_008c: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
+			IL_0091: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0096: stloc.2
+			IL_0097: ldloc.2
+			IL_0098: ldloc.s 4
+			IL_009a: ldc.r8 0.0
+			IL_00a3: box [System.Runtime]System.Double
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_00ad: stloc.s 6
+			IL_00af: ldloc.3
+			IL_00b0: ldloc.s 6
+			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+			IL_00b7: stloc.s 6
+			IL_00b9: ldloc.s 6
+			IL_00bb: stloc.1
+			IL_00bc: ldstr "console"
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00cb: stloc.s 6
+			IL_00cd: ldc.i4.0
+			IL_00ce: newarr [System.Runtime]System.Object
+			IL_00d3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_00d8: ldloc.1
+			IL_00d9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+			IL_00de: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+			IL_00e3: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::.ctor()
+			IL_00e8: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+			IL_00ed: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_00f2: dup
+			IL_00f3: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
+			IL_00f8: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_00fd: ldstr "prototype"
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0107: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_010c: stloc.3
+			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0117: stloc.3
+			IL_0118: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+			IL_011d: ldloc.3
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0123: stloc.3
+			IL_0124: ldloc.3
+			IL_0125: isinst Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
+			IL_012a: dup
+			IL_012b: brfalse IL_013b
 
-			IL_014f: callvirt instance object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::n()
-			IL_0154: stloc.s 4
-			IL_0156: br IL_016a
+			IL_0130: callvirt instance object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::n()
+			IL_0135: stloc.3
+			IL_0136: br IL_0148
 
-			IL_015b: pop
-			IL_015c: ldloc.s 4
-			IL_015e: ldstr "n"
-			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0168: stloc.s 4
+			IL_013b: pop
+			IL_013c: ldloc.3
+			IL_013d: ldstr "n"
+			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0147: stloc.3
 
-			IL_016a: ldloc.s 7
-			IL_016c: ldstr "log"
-			IL_0171: ldloc.s 4
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0178: pop
-			IL_0179: ldnull
-			IL_017a: ret
+			IL_0148: ldloc.s 6
+			IL_014a: ldstr "log"
+			IL_014f: ldloc.3
+			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0155: pop
+			IL_0156: ldnull
+			IL_0157: ret
 		} // end of method makeAndRun::__js_call__
 
 	} // end of class makeAndRun
@@ -557,7 +551,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22fc
+				// Method begins at RVA 0x22c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -577,7 +571,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2305
+				// Method begins at RVA 0x22cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -602,7 +596,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2329
+				// Method begins at RVA 0x22f1
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -618,7 +612,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2338
+				// Method begins at RVA 0x2300
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -630,7 +624,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x233b
+				// Method begins at RVA 0x2303
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -645,7 +639,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x233e
+				// Method begins at RVA 0x2306
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -661,7 +655,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x234a
+				// Method begins at RVA 0x2312
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -680,7 +674,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2356
+				// Method begins at RVA 0x231e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -693,7 +687,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x235e
+				// Method begins at RVA 0x2326
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -705,7 +699,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2361
+				// Method begins at RVA 0x2329
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -720,7 +714,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2364
+				// Method begins at RVA 0x232c
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -749,7 +743,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22ab
+			// Method begins at RVA 0x2274
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -765,7 +759,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22e8
+			// Method begins at RVA 0x22b0
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -791,7 +785,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22f3
+			// Method begins at RVA 0x22bb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -817,7 +811,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 199 (0xc7)
+		// Code size: 177 (0xb1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope,
@@ -825,9 +819,8 @@
 			[2] object,
 			[3] object[],
 			[4] class [System.Runtime]System.Type,
-			[5] class [System.Runtime]System.Type,
-			[6] object,
-			[7] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m
+			[5] object,
+			[6] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m
 		)
 
 		IL_0000: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope::.ctor()
@@ -853,54 +846,49 @@
 		IL_0030: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
 		IL_0035: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_003a: stloc.s 4
-		IL_003c: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
-		IL_0041: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0046: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
-		IL_004b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0050: stloc.s 5
-		IL_0052: ldloc.s 5
-		IL_0054: ldstr "prototype"
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_005e: stloc.s 6
-		IL_0060: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0065: stloc.3
-		IL_0066: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::.ctor()
-		IL_006b: ldc.i4.0
-		IL_006c: conv.r8
-		IL_006d: ldstr "m"
-		IL_0072: ldc.i4.0
-		IL_0073: ldc.i4.1
-		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0, float64, string, bool, bool)
-		IL_0079: stloc.s 7
-		IL_007b: ldloc.s 7
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0)
-		IL_0082: stloc.s 7
-		IL_0084: ldloc.s 6
-		IL_0086: ldstr "m"
-		IL_008b: ldloc.s 7
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0092: pop
-		IL_0093: ldc.i4.1
-		IL_0094: newarr [System.Runtime]System.Object
-		IL_0099: dup
-		IL_009a: ldc.i4.0
-		IL_009b: ldloc.0
-		IL_009c: stelem.ref
-		IL_009d: stloc.3
-		IL_009e: ldloc.s 4
-		IL_00a0: ldloc.3
-		IL_00a1: ldc.r8 0.0
-		IL_00aa: box [System.Runtime]System.Double
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00b4: stloc.s 6
-		IL_00b6: ldloc.s 6
-		IL_00b8: stloc.2
-		IL_00b9: nop
-		IL_00ba: ldloc.1
-		IL_00bb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00c5: pop
-		IL_00c6: ret
+		IL_003c: ldloc.s 4
+		IL_003e: ldstr "prototype"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0048: stloc.s 5
+		IL_004a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004f: stloc.3
+		IL_0050: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::.ctor()
+		IL_0055: ldc.i4.0
+		IL_0056: conv.r8
+		IL_0057: ldstr "m"
+		IL_005c: ldc.i4.0
+		IL_005d: ldc.i4.1
+		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0, float64, string, bool, bool)
+		IL_0063: stloc.s 6
+		IL_0065: ldloc.s 6
+		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0)
+		IL_006c: stloc.s 6
+		IL_006e: ldloc.s 5
+		IL_0070: ldstr "m"
+		IL_0075: ldloc.s 6
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_007c: pop
+		IL_007d: ldc.i4.1
+		IL_007e: newarr [System.Runtime]System.Object
+		IL_0083: dup
+		IL_0084: ldc.i4.0
+		IL_0085: ldloc.0
+		IL_0086: stelem.ref
+		IL_0087: stloc.3
+		IL_0088: ldloc.s 4
+		IL_008a: ldloc.3
+		IL_008b: ldc.r8 0.0
+		IL_0094: box [System.Runtime]System.Double
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_009e: stloc.s 5
+		IL_00a0: ldloc.s 5
+		IL_00a2: stloc.2
+		IL_00a3: nop
+		IL_00a4: ldloc.1
+		IL_00a5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00af: pop
+		IL_00b0: ret
 	} // end of method Classes_Inheritance_NestedClassExtendsGlobal::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_NestedClassExtendsGlobal
@@ -912,7 +900,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x243b
+		// Method begins at RVA 0x2403
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2323
+					// Method begins at RVA 0x22f3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x232c
+					// Method begins at RVA 0x22fc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 						object[] capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x238b
+					// Method begins at RVA 0x235b
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -83,7 +83,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x239a
+					// Method begins at RVA 0x236a
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -95,7 +95,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x239d
+					// Method begins at RVA 0x236d
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -110,7 +110,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x23a0
+					// Method begins at RVA 0x2370
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -126,7 +126,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x23ac
+					// Method begins at RVA 0x237c
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -150,7 +150,7 @@
 						object[] capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x23b8
+					// Method begins at RVA 0x2388
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -166,7 +166,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x23c7
+					// Method begins at RVA 0x2397
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -178,7 +178,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x23ca
+					// Method begins at RVA 0x239a
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -193,7 +193,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x23cd
+					// Method begins at RVA 0x239d
 					// Header size: 1
 					// Code size: 40 (0x28)
 					.maxstack 8
@@ -227,7 +227,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22ac
+				// Method begins at RVA 0x227c
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -251,7 +251,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2306
+				// Method begins at RVA 0x22d6
 				// Header size: 1
 				// Code size: 10 (0xa)
 				.maxstack 8
@@ -273,7 +273,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2335
+					// Method begins at RVA 0x2305
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -293,7 +293,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x233e
+					// Method begins at RVA 0x230e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -318,7 +318,7 @@
 						object[] capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x23f6
+					// Method begins at RVA 0x23c6
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -334,7 +334,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2405
+					// Method begins at RVA 0x23d5
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -346,7 +346,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2408
+					// Method begins at RVA 0x23d8
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -361,7 +361,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x240b
+					// Method begins at RVA 0x23db
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -377,7 +377,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x2417
+					// Method begins at RVA 0x23e7
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -403,7 +403,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x2423
+					// Method begins at RVA 0x23f3
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -422,7 +422,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2439
+					// Method begins at RVA 0x2409
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -434,7 +434,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x243c
+					// Method begins at RVA 0x240c
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -446,7 +446,7 @@
 				.method family hidebysig virtual 
 					instance object GetLexicalSuperReceiverCore () cil managed 
 				{
-					// Method begins at RVA 0x243f
+					// Method begins at RVA 0x240f
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -459,7 +459,7 @@
 				.method family hidebysig virtual 
 					instance object[] GetLexicalSuperScopesCore () cil managed 
 				{
-					// Method begins at RVA 0x2447
+					// Method begins at RVA 0x2417
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -475,7 +475,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x244f
+					// Method begins at RVA 0x241f
 					// Header size: 1
 					// Code size: 35 (0x23)
 					.maxstack 8
@@ -508,7 +508,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22c8
+				// Method begins at RVA 0x2298
 				// Header size: 12
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -535,7 +535,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22ec
+				// Method begins at RVA 0x22bc
 				// Header size: 12
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -560,7 +560,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x231a
+				// Method begins at RVA 0x22ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -585,7 +585,7 @@
 					class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2347
+				// Method begins at RVA 0x2317
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -601,7 +601,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2356
+				// Method begins at RVA 0x2326
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -613,7 +613,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2359
+				// Method begins at RVA 0x2329
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -628,7 +628,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x235c
+				// Method begins at RVA 0x232c
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -647,7 +647,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x236e
+				// Method begins at RVA 0x233e
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -665,7 +665,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x237c
+				// Method begins at RVA 0x234c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -695,19 +695,18 @@
 			)
 			// Method begins at RVA 0x2098
 			// Header size: 12
-			// Code size: 518 (0x206)
+			// Code size: 472 (0x1d8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope,
 				[1] object,
 				[2] object,
 				[3] class [System.Runtime]System.Type,
-				[4] class [System.Runtime]System.Type,
-				[5] object,
-				[6] object[],
-				[7] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m,
-				[8] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n,
-				[9] object
+				[4] object,
+				[5] object[],
+				[6] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m,
+				[7] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n,
+				[8] object
 			)
 
 			IL_0000: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::.ctor()
@@ -717,180 +716,170 @@
 			IL_0010: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
 			IL_0015: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_001a: stloc.3
-			IL_001b: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
-			IL_0020: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0025: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
-			IL_002a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_002f: stloc.s 4
-			IL_0031: ldloc.s 4
-			IL_0033: ldstr "prototype"
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003d: stloc.s 5
-			IL_003f: ldc.i4.2
-			IL_0040: newarr [System.Runtime]System.Object
-			IL_0045: dup
+			IL_001b: ldloc.3
+			IL_001c: ldstr "prototype"
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0026: stloc.s 4
+			IL_0028: ldc.i4.2
+			IL_0029: newarr [System.Runtime]System.Object
+			IL_002e: dup
+			IL_002f: ldc.i4.0
+			IL_0030: ldarg.0
+			IL_0031: stelem.ref
+			IL_0032: dup
+			IL_0033: ldc.i4.1
+			IL_0034: ldloc.0
+			IL_0035: stelem.ref
+			IL_0036: stloc.s 5
+			IL_0038: ldloc.s 5
+			IL_003a: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m::.ctor(object[])
+			IL_003f: ldc.i4.0
+			IL_0040: conv.r8
+			IL_0041: ldstr "m"
 			IL_0046: ldc.i4.0
-			IL_0047: ldarg.0
-			IL_0048: stelem.ref
-			IL_0049: dup
-			IL_004a: ldc.i4.1
-			IL_004b: ldloc.0
-			IL_004c: stelem.ref
+			IL_0047: ldc.i4.1
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0, float64, string, bool, bool)
 			IL_004d: stloc.s 6
 			IL_004f: ldloc.s 6
-			IL_0051: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m::.ctor(object[])
-			IL_0056: ldc.i4.0
-			IL_0057: conv.r8
-			IL_0058: ldstr "m"
-			IL_005d: ldc.i4.0
-			IL_005e: ldc.i4.1
-			IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0, float64, string, bool, bool)
-			IL_0064: stloc.s 7
-			IL_0066: ldloc.s 7
-			IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0)
-			IL_006d: stloc.s 7
-			IL_006f: ldloc.s 5
-			IL_0071: ldstr "m"
-			IL_0076: ldloc.s 7
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_007d: pop
-			IL_007e: ldc.i4.2
-			IL_007f: newarr [System.Runtime]System.Object
-			IL_0084: dup
-			IL_0085: ldc.i4.0
-			IL_0086: ldarg.0
-			IL_0087: stelem.ref
-			IL_0088: dup
-			IL_0089: ldc.i4.1
-			IL_008a: ldloc.0
-			IL_008b: stelem.ref
-			IL_008c: stloc.s 6
-			IL_008e: ldloc.3
-			IL_008f: ldloc.s 6
-			IL_0091: ldc.r8 0.0
-			IL_009a: box [System.Runtime]System.Double
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_00a4: stloc.s 5
-			IL_00a6: ldloc.s 5
-			IL_00a8: stloc.1
-			IL_00a9: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_00ae: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00b3: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_00b8: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00bd: stloc.3
-			IL_00be: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_00c3: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00c8: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_00cd: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00d2: stloc.s 4
-			IL_00d4: ldloc.s 4
-			IL_00d6: ldstr "prototype"
-			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e0: stloc.s 5
-			IL_00e2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_00e7: stloc.s 6
-			IL_00e9: ldloc.s 5
-			IL_00eb: ldloc.s 6
-			IL_00ed: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n::.ctor(class [System.Runtime]System.Object, object[])
-			IL_00f2: ldc.i4.0
-			IL_00f3: conv.r8
-			IL_00f4: ldstr "n"
-			IL_00f9: ldc.i4.1
-			IL_00fa: ldc.i4.1
-			IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0, float64, string, bool, bool)
-			IL_0100: stloc.s 8
-			IL_0102: ldloc.s 8
-			IL_0104: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0)
-			IL_0109: stloc.s 8
-			IL_010b: ldloc.s 5
-			IL_010d: ldstr "n"
-			IL_0112: ldloc.s 8
-			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_0119: pop
-			IL_011a: ldc.i4.2
-			IL_011b: newarr [System.Runtime]System.Object
-			IL_0120: dup
-			IL_0121: ldc.i4.0
-			IL_0122: ldarg.0
-			IL_0123: stelem.ref
-			IL_0124: dup
-			IL_0125: ldc.i4.1
-			IL_0126: ldloc.0
-			IL_0127: stelem.ref
-			IL_0128: stloc.s 6
-			IL_012a: ldloc.3
-			IL_012b: ldloc.s 6
-			IL_012d: ldc.r8 0.0
-			IL_0136: box [System.Runtime]System.Double
-			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0)
+			IL_0056: stloc.s 6
+			IL_0058: ldloc.s 4
+			IL_005a: ldstr "m"
+			IL_005f: ldloc.s 6
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_0066: pop
+			IL_0067: ldc.i4.2
+			IL_0068: newarr [System.Runtime]System.Object
+			IL_006d: dup
+			IL_006e: ldc.i4.0
+			IL_006f: ldarg.0
+			IL_0070: stelem.ref
+			IL_0071: dup
+			IL_0072: ldc.i4.1
+			IL_0073: ldloc.0
+			IL_0074: stelem.ref
+			IL_0075: stloc.s 5
+			IL_0077: ldloc.3
+			IL_0078: ldloc.s 5
+			IL_007a: ldc.r8 0.0
+			IL_0083: box [System.Runtime]System.Double
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_008d: stloc.s 4
+			IL_008f: ldloc.s 4
+			IL_0091: stloc.1
+			IL_0092: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_0097: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_009c: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_00a1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_00a6: stloc.3
+			IL_00a7: ldloc.3
+			IL_00a8: ldstr "prototype"
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b2: stloc.s 4
+			IL_00b4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_00b9: stloc.s 5
+			IL_00bb: ldloc.s 4
+			IL_00bd: ldloc.s 5
+			IL_00bf: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n::.ctor(class [System.Runtime]System.Object, object[])
+			IL_00c4: ldc.i4.0
+			IL_00c5: conv.r8
+			IL_00c6: ldstr "n"
+			IL_00cb: ldc.i4.1
+			IL_00cc: ldc.i4.1
+			IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0, float64, string, bool, bool)
+			IL_00d2: stloc.s 7
+			IL_00d4: ldloc.s 7
+			IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0)
+			IL_00db: stloc.s 7
+			IL_00dd: ldloc.s 4
+			IL_00df: ldstr "n"
+			IL_00e4: ldloc.s 7
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_00eb: pop
+			IL_00ec: ldc.i4.2
+			IL_00ed: newarr [System.Runtime]System.Object
+			IL_00f2: dup
+			IL_00f3: ldc.i4.0
+			IL_00f4: ldarg.0
+			IL_00f5: stelem.ref
+			IL_00f6: dup
+			IL_00f7: ldc.i4.1
+			IL_00f8: ldloc.0
+			IL_00f9: stelem.ref
+			IL_00fa: stloc.s 5
+			IL_00fc: ldloc.3
+			IL_00fd: ldloc.s 5
+			IL_00ff: ldc.r8 0.0
+			IL_0108: box [System.Runtime]System.Double
+			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_0112: stloc.s 4
+			IL_0114: ldloc.s 4
+			IL_0116: ldloc.1
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+			IL_011c: stloc.s 4
+			IL_011e: ldloc.s 4
+			IL_0120: stloc.2
+			IL_0121: ldstr "console"
+			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0130: stloc.s 4
+			IL_0132: ldc.i4.2
+			IL_0133: newarr [System.Runtime]System.Object
+			IL_0138: dup
+			IL_0139: ldc.i4.0
+			IL_013a: ldarg.0
+			IL_013b: stelem.ref
+			IL_013c: dup
+			IL_013d: ldc.i4.1
+			IL_013e: ldloc.0
+			IL_013f: stelem.ref
 			IL_0140: stloc.s 5
 			IL_0142: ldloc.s 5
-			IL_0144: ldloc.1
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-			IL_014a: stloc.s 5
-			IL_014c: ldloc.s 5
-			IL_014e: stloc.2
-			IL_014f: ldstr "console"
-			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_015e: stloc.s 5
-			IL_0160: ldc.i4.2
-			IL_0161: newarr [System.Runtime]System.Object
-			IL_0166: dup
-			IL_0167: ldc.i4.0
-			IL_0168: ldarg.0
-			IL_0169: stelem.ref
-			IL_016a: dup
-			IL_016b: ldc.i4.1
-			IL_016c: ldloc.0
-			IL_016d: stelem.ref
-			IL_016e: stloc.s 6
-			IL_0170: ldloc.s 6
-			IL_0172: ldc.i4.0
-			IL_0173: newarr [System.Runtime]System.Object
-			IL_0178: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_017d: ldloc.2
-			IL_017e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-			IL_0183: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-			IL_0188: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
-			IL_018d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-			IL_0192: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_0197: dup
-			IL_0198: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_019d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_01a2: ldstr "prototype"
-			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_01ac: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_01b1: stloc.s 9
-			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_01bd: stloc.s 9
-			IL_01bf: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-			IL_01c4: ldloc.s 9
-			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01cb: stloc.s 9
-			IL_01cd: ldloc.s 9
-			IL_01cf: isinst Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_01d4: dup
-			IL_01d5: brfalse IL_01e6
+			IL_0144: ldc.i4.0
+			IL_0145: newarr [System.Runtime]System.Object
+			IL_014a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_014f: ldloc.2
+			IL_0150: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+			IL_0155: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+			IL_015a: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
+			IL_015f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+			IL_0164: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_0169: dup
+			IL_016a: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_016f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0174: ldstr "prototype"
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_017e: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0183: stloc.s 8
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_018f: stloc.s 8
+			IL_0191: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+			IL_0196: ldloc.s 8
+			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_019d: stloc.s 8
+			IL_019f: ldloc.s 8
+			IL_01a1: isinst Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_01a6: dup
+			IL_01a7: brfalse IL_01b8
 
-			IL_01da: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
-			IL_01df: stloc.s 9
-			IL_01e1: br IL_01f5
+			IL_01ac: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
+			IL_01b1: stloc.s 8
+			IL_01b3: br IL_01c7
 
-			IL_01e6: pop
-			IL_01e7: ldloc.s 9
-			IL_01e9: ldstr "n"
-			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_01f3: stloc.s 9
+			IL_01b8: pop
+			IL_01b9: ldloc.s 8
+			IL_01bb: ldstr "n"
+			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_01c5: stloc.s 8
 
-			IL_01f5: ldloc.s 5
-			IL_01f7: ldstr "log"
-			IL_01fc: ldloc.s 9
-			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0203: pop
-			IL_0204: ldnull
-			IL_0205: ret
+			IL_01c7: ldloc.s 4
+			IL_01c9: ldstr "log"
+			IL_01ce: ldloc.s 8
+			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01d5: pop
+			IL_01d6: ldnull
+			IL_01d7: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -909,7 +898,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2311
+			// Method begins at RVA 0x22e1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -982,7 +971,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2473
+		// Method begins at RVA 0x2443
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperMethodCall.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperMethodCall.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2270
+				// Method begins at RVA 0x2240
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2279
+				// Method begins at RVA 0x2249
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2294
+				// Method begins at RVA 0x2264
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22a3
+				// Method begins at RVA 0x2273
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22a6
+				// Method begins at RVA 0x2276
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22a9
+				// Method begins at RVA 0x2279
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22b5
+				// Method begins at RVA 0x2285
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c1
+				// Method begins at RVA 0x2291
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22c9
+				// Method begins at RVA 0x2299
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22cc
+				// Method begins at RVA 0x229c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22cf
+				// Method begins at RVA 0x229f
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x221f
+			// Method begins at RVA 0x21f1
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -226,7 +226,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x225c
+			// Method begins at RVA 0x222c
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -248,7 +248,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2282
+				// Method begins at RVA 0x2252
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -268,7 +268,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228b
+				// Method begins at RVA 0x225b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -293,7 +293,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22f8
+				// Method begins at RVA 0x22c8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -309,7 +309,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2307
+				// Method begins at RVA 0x22d7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -321,7 +321,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x230a
+				// Method begins at RVA 0x22da
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -336,7 +336,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x230d
+				// Method begins at RVA 0x22dd
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -352,7 +352,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2319
+				// Method begins at RVA 0x22e9
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -378,7 +378,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x2325
+				// Method begins at RVA 0x22f5
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -397,7 +397,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x233b
+				// Method begins at RVA 0x230b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -409,7 +409,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x233e
+				// Method begins at RVA 0x230e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -421,7 +421,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x2341
+				// Method begins at RVA 0x2311
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -434,7 +434,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x2349
+				// Method begins at RVA 0x2319
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -450,7 +450,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2351
+				// Method begins at RVA 0x2321
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -478,7 +478,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2227
+			// Method begins at RVA 0x21f9
 			// Header size: 1
 			// Code size: 13 (0xd)
 			.maxstack 8
@@ -496,7 +496,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2238
+			// Method begins at RVA 0x2208
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -523,7 +523,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2267
+			// Method begins at RVA 0x2237
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -549,19 +549,18 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 451 (0x1c3)
+		// Code size: 405 (0x195)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_SuperMethodCall/Scope,
 			[1] object,
 			[2] object,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object,
-			[6] object[],
-			[7] class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m,
-			[8] class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m,
-			[9] object
+			[4] object,
+			[5] object[],
+			[6] class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m,
+			[7] class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/Scope::.ctor()
@@ -572,136 +571,126 @@
 		IL_0011: ldtoken Modules.Classes_Inheritance_SuperMethodCall/B
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.Classes_Inheritance_SuperMethodCall/B
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Classes_Inheritance_SuperMethodCall/B
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: stloc.s 5
-		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0045: stloc.s 6
-		IL_0047: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m::.ctor()
-		IL_004c: ldc.i4.0
-		IL_004d: conv.r8
-		IL_004e: ldstr "m"
-		IL_0053: ldc.i4.0
-		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0, float64, string, bool, bool)
-		IL_005a: stloc.s 7
-		IL_005c: ldloc.s 7
-		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0)
-		IL_0063: stloc.s 7
-		IL_0065: ldloc.s 5
-		IL_0067: ldstr "m"
-		IL_006c: ldloc.s 7
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0073: pop
-		IL_0074: ldc.i4.1
-		IL_0075: newarr [System.Runtime]System.Object
-		IL_007a: dup
-		IL_007b: ldc.i4.0
-		IL_007c: ldloc.0
-		IL_007d: stelem.ref
-		IL_007e: stloc.s 6
-		IL_0080: ldloc.3
-		IL_0081: ldloc.s 6
-		IL_0083: ldc.r8 0.0
-		IL_008c: box [System.Runtime]System.Double
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0096: stloc.s 5
-		IL_0098: ldloc.s 5
-		IL_009a: stloc.1
-		IL_009b: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
-		IL_00a0: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00a5: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
-		IL_00aa: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00af: stloc.3
-		IL_00b0: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
-		IL_00b5: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00ba: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
-		IL_00bf: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00c4: stloc.s 4
-		IL_00c6: ldloc.s 4
-		IL_00c8: ldstr "prototype"
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d2: stloc.s 5
-		IL_00d4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00d9: stloc.s 6
-		IL_00db: ldloc.s 5
-		IL_00dd: ldloc.s 6
-		IL_00df: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m::.ctor(class [System.Runtime]System.Object, object[])
-		IL_00e4: ldc.i4.0
-		IL_00e5: conv.r8
-		IL_00e6: ldstr "m"
-		IL_00eb: ldc.i4.1
-		IL_00ec: ldc.i4.1
-		IL_00ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0, float64, string, bool, bool)
-		IL_00f2: stloc.s 8
-		IL_00f4: ldloc.s 8
-		IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0)
-		IL_00fb: stloc.s 8
-		IL_00fd: ldloc.s 5
-		IL_00ff: ldstr "m"
-		IL_0104: ldloc.s 8
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_010b: pop
-		IL_010c: ldc.i4.1
-		IL_010d: newarr [System.Runtime]System.Object
-		IL_0112: dup
-		IL_0113: ldc.i4.0
-		IL_0114: ldloc.0
-		IL_0115: stelem.ref
-		IL_0116: stloc.s 6
-		IL_0118: ldloc.3
-		IL_0119: ldloc.s 6
-		IL_011b: ldc.r8 0.0
-		IL_0124: box [System.Runtime]System.Double
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_012e: stloc.s 5
-		IL_0130: ldloc.s 5
-		IL_0132: ldloc.1
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0138: stloc.s 5
-		IL_013a: ldloc.s 5
-		IL_013c: stloc.2
-		IL_013d: ldstr "console"
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014c: stloc.s 5
-		IL_014e: ldc.i4.0
-		IL_014f: newarr [System.Runtime]System.Object
-		IL_0154: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0159: ldloc.2
-		IL_015a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_015f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0164: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D::.ctor()
-		IL_0169: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_016e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0173: dup
-		IL_0174: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
-		IL_0179: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_017e: ldstr "prototype"
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0188: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_018d: stloc.s 9
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_0199: stloc.s 9
-		IL_019b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_01a0: ldloc.s 9
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a7: ldstr "m"
-		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01b1: stloc.s 9
-		IL_01b3: ldloc.s 5
-		IL_01b5: ldstr "log"
-		IL_01ba: ldloc.s 9
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c1: pop
-		IL_01c2: ret
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: stloc.s 4
+		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002e: stloc.s 5
+		IL_0030: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m::.ctor()
+		IL_0035: ldc.i4.0
+		IL_0036: conv.r8
+		IL_0037: ldstr "m"
+		IL_003c: ldc.i4.0
+		IL_003d: ldc.i4.1
+		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0, float64, string, bool, bool)
+		IL_0043: stloc.s 6
+		IL_0045: ldloc.s 6
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0)
+		IL_004c: stloc.s 6
+		IL_004e: ldloc.s 4
+		IL_0050: ldstr "m"
+		IL_0055: ldloc.s 6
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005c: pop
+		IL_005d: ldc.i4.1
+		IL_005e: newarr [System.Runtime]System.Object
+		IL_0063: dup
+		IL_0064: ldc.i4.0
+		IL_0065: ldloc.0
+		IL_0066: stelem.ref
+		IL_0067: stloc.s 5
+		IL_0069: ldloc.3
+		IL_006a: ldloc.s 5
+		IL_006c: ldc.r8 0.0
+		IL_0075: box [System.Runtime]System.Double
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_007f: stloc.s 4
+		IL_0081: ldloc.s 4
+		IL_0083: stloc.1
+		IL_0084: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
+		IL_0089: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_008e: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
+		IL_0093: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0098: stloc.3
+		IL_0099: ldloc.3
+		IL_009a: ldstr "prototype"
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a4: stloc.s 4
+		IL_00a6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ab: stloc.s 5
+		IL_00ad: ldloc.s 4
+		IL_00af: ldloc.s 5
+		IL_00b1: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m::.ctor(class [System.Runtime]System.Object, object[])
+		IL_00b6: ldc.i4.0
+		IL_00b7: conv.r8
+		IL_00b8: ldstr "m"
+		IL_00bd: ldc.i4.1
+		IL_00be: ldc.i4.1
+		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0, float64, string, bool, bool)
+		IL_00c4: stloc.s 7
+		IL_00c6: ldloc.s 7
+		IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0)
+		IL_00cd: stloc.s 7
+		IL_00cf: ldloc.s 4
+		IL_00d1: ldstr "m"
+		IL_00d6: ldloc.s 7
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00dd: pop
+		IL_00de: ldc.i4.1
+		IL_00df: newarr [System.Runtime]System.Object
+		IL_00e4: dup
+		IL_00e5: ldc.i4.0
+		IL_00e6: ldloc.0
+		IL_00e7: stelem.ref
+		IL_00e8: stloc.s 5
+		IL_00ea: ldloc.3
+		IL_00eb: ldloc.s 5
+		IL_00ed: ldc.r8 0.0
+		IL_00f6: box [System.Runtime]System.Double
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0100: stloc.s 4
+		IL_0102: ldloc.s 4
+		IL_0104: ldloc.1
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_010a: stloc.s 4
+		IL_010c: ldloc.s 4
+		IL_010e: stloc.2
+		IL_010f: ldstr "console"
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011e: stloc.s 4
+		IL_0120: ldc.i4.0
+		IL_0121: newarr [System.Runtime]System.Object
+		IL_0126: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_012b: ldloc.2
+		IL_012c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0131: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0136: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D::.ctor()
+		IL_013b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_0140: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0145: dup
+		IL_0146: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
+		IL_014b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0150: ldstr "prototype"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_015a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_015f: stloc.s 8
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_016b: stloc.s 8
+		IL_016d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_0172: ldloc.s 8
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0179: ldstr "m"
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0183: stloc.s 8
+		IL_0185: ldloc.s 4
+		IL_0187: ldstr "log"
+		IL_018c: ldloc.s 8
+		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0193: pop
+		IL_0194: ret
 	} // end of method Classes_Inheritance_SuperMethodCall::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_SuperMethodCall
@@ -713,7 +702,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2375
+		// Method begins at RVA 0x2345
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x235e
+				// Method begins at RVA 0x2346
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2367
+				// Method begins at RVA 0x234f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2370
+				// Method begins at RVA 0x2358
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2379
+				// Method begins at RVA 0x2361
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2382
+				// Method begins at RVA 0x236a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x238b
+				// Method begins at RVA 0x2373
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -143,7 +143,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2394
+				// Method begins at RVA 0x237c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -159,7 +159,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23a3
+				// Method begins at RVA 0x238b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -171,7 +171,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23a6
+				// Method begins at RVA 0x238e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -186,7 +186,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23a9
+				// Method begins at RVA 0x2391
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -202,7 +202,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x23b5
+				// Method begins at RVA 0x239d
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -221,7 +221,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c1
+				// Method begins at RVA 0x23a9
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -234,7 +234,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23c9
+				// Method begins at RVA 0x23b1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -246,7 +246,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23cc
+				// Method begins at RVA 0x23b4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -261,7 +261,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23cf
+				// Method begins at RVA 0x23b7
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -288,7 +288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f3
+				// Method begins at RVA 0x23db
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -301,7 +301,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23fb
+				// Method begins at RVA 0x23e3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -313,7 +313,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23fe
+				// Method begins at RVA 0x23e6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -328,7 +328,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2401
+				// Method begins at RVA 0x23e9
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -355,7 +355,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2425
+				// Method begins at RVA 0x240d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -368,7 +368,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x242d
+				// Method begins at RVA 0x2415
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -380,7 +380,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2430
+				// Method begins at RVA 0x2418
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -395,7 +395,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2433
+				// Method begins at RVA 0x241b
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -423,7 +423,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245c
+				// Method begins at RVA 0x2444
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -436,7 +436,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2464
+				// Method begins at RVA 0x244c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -448,7 +448,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2467
+				// Method begins at RVA 0x244f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -463,7 +463,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x246a
+				// Method begins at RVA 0x2452
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -496,7 +496,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2317
+			// Method begins at RVA 0x2301
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -515,7 +515,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2328
+			// Method begins at RVA 0x2310
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -538,7 +538,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x234a
+			// Method begins at RVA 0x2332
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -553,7 +553,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x234d
+			// Method begins at RVA 0x2335
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -569,7 +569,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2347
+			// Method begins at RVA 0x232f
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -587,7 +587,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2355
+			// Method begins at RVA 0x233d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -613,7 +613,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 699 (0x2bb)
+		// Code size: 677 (0x2a5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Method_DefaultReturnUndefined/Scope,
@@ -627,16 +627,15 @@
 			[8] object,
 			[9] object,
 			[10] class [System.Runtime]System.Type,
-			[11] class [System.Runtime]System.Type,
-			[12] object,
-			[13] object[],
-			[14] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing,
-			[15] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined,
-			[16] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue,
-			[17] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis,
-			[18] class Modules.Classes_Method_DefaultReturnUndefined/Calculator,
-			[19] bool,
-			[20] float64
+			[11] object,
+			[12] object[],
+			[13] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing,
+			[14] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined,
+			[15] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue,
+			[16] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis,
+			[17] class Modules.Classes_Method_DefaultReturnUndefined/Calculator,
+			[18] bool,
+			[19] float64
 		)
 
 		IL_0000: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Scope::.ctor()
@@ -647,226 +646,221 @@
 		IL_0011: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.s 10
-		IL_001d: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
-		IL_0022: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0027: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
-		IL_002c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0031: stloc.s 11
-		IL_0033: ldloc.s 11
-		IL_0035: ldstr "prototype"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003f: stloc.s 12
-		IL_0041: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0046: stloc.s 13
-		IL_0048: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::.ctor()
-		IL_004d: ldc.i4.0
-		IL_004e: conv.r8
-		IL_004f: ldstr "doNothing"
-		IL_0054: ldc.i4.1
-		IL_0055: ldc.i4.1
-		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0, float64, string, bool, bool)
-		IL_005b: stloc.s 14
-		IL_005d: ldloc.s 14
-		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0)
-		IL_0064: stloc.s 14
-		IL_0066: ldloc.s 12
-		IL_0068: ldstr "doNothing"
-		IL_006d: ldloc.s 14
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0074: pop
-		IL_0075: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_007a: stloc.s 13
-		IL_007c: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::.ctor()
-		IL_0081: ldc.i4.0
-		IL_0082: conv.r8
-		IL_0083: ldstr "returnsUndefined"
-		IL_0088: ldc.i4.0
-		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0, float64, string, bool, bool)
-		IL_008f: stloc.s 15
-		IL_0091: ldloc.s 15
-		IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0)
-		IL_0098: stloc.s 15
-		IL_009a: ldloc.s 12
-		IL_009c: ldstr "returnsUndefined"
-		IL_00a1: ldloc.s 15
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00a8: pop
-		IL_00a9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ae: stloc.s 13
-		IL_00b0: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::.ctor()
-		IL_00b5: ldc.i4.0
-		IL_00b6: conv.r8
-		IL_00b7: ldstr "returnsValue"
-		IL_00bc: ldc.i4.1
-		IL_00bd: ldc.i4.1
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0, float64, string, bool, bool)
-		IL_00c3: stloc.s 16
-		IL_00c5: ldloc.s 16
-		IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0)
-		IL_00cc: stloc.s 16
-		IL_00ce: ldloc.s 12
-		IL_00d0: ldstr "returnsValue"
-		IL_00d5: ldloc.s 16
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00dc: pop
-		IL_00dd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00e2: stloc.s 13
-		IL_00e4: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::.ctor()
-		IL_00e9: ldc.i4.0
-		IL_00ea: conv.r8
-		IL_00eb: ldstr "returnsThis"
-		IL_00f0: ldc.i4.1
-		IL_00f1: ldc.i4.1
-		IL_00f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0, float64, string, bool, bool)
-		IL_00f7: stloc.s 17
-		IL_00f9: ldloc.s 17
-		IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0)
-		IL_0100: stloc.s 17
-		IL_0102: ldloc.s 12
-		IL_0104: ldstr "returnsThis"
-		IL_0109: ldloc.s 17
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0110: pop
-		IL_0111: ldc.i4.1
-		IL_0112: newarr [System.Runtime]System.Object
-		IL_0117: dup
-		IL_0118: ldc.i4.0
-		IL_0119: ldloc.0
-		IL_011a: stelem.ref
-		IL_011b: stloc.s 13
-		IL_011d: ldloc.s 10
-		IL_011f: ldloc.s 13
-		IL_0121: ldc.r8 1
-		IL_012a: box [System.Runtime]System.Double
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0134: stloc.s 12
-		IL_0136: ldloc.s 12
-		IL_0138: stloc.1
-		IL_0139: ldc.i4.1
-		IL_013a: newarr [System.Runtime]System.Object
-		IL_013f: dup
-		IL_0140: ldc.i4.0
-		IL_0141: ldc.r8 10
-		IL_014a: box [System.Runtime]System.Double
-		IL_014f: stelem.ref
-		IL_0150: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0155: ldc.r8 10
-		IL_015e: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator::.ctor(float64)
-		IL_0163: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0168: stloc.2
-		IL_0169: ldloc.2
-		IL_016a: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
-		IL_016f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0174: ldstr "prototype"
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_017e: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0183: ldloc.2
-		IL_0184: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
-		IL_0189: stloc.s 18
-		IL_018b: ldloc.s 18
-		IL_018d: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::doNothing()
-		IL_0192: stloc.3
-		IL_0193: ldstr "console"
-		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a2: stloc.s 12
-		IL_01a4: ldloc.3
-		IL_01a5: ldnull
-		IL_01a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01ab: stloc.s 19
-		IL_01ad: ldloc.s 19
-		IL_01af: brfalse IL_01c0
+		IL_001d: ldloc.s 10
+		IL_001f: ldstr "prototype"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0029: stloc.s 11
+		IL_002b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0030: stloc.s 12
+		IL_0032: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::.ctor()
+		IL_0037: ldc.i4.0
+		IL_0038: conv.r8
+		IL_0039: ldstr "doNothing"
+		IL_003e: ldc.i4.1
+		IL_003f: ldc.i4.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.s 13
+		IL_0047: ldloc.s 13
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0)
+		IL_004e: stloc.s 13
+		IL_0050: ldloc.s 11
+		IL_0052: ldstr "doNothing"
+		IL_0057: ldloc.s 13
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005e: pop
+		IL_005f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0064: stloc.s 12
+		IL_0066: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::.ctor()
+		IL_006b: ldc.i4.0
+		IL_006c: conv.r8
+		IL_006d: ldstr "returnsUndefined"
+		IL_0072: ldc.i4.0
+		IL_0073: ldc.i4.1
+		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0, float64, string, bool, bool)
+		IL_0079: stloc.s 14
+		IL_007b: ldloc.s 14
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0)
+		IL_0082: stloc.s 14
+		IL_0084: ldloc.s 11
+		IL_0086: ldstr "returnsUndefined"
+		IL_008b: ldloc.s 14
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0092: pop
+		IL_0093: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0098: stloc.s 12
+		IL_009a: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::.ctor()
+		IL_009f: ldc.i4.0
+		IL_00a0: conv.r8
+		IL_00a1: ldstr "returnsValue"
+		IL_00a6: ldc.i4.1
+		IL_00a7: ldc.i4.1
+		IL_00a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0, float64, string, bool, bool)
+		IL_00ad: stloc.s 15
+		IL_00af: ldloc.s 15
+		IL_00b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0)
+		IL_00b6: stloc.s 15
+		IL_00b8: ldloc.s 11
+		IL_00ba: ldstr "returnsValue"
+		IL_00bf: ldloc.s 15
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00c6: pop
+		IL_00c7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00cc: stloc.s 12
+		IL_00ce: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::.ctor()
+		IL_00d3: ldc.i4.0
+		IL_00d4: conv.r8
+		IL_00d5: ldstr "returnsThis"
+		IL_00da: ldc.i4.1
+		IL_00db: ldc.i4.1
+		IL_00dc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0, float64, string, bool, bool)
+		IL_00e1: stloc.s 16
+		IL_00e3: ldloc.s 16
+		IL_00e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0)
+		IL_00ea: stloc.s 16
+		IL_00ec: ldloc.s 11
+		IL_00ee: ldstr "returnsThis"
+		IL_00f3: ldloc.s 16
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00fa: pop
+		IL_00fb: ldc.i4.1
+		IL_00fc: newarr [System.Runtime]System.Object
+		IL_0101: dup
+		IL_0102: ldc.i4.0
+		IL_0103: ldloc.0
+		IL_0104: stelem.ref
+		IL_0105: stloc.s 12
+		IL_0107: ldloc.s 10
+		IL_0109: ldloc.s 12
+		IL_010b: ldc.r8 1
+		IL_0114: box [System.Runtime]System.Double
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_011e: stloc.s 11
+		IL_0120: ldloc.s 11
+		IL_0122: stloc.1
+		IL_0123: ldc.i4.1
+		IL_0124: newarr [System.Runtime]System.Object
+		IL_0129: dup
+		IL_012a: ldc.i4.0
+		IL_012b: ldc.r8 10
+		IL_0134: box [System.Runtime]System.Double
+		IL_0139: stelem.ref
+		IL_013a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_013f: ldc.r8 10
+		IL_0148: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator::.ctor(float64)
+		IL_014d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0152: stloc.2
+		IL_0153: ldloc.2
+		IL_0154: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
+		IL_0159: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_015e: ldstr "prototype"
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0168: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_016d: ldloc.2
+		IL_016e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
+		IL_0173: stloc.s 17
+		IL_0175: ldloc.s 17
+		IL_0177: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::doNothing()
+		IL_017c: stloc.3
+		IL_017d: ldstr "console"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018c: stloc.s 11
+		IL_018e: ldloc.3
+		IL_018f: ldnull
+		IL_0190: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0195: stloc.s 18
+		IL_0197: ldloc.s 18
+		IL_0199: brfalse IL_01aa
 
-		IL_01b4: ldstr "undefined"
-		IL_01b9: stloc.s 4
-		IL_01bb: br IL_01c7
+		IL_019e: ldstr "undefined"
+		IL_01a3: stloc.s 4
+		IL_01a5: br IL_01b1
 
-		IL_01c0: ldstr "not undefined"
-		IL_01c5: stloc.s 4
+		IL_01aa: ldstr "not undefined"
+		IL_01af: stloc.s 4
 
-		IL_01c7: ldloc.s 12
-		IL_01c9: ldstr "log"
-		IL_01ce: ldloc.s 4
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d5: pop
-		IL_01d6: ldloc.2
-		IL_01d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
-		IL_01dc: stloc.s 18
-		IL_01de: ldloc.s 18
-		IL_01e0: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsUndefined()
-		IL_01e5: stloc.s 5
-		IL_01e7: ldstr "console"
-		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f6: stloc.s 12
-		IL_01f8: ldloc.s 5
-		IL_01fa: ldnull
-		IL_01fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0200: stloc.s 19
-		IL_0202: ldloc.s 19
-		IL_0204: brfalse IL_0215
+		IL_01b1: ldloc.s 11
+		IL_01b3: ldstr "log"
+		IL_01b8: ldloc.s 4
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bf: pop
+		IL_01c0: ldloc.2
+		IL_01c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
+		IL_01c6: stloc.s 17
+		IL_01c8: ldloc.s 17
+		IL_01ca: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsUndefined()
+		IL_01cf: stloc.s 5
+		IL_01d1: ldstr "console"
+		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e0: stloc.s 11
+		IL_01e2: ldloc.s 5
+		IL_01e4: ldnull
+		IL_01e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01ea: stloc.s 18
+		IL_01ec: ldloc.s 18
+		IL_01ee: brfalse IL_01ff
 
-		IL_0209: ldstr "undefined"
-		IL_020e: stloc.s 6
-		IL_0210: br IL_021c
+		IL_01f3: ldstr "undefined"
+		IL_01f8: stloc.s 6
+		IL_01fa: br IL_0206
 
-		IL_0215: ldstr "not undefined"
-		IL_021a: stloc.s 6
+		IL_01ff: ldstr "not undefined"
+		IL_0204: stloc.s 6
 
-		IL_021c: ldloc.s 12
-		IL_021e: ldstr "log"
-		IL_0223: ldloc.s 6
-		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_022a: pop
-		IL_022b: ldloc.2
-		IL_022c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
-		IL_0231: stloc.s 18
-		IL_0233: ldloc.s 18
-		IL_0235: callvirt instance float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
-		IL_023a: stloc.s 20
-		IL_023c: ldloc.s 20
-		IL_023e: box [System.Runtime]System.Double
-		IL_0243: stloc.s 7
-		IL_0245: ldstr "console"
-		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0254: ldstr "log"
-		IL_0259: ldloc.s 7
-		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0260: pop
-		IL_0261: ldloc.2
-		IL_0262: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
-		IL_0267: stloc.s 18
-		IL_0269: ldloc.s 18
-		IL_026b: callvirt instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
-		IL_0270: stloc.s 18
-		IL_0272: ldloc.s 18
-		IL_0274: stloc.s 8
-		IL_0276: ldstr "console"
-		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0285: stloc.s 12
-		IL_0287: ldloc.s 8
-		IL_0289: ldloc.2
-		IL_028a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_028f: stloc.s 19
-		IL_0291: ldloc.s 19
-		IL_0293: brfalse IL_02a4
+		IL_0206: ldloc.s 11
+		IL_0208: ldstr "log"
+		IL_020d: ldloc.s 6
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0214: pop
+		IL_0215: ldloc.2
+		IL_0216: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
+		IL_021b: stloc.s 17
+		IL_021d: ldloc.s 17
+		IL_021f: callvirt instance float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
+		IL_0224: stloc.s 19
+		IL_0226: ldloc.s 19
+		IL_0228: box [System.Runtime]System.Double
+		IL_022d: stloc.s 7
+		IL_022f: ldstr "console"
+		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_023e: ldstr "log"
+		IL_0243: ldloc.s 7
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024a: pop
+		IL_024b: ldloc.2
+		IL_024c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
+		IL_0251: stloc.s 17
+		IL_0253: ldloc.s 17
+		IL_0255: callvirt instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
+		IL_025a: stloc.s 17
+		IL_025c: ldloc.s 17
+		IL_025e: stloc.s 8
+		IL_0260: ldstr "console"
+		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_026f: stloc.s 11
+		IL_0271: ldloc.s 8
+		IL_0273: ldloc.2
+		IL_0274: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0279: stloc.s 18
+		IL_027b: ldloc.s 18
+		IL_027d: brfalse IL_028e
 
-		IL_0298: ldstr "same instance"
-		IL_029d: stloc.s 9
-		IL_029f: br IL_02ab
+		IL_0282: ldstr "same instance"
+		IL_0287: stloc.s 9
+		IL_0289: br IL_0295
 
-		IL_02a4: ldstr "different"
-		IL_02a9: stloc.s 9
+		IL_028e: ldstr "different"
+		IL_0293: stloc.s 9
 
-		IL_02ab: ldloc.s 12
-		IL_02ad: ldstr "log"
-		IL_02b2: ldloc.s 9
-		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b9: pop
-		IL_02ba: ret
+		IL_0295: ldloc.s 11
+		IL_0297: ldstr "log"
+		IL_029c: ldloc.s 9
+		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a3: pop
+		IL_02a4: ret
 	} // end of method Classes_Method_DefaultReturnUndefined::__js_module_init__
 
 } // end of class Modules.Classes_Method_DefaultReturnUndefined
@@ -878,7 +872,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x248e
+		// Method begins at RVA 0x2476
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22aa
+			// Method begins at RVA 0x2292
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22bc
+				// Method begins at RVA 0x22a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -174,7 +174,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c5
+				// Method begins at RVA 0x22ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -194,7 +194,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ce
+				// Method begins at RVA 0x22b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -219,7 +219,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22d7
+				// Method begins at RVA 0x22bf
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -235,7 +235,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22e6
+				// Method begins at RVA 0x22ce
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -247,7 +247,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22e9
+				// Method begins at RVA 0x22d1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -262,7 +262,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22ec
+				// Method begins at RVA 0x22d4
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -278,7 +278,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22f8
+				// Method begins at RVA 0x22e0
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -297,7 +297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2304
+				// Method begins at RVA 0x22ec
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -310,7 +310,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x230c
+				// Method begins at RVA 0x22f4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -322,7 +322,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x230f
+				// Method begins at RVA 0x22f7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -337,7 +337,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2312
+				// Method begins at RVA 0x22fa
 				// Header size: 1
 				// Code size: 49 (0x31)
 				.maxstack 8
@@ -370,7 +370,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2344
+				// Method begins at RVA 0x232c
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -383,7 +383,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x234c
+				// Method begins at RVA 0x2334
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -395,7 +395,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x234f
+				// Method begins at RVA 0x2337
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -410,7 +410,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2352
+				// Method begins at RVA 0x233a
 				// Header size: 1
 				// Code size: 49 (0x31)
 				.maxstack 8
@@ -444,7 +444,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2278
+			// Method begins at RVA 0x225e
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -463,7 +463,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2280
+			// Method begins at RVA 0x2268
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -488,7 +488,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2296
+			// Method begins at RVA 0x227e
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -511,7 +511,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22b3
+			// Method begins at RVA 0x229b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -537,17 +537,16 @@
 	{
 		// Method begins at RVA 0x2190
 		// Header size: 12
-		// Code size: 220 (0xdc)
+		// Code size: 194 (0xc2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_Class_Lib/Scope,
 			[1] object,
 			[2] class [System.Runtime]System.Type,
-			[3] class [System.Runtime]System.Type,
-			[4] object,
-			[5] object[],
-			[6] class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add,
-			[7] class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply
+			[3] object,
+			[4] object[],
+			[5] class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add,
+			[6] class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Export_Class_Lib/Scope::.ctor()
@@ -558,73 +557,68 @@
 		IL_0011: ldtoken Modules.CommonJS_Export_Class_Lib/Calculator
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.2
-		IL_001c: ldtoken Modules.CommonJS_Export_Class_Lib/Calculator
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.CommonJS_Export_Class_Lib/Calculator
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.3
-		IL_0031: ldloc.3
-		IL_0032: ldstr "prototype"
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003c: stloc.s 4
-		IL_003e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0043: stloc.s 5
-		IL_0045: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add::.ctor()
-		IL_004a: ldc.i4.2
-		IL_004b: conv.r8
-		IL_004c: ldstr "add"
-		IL_0051: ldc.i4.0
-		IL_0052: ldc.i4.1
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0, float64, string, bool, bool)
-		IL_0058: stloc.s 6
-		IL_005a: ldloc.s 6
-		IL_005c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0)
-		IL_0061: stloc.s 6
-		IL_0063: ldloc.s 4
-		IL_0065: ldstr "add"
-		IL_006a: ldloc.s 6
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0071: pop
-		IL_0072: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0077: stloc.s 5
-		IL_0079: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::.ctor()
-		IL_007e: ldc.i4.2
-		IL_007f: conv.r8
-		IL_0080: ldstr "multiply"
-		IL_0085: ldc.i4.0
-		IL_0086: ldc.i4.1
-		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0, float64, string, bool, bool)
-		IL_008c: stloc.s 7
-		IL_008e: ldloc.s 7
-		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0)
-		IL_0095: stloc.s 7
-		IL_0097: ldloc.s 4
-		IL_0099: ldstr "multiply"
-		IL_009e: ldloc.s 7
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00a5: pop
-		IL_00a6: ldc.i4.1
-		IL_00a7: newarr [System.Runtime]System.Object
-		IL_00ac: dup
-		IL_00ad: ldc.i4.0
-		IL_00ae: ldloc.0
-		IL_00af: stelem.ref
-		IL_00b0: stloc.s 5
-		IL_00b2: ldloc.2
-		IL_00b3: ldloc.s 5
-		IL_00b5: ldc.r8 0.0
-		IL_00be: box [System.Runtime]System.Double
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00c8: stloc.s 4
-		IL_00ca: ldloc.s 4
-		IL_00cc: stloc.1
-		IL_00cd: ldarg.2
-		IL_00ce: ldstr "exports"
-		IL_00d3: ldloc.1
-		IL_00d4: ldc.i4.1
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00da: pop
-		IL_00db: ret
+		IL_001c: ldloc.2
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: stloc.3
+		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002d: stloc.s 4
+		IL_002f: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add::.ctor()
+		IL_0034: ldc.i4.2
+		IL_0035: conv.r8
+		IL_0036: ldstr "add"
+		IL_003b: ldc.i4.0
+		IL_003c: ldc.i4.1
+		IL_003d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0, float64, string, bool, bool)
+		IL_0042: stloc.s 5
+		IL_0044: ldloc.s 5
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0)
+		IL_004b: stloc.s 5
+		IL_004d: ldloc.3
+		IL_004e: ldstr "add"
+		IL_0053: ldloc.s 5
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005a: pop
+		IL_005b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0060: stloc.s 4
+		IL_0062: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::.ctor()
+		IL_0067: ldc.i4.2
+		IL_0068: conv.r8
+		IL_0069: ldstr "multiply"
+		IL_006e: ldc.i4.0
+		IL_006f: ldc.i4.1
+		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0, float64, string, bool, bool)
+		IL_0075: stloc.s 6
+		IL_0077: ldloc.s 6
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0)
+		IL_007e: stloc.s 6
+		IL_0080: ldloc.3
+		IL_0081: ldstr "multiply"
+		IL_0086: ldloc.s 6
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_008d: pop
+		IL_008e: ldc.i4.1
+		IL_008f: newarr [System.Runtime]System.Object
+		IL_0094: dup
+		IL_0095: ldc.i4.0
+		IL_0096: ldloc.0
+		IL_0097: stelem.ref
+		IL_0098: stloc.s 4
+		IL_009a: ldloc.2
+		IL_009b: ldloc.s 4
+		IL_009d: ldc.r8 0.0
+		IL_00a6: box [System.Runtime]System.Double
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00b0: stloc.3
+		IL_00b1: ldloc.3
+		IL_00b2: stloc.1
+		IL_00b3: ldarg.2
+		IL_00b4: ldstr "exports"
+		IL_00b9: ldloc.1
+		IL_00ba: ldc.i4.1
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_00c0: pop
+		IL_00c1: ret
 	} // end of method CommonJS_Export_Class_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_Class_Lib
@@ -636,7 +630,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2384
+		// Method begins at RVA 0x236c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22dc
+			// Method begins at RVA 0x22c4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -190,7 +190,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ee
+				// Method begins at RVA 0x22d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f7
+				// Method begins at RVA 0x22df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -230,7 +230,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2300
+				// Method begins at RVA 0x22e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -255,7 +255,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2309
+				// Method begins at RVA 0x22f1
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -271,7 +271,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2318
+				// Method begins at RVA 0x2300
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -283,7 +283,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x231b
+				// Method begins at RVA 0x2303
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -298,7 +298,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x231e
+				// Method begins at RVA 0x2306
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -314,7 +314,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x232a
+				// Method begins at RVA 0x2312
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -333,7 +333,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2336
+				// Method begins at RVA 0x231e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -346,7 +346,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x233e
+				// Method begins at RVA 0x2326
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -358,7 +358,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2341
+				// Method begins at RVA 0x2329
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -373,7 +373,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2344
+				// Method begins at RVA 0x232c
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -408,7 +408,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2280
+			// Method begins at RVA 0x2267
 			// Header size: 1
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -430,7 +430,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2298
+			// Method begins at RVA 0x2280
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -469,7 +469,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e5
+			// Method begins at RVA 0x22cd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -495,16 +495,15 @@
 	{
 		// Method begins at RVA 0x21cc
 		// Header size: 12
-		// Code size: 168 (0xa8)
+		// Code size: 143 (0x8f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ClassWithConstructor_Lib/Scope,
 			[1] object,
 			[2] class [System.Runtime]System.Type,
-			[3] class [System.Runtime]System.Type,
-			[4] object,
-			[5] object[],
-			[6] class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet
+			[3] object,
+			[4] object[],
+			[5] class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Export_ClassWithConstructor_Lib/Scope::.ctor()
@@ -515,55 +514,50 @@
 		IL_0011: ldtoken Modules.CommonJS_Export_ClassWithConstructor_Lib/Person
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.2
-		IL_001c: ldtoken Modules.CommonJS_Export_ClassWithConstructor_Lib/Person
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.CommonJS_Export_ClassWithConstructor_Lib/Person
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.3
-		IL_0031: ldloc.3
-		IL_0032: ldstr "prototype"
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003c: stloc.s 4
-		IL_003e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0043: stloc.s 5
-		IL_0045: newobj instance void Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet::.ctor()
-		IL_004a: ldc.i4.0
-		IL_004b: conv.r8
-		IL_004c: ldstr "greet"
-		IL_0051: ldc.i4.1
-		IL_0052: ldc.i4.1
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0, float64, string, bool, bool)
-		IL_0058: stloc.s 6
-		IL_005a: ldloc.s 6
-		IL_005c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0)
-		IL_0061: stloc.s 6
-		IL_0063: ldloc.s 4
-		IL_0065: ldstr "greet"
-		IL_006a: ldloc.s 6
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0071: pop
-		IL_0072: ldc.i4.1
-		IL_0073: newarr [System.Runtime]System.Object
-		IL_0078: dup
-		IL_0079: ldc.i4.0
-		IL_007a: ldloc.0
-		IL_007b: stelem.ref
-		IL_007c: stloc.s 5
-		IL_007e: ldloc.2
-		IL_007f: ldloc.s 5
-		IL_0081: ldc.r8 2
-		IL_008a: box [System.Runtime]System.Double
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0094: stloc.s 4
-		IL_0096: ldloc.s 4
-		IL_0098: stloc.1
-		IL_0099: ldarg.2
-		IL_009a: ldstr "exports"
-		IL_009f: ldloc.1
-		IL_00a0: ldc.i4.1
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00a6: pop
-		IL_00a7: ret
+		IL_001c: ldloc.2
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: stloc.3
+		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002d: stloc.s 4
+		IL_002f: newobj instance void Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet::.ctor()
+		IL_0034: ldc.i4.0
+		IL_0035: conv.r8
+		IL_0036: ldstr "greet"
+		IL_003b: ldc.i4.1
+		IL_003c: ldc.i4.1
+		IL_003d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0, float64, string, bool, bool)
+		IL_0042: stloc.s 5
+		IL_0044: ldloc.s 5
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0)
+		IL_004b: stloc.s 5
+		IL_004d: ldloc.3
+		IL_004e: ldstr "greet"
+		IL_0053: ldloc.s 5
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005a: pop
+		IL_005b: ldc.i4.1
+		IL_005c: newarr [System.Runtime]System.Object
+		IL_0061: dup
+		IL_0062: ldc.i4.0
+		IL_0063: ldloc.0
+		IL_0064: stelem.ref
+		IL_0065: stloc.s 4
+		IL_0067: ldloc.2
+		IL_0068: ldloc.s 4
+		IL_006a: ldc.r8 2
+		IL_0073: box [System.Runtime]System.Double
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_007d: stloc.3
+		IL_007e: ldloc.3
+		IL_007f: stloc.1
+		IL_0080: ldarg.2
+		IL_0081: ldstr "exports"
+		IL_0086: ldloc.1
+		IL_0087: ldc.i4.1
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_008d: pop
+		IL_008e: ret
 	} // end of method CommonJS_Export_ClassWithConstructor_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_ClassWithConstructor_Lib
@@ -575,7 +569,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2368
+		// Method begins at RVA 0x2350
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ClassExpression_ExtendsArray.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ClassExpression_ExtendsArray.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x223f
+				// Method begins at RVA 0x222b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x225a
+						// Method begins at RVA 0x2246
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2251
+					// Method begins at RVA 0x223d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2248
+				// Method begins at RVA 0x2234
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2263
+				// Method begins at RVA 0x224f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,7 +131,7 @@
 					object[] capture2
 				) cil managed 
 			{
-				// Method begins at RVA 0x226c
+				// Method begins at RVA 0x2258
 				// Header size: 1
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -153,7 +153,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2289
+				// Method begins at RVA 0x2275
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x228c
+				// Method begins at RVA 0x2278
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -177,7 +177,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x228f
+				// Method begins at RVA 0x227b
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -190,7 +190,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x2297
+				// Method begins at RVA 0x2283
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -206,7 +206,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x229f
+				// Method begins at RVA 0x228b
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -222,7 +222,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22ab
+				// Method begins at RVA 0x2297
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -241,7 +241,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b7
+				// Method begins at RVA 0x22a3
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -254,7 +254,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22bf
+				// Method begins at RVA 0x22ab
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -266,7 +266,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22c2
+				// Method begins at RVA 0x22ae
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -281,7 +281,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22c5
+				// Method begins at RVA 0x22b1
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -314,7 +314,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2148
+			// Method begins at RVA 0x2134
 			// Header size: 12
 			// Code size: 182 (0xb6)
 			.maxstack 10
@@ -417,7 +417,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x220c
+			// Method begins at RVA 0x21f8
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -453,7 +453,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2236
+			// Method begins at RVA 0x2222
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -479,7 +479,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 236 (0xec)
+		// Code size: 213 (0xd5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/Scope,
@@ -487,8 +487,7 @@
 			[2] class [System.Runtime]System.Type,
 			[3] object,
 			[4] object,
-			[5] class [System.Runtime]System.Type,
-			[6] class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item
+			[5] class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/Scope::.ctor()
@@ -524,47 +523,42 @@
 		IL_005d: ldtoken Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList
 		IL_0062: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0067: stloc.2
-		IL_0068: ldtoken Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList
-		IL_006d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0072: ldtoken Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList
-		IL_0077: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_007c: stloc.s 5
-		IL_007e: ldloc.s 5
-		IL_0080: ldstr "prototype"
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_008a: stloc.3
-		IL_008b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0090: stloc.1
-		IL_0091: newobj instance void Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item::.ctor()
-		IL_0096: ldc.i4.1
-		IL_0097: conv.r8
-		IL_0098: ldstr "item"
-		IL_009d: ldc.i4.1
-		IL_009e: ldc.i4.1
-		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0, float64, string, bool, bool)
-		IL_00a4: stloc.s 6
-		IL_00a6: ldloc.s 6
-		IL_00a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0)
-		IL_00ad: stloc.s 6
-		IL_00af: ldloc.3
-		IL_00b0: ldstr "item"
-		IL_00b5: ldloc.s 6
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00bc: pop
-		IL_00bd: ldarg.2
-		IL_00be: ldstr "exports"
-		IL_00c3: ldloc.s 4
-		IL_00c5: ldc.i4.1
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00cb: pop
-		IL_00cc: ldstr "console"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00db: ldstr "log"
-		IL_00e0: ldstr "ok"
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ea: pop
-		IL_00eb: ret
+		IL_0068: ldloc.2
+		IL_0069: ldstr "prototype"
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0073: stloc.3
+		IL_0074: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0079: stloc.1
+		IL_007a: newobj instance void Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item::.ctor()
+		IL_007f: ldc.i4.1
+		IL_0080: conv.r8
+		IL_0081: ldstr "item"
+		IL_0086: ldc.i4.1
+		IL_0087: ldc.i4.1
+		IL_0088: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0, float64, string, bool, bool)
+		IL_008d: stloc.s 5
+		IL_008f: ldloc.s 5
+		IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0)
+		IL_0096: stloc.s 5
+		IL_0098: ldloc.3
+		IL_0099: ldstr "item"
+		IL_009e: ldloc.s 5
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00a5: pop
+		IL_00a6: ldarg.2
+		IL_00a7: ldstr "exports"
+		IL_00ac: ldloc.s 4
+		IL_00ae: ldc.i4.1
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_00b4: pop
+		IL_00b5: ldstr "console"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c4: ldstr "log"
+		IL_00c9: ldstr "ok"
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d3: pop
+		IL_00d4: ret
 	} // end of method CommonJS_Module_Exports_ClassExpression_ExtendsArray::__js_module_init__
 
 } // end of class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray
@@ -576,7 +570,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22f0
+		// Method begins at RVA 0x22dc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa0
+				// Method begins at RVA 0x2a8c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b03
+				// Method begins at RVA 0x2aef
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2b0b
+				// Method begins at RVA 0x2af7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2b0e
+				// Method begins at RVA 0x2afa
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -78,7 +78,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b11
+				// Method begins at RVA 0x2afd
 				// Header size: 1
 				// Code size: 25 (0x19)
 				.maxstack 8
@@ -101,7 +101,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b2b
+				// Method begins at RVA 0x2b17
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -123,7 +123,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b41
+				// Method begins at RVA 0x2b2d
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -150,7 +150,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28ff
+			// Method begins at RVA 0x28e9
 			// Header size: 1
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -186,7 +186,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa9
+				// Method begins at RVA 0x2a95
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -206,7 +206,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b50
+				// Method begins at RVA 0x2b3c
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -219,7 +219,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2b58
+				// Method begins at RVA 0x2b44
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -231,7 +231,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2b5b
+				// Method begins at RVA 0x2b47
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -246,7 +246,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b5e
+				// Method begins at RVA 0x2b4a
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -263,7 +263,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b6a
+				// Method begins at RVA 0x2b56
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -279,7 +279,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b72
+				// Method begins at RVA 0x2b5e
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -304,7 +304,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2930
+			// Method begins at RVA 0x291c
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -345,7 +345,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab2
+				// Method begins at RVA 0x2a9e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -370,7 +370,7 @@
 					class Modules.Function_ConstructedInstance_ObjectSemantics/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b81
+				// Method begins at RVA 0x2b6d
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -386,7 +386,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2b90
+				// Method begins at RVA 0x2b7c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -398,7 +398,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2b93
+				// Method begins at RVA 0x2b7f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -413,7 +413,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b96
+				// Method begins at RVA 0x2b82
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -432,7 +432,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ba8
+				// Method begins at RVA 0x2b94
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -450,7 +450,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bb6
+				// Method begins at RVA 0x2ba2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -478,7 +478,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2970
+			// Method begins at RVA 0x295c
 			// Header size: 1
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -512,7 +512,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2abb
+				// Method begins at RVA 0x2aa7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -532,7 +532,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bc5
+				// Method begins at RVA 0x2bb1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -545,7 +545,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2bcd
+				// Method begins at RVA 0x2bb9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -557,7 +557,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2bd0
+				// Method begins at RVA 0x2bbc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -572,7 +572,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bd3
+				// Method begins at RVA 0x2bbf
 				// Header size: 1
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -590,7 +590,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2be4
+				// Method begins at RVA 0x2bd0
 				// Header size: 1
 				// Code size: 12 (0xc)
 				.maxstack 8
@@ -607,7 +607,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bf1
+				// Method begins at RVA 0x2bdd
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -632,7 +632,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29a3
+			// Method begins at RVA 0x298f
 			// Header size: 1
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -665,7 +665,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2acd
+					// Method begins at RVA 0x2ab9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -692,7 +692,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x2c52
+					// Method begins at RVA 0x2c3e
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -711,7 +711,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2c68
+					// Method begins at RVA 0x2c54
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -723,7 +723,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2c6b
+					// Method begins at RVA 0x2c57
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -738,7 +738,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2c6e
+					// Method begins at RVA 0x2c5a
 					// Header size: 1
 					// Code size: 24 (0x18)
 					.maxstack 8
@@ -760,7 +760,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x2c87
+					// Method begins at RVA 0x2c73
 					// Header size: 1
 					// Code size: 20 (0x14)
 					.maxstack 8
@@ -781,7 +781,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x2c9c
+					// Method begins at RVA 0x2c88
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -808,7 +808,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a34
+				// Method begins at RVA 0x2a20
 				// Header size: 12
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -854,7 +854,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac4
+				// Method begins at RVA 0x2ab0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -879,7 +879,7 @@
 					class Modules.Function_ConstructedInstance_ObjectSemantics/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c00
+				// Method begins at RVA 0x2bec
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -895,7 +895,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2c0f
+				// Method begins at RVA 0x2bfb
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -907,7 +907,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2c12
+				// Method begins at RVA 0x2bfe
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -922,7 +922,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c15
+				// Method begins at RVA 0x2c01
 				// Header size: 1
 				// Code size: 24 (0x18)
 				.maxstack 8
@@ -944,7 +944,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c2e
+				// Method begins at RVA 0x2c1a
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -965,7 +965,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c43
+				// Method begins at RVA 0x2c2f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -994,7 +994,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x29cc
+			// Method begins at RVA 0x29b8
 			// Header size: 12
 			// Code size: 59 (0x3b)
 			.maxstack 8
@@ -1050,7 +1050,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad6
+				// Method begins at RVA 0x2ac2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1070,7 +1070,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2cab
+				// Method begins at RVA 0x2c97
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1083,7 +1083,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2cb3
+				// Method begins at RVA 0x2c9f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1095,7 +1095,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2cb6
+				// Method begins at RVA 0x2ca2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1109,7 +1109,7 @@
 					object thisArgument
 				) cil managed 
 			{
-				// Method begins at RVA 0x2cb9
+				// Method begins at RVA 0x2ca5
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1125,7 +1125,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2cc1
+				// Method begins at RVA 0x2cad
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -1145,7 +1145,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2cd4
+				// Method begins at RVA 0x2cc0
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1164,7 +1164,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ce3
+				// Method begins at RVA 0x2ccf
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1190,7 +1190,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a13
+			// Method begins at RVA 0x29ff
 			// Header size: 1
 			// Code size: 25 (0x19)
 			.maxstack 8
@@ -1219,7 +1219,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2adf
+				// Method begins at RVA 0x2acb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1239,7 +1239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2cf2
+				// Method begins at RVA 0x2cde
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1252,7 +1252,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2cfa
+				// Method begins at RVA 0x2ce6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1264,7 +1264,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2cfd
+				// Method begins at RVA 0x2ce9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1279,7 +1279,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d00
+				// Method begins at RVA 0x2cec
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1296,7 +1296,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d0c
+				// Method begins at RVA 0x2cf8
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1312,7 +1312,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d14
+				// Method begins at RVA 0x2d00
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1337,7 +1337,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a2d
+			// Method begins at RVA 0x2a19
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -1359,7 +1359,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae8
+				// Method begins at RVA 0x2ad4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1379,7 +1379,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d23
+				// Method begins at RVA 0x2d0f
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1392,7 +1392,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2d2b
+				// Method begins at RVA 0x2d17
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1404,7 +1404,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2d2e
+				// Method begins at RVA 0x2d1a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1419,7 +1419,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d31
+				// Method begins at RVA 0x2d1d
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1436,7 +1436,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d3d
+				// Method begins at RVA 0x2d29
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1452,7 +1452,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d45
+				// Method begins at RVA 0x2d31
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1477,7 +1477,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a30
+			// Method begins at RVA 0x2a1c
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -1499,7 +1499,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2af1
+				// Method begins at RVA 0x2add
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1519,7 +1519,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2afa
+				// Method begins at RVA 0x2ae6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1544,7 +1544,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d54
+				// Method begins at RVA 0x2d40
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1560,7 +1560,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2d63
+				// Method begins at RVA 0x2d4f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1572,7 +1572,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2d66
+				// Method begins at RVA 0x2d52
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1587,7 +1587,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d69
+				// Method begins at RVA 0x2d55
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1603,7 +1603,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d75
+				// Method begins at RVA 0x2d61
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1622,7 +1622,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d81
+				// Method begins at RVA 0x2d6d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1635,7 +1635,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2d89
+				// Method begins at RVA 0x2d75
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1647,7 +1647,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2d8c
+				// Method begins at RVA 0x2d78
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1662,7 +1662,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d8f
+				// Method begins at RVA 0x2d7b
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1684,7 +1684,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a6f
+			// Method begins at RVA 0x2a5b
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1702,7 +1702,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a78
+			// Method begins at RVA 0x2a64
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1751,7 +1751,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a97
+			// Method begins at RVA 0x2a83
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1777,7 +1777,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2211 (0x8a3)
+		// Code size: 2189 (0x88d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ConstructedInstance_ObjectSemantics/Scope,
@@ -1806,8 +1806,7 @@
 			[23] object,
 			[24] object,
 			[25] class [System.Runtime]System.Type,
-			[26] class [System.Runtime]System.Type,
-			[27] class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read
+			[26] class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -2450,79 +2449,74 @@
 		IL_07b4: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
 		IL_07b9: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_07be: stloc.s 25
-		IL_07c0: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
-		IL_07c5: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_07ca: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
-		IL_07cf: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_07d4: stloc.s 26
-		IL_07d6: ldloc.s 26
-		IL_07d8: ldstr "prototype"
-		IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07e2: pop
-		IL_07e3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_07e8: stloc.s 16
-		IL_07ea: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::.ctor()
-		IL_07ef: ldc.i4.1
-		IL_07f0: conv.r8
-		IL_07f1: ldstr "read"
-		IL_07f6: ldc.i4.0
-		IL_07f7: ldc.i4.1
-		IL_07f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0, float64, string, bool, bool)
-		IL_07fd: stloc.s 27
-		IL_07ff: ldloc.s 27
-		IL_0801: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0)
-		IL_0806: stloc.s 27
-		IL_0808: ldloc.s 25
-		IL_080a: ldstr "read"
-		IL_080f: ldloc.s 27
-		IL_0811: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0816: pop
-		IL_0817: ldc.i4.1
-		IL_0818: newarr [System.Runtime]System.Object
-		IL_081d: dup
-		IL_081e: ldc.i4.0
-		IL_081f: ldloc.0
-		IL_0820: stelem.ref
-		IL_0821: stloc.s 16
-		IL_0823: ldloc.s 25
-		IL_0825: ldloc.s 16
-		IL_0827: ldc.r8 0.0
-		IL_0830: box [System.Runtime]System.Double
-		IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_083a: stloc.s 24
-		IL_083c: ldloc.s 24
-		IL_083e: stloc.s 15
-		IL_0840: ldstr "console"
-		IL_0845: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_084a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_084f: stloc.s 24
-		IL_0851: ldloc.1
-		IL_0852: ldc.i4.2
-		IL_0853: newarr [System.Runtime]System.Object
-		IL_0858: dup
-		IL_0859: ldc.i4.0
-		IL_085a: ldc.r8 6
-		IL_0863: box [System.Runtime]System.Double
-		IL_0868: stelem.ref
-		IL_0869: dup
-		IL_086a: ldc.i4.1
-		IL_086b: ldc.r8 1
-		IL_0874: box [System.Runtime]System.Double
-		IL_0879: stelem.ref
-		IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_087f: stloc.s 23
-		IL_0881: ldloc.s 15
-		IL_0883: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_0888: stloc.s 19
-		IL_088a: ldloc.s 23
-		IL_088c: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
-		IL_0891: stloc.s 23
-		IL_0893: ldloc.s 24
-		IL_0895: ldstr "log"
-		IL_089a: ldloc.s 23
-		IL_089c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_08a1: pop
-		IL_08a2: ret
+		IL_07c0: ldloc.s 25
+		IL_07c2: ldstr "prototype"
+		IL_07c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07cc: pop
+		IL_07cd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_07d2: stloc.s 16
+		IL_07d4: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::.ctor()
+		IL_07d9: ldc.i4.1
+		IL_07da: conv.r8
+		IL_07db: ldstr "read"
+		IL_07e0: ldc.i4.0
+		IL_07e1: ldc.i4.1
+		IL_07e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0, float64, string, bool, bool)
+		IL_07e7: stloc.s 26
+		IL_07e9: ldloc.s 26
+		IL_07eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0)
+		IL_07f0: stloc.s 26
+		IL_07f2: ldloc.s 25
+		IL_07f4: ldstr "read"
+		IL_07f9: ldloc.s 26
+		IL_07fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0800: pop
+		IL_0801: ldc.i4.1
+		IL_0802: newarr [System.Runtime]System.Object
+		IL_0807: dup
+		IL_0808: ldc.i4.0
+		IL_0809: ldloc.0
+		IL_080a: stelem.ref
+		IL_080b: stloc.s 16
+		IL_080d: ldloc.s 25
+		IL_080f: ldloc.s 16
+		IL_0811: ldc.r8 0.0
+		IL_081a: box [System.Runtime]System.Double
+		IL_081f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0824: stloc.s 24
+		IL_0826: ldloc.s 24
+		IL_0828: stloc.s 15
+		IL_082a: ldstr "console"
+		IL_082f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0834: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0839: stloc.s 24
+		IL_083b: ldloc.1
+		IL_083c: ldc.i4.2
+		IL_083d: newarr [System.Runtime]System.Object
+		IL_0842: dup
+		IL_0843: ldc.i4.0
+		IL_0844: ldc.r8 6
+		IL_084d: box [System.Runtime]System.Double
+		IL_0852: stelem.ref
+		IL_0853: dup
+		IL_0854: ldc.i4.1
+		IL_0855: ldc.r8 1
+		IL_085e: box [System.Runtime]System.Double
+		IL_0863: stelem.ref
+		IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_0869: stloc.s 23
+		IL_086b: ldloc.s 15
+		IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_0872: stloc.s 19
+		IL_0874: ldloc.s 23
+		IL_0876: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
+		IL_087b: stloc.s 23
+		IL_087d: ldloc.s 24
+		IL_087f: ldstr "log"
+		IL_0884: ldloc.s 23
+		IL_0886: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_088b: pop
+		IL_088c: ret
 	} // end of method Function_ConstructedInstance_ObjectSemantics::__js_module_init__
 
 } // end of class Modules.Function_ConstructedInstance_ObjectSemantics
@@ -2534,7 +2528,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2d9d
+		// Method begins at RVA 0x2d89
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3098
+				// Method begins at RVA 0x3080
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x319d
+				// Method begins at RVA 0x3185
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x31a5
+				// Method begins at RVA 0x318d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x31a8
+				// Method begins at RVA 0x3190
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -78,7 +78,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x31ab
+				// Method begins at RVA 0x3193
 				// Header size: 1
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -99,7 +99,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x31c3
+				// Method begins at RVA 0x31ab
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -119,7 +119,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x31d7
+				// Method begins at RVA 0x31bf
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -145,7 +145,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27f0
+			// Method begins at RVA 0x27da
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -173,7 +173,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30a1
+				// Method begins at RVA 0x3089
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -193,7 +193,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e6
+				// Method begins at RVA 0x31ce
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -206,7 +206,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x31ee
+				// Method begins at RVA 0x31d6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -218,7 +218,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x31f1
+				// Method begins at RVA 0x31d9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -233,7 +233,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x31f4
+				// Method begins at RVA 0x31dc
 				// Header size: 1
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -254,7 +254,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x320c
+				// Method begins at RVA 0x31f4
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -274,7 +274,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3220
+				// Method begins at RVA 0x3208
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -300,7 +300,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2809
+			// Method begins at RVA 0x27f3
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -326,7 +326,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30aa
+				// Method begins at RVA 0x3092
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -346,7 +346,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x322f
+				// Method begins at RVA 0x3217
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -359,7 +359,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3237
+				// Method begins at RVA 0x321f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -371,7 +371,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x323a
+				// Method begins at RVA 0x3222
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -386,7 +386,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x323d
+				// Method begins at RVA 0x3225
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -411,7 +411,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3261
+				// Method begins at RVA 0x3249
 				// Header size: 1
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -435,7 +435,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3281
+				// Method begins at RVA 0x3269
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -462,7 +462,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2820
+			// Method begins at RVA 0x280a
 			// Header size: 1
 			// Code size: 25 (0x19)
 			.maxstack 8
@@ -490,7 +490,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30b3
+				// Method begins at RVA 0x309b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -510,7 +510,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3290
+				// Method begins at RVA 0x3278
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -523,7 +523,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3298
+				// Method begins at RVA 0x3280
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -535,7 +535,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x329b
+				// Method begins at RVA 0x3283
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -550,7 +550,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x329e
+				// Method begins at RVA 0x3286
 				// Header size: 1
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -571,7 +571,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x32b6
+				// Method begins at RVA 0x329e
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -591,7 +591,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x32ca
+				// Method begins at RVA 0x32b2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -617,7 +617,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x283a
+			// Method begins at RVA 0x2824
 			// Header size: 1
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -655,7 +655,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30bc
+				// Method begins at RVA 0x30a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -675,7 +675,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32d9
+				// Method begins at RVA 0x32c1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -688,7 +688,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x32e1
+				// Method begins at RVA 0x32c9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -700,7 +700,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x32e4
+				// Method begins at RVA 0x32cc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -715,7 +715,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x32e7
+				// Method begins at RVA 0x32cf
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -744,7 +744,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3317
+				// Method begins at RVA 0x32ff
 				// Header size: 1
 				// Code size: 43 (0x2b)
 				.maxstack 8
@@ -772,7 +772,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3343
+				// Method begins at RVA 0x332b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -800,7 +800,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2870
+			// Method begins at RVA 0x2858
 			// Header size: 12
 			// Code size: 61 (0x3d)
 			.maxstack 9
@@ -841,7 +841,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30c5
+				// Method begins at RVA 0x30ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -866,7 +866,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3352
+				// Method begins at RVA 0x333a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -882,7 +882,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3361
+				// Method begins at RVA 0x3349
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -894,7 +894,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3364
+				// Method begins at RVA 0x334c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -909,7 +909,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3367
+				// Method begins at RVA 0x334f
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -928,7 +928,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3379
+				// Method begins at RVA 0x3361
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -946,7 +946,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3387
+				// Method begins at RVA 0x336f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -974,7 +974,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x28bc
+			// Method begins at RVA 0x28a4
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -1011,7 +1011,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30ce
+				// Method begins at RVA 0x30b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1036,7 +1036,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3396
+				// Method begins at RVA 0x337e
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1052,7 +1052,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x33a5
+				// Method begins at RVA 0x338d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1064,7 +1064,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x33a8
+				// Method begins at RVA 0x3390
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1079,7 +1079,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x33ab
+				// Method begins at RVA 0x3393
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1098,7 +1098,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x33bd
+				// Method begins at RVA 0x33a5
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1116,7 +1116,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x33cb
+				// Method begins at RVA 0x33b3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1144,7 +1144,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x28f4
+			// Method begins at RVA 0x28dc
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -1181,7 +1181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30d7
+				// Method begins at RVA 0x30bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1206,7 +1206,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x33da
+				// Method begins at RVA 0x33c2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1222,7 +1222,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x33e9
+				// Method begins at RVA 0x33d1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1234,7 +1234,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x33ec
+				// Method begins at RVA 0x33d4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1249,7 +1249,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x33ef
+				// Method begins at RVA 0x33d7
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1268,7 +1268,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3401
+				// Method begins at RVA 0x33e9
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1286,7 +1286,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x340f
+				// Method begins at RVA 0x33f7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1314,7 +1314,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x292c
+			// Method begins at RVA 0x2914
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -1384,7 +1384,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30f2
+					// Method begins at RVA 0x30da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1411,7 +1411,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x3462
+					// Method begins at RVA 0x344a
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -1430,7 +1430,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x3478
+					// Method begins at RVA 0x3460
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1442,7 +1442,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x347b
+					// Method begins at RVA 0x3463
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1457,7 +1457,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x347e
+					// Method begins at RVA 0x3466
 					// Header size: 1
 					// Code size: 13 (0xd)
 					.maxstack 8
@@ -1482,7 +1482,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2db0
+				// Method begins at RVA 0x2d98
 				// Header size: 12
 				// Code size: 74 (0x4a)
 				.maxstack 8
@@ -1540,7 +1540,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30e9
+					// Method begins at RVA 0x30d1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1560,7 +1560,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30fb
+					// Method begins at RVA 0x30e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1578,7 +1578,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30e0
+				// Method begins at RVA 0x30c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1603,7 +1603,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x341e
+				// Method begins at RVA 0x3406
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1619,7 +1619,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x342d
+				// Method begins at RVA 0x3415
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1631,7 +1631,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3430
+				// Method begins at RVA 0x3418
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1646,7 +1646,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3433
+				// Method begins at RVA 0x341b
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1665,7 +1665,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3445
+				// Method begins at RVA 0x342d
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1683,7 +1683,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3453
+				// Method begins at RVA 0x343b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1711,7 +1711,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2994
+			// Method begins at RVA 0x297c
 			// Header size: 12
 			// Code size: 212 (0xd4)
 			.maxstack 8
@@ -1846,7 +1846,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3104
+				// Method begins at RVA 0x30ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1871,7 +1871,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x348c
+				// Method begins at RVA 0x3474
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1887,7 +1887,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x349b
+				// Method begins at RVA 0x3483
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1899,7 +1899,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x349e
+				// Method begins at RVA 0x3486
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1914,7 +1914,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x34a1
+				// Method begins at RVA 0x3489
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1933,7 +1933,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x34b3
+				// Method begins at RVA 0x349b
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1951,7 +1951,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x34c1
+				// Method begins at RVA 0x34a9
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1979,7 +1979,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2a84
+			// Method begins at RVA 0x2a6c
 			// Header size: 12
 			// Code size: 73 (0x49)
 			.maxstack 8
@@ -2038,7 +2038,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3170
+				// Method begins at RVA 0x3158
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2063,7 +2063,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3752
+				// Method begins at RVA 0x373a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2079,7 +2079,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3761
+				// Method begins at RVA 0x3749
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2091,7 +2091,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3764
+				// Method begins at RVA 0x374c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2106,7 +2106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3767
+				// Method begins at RVA 0x374f
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -2125,7 +2125,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3779
+				// Method begins at RVA 0x3761
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -2143,7 +2143,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3787
+				// Method begins at RVA 0x376f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2171,7 +2171,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2adc
+			// Method begins at RVA 0x2ac4
 			// Header size: 12
 			// Code size: 119 (0x77)
 			.maxstack 8
@@ -2233,7 +2233,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3179
+				// Method begins at RVA 0x3161
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2258,7 +2258,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3796
+				// Method begins at RVA 0x377e
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2274,7 +2274,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x37a5
+				// Method begins at RVA 0x378d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2286,7 +2286,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x37a8
+				// Method begins at RVA 0x3790
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2301,7 +2301,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x37ab
+				// Method begins at RVA 0x3793
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -2320,7 +2320,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x37bd
+				// Method begins at RVA 0x37a5
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -2338,7 +2338,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x37cb
+				// Method begins at RVA 0x37b3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2366,7 +2366,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2b60
+			// Method begins at RVA 0x2b48
 			// Header size: 12
 			// Code size: 162 (0xa2)
 			.maxstack 8
@@ -2446,7 +2446,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3182
+				// Method begins at RVA 0x316a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2471,7 +2471,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x37da
+				// Method begins at RVA 0x37c2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2487,7 +2487,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x37e9
+				// Method begins at RVA 0x37d1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2499,7 +2499,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x37ec
+				// Method begins at RVA 0x37d4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2514,7 +2514,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x37ef
+				// Method begins at RVA 0x37d7
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -2533,7 +2533,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3801
+				// Method begins at RVA 0x37e9
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -2551,7 +2551,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x380f
+				// Method begins at RVA 0x37f7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2579,7 +2579,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2c10
+			// Method begins at RVA 0x2bf8
 			// Header size: 12
 			// Code size: 129 (0x81)
 			.maxstack 8
@@ -2645,7 +2645,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x318b
+				// Method begins at RVA 0x3173
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2670,7 +2670,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x381e
+				// Method begins at RVA 0x3806
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2686,7 +2686,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x382d
+				// Method begins at RVA 0x3815
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2698,7 +2698,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3830
+				// Method begins at RVA 0x3818
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2713,7 +2713,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3833
+				// Method begins at RVA 0x381b
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -2732,7 +2732,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3845
+				// Method begins at RVA 0x382d
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -2750,7 +2750,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3853
+				// Method begins at RVA 0x383b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2778,7 +2778,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2ca0
+			// Method begins at RVA 0x2c88
 			// Header size: 12
 			// Code size: 124 (0x7c)
 			.maxstack 8
@@ -2841,7 +2841,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3194
+				// Method begins at RVA 0x317c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2866,7 +2866,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3862
+				// Method begins at RVA 0x384a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2882,7 +2882,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3871
+				// Method begins at RVA 0x3859
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2894,7 +2894,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3874
+				// Method begins at RVA 0x385c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2909,7 +2909,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3877
+				// Method begins at RVA 0x385f
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -2928,7 +2928,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3889
+				// Method begins at RVA 0x3871
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -2946,7 +2946,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3897
+				// Method begins at RVA 0x387f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2974,7 +2974,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2d28
+			// Method begins at RVA 0x2d10
 			// Header size: 12
 			// Code size: 124 (0x7c)
 			.maxstack 8
@@ -3037,7 +3037,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x310d
+				// Method begins at RVA 0x30f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3057,7 +3057,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3116
+				// Method begins at RVA 0x30fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3077,7 +3077,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x311f
+				// Method begins at RVA 0x3107
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3097,7 +3097,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3128
+				// Method begins at RVA 0x3110
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3117,7 +3117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3131
+				// Method begins at RVA 0x3119
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3137,7 +3137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x313a
+				// Method begins at RVA 0x3122
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3157,7 +3157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3143
+				// Method begins at RVA 0x312b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3177,7 +3177,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x314c
+				// Method begins at RVA 0x3134
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3197,7 +3197,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3155
+				// Method begins at RVA 0x313d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3217,7 +3217,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x315e
+				// Method begins at RVA 0x3146
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3237,7 +3237,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3167
+				// Method begins at RVA 0x314f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3262,7 +3262,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x34d0
+				// Method begins at RVA 0x34b8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3278,7 +3278,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x34df
+				// Method begins at RVA 0x34c7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3290,7 +3290,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x34e2
+				// Method begins at RVA 0x34ca
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3305,7 +3305,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x34e5
+				// Method begins at RVA 0x34cd
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -3321,7 +3321,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x34f1
+				// Method begins at RVA 0x34d9
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -3340,7 +3340,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34fd
+				// Method begins at RVA 0x34e5
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3353,7 +3353,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3505
+				// Method begins at RVA 0x34ed
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3365,7 +3365,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3508
+				// Method begins at RVA 0x34f0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3380,7 +3380,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x350b
+				// Method begins at RVA 0x34f3
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -3410,7 +3410,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3536
+				// Method begins at RVA 0x351e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3423,7 +3423,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x353e
+				// Method begins at RVA 0x3526
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3435,7 +3435,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3541
+				// Method begins at RVA 0x3529
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3450,7 +3450,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3544
+				// Method begins at RVA 0x352c
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -3477,7 +3477,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3568
+				// Method begins at RVA 0x3550
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3490,7 +3490,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3570
+				// Method begins at RVA 0x3558
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3502,7 +3502,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3573
+				// Method begins at RVA 0x355b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3517,7 +3517,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3576
+				// Method begins at RVA 0x355e
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -3544,7 +3544,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x359a
+				// Method begins at RVA 0x3582
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3557,7 +3557,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x35a2
+				// Method begins at RVA 0x358a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3569,7 +3569,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x35a5
+				// Method begins at RVA 0x358d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3584,7 +3584,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x35a8
+				// Method begins at RVA 0x3590
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -3611,7 +3611,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35cc
+				// Method begins at RVA 0x35b4
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3624,7 +3624,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x35d4
+				// Method begins at RVA 0x35bc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3636,7 +3636,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x35d7
+				// Method begins at RVA 0x35bf
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3651,7 +3651,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x35da
+				// Method begins at RVA 0x35c2
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -3678,7 +3678,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35fe
+				// Method begins at RVA 0x35e6
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3691,7 +3691,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3606
+				// Method begins at RVA 0x35ee
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3703,7 +3703,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3609
+				// Method begins at RVA 0x35f1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3718,7 +3718,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x360c
+				// Method begins at RVA 0x35f4
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -3746,7 +3746,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3635
+				// Method begins at RVA 0x361d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3759,7 +3759,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x363d
+				// Method begins at RVA 0x3625
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3771,7 +3771,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3640
+				// Method begins at RVA 0x3628
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3786,7 +3786,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3644
+				// Method begins at RVA 0x362c
 				// Header size: 12
 				// Code size: 148 (0x94)
 				.maxstack 12
@@ -3850,7 +3850,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36e4
+				// Method begins at RVA 0x36cc
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3863,7 +3863,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x36ec
+				// Method begins at RVA 0x36d4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3875,7 +3875,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x36ef
+				// Method begins at RVA 0x36d7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3890,7 +3890,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x36f2
+				// Method begins at RVA 0x36da
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -3918,7 +3918,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x371b
+				// Method begins at RVA 0x3703
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3931,7 +3931,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3723
+				// Method begins at RVA 0x370b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3943,7 +3943,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3726
+				// Method begins at RVA 0x370e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3958,7 +3958,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3729
+				// Method begins at RVA 0x3711
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -3992,7 +3992,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x307b
+			// Method begins at RVA 0x3063
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -4014,7 +4014,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2eb0
+			// Method begins at RVA 0x2e98
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -4044,7 +4044,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ed9
+			// Method begins at RVA 0x2ec1
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -4060,7 +4060,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e1c
+			// Method begins at RVA 0x2e04
 			// Header size: 12
 			// Code size: 135 (0x87)
 			.maxstack 8
@@ -4121,7 +4121,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e06
+			// Method begins at RVA 0x2dee
 			// Header size: 1
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -4139,7 +4139,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x302c
+			// Method begins at RVA 0x3014
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -4170,7 +4170,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ee1
+			// Method begins at RVA 0x2ec9
 			// Header size: 1
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -4207,7 +4207,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3062
+			// Method begins at RVA 0x304a
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -4238,7 +4238,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f08
+			// Method begins at RVA 0x2ef0
 			// Header size: 12
 			// Code size: 124 (0x7c)
 			.maxstack 13
@@ -4275,7 +4275,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f90
+			// Method begins at RVA 0x2f78
 			// Header size: 12
 			// Code size: 144 (0x90)
 			.maxstack 16
@@ -4352,7 +4352,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x308f
+			// Method begins at RVA 0x3077
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4378,7 +4378,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1940 (0x794)
+		// Code size: 1918 (0x77e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerCallResults/Scope,
@@ -4399,20 +4399,19 @@
 			[15] class Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g,
 			[16] class Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h,
 			[17] class [System.Runtime]System.Type,
-			[18] class [System.Runtime]System.Type,
-			[19] object,
-			[20] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add,
-			[21] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue,
-			[22] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain,
-			[23] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce,
-			[24] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next,
-			[25] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext,
-			[26] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum,
-			[27] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum,
-			[28] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor,
-			[29] object,
-			[30] float64,
-			[31] object
+			[18] object,
+			[19] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add,
+			[20] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue,
+			[21] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain,
+			[22] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce,
+			[23] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next,
+			[24] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext,
+			[25] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum,
+			[26] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum,
+			[27] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor,
+			[28] object,
+			[29] float64,
+			[30] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_SchedulerCallResults/Scope::.ctor()
@@ -4707,399 +4706,394 @@
 		IL_027c: ldtoken Modules.Function_SchedulerCallResults/Counter
 		IL_0281: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0286: stloc.s 17
-		IL_0288: ldtoken Modules.Function_SchedulerCallResults/Counter
-		IL_028d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0292: ldtoken Modules.Function_SchedulerCallResults/Counter
-		IL_0297: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_029c: stloc.s 18
-		IL_029e: ldloc.s 18
-		IL_02a0: ldstr "prototype"
-		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02aa: stloc.s 19
-		IL_02ac: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02b1: stloc.s 14
-		IL_02b3: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add::.ctor()
-		IL_02b8: ldc.i4.1
-		IL_02b9: conv.r8
-		IL_02ba: ldstr "add"
-		IL_02bf: ldc.i4.1
-		IL_02c0: ldc.i4.1
-		IL_02c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0, float64, string, bool, bool)
-		IL_02c6: stloc.s 20
-		IL_02c8: ldloc.s 20
-		IL_02ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0)
-		IL_02cf: stloc.s 20
-		IL_02d1: ldloc.s 19
-		IL_02d3: ldstr "add"
-		IL_02d8: ldloc.s 20
-		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02df: pop
-		IL_02e0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02e5: stloc.s 14
-		IL_02e7: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue::.ctor()
-		IL_02ec: ldc.i4.0
-		IL_02ed: conv.r8
-		IL_02ee: ldstr "getValue"
-		IL_02f3: ldc.i4.1
-		IL_02f4: ldc.i4.1
-		IL_02f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0, float64, string, bool, bool)
-		IL_02fa: stloc.s 21
-		IL_02fc: ldloc.s 21
-		IL_02fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0)
-		IL_0303: stloc.s 21
-		IL_0305: ldloc.s 19
-		IL_0307: ldstr "getValue"
-		IL_030c: ldloc.s 21
-		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0313: pop
-		IL_0314: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0319: stloc.s 14
-		IL_031b: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain::.ctor()
-		IL_0320: ldc.i4.0
-		IL_0321: conv.r8
-		IL_0322: ldstr "chain"
-		IL_0327: ldc.i4.1
-		IL_0328: ldc.i4.1
-		IL_0329: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0, float64, string, bool, bool)
-		IL_032e: stloc.s 22
-		IL_0330: ldloc.s 22
-		IL_0332: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0)
-		IL_0337: stloc.s 22
-		IL_0339: ldloc.s 19
-		IL_033b: ldstr "chain"
-		IL_0340: ldloc.s 22
-		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0347: pop
-		IL_0348: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_034d: stloc.s 14
-		IL_034f: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::.ctor()
-		IL_0354: ldc.i4.0
-		IL_0355: conv.r8
-		IL_0356: ldstr "addOnce"
-		IL_035b: ldc.i4.1
-		IL_035c: ldc.i4.1
-		IL_035d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0, float64, string, bool, bool)
-		IL_0362: stloc.s 23
-		IL_0364: ldloc.s 23
-		IL_0366: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0)
-		IL_036b: stloc.s 23
-		IL_036d: ldloc.s 19
-		IL_036f: ldstr "addOnce"
-		IL_0374: ldloc.s 23
-		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_037b: pop
-		IL_037c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0381: stloc.s 14
-		IL_0383: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next::.ctor()
-		IL_0388: ldc.i4.0
-		IL_0389: conv.r8
-		IL_038a: ldstr "next"
-		IL_038f: ldc.i4.1
-		IL_0390: ldc.i4.1
-		IL_0391: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0, float64, string, bool, bool)
-		IL_0396: stloc.s 24
-		IL_0398: ldloc.s 24
-		IL_039a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0)
-		IL_039f: stloc.s 24
-		IL_03a1: ldloc.s 19
-		IL_03a3: ldstr "next"
-		IL_03a8: ldloc.s 24
-		IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_03af: pop
-		IL_03b0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03b5: stloc.s 14
-		IL_03b7: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext::.ctor()
-		IL_03bc: ldc.i4.0
-		IL_03bd: conv.r8
-		IL_03be: ldstr "maxNext"
-		IL_03c3: ldc.i4.1
-		IL_03c4: ldc.i4.1
-		IL_03c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0, float64, string, bool, bool)
-		IL_03ca: stloc.s 25
-		IL_03cc: ldloc.s 25
-		IL_03ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0)
-		IL_03d3: stloc.s 25
-		IL_03d5: ldloc.s 19
-		IL_03d7: ldstr "maxNext"
-		IL_03dc: ldloc.s 25
-		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_03e3: pop
-		IL_03e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03e9: stloc.s 14
-		IL_03eb: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum::.ctor()
-		IL_03f0: ldc.i4.s 9
-		IL_03f2: conv.r8
-		IL_03f3: ldstr "sum"
-		IL_03f8: ldc.i4.0
-		IL_03f9: ldc.i4.1
-		IL_03fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0, float64, string, bool, bool)
-		IL_03ff: stloc.s 26
-		IL_0401: ldloc.s 26
-		IL_0403: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0)
-		IL_0408: stloc.s 26
-		IL_040a: ldloc.s 19
-		IL_040c: ldstr "sum"
-		IL_0411: ldloc.s 26
-		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0418: pop
-		IL_0419: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_041e: stloc.s 14
-		IL_0420: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::.ctor()
-		IL_0425: ldc.i4.0
-		IL_0426: conv.r8
-		IL_0427: ldstr "maxSum"
-		IL_042c: ldc.i4.1
-		IL_042d: ldc.i4.1
-		IL_042e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0, float64, string, bool, bool)
-		IL_0433: stloc.s 27
-		IL_0435: ldloc.s 27
-		IL_0437: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0)
-		IL_043c: stloc.s 27
-		IL_043e: ldloc.s 19
-		IL_0440: ldstr "maxSum"
-		IL_0445: ldloc.s 27
-		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_044c: pop
-		IL_044d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0452: stloc.s 14
-		IL_0454: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::.ctor()
-		IL_0459: ldc.i4.0
-		IL_045a: conv.r8
-		IL_045b: ldstr "maxSumWithFloor"
-		IL_0460: ldc.i4.1
-		IL_0461: ldc.i4.1
-		IL_0462: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0, float64, string, bool, bool)
-		IL_0467: stloc.s 28
-		IL_0469: ldloc.s 28
-		IL_046b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0)
-		IL_0470: stloc.s 28
-		IL_0472: ldloc.s 19
-		IL_0474: ldstr "maxSumWithFloor"
-		IL_0479: ldloc.s 28
-		IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0480: pop
-		IL_0481: ldc.i4.1
-		IL_0482: newarr [System.Runtime]System.Object
-		IL_0487: dup
-		IL_0488: ldc.i4.0
-		IL_0489: ldloc.0
-		IL_048a: stelem.ref
-		IL_048b: stloc.s 14
-		IL_048d: ldloc.s 17
-		IL_048f: ldloc.s 14
-		IL_0491: ldc.r8 1
-		IL_049a: box [System.Runtime]System.Double
-		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_04a4: stloc.s 19
-		IL_04a6: ldloc.0
-		IL_04a7: ldloc.s 19
-		IL_04a9: stfld object Modules.Function_SchedulerCallResults/Scope::Counter
-		IL_04ae: nop
-		IL_04af: nop
-		IL_04b0: nop
-		IL_04b1: nop
-		IL_04b2: nop
-		IL_04b3: ldstr "console"
-		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04c2: stloc.s 19
-		IL_04c4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04c9: stloc.s 14
-		IL_04cb: ldloc.1
-		IL_04cc: ldloc.s 14
-		IL_04ce: ldc.r8 9
-		IL_04d7: box [System.Runtime]System.Double
-		IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_04e1: stloc.s 29
-		IL_04e3: ldloc.s 19
-		IL_04e5: ldstr "log"
-		IL_04ea: ldloc.s 29
-		IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04f1: pop
-		IL_04f2: ldstr "console"
-		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0501: stloc.s 29
-		IL_0503: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0508: stloc.s 14
-		IL_050a: ldc.r8 2.7
-		IL_0513: neg
-		IL_0514: stloc.s 30
-		IL_0516: ldloc.s 30
-		IL_0518: box [System.Runtime]System.Double
-		IL_051d: stloc.s 31
-		IL_051f: ldloc.2
-		IL_0520: ldloc.s 14
-		IL_0522: ldloc.s 31
-		IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0529: stloc.s 19
-		IL_052b: ldloc.s 29
-		IL_052d: ldstr "log"
-		IL_0532: ldloc.s 19
-		IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0539: pop
-		IL_053a: ldstr "console"
-		IL_053f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0544: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0549: stloc.s 19
-		IL_054b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0550: stloc.s 14
-		IL_0552: ldloc.3
-		IL_0553: ldloc.s 14
-		IL_0555: ldc.r8 1.2
-		IL_055e: box [System.Runtime]System.Double
-		IL_0563: ldc.r8 1.1
-		IL_056c: box [System.Runtime]System.Double
-		IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0576: stloc.s 29
-		IL_0578: ldloc.s 19
-		IL_057a: ldstr "log"
-		IL_057f: ldloc.s 29
-		IL_0581: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0586: pop
-		IL_0587: ldstr "console"
-		IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0591: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0596: stloc.s 29
-		IL_0598: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_059d: stloc.s 14
-		IL_059f: ldloc.s 4
-		IL_05a1: ldloc.s 14
-		IL_05a3: ldc.r8 9
-		IL_05ac: box [System.Runtime]System.Double
-		IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_05b6: stloc.s 19
-		IL_05b8: ldloc.s 29
-		IL_05ba: ldstr "log"
-		IL_05bf: ldloc.s 19
-		IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05c6: pop
-		IL_05c7: ldstr "console"
-		IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05d6: stloc.s 19
-		IL_05d8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05dd: stloc.s 14
-		IL_05df: ldloc.s 5
-		IL_05e1: ldloc.s 14
-		IL_05e3: ldc.r8 2
-		IL_05ec: box [System.Runtime]System.Double
-		IL_05f1: ldc.r8 3
-		IL_05fa: box [System.Runtime]System.Double
-		IL_05ff: ldc.r8 2
-		IL_0608: box [System.Runtime]System.Double
-		IL_060d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_0612: stloc.s 29
-		IL_0614: ldloc.s 19
-		IL_0616: ldstr "log"
-		IL_061b: ldloc.s 29
-		IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0622: pop
-		IL_0623: ldstr "console"
-		IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0632: stloc.s 29
-		IL_0634: ldloc.s 6
-		IL_0636: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_063b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0640: stloc.s 19
-		IL_0642: ldloc.s 29
-		IL_0644: ldstr "log"
-		IL_0649: ldloc.s 19
-		IL_064b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0650: pop
-		IL_0651: ldstr "console"
-		IL_0656: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_065b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0660: stloc.s 19
-		IL_0662: ldloc.s 7
-		IL_0664: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_066e: stloc.s 29
-		IL_0670: ldloc.s 19
-		IL_0672: ldstr "log"
-		IL_0677: ldloc.s 29
-		IL_0679: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_067e: pop
-		IL_067f: ldstr "console"
-		IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_068e: stloc.s 29
-		IL_0690: ldloc.s 8
-		IL_0692: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0697: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_069c: stloc.s 19
-		IL_069e: ldloc.s 29
-		IL_06a0: ldstr "log"
-		IL_06a5: ldloc.s 19
-		IL_06a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06ac: pop
-		IL_06ad: ldstr "console"
-		IL_06b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06bc: stloc.s 19
-		IL_06be: ldloc.s 9
-		IL_06c0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_06c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_06ca: stloc.s 29
-		IL_06cc: ldloc.s 19
-		IL_06ce: ldstr "log"
-		IL_06d3: ldloc.s 29
-		IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06da: pop
-		IL_06db: ldstr "console"
-		IL_06e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06ea: stloc.s 29
-		IL_06ec: ldloc.s 10
-		IL_06ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_06f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_06f8: stloc.s 19
-		IL_06fa: ldloc.s 29
-		IL_06fc: ldstr "log"
-		IL_0701: ldloc.s 19
-		IL_0703: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0708: pop
-		IL_0709: ldstr "console"
-		IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0713: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0718: stloc.s 19
-		IL_071a: ldloc.s 11
-		IL_071c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0721: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0726: stloc.s 29
-		IL_0728: ldloc.s 19
-		IL_072a: ldstr "log"
-		IL_072f: ldloc.s 29
-		IL_0731: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0736: pop
-		IL_0737: ldstr "console"
-		IL_073c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0746: stloc.s 29
-		IL_0748: ldloc.s 12
-		IL_074a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_074f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0754: stloc.s 19
-		IL_0756: ldloc.s 29
-		IL_0758: ldstr "log"
-		IL_075d: ldloc.s 19
-		IL_075f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0764: pop
-		IL_0765: ldstr "console"
-		IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_076f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0774: stloc.s 19
-		IL_0776: ldloc.s 13
-		IL_0778: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_077d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0782: stloc.s 29
-		IL_0784: ldloc.s 19
-		IL_0786: ldstr "log"
-		IL_078b: ldloc.s 29
-		IL_078d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0792: pop
-		IL_0793: ret
+		IL_0288: ldloc.s 17
+		IL_028a: ldstr "prototype"
+		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0294: stloc.s 18
+		IL_0296: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_029b: stloc.s 14
+		IL_029d: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add::.ctor()
+		IL_02a2: ldc.i4.1
+		IL_02a3: conv.r8
+		IL_02a4: ldstr "add"
+		IL_02a9: ldc.i4.1
+		IL_02aa: ldc.i4.1
+		IL_02ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0, float64, string, bool, bool)
+		IL_02b0: stloc.s 19
+		IL_02b2: ldloc.s 19
+		IL_02b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0)
+		IL_02b9: stloc.s 19
+		IL_02bb: ldloc.s 18
+		IL_02bd: ldstr "add"
+		IL_02c2: ldloc.s 19
+		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02c9: pop
+		IL_02ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02cf: stloc.s 14
+		IL_02d1: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue::.ctor()
+		IL_02d6: ldc.i4.0
+		IL_02d7: conv.r8
+		IL_02d8: ldstr "getValue"
+		IL_02dd: ldc.i4.1
+		IL_02de: ldc.i4.1
+		IL_02df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0, float64, string, bool, bool)
+		IL_02e4: stloc.s 20
+		IL_02e6: ldloc.s 20
+		IL_02e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0)
+		IL_02ed: stloc.s 20
+		IL_02ef: ldloc.s 18
+		IL_02f1: ldstr "getValue"
+		IL_02f6: ldloc.s 20
+		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02fd: pop
+		IL_02fe: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0303: stloc.s 14
+		IL_0305: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain::.ctor()
+		IL_030a: ldc.i4.0
+		IL_030b: conv.r8
+		IL_030c: ldstr "chain"
+		IL_0311: ldc.i4.1
+		IL_0312: ldc.i4.1
+		IL_0313: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0, float64, string, bool, bool)
+		IL_0318: stloc.s 21
+		IL_031a: ldloc.s 21
+		IL_031c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0)
+		IL_0321: stloc.s 21
+		IL_0323: ldloc.s 18
+		IL_0325: ldstr "chain"
+		IL_032a: ldloc.s 21
+		IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0331: pop
+		IL_0332: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0337: stloc.s 14
+		IL_0339: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::.ctor()
+		IL_033e: ldc.i4.0
+		IL_033f: conv.r8
+		IL_0340: ldstr "addOnce"
+		IL_0345: ldc.i4.1
+		IL_0346: ldc.i4.1
+		IL_0347: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0, float64, string, bool, bool)
+		IL_034c: stloc.s 22
+		IL_034e: ldloc.s 22
+		IL_0350: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0)
+		IL_0355: stloc.s 22
+		IL_0357: ldloc.s 18
+		IL_0359: ldstr "addOnce"
+		IL_035e: ldloc.s 22
+		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0365: pop
+		IL_0366: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_036b: stloc.s 14
+		IL_036d: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next::.ctor()
+		IL_0372: ldc.i4.0
+		IL_0373: conv.r8
+		IL_0374: ldstr "next"
+		IL_0379: ldc.i4.1
+		IL_037a: ldc.i4.1
+		IL_037b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0, float64, string, bool, bool)
+		IL_0380: stloc.s 23
+		IL_0382: ldloc.s 23
+		IL_0384: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0)
+		IL_0389: stloc.s 23
+		IL_038b: ldloc.s 18
+		IL_038d: ldstr "next"
+		IL_0392: ldloc.s 23
+		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0399: pop
+		IL_039a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_039f: stloc.s 14
+		IL_03a1: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext::.ctor()
+		IL_03a6: ldc.i4.0
+		IL_03a7: conv.r8
+		IL_03a8: ldstr "maxNext"
+		IL_03ad: ldc.i4.1
+		IL_03ae: ldc.i4.1
+		IL_03af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0, float64, string, bool, bool)
+		IL_03b4: stloc.s 24
+		IL_03b6: ldloc.s 24
+		IL_03b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0)
+		IL_03bd: stloc.s 24
+		IL_03bf: ldloc.s 18
+		IL_03c1: ldstr "maxNext"
+		IL_03c6: ldloc.s 24
+		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_03cd: pop
+		IL_03ce: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03d3: stloc.s 14
+		IL_03d5: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum::.ctor()
+		IL_03da: ldc.i4.s 9
+		IL_03dc: conv.r8
+		IL_03dd: ldstr "sum"
+		IL_03e2: ldc.i4.0
+		IL_03e3: ldc.i4.1
+		IL_03e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0, float64, string, bool, bool)
+		IL_03e9: stloc.s 25
+		IL_03eb: ldloc.s 25
+		IL_03ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0)
+		IL_03f2: stloc.s 25
+		IL_03f4: ldloc.s 18
+		IL_03f6: ldstr "sum"
+		IL_03fb: ldloc.s 25
+		IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0402: pop
+		IL_0403: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0408: stloc.s 14
+		IL_040a: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::.ctor()
+		IL_040f: ldc.i4.0
+		IL_0410: conv.r8
+		IL_0411: ldstr "maxSum"
+		IL_0416: ldc.i4.1
+		IL_0417: ldc.i4.1
+		IL_0418: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0, float64, string, bool, bool)
+		IL_041d: stloc.s 26
+		IL_041f: ldloc.s 26
+		IL_0421: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0)
+		IL_0426: stloc.s 26
+		IL_0428: ldloc.s 18
+		IL_042a: ldstr "maxSum"
+		IL_042f: ldloc.s 26
+		IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0436: pop
+		IL_0437: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_043c: stloc.s 14
+		IL_043e: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::.ctor()
+		IL_0443: ldc.i4.0
+		IL_0444: conv.r8
+		IL_0445: ldstr "maxSumWithFloor"
+		IL_044a: ldc.i4.1
+		IL_044b: ldc.i4.1
+		IL_044c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0, float64, string, bool, bool)
+		IL_0451: stloc.s 27
+		IL_0453: ldloc.s 27
+		IL_0455: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0)
+		IL_045a: stloc.s 27
+		IL_045c: ldloc.s 18
+		IL_045e: ldstr "maxSumWithFloor"
+		IL_0463: ldloc.s 27
+		IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_046a: pop
+		IL_046b: ldc.i4.1
+		IL_046c: newarr [System.Runtime]System.Object
+		IL_0471: dup
+		IL_0472: ldc.i4.0
+		IL_0473: ldloc.0
+		IL_0474: stelem.ref
+		IL_0475: stloc.s 14
+		IL_0477: ldloc.s 17
+		IL_0479: ldloc.s 14
+		IL_047b: ldc.r8 1
+		IL_0484: box [System.Runtime]System.Double
+		IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_048e: stloc.s 18
+		IL_0490: ldloc.0
+		IL_0491: ldloc.s 18
+		IL_0493: stfld object Modules.Function_SchedulerCallResults/Scope::Counter
+		IL_0498: nop
+		IL_0499: nop
+		IL_049a: nop
+		IL_049b: nop
+		IL_049c: nop
+		IL_049d: ldstr "console"
+		IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04ac: stloc.s 18
+		IL_04ae: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04b3: stloc.s 14
+		IL_04b5: ldloc.1
+		IL_04b6: ldloc.s 14
+		IL_04b8: ldc.r8 9
+		IL_04c1: box [System.Runtime]System.Double
+		IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_04cb: stloc.s 28
+		IL_04cd: ldloc.s 18
+		IL_04cf: ldstr "log"
+		IL_04d4: ldloc.s 28
+		IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04db: pop
+		IL_04dc: ldstr "console"
+		IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04eb: stloc.s 28
+		IL_04ed: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04f2: stloc.s 14
+		IL_04f4: ldc.r8 2.7
+		IL_04fd: neg
+		IL_04fe: stloc.s 29
+		IL_0500: ldloc.s 29
+		IL_0502: box [System.Runtime]System.Double
+		IL_0507: stloc.s 30
+		IL_0509: ldloc.2
+		IL_050a: ldloc.s 14
+		IL_050c: ldloc.s 30
+		IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0513: stloc.s 18
+		IL_0515: ldloc.s 28
+		IL_0517: ldstr "log"
+		IL_051c: ldloc.s 18
+		IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0523: pop
+		IL_0524: ldstr "console"
+		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0533: stloc.s 18
+		IL_0535: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_053a: stloc.s 14
+		IL_053c: ldloc.3
+		IL_053d: ldloc.s 14
+		IL_053f: ldc.r8 1.2
+		IL_0548: box [System.Runtime]System.Double
+		IL_054d: ldc.r8 1.1
+		IL_0556: box [System.Runtime]System.Double
+		IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0560: stloc.s 28
+		IL_0562: ldloc.s 18
+		IL_0564: ldstr "log"
+		IL_0569: ldloc.s 28
+		IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0570: pop
+		IL_0571: ldstr "console"
+		IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0580: stloc.s 28
+		IL_0582: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0587: stloc.s 14
+		IL_0589: ldloc.s 4
+		IL_058b: ldloc.s 14
+		IL_058d: ldc.r8 9
+		IL_0596: box [System.Runtime]System.Double
+		IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_05a0: stloc.s 18
+		IL_05a2: ldloc.s 28
+		IL_05a4: ldstr "log"
+		IL_05a9: ldloc.s 18
+		IL_05ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05b0: pop
+		IL_05b1: ldstr "console"
+		IL_05b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05c0: stloc.s 18
+		IL_05c2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05c7: stloc.s 14
+		IL_05c9: ldloc.s 5
+		IL_05cb: ldloc.s 14
+		IL_05cd: ldc.r8 2
+		IL_05d6: box [System.Runtime]System.Double
+		IL_05db: ldc.r8 3
+		IL_05e4: box [System.Runtime]System.Double
+		IL_05e9: ldc.r8 2
+		IL_05f2: box [System.Runtime]System.Double
+		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_05fc: stloc.s 28
+		IL_05fe: ldloc.s 18
+		IL_0600: ldstr "log"
+		IL_0605: ldloc.s 28
+		IL_0607: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_060c: pop
+		IL_060d: ldstr "console"
+		IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_061c: stloc.s 28
+		IL_061e: ldloc.s 6
+		IL_0620: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0625: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_062a: stloc.s 18
+		IL_062c: ldloc.s 28
+		IL_062e: ldstr "log"
+		IL_0633: ldloc.s 18
+		IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_063a: pop
+		IL_063b: ldstr "console"
+		IL_0640: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_064a: stloc.s 18
+		IL_064c: ldloc.s 7
+		IL_064e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0658: stloc.s 28
+		IL_065a: ldloc.s 18
+		IL_065c: ldstr "log"
+		IL_0661: ldloc.s 28
+		IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0668: pop
+		IL_0669: ldstr "console"
+		IL_066e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0673: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0678: stloc.s 28
+		IL_067a: ldloc.s 8
+		IL_067c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0686: stloc.s 18
+		IL_0688: ldloc.s 28
+		IL_068a: ldstr "log"
+		IL_068f: ldloc.s 18
+		IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0696: pop
+		IL_0697: ldstr "console"
+		IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06a6: stloc.s 18
+		IL_06a8: ldloc.s 9
+		IL_06aa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_06b4: stloc.s 28
+		IL_06b6: ldloc.s 18
+		IL_06b8: ldstr "log"
+		IL_06bd: ldloc.s 28
+		IL_06bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06c4: pop
+		IL_06c5: ldstr "console"
+		IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06d4: stloc.s 28
+		IL_06d6: ldloc.s 10
+		IL_06d8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_06e2: stloc.s 18
+		IL_06e4: ldloc.s 28
+		IL_06e6: ldstr "log"
+		IL_06eb: ldloc.s 18
+		IL_06ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06f2: pop
+		IL_06f3: ldstr "console"
+		IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0702: stloc.s 18
+		IL_0704: ldloc.s 11
+		IL_0706: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0710: stloc.s 28
+		IL_0712: ldloc.s 18
+		IL_0714: ldstr "log"
+		IL_0719: ldloc.s 28
+		IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0720: pop
+		IL_0721: ldstr "console"
+		IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0730: stloc.s 28
+		IL_0732: ldloc.s 12
+		IL_0734: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_073e: stloc.s 18
+		IL_0740: ldloc.s 28
+		IL_0742: ldstr "log"
+		IL_0747: ldloc.s 18
+		IL_0749: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_074e: pop
+		IL_074f: ldstr "console"
+		IL_0754: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_075e: stloc.s 18
+		IL_0760: ldloc.s 13
+		IL_0762: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0767: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_076c: stloc.s 28
+		IL_076e: ldloc.s 18
+		IL_0770: ldstr "log"
+		IL_0775: ldloc.s 28
+		IL_0777: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_077c: pop
+		IL_077d: ret
 	} // end of method Function_SchedulerCallResults::__js_module_init__
 
 } // end of class Modules.Function_SchedulerCallResults
@@ -5111,7 +5105,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x38a6
+		// Method begins at RVA 0x388e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_SimpleYield.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_SimpleYield.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243e
+				// Method begins at RVA 0x242a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2447
+				// Method begins at RVA 0x2433
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2450
+				// Method begins at RVA 0x243c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x245f
+				// Method begins at RVA 0x244b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2462
+				// Method begins at RVA 0x244e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2465
+				// Method begins at RVA 0x2451
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2471
+				// Method begins at RVA 0x245d
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x247d
+				// Method begins at RVA 0x2469
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2485
+				// Method begins at RVA 0x2471
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2488
+				// Method begins at RVA 0x2474
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x248b
+				// Method begins at RVA 0x2477
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -209,7 +209,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22d4
+			// Method begins at RVA 0x22be
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -228,7 +228,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22dc
+			// Method begins at RVA 0x22c8
 			// Header size: 12
 			// Code size: 333 (0x14d)
 			.maxstack 8
@@ -376,7 +376,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2435
+			// Method begins at RVA 0x2421
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -402,7 +402,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 632 (0x278)
+		// Code size: 610 (0x262)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Generator_ClassMethod_SimpleYield/Scope,
@@ -411,12 +411,11 @@
 			[3] object,
 			[4] object,
 			[5] class [System.Runtime]System.Type,
-			[6] class [System.Runtime]System.Type,
-			[7] object[],
-			[8] object,
-			[9] class Modules.Generator_ClassMethod_SimpleYield/Gen,
-			[10] object,
-			[11] object
+			[6] object[],
+			[7] object,
+			[8] class Modules.Generator_ClassMethod_SimpleYield/Gen,
+			[9] object,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Generator_ClassMethod_SimpleYield/Scope::.ctor()
@@ -427,237 +426,232 @@
 		IL_0011: ldtoken Modules.Generator_ClassMethod_SimpleYield/Gen
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.s 5
-		IL_001d: ldtoken Modules.Generator_ClassMethod_SimpleYield/Gen
-		IL_0022: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0027: ldtoken Modules.Generator_ClassMethod_SimpleYield/Gen
-		IL_002c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0031: stloc.s 6
-		IL_0033: ldloc.s 6
-		IL_0035: ldstr "prototype"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003f: pop
-		IL_0040: ldc.i4.1
-		IL_0041: newarr [System.Runtime]System.Object
-		IL_0046: dup
-		IL_0047: ldc.i4.0
-		IL_0048: ldloc.0
+		IL_001d: ldloc.s 5
+		IL_001f: ldstr "prototype"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0029: pop
+		IL_002a: ldc.i4.1
+		IL_002b: newarr [System.Runtime]System.Object
+		IL_0030: dup
+		IL_0031: ldc.i4.0
+		IL_0032: ldloc.0
+		IL_0033: stelem.ref
+		IL_0034: stloc.s 6
+		IL_0036: ldc.i4.s 10
+		IL_0038: newarr [System.Runtime]System.Object
+		IL_003d: dup
+		IL_003e: ldc.i4.0
+		IL_003f: ldloc.s 5
+		IL_0041: stelem.ref
+		IL_0042: dup
+		IL_0043: ldc.i4.1
+		IL_0044: ldstr "values"
 		IL_0049: stelem.ref
-		IL_004a: stloc.s 7
-		IL_004c: ldc.i4.s 10
-		IL_004e: newarr [System.Runtime]System.Object
-		IL_0053: dup
-		IL_0054: ldc.i4.0
-		IL_0055: ldloc.s 5
-		IL_0057: stelem.ref
-		IL_0058: dup
-		IL_0059: ldc.i4.1
-		IL_005a: ldstr "values"
-		IL_005f: stelem.ref
-		IL_0060: dup
-		IL_0061: ldc.i4.2
-		IL_0062: ldstr "values"
-		IL_0067: stelem.ref
-		IL_0068: dup
-		IL_0069: ldc.i4.3
-		IL_006a: ldc.r8 0.0
-		IL_0073: box [System.Runtime]System.Double
-		IL_0078: stelem.ref
-		IL_0079: dup
-		IL_007a: ldc.i4.4
-		IL_007b: ldstr "values"
-		IL_0080: stelem.ref
-		IL_0081: dup
-		IL_0082: ldc.i4.5
-		IL_0083: ldc.i4.0
-		IL_0084: box [System.Runtime]System.Boolean
-		IL_0089: stelem.ref
-		IL_008a: dup
-		IL_008b: ldc.i4.6
-		IL_008c: ldc.i4.0
-		IL_008d: box [System.Runtime]System.Boolean
-		IL_0092: stelem.ref
-		IL_0093: dup
-		IL_0094: ldc.i4.7
-		IL_0095: ldc.i4.1
-		IL_0096: box [System.Runtime]System.Boolean
-		IL_009b: stelem.ref
-		IL_009c: dup
-		IL_009d: ldc.i4.8
-		IL_009e: ldc.i4.0
-		IL_009f: box [System.Runtime]System.Boolean
+		IL_004a: dup
+		IL_004b: ldc.i4.2
+		IL_004c: ldstr "values"
+		IL_0051: stelem.ref
+		IL_0052: dup
+		IL_0053: ldc.i4.3
+		IL_0054: ldc.r8 0.0
+		IL_005d: box [System.Runtime]System.Double
+		IL_0062: stelem.ref
+		IL_0063: dup
+		IL_0064: ldc.i4.4
+		IL_0065: ldstr "values"
+		IL_006a: stelem.ref
+		IL_006b: dup
+		IL_006c: ldc.i4.5
+		IL_006d: ldc.i4.0
+		IL_006e: box [System.Runtime]System.Boolean
+		IL_0073: stelem.ref
+		IL_0074: dup
+		IL_0075: ldc.i4.6
+		IL_0076: ldc.i4.0
+		IL_0077: box [System.Runtime]System.Boolean
+		IL_007c: stelem.ref
+		IL_007d: dup
+		IL_007e: ldc.i4.7
+		IL_007f: ldc.i4.1
+		IL_0080: box [System.Runtime]System.Boolean
+		IL_0085: stelem.ref
+		IL_0086: dup
+		IL_0087: ldc.i4.8
+		IL_0088: ldc.i4.0
+		IL_0089: box [System.Runtime]System.Boolean
+		IL_008e: stelem.ref
+		IL_008f: dup
+		IL_0090: ldc.i4.s 9
+		IL_0092: ldloc.s 6
+		IL_0094: stelem.ref
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_009a: pop
+		IL_009b: ldc.i4.1
+		IL_009c: newarr [System.Runtime]System.Object
+		IL_00a1: dup
+		IL_00a2: ldc.i4.0
+		IL_00a3: ldloc.0
 		IL_00a4: stelem.ref
-		IL_00a5: dup
-		IL_00a6: ldc.i4.s 9
-		IL_00a8: ldloc.s 7
-		IL_00aa: stelem.ref
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00b0: pop
-		IL_00b1: ldc.i4.1
-		IL_00b2: newarr [System.Runtime]System.Object
-		IL_00b7: dup
-		IL_00b8: ldc.i4.0
-		IL_00b9: ldloc.0
-		IL_00ba: stelem.ref
-		IL_00bb: stloc.s 7
-		IL_00bd: ldloc.s 5
-		IL_00bf: ldloc.s 7
-		IL_00c1: ldc.r8 0.0
-		IL_00ca: box [System.Runtime]System.Double
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00d4: stloc.s 8
-		IL_00d6: ldloc.s 8
-		IL_00d8: stloc.1
-		IL_00d9: ldc.i4.0
-		IL_00da: newarr [System.Runtime]System.Object
-		IL_00df: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00e4: newobj instance void Modules.Generator_ClassMethod_SimpleYield/Gen::.ctor()
-		IL_00e9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00ee: stloc.2
-		IL_00ef: ldloc.2
-		IL_00f0: ldtoken Modules.Generator_ClassMethod_SimpleYield/Gen
-		IL_00f5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00fa: ldstr "prototype"
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0104: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0109: ldloc.2
-		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Generator_ClassMethod_SimpleYield/Gen>(!!0)
-		IL_010f: stloc.s 9
-		IL_0111: ldloc.s 9
-		IL_0113: ldc.i4.1
-		IL_0114: newarr [System.Runtime]System.Object
-		IL_0119: dup
-		IL_011a: ldc.i4.0
-		IL_011b: ldloc.0
-		IL_011c: stelem.ref
-		IL_011d: ldnull
-		IL_011e: callvirt instance object Modules.Generator_ClassMethod_SimpleYield/Gen::values(object[], object)
-		IL_0123: stloc.3
-		IL_0124: ldnull
+		IL_00a5: stloc.s 6
+		IL_00a7: ldloc.s 5
+		IL_00a9: ldloc.s 6
+		IL_00ab: ldc.r8 0.0
+		IL_00b4: box [System.Runtime]System.Double
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00be: stloc.s 7
+		IL_00c0: ldloc.s 7
+		IL_00c2: stloc.1
+		IL_00c3: ldc.i4.0
+		IL_00c4: newarr [System.Runtime]System.Object
+		IL_00c9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00ce: newobj instance void Modules.Generator_ClassMethod_SimpleYield/Gen::.ctor()
+		IL_00d3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00d8: stloc.2
+		IL_00d9: ldloc.2
+		IL_00da: ldtoken Modules.Generator_ClassMethod_SimpleYield/Gen
+		IL_00df: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00e4: ldstr "prototype"
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00ee: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00f3: ldloc.2
+		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Generator_ClassMethod_SimpleYield/Gen>(!!0)
+		IL_00f9: stloc.s 8
+		IL_00fb: ldloc.s 8
+		IL_00fd: ldc.i4.1
+		IL_00fe: newarr [System.Runtime]System.Object
+		IL_0103: dup
+		IL_0104: ldc.i4.0
+		IL_0105: ldloc.0
+		IL_0106: stelem.ref
+		IL_0107: ldnull
+		IL_0108: callvirt instance object Modules.Generator_ClassMethod_SimpleYield/Gen::values(object[], object)
+		IL_010d: stloc.3
+		IL_010e: ldnull
+		IL_010f: stloc.s 4
+		IL_0111: ldloc.3
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0117: ldstr "next"
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0121: stloc.s 7
+		IL_0123: ldloc.s 7
 		IL_0125: stloc.s 4
-		IL_0127: ldloc.3
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012d: ldstr "next"
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0137: stloc.s 8
-		IL_0139: ldloc.s 8
-		IL_013b: stloc.s 4
-		IL_013d: ldstr "console"
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014c: stloc.s 8
-		IL_014e: ldloc.s 4
-		IL_0150: ldstr "value"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015a: stloc.s 10
-		IL_015c: ldloc.s 4
-		IL_015e: ldstr "done"
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0168: stloc.s 11
-		IL_016a: ldloc.s 8
-		IL_016c: ldstr "log"
-		IL_0171: ldc.i4.4
-		IL_0172: newarr [System.Runtime]System.Object
-		IL_0177: dup
-		IL_0178: ldc.i4.0
-		IL_0179: ldstr "v1:"
-		IL_017e: stelem.ref
-		IL_017f: dup
-		IL_0180: ldc.i4.1
-		IL_0181: ldloc.s 10
-		IL_0183: stelem.ref
-		IL_0184: dup
-		IL_0185: ldc.i4.2
-		IL_0186: ldstr "done:"
-		IL_018b: stelem.ref
-		IL_018c: dup
-		IL_018d: ldc.i4.3
-		IL_018e: ldloc.s 11
-		IL_0190: stelem.ref
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0196: pop
-		IL_0197: ldloc.3
-		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019d: ldstr "next"
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01a7: stloc.s 8
-		IL_01a9: ldloc.s 8
-		IL_01ab: stloc.s 4
-		IL_01ad: ldstr "console"
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bc: stloc.s 8
-		IL_01be: ldloc.s 4
-		IL_01c0: ldstr "value"
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ca: stloc.s 11
-		IL_01cc: ldloc.s 4
-		IL_01ce: ldstr "done"
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01d8: stloc.s 10
-		IL_01da: ldloc.s 8
-		IL_01dc: ldstr "log"
-		IL_01e1: ldc.i4.4
-		IL_01e2: newarr [System.Runtime]System.Object
-		IL_01e7: dup
-		IL_01e8: ldc.i4.0
-		IL_01e9: ldstr "v2:"
-		IL_01ee: stelem.ref
-		IL_01ef: dup
-		IL_01f0: ldc.i4.1
-		IL_01f1: ldloc.s 11
-		IL_01f3: stelem.ref
-		IL_01f4: dup
-		IL_01f5: ldc.i4.2
-		IL_01f6: ldstr "done:"
-		IL_01fb: stelem.ref
-		IL_01fc: dup
-		IL_01fd: ldc.i4.3
-		IL_01fe: ldloc.s 10
-		IL_0200: stelem.ref
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0206: pop
-		IL_0207: ldloc.3
-		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020d: ldstr "next"
-		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0217: stloc.s 8
-		IL_0219: ldloc.s 8
-		IL_021b: stloc.s 4
-		IL_021d: ldstr "console"
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022c: stloc.s 8
-		IL_022e: ldloc.s 4
-		IL_0230: ldstr "value"
-		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_023a: stloc.s 10
-		IL_023c: ldloc.s 4
-		IL_023e: ldstr "done"
-		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0248: stloc.s 11
-		IL_024a: ldloc.s 8
-		IL_024c: ldstr "log"
-		IL_0251: ldc.i4.4
-		IL_0252: newarr [System.Runtime]System.Object
-		IL_0257: dup
-		IL_0258: ldc.i4.0
-		IL_0259: ldstr "v3:"
-		IL_025e: stelem.ref
-		IL_025f: dup
-		IL_0260: ldc.i4.1
-		IL_0261: ldloc.s 10
-		IL_0263: stelem.ref
-		IL_0264: dup
-		IL_0265: ldc.i4.2
-		IL_0266: ldstr "done:"
-		IL_026b: stelem.ref
-		IL_026c: dup
-		IL_026d: ldc.i4.3
-		IL_026e: ldloc.s 11
-		IL_0270: stelem.ref
-		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0276: pop
-		IL_0277: ret
+		IL_0127: ldstr "console"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0136: stloc.s 7
+		IL_0138: ldloc.s 4
+		IL_013a: ldstr "value"
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0144: stloc.s 9
+		IL_0146: ldloc.s 4
+		IL_0148: ldstr "done"
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0152: stloc.s 10
+		IL_0154: ldloc.s 7
+		IL_0156: ldstr "log"
+		IL_015b: ldc.i4.4
+		IL_015c: newarr [System.Runtime]System.Object
+		IL_0161: dup
+		IL_0162: ldc.i4.0
+		IL_0163: ldstr "v1:"
+		IL_0168: stelem.ref
+		IL_0169: dup
+		IL_016a: ldc.i4.1
+		IL_016b: ldloc.s 9
+		IL_016d: stelem.ref
+		IL_016e: dup
+		IL_016f: ldc.i4.2
+		IL_0170: ldstr "done:"
+		IL_0175: stelem.ref
+		IL_0176: dup
+		IL_0177: ldc.i4.3
+		IL_0178: ldloc.s 10
+		IL_017a: stelem.ref
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0180: pop
+		IL_0181: ldloc.3
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0187: ldstr "next"
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0191: stloc.s 7
+		IL_0193: ldloc.s 7
+		IL_0195: stloc.s 4
+		IL_0197: ldstr "console"
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a6: stloc.s 7
+		IL_01a8: ldloc.s 4
+		IL_01aa: ldstr "value"
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01b4: stloc.s 10
+		IL_01b6: ldloc.s 4
+		IL_01b8: ldstr "done"
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c2: stloc.s 9
+		IL_01c4: ldloc.s 7
+		IL_01c6: ldstr "log"
+		IL_01cb: ldc.i4.4
+		IL_01cc: newarr [System.Runtime]System.Object
+		IL_01d1: dup
+		IL_01d2: ldc.i4.0
+		IL_01d3: ldstr "v2:"
+		IL_01d8: stelem.ref
+		IL_01d9: dup
+		IL_01da: ldc.i4.1
+		IL_01db: ldloc.s 10
+		IL_01dd: stelem.ref
+		IL_01de: dup
+		IL_01df: ldc.i4.2
+		IL_01e0: ldstr "done:"
+		IL_01e5: stelem.ref
+		IL_01e6: dup
+		IL_01e7: ldc.i4.3
+		IL_01e8: ldloc.s 9
+		IL_01ea: stelem.ref
+		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_01f0: pop
+		IL_01f1: ldloc.3
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f7: ldstr "next"
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0201: stloc.s 7
+		IL_0203: ldloc.s 7
+		IL_0205: stloc.s 4
+		IL_0207: ldstr "console"
+		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0216: stloc.s 7
+		IL_0218: ldloc.s 4
+		IL_021a: ldstr "value"
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0224: stloc.s 9
+		IL_0226: ldloc.s 4
+		IL_0228: ldstr "done"
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0232: stloc.s 10
+		IL_0234: ldloc.s 7
+		IL_0236: ldstr "log"
+		IL_023b: ldc.i4.4
+		IL_023c: newarr [System.Runtime]System.Object
+		IL_0241: dup
+		IL_0242: ldc.i4.0
+		IL_0243: ldstr "v3:"
+		IL_0248: stelem.ref
+		IL_0249: dup
+		IL_024a: ldc.i4.1
+		IL_024b: ldloc.s 9
+		IL_024d: stelem.ref
+		IL_024e: dup
+		IL_024f: ldc.i4.2
+		IL_0250: ldstr "done:"
+		IL_0255: stelem.ref
+		IL_0256: dup
+		IL_0257: ldc.i4.3
+		IL_0258: ldloc.s 10
+		IL_025a: stelem.ref
+		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0260: pop
+		IL_0261: ret
 	} // end of method Generator_ClassMethod_SimpleYield::__js_module_init__
 
 } // end of class Modules.Generator_ClassMethod_SimpleYield
@@ -669,7 +663,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24af
+		// Method begins at RVA 0x249b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_WithThis.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_WithThis.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x237e
+				// Method begins at RVA 0x236a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2387
+				// Method begins at RVA 0x2373
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2390
+				// Method begins at RVA 0x237c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2399
+				// Method begins at RVA 0x2385
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23a8
+				// Method begins at RVA 0x2394
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23ab
+				// Method begins at RVA 0x2397
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23ae
+				// Method begins at RVA 0x239a
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -142,7 +142,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x23ba
+				// Method begins at RVA 0x23a6
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c6
+				// Method begins at RVA 0x23b2
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -174,7 +174,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23ce
+				// Method begins at RVA 0x23ba
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -186,7 +186,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23d1
+				// Method begins at RVA 0x23bd
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -201,7 +201,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23d4
+				// Method begins at RVA 0x23c0
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -232,7 +232,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2264
+			// Method begins at RVA 0x224e
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -254,7 +254,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x227c
+			// Method begins at RVA 0x2268
 			// Header size: 12
 			// Code size: 237 (0xed)
 			.maxstack 8
@@ -369,7 +369,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2375
+			// Method begins at RVA 0x2361
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -395,7 +395,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 520 (0x208)
+		// Code size: 498 (0x1f2)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Generator_ClassMethod_WithThis/Scope,
@@ -404,12 +404,11 @@
 			[3] object,
 			[4] object,
 			[5] class [System.Runtime]System.Type,
-			[6] class [System.Runtime]System.Type,
-			[7] object[],
-			[8] object,
-			[9] class Modules.Generator_ClassMethod_WithThis/Counter,
-			[10] object,
-			[11] object
+			[6] object[],
+			[7] object,
+			[8] class Modules.Generator_ClassMethod_WithThis/Counter,
+			[9] object,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Generator_ClassMethod_WithThis/Scope::.ctor()
@@ -420,196 +419,191 @@
 		IL_0011: ldtoken Modules.Generator_ClassMethod_WithThis/Counter
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.s 5
-		IL_001d: ldtoken Modules.Generator_ClassMethod_WithThis/Counter
-		IL_0022: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0027: ldtoken Modules.Generator_ClassMethod_WithThis/Counter
-		IL_002c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0031: stloc.s 6
-		IL_0033: ldloc.s 6
-		IL_0035: ldstr "prototype"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003f: pop
-		IL_0040: ldc.i4.1
-		IL_0041: newarr [System.Runtime]System.Object
-		IL_0046: dup
-		IL_0047: ldc.i4.0
-		IL_0048: ldloc.0
+		IL_001d: ldloc.s 5
+		IL_001f: ldstr "prototype"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0029: pop
+		IL_002a: ldc.i4.1
+		IL_002b: newarr [System.Runtime]System.Object
+		IL_0030: dup
+		IL_0031: ldc.i4.0
+		IL_0032: ldloc.0
+		IL_0033: stelem.ref
+		IL_0034: stloc.s 6
+		IL_0036: ldc.i4.s 10
+		IL_0038: newarr [System.Runtime]System.Object
+		IL_003d: dup
+		IL_003e: ldc.i4.0
+		IL_003f: ldloc.s 5
+		IL_0041: stelem.ref
+		IL_0042: dup
+		IL_0043: ldc.i4.1
+		IL_0044: ldstr "getCountLater"
 		IL_0049: stelem.ref
-		IL_004a: stloc.s 7
-		IL_004c: ldc.i4.s 10
-		IL_004e: newarr [System.Runtime]System.Object
-		IL_0053: dup
-		IL_0054: ldc.i4.0
-		IL_0055: ldloc.s 5
-		IL_0057: stelem.ref
-		IL_0058: dup
-		IL_0059: ldc.i4.1
-		IL_005a: ldstr "getCountLater"
-		IL_005f: stelem.ref
-		IL_0060: dup
-		IL_0061: ldc.i4.2
-		IL_0062: ldstr "getCountLater"
-		IL_0067: stelem.ref
-		IL_0068: dup
-		IL_0069: ldc.i4.3
-		IL_006a: ldc.r8 0.0
-		IL_0073: box [System.Runtime]System.Double
-		IL_0078: stelem.ref
-		IL_0079: dup
-		IL_007a: ldc.i4.4
-		IL_007b: ldstr "getCountLater"
-		IL_0080: stelem.ref
-		IL_0081: dup
-		IL_0082: ldc.i4.5
-		IL_0083: ldc.i4.0
-		IL_0084: box [System.Runtime]System.Boolean
-		IL_0089: stelem.ref
-		IL_008a: dup
-		IL_008b: ldc.i4.6
-		IL_008c: ldc.i4.0
-		IL_008d: box [System.Runtime]System.Boolean
-		IL_0092: stelem.ref
-		IL_0093: dup
-		IL_0094: ldc.i4.7
-		IL_0095: ldc.i4.1
-		IL_0096: box [System.Runtime]System.Boolean
-		IL_009b: stelem.ref
-		IL_009c: dup
-		IL_009d: ldc.i4.8
-		IL_009e: ldc.i4.0
-		IL_009f: box [System.Runtime]System.Boolean
+		IL_004a: dup
+		IL_004b: ldc.i4.2
+		IL_004c: ldstr "getCountLater"
+		IL_0051: stelem.ref
+		IL_0052: dup
+		IL_0053: ldc.i4.3
+		IL_0054: ldc.r8 0.0
+		IL_005d: box [System.Runtime]System.Double
+		IL_0062: stelem.ref
+		IL_0063: dup
+		IL_0064: ldc.i4.4
+		IL_0065: ldstr "getCountLater"
+		IL_006a: stelem.ref
+		IL_006b: dup
+		IL_006c: ldc.i4.5
+		IL_006d: ldc.i4.0
+		IL_006e: box [System.Runtime]System.Boolean
+		IL_0073: stelem.ref
+		IL_0074: dup
+		IL_0075: ldc.i4.6
+		IL_0076: ldc.i4.0
+		IL_0077: box [System.Runtime]System.Boolean
+		IL_007c: stelem.ref
+		IL_007d: dup
+		IL_007e: ldc.i4.7
+		IL_007f: ldc.i4.1
+		IL_0080: box [System.Runtime]System.Boolean
+		IL_0085: stelem.ref
+		IL_0086: dup
+		IL_0087: ldc.i4.8
+		IL_0088: ldc.i4.0
+		IL_0089: box [System.Runtime]System.Boolean
+		IL_008e: stelem.ref
+		IL_008f: dup
+		IL_0090: ldc.i4.s 9
+		IL_0092: ldloc.s 6
+		IL_0094: stelem.ref
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_009a: pop
+		IL_009b: ldc.i4.1
+		IL_009c: newarr [System.Runtime]System.Object
+		IL_00a1: dup
+		IL_00a2: ldc.i4.0
+		IL_00a3: ldloc.0
 		IL_00a4: stelem.ref
-		IL_00a5: dup
-		IL_00a6: ldc.i4.s 9
-		IL_00a8: ldloc.s 7
-		IL_00aa: stelem.ref
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00b0: pop
-		IL_00b1: ldc.i4.1
-		IL_00b2: newarr [System.Runtime]System.Object
-		IL_00b7: dup
-		IL_00b8: ldc.i4.0
-		IL_00b9: ldloc.0
-		IL_00ba: stelem.ref
-		IL_00bb: stloc.s 7
-		IL_00bd: ldloc.s 5
-		IL_00bf: ldloc.s 7
-		IL_00c1: ldc.r8 0.0
-		IL_00ca: box [System.Runtime]System.Double
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00d4: stloc.s 8
-		IL_00d6: ldloc.s 8
-		IL_00d8: stloc.1
-		IL_00d9: ldc.i4.0
-		IL_00da: newarr [System.Runtime]System.Object
-		IL_00df: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00e4: newobj instance void Modules.Generator_ClassMethod_WithThis/Counter::.ctor()
-		IL_00e9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00ee: stloc.2
-		IL_00ef: ldloc.2
-		IL_00f0: ldtoken Modules.Generator_ClassMethod_WithThis/Counter
-		IL_00f5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00fa: ldstr "prototype"
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0104: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0109: ldloc.2
-		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Generator_ClassMethod_WithThis/Counter>(!!0)
-		IL_010f: stloc.s 9
-		IL_0111: ldloc.s 9
-		IL_0113: ldc.i4.1
-		IL_0114: newarr [System.Runtime]System.Object
-		IL_0119: dup
-		IL_011a: ldc.i4.0
-		IL_011b: ldloc.0
-		IL_011c: stelem.ref
-		IL_011d: ldnull
-		IL_011e: callvirt instance object Modules.Generator_ClassMethod_WithThis/Counter::getCountLater(object[], object)
-		IL_0123: stloc.3
-		IL_0124: ldnull
+		IL_00a5: stloc.s 6
+		IL_00a7: ldloc.s 5
+		IL_00a9: ldloc.s 6
+		IL_00ab: ldc.r8 0.0
+		IL_00b4: box [System.Runtime]System.Double
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00be: stloc.s 7
+		IL_00c0: ldloc.s 7
+		IL_00c2: stloc.1
+		IL_00c3: ldc.i4.0
+		IL_00c4: newarr [System.Runtime]System.Object
+		IL_00c9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00ce: newobj instance void Modules.Generator_ClassMethod_WithThis/Counter::.ctor()
+		IL_00d3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00d8: stloc.2
+		IL_00d9: ldloc.2
+		IL_00da: ldtoken Modules.Generator_ClassMethod_WithThis/Counter
+		IL_00df: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00e4: ldstr "prototype"
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00ee: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00f3: ldloc.2
+		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Generator_ClassMethod_WithThis/Counter>(!!0)
+		IL_00f9: stloc.s 8
+		IL_00fb: ldloc.s 8
+		IL_00fd: ldc.i4.1
+		IL_00fe: newarr [System.Runtime]System.Object
+		IL_0103: dup
+		IL_0104: ldc.i4.0
+		IL_0105: ldloc.0
+		IL_0106: stelem.ref
+		IL_0107: ldnull
+		IL_0108: callvirt instance object Modules.Generator_ClassMethod_WithThis/Counter::getCountLater(object[], object)
+		IL_010d: stloc.3
+		IL_010e: ldnull
+		IL_010f: stloc.s 4
+		IL_0111: ldloc.3
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0117: ldstr "next"
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0121: stloc.s 7
+		IL_0123: ldloc.s 7
 		IL_0125: stloc.s 4
-		IL_0127: ldloc.3
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012d: ldstr "next"
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0137: stloc.s 8
-		IL_0139: ldloc.s 8
-		IL_013b: stloc.s 4
-		IL_013d: ldstr "console"
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014c: stloc.s 8
-		IL_014e: ldloc.s 4
-		IL_0150: ldstr "value"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015a: stloc.s 10
-		IL_015c: ldloc.s 4
-		IL_015e: ldstr "done"
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0168: stloc.s 11
-		IL_016a: ldloc.s 8
-		IL_016c: ldstr "log"
-		IL_0171: ldc.i4.4
-		IL_0172: newarr [System.Runtime]System.Object
-		IL_0177: dup
-		IL_0178: ldc.i4.0
-		IL_0179: ldstr "t1:"
-		IL_017e: stelem.ref
-		IL_017f: dup
-		IL_0180: ldc.i4.1
-		IL_0181: ldloc.s 10
-		IL_0183: stelem.ref
-		IL_0184: dup
-		IL_0185: ldc.i4.2
-		IL_0186: ldstr "done:"
-		IL_018b: stelem.ref
-		IL_018c: dup
-		IL_018d: ldc.i4.3
-		IL_018e: ldloc.s 11
-		IL_0190: stelem.ref
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0196: pop
-		IL_0197: ldloc.3
-		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019d: ldstr "next"
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01a7: stloc.s 8
-		IL_01a9: ldloc.s 8
-		IL_01ab: stloc.s 4
-		IL_01ad: ldstr "console"
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bc: stloc.s 8
-		IL_01be: ldloc.s 4
-		IL_01c0: ldstr "value"
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ca: stloc.s 11
-		IL_01cc: ldloc.s 4
-		IL_01ce: ldstr "done"
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01d8: stloc.s 10
-		IL_01da: ldloc.s 8
-		IL_01dc: ldstr "log"
-		IL_01e1: ldc.i4.4
-		IL_01e2: newarr [System.Runtime]System.Object
-		IL_01e7: dup
-		IL_01e8: ldc.i4.0
-		IL_01e9: ldstr "t2:"
-		IL_01ee: stelem.ref
-		IL_01ef: dup
-		IL_01f0: ldc.i4.1
-		IL_01f1: ldloc.s 11
-		IL_01f3: stelem.ref
-		IL_01f4: dup
-		IL_01f5: ldc.i4.2
-		IL_01f6: ldstr "done:"
-		IL_01fb: stelem.ref
-		IL_01fc: dup
-		IL_01fd: ldc.i4.3
-		IL_01fe: ldloc.s 10
-		IL_0200: stelem.ref
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0206: pop
-		IL_0207: ret
+		IL_0127: ldstr "console"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0136: stloc.s 7
+		IL_0138: ldloc.s 4
+		IL_013a: ldstr "value"
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0144: stloc.s 9
+		IL_0146: ldloc.s 4
+		IL_0148: ldstr "done"
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0152: stloc.s 10
+		IL_0154: ldloc.s 7
+		IL_0156: ldstr "log"
+		IL_015b: ldc.i4.4
+		IL_015c: newarr [System.Runtime]System.Object
+		IL_0161: dup
+		IL_0162: ldc.i4.0
+		IL_0163: ldstr "t1:"
+		IL_0168: stelem.ref
+		IL_0169: dup
+		IL_016a: ldc.i4.1
+		IL_016b: ldloc.s 9
+		IL_016d: stelem.ref
+		IL_016e: dup
+		IL_016f: ldc.i4.2
+		IL_0170: ldstr "done:"
+		IL_0175: stelem.ref
+		IL_0176: dup
+		IL_0177: ldc.i4.3
+		IL_0178: ldloc.s 10
+		IL_017a: stelem.ref
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0180: pop
+		IL_0181: ldloc.3
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0187: ldstr "next"
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0191: stloc.s 7
+		IL_0193: ldloc.s 7
+		IL_0195: stloc.s 4
+		IL_0197: ldstr "console"
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a6: stloc.s 7
+		IL_01a8: ldloc.s 4
+		IL_01aa: ldstr "value"
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01b4: stloc.s 10
+		IL_01b6: ldloc.s 4
+		IL_01b8: ldstr "done"
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c2: stloc.s 9
+		IL_01c4: ldloc.s 7
+		IL_01c6: ldstr "log"
+		IL_01cb: ldc.i4.4
+		IL_01cc: newarr [System.Runtime]System.Object
+		IL_01d1: dup
+		IL_01d2: ldc.i4.0
+		IL_01d3: ldstr "t2:"
+		IL_01d8: stelem.ref
+		IL_01d9: dup
+		IL_01da: ldc.i4.1
+		IL_01db: ldloc.s 10
+		IL_01dd: stelem.ref
+		IL_01de: dup
+		IL_01df: ldc.i4.2
+		IL_01e0: ldstr "done:"
+		IL_01e5: stelem.ref
+		IL_01e6: dup
+		IL_01e7: ldc.i4.3
+		IL_01e8: ldloc.s 9
+		IL_01ea: stelem.ref
+		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_01f0: pop
+		IL_01f1: ret
 	} // end of method Generator_ClassMethod_WithThis::__js_module_init__
 
 } // end of class Modules.Generator_ClassMethod_WithThis
@@ -621,7 +615,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23f8
+		// Method begins at RVA 0x23e4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_YieldAssign.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_YieldAssign.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2448
+				// Method begins at RVA 0x2430
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2451
+				// Method begins at RVA 0x2439
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x245a
+				// Method begins at RVA 0x2442
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2469
+				// Method begins at RVA 0x2451
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x246c
+				// Method begins at RVA 0x2454
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x246f
+				// Method begins at RVA 0x2457
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x247b
+				// Method begins at RVA 0x2463
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2487
+				// Method begins at RVA 0x246f
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x248f
+				// Method begins at RVA 0x2477
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2492
+				// Method begins at RVA 0x247a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2495
+				// Method begins at RVA 0x247d
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -209,7 +209,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22e2
+			// Method begins at RVA 0x22cc
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -228,7 +228,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22ec
+			// Method begins at RVA 0x22d4
 			// Header size: 12
 			// Code size: 327 (0x147)
 			.maxstack 8
@@ -379,7 +379,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x243f
+			// Method begins at RVA 0x2427
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -405,7 +405,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 646 (0x286)
+		// Code size: 624 (0x270)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Generator_ClassMethod_YieldAssign/Scope,
@@ -414,12 +414,11 @@
 			[3] object,
 			[4] object,
 			[5] class [System.Runtime]System.Type,
-			[6] class [System.Runtime]System.Type,
-			[7] object[],
-			[8] object,
-			[9] class Modules.Generator_ClassMethod_YieldAssign/Gen,
-			[10] object,
-			[11] object
+			[6] object[],
+			[7] object,
+			[8] class Modules.Generator_ClassMethod_YieldAssign/Gen,
+			[9] object,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Generator_ClassMethod_YieldAssign/Scope::.ctor()
@@ -430,239 +429,234 @@
 		IL_0011: ldtoken Modules.Generator_ClassMethod_YieldAssign/Gen
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.s 5
-		IL_001d: ldtoken Modules.Generator_ClassMethod_YieldAssign/Gen
-		IL_0022: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0027: ldtoken Modules.Generator_ClassMethod_YieldAssign/Gen
-		IL_002c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0031: stloc.s 6
-		IL_0033: ldloc.s 6
-		IL_0035: ldstr "prototype"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003f: pop
-		IL_0040: ldc.i4.1
-		IL_0041: newarr [System.Runtime]System.Object
-		IL_0046: dup
-		IL_0047: ldc.i4.0
-		IL_0048: ldloc.0
+		IL_001d: ldloc.s 5
+		IL_001f: ldstr "prototype"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0029: pop
+		IL_002a: ldc.i4.1
+		IL_002b: newarr [System.Runtime]System.Object
+		IL_0030: dup
+		IL_0031: ldc.i4.0
+		IL_0032: ldloc.0
+		IL_0033: stelem.ref
+		IL_0034: stloc.s 6
+		IL_0036: ldc.i4.s 10
+		IL_0038: newarr [System.Runtime]System.Object
+		IL_003d: dup
+		IL_003e: ldc.i4.0
+		IL_003f: ldloc.s 5
+		IL_0041: stelem.ref
+		IL_0042: dup
+		IL_0043: ldc.i4.1
+		IL_0044: ldstr "values"
 		IL_0049: stelem.ref
-		IL_004a: stloc.s 7
-		IL_004c: ldc.i4.s 10
-		IL_004e: newarr [System.Runtime]System.Object
-		IL_0053: dup
-		IL_0054: ldc.i4.0
-		IL_0055: ldloc.s 5
-		IL_0057: stelem.ref
-		IL_0058: dup
-		IL_0059: ldc.i4.1
-		IL_005a: ldstr "values"
-		IL_005f: stelem.ref
-		IL_0060: dup
-		IL_0061: ldc.i4.2
-		IL_0062: ldstr "values"
-		IL_0067: stelem.ref
-		IL_0068: dup
-		IL_0069: ldc.i4.3
-		IL_006a: ldc.r8 0.0
-		IL_0073: box [System.Runtime]System.Double
-		IL_0078: stelem.ref
-		IL_0079: dup
-		IL_007a: ldc.i4.4
-		IL_007b: ldstr "values"
-		IL_0080: stelem.ref
-		IL_0081: dup
-		IL_0082: ldc.i4.5
-		IL_0083: ldc.i4.0
-		IL_0084: box [System.Runtime]System.Boolean
-		IL_0089: stelem.ref
-		IL_008a: dup
-		IL_008b: ldc.i4.6
-		IL_008c: ldc.i4.0
-		IL_008d: box [System.Runtime]System.Boolean
-		IL_0092: stelem.ref
-		IL_0093: dup
-		IL_0094: ldc.i4.7
-		IL_0095: ldc.i4.1
-		IL_0096: box [System.Runtime]System.Boolean
-		IL_009b: stelem.ref
-		IL_009c: dup
-		IL_009d: ldc.i4.8
-		IL_009e: ldc.i4.0
-		IL_009f: box [System.Runtime]System.Boolean
+		IL_004a: dup
+		IL_004b: ldc.i4.2
+		IL_004c: ldstr "values"
+		IL_0051: stelem.ref
+		IL_0052: dup
+		IL_0053: ldc.i4.3
+		IL_0054: ldc.r8 0.0
+		IL_005d: box [System.Runtime]System.Double
+		IL_0062: stelem.ref
+		IL_0063: dup
+		IL_0064: ldc.i4.4
+		IL_0065: ldstr "values"
+		IL_006a: stelem.ref
+		IL_006b: dup
+		IL_006c: ldc.i4.5
+		IL_006d: ldc.i4.0
+		IL_006e: box [System.Runtime]System.Boolean
+		IL_0073: stelem.ref
+		IL_0074: dup
+		IL_0075: ldc.i4.6
+		IL_0076: ldc.i4.0
+		IL_0077: box [System.Runtime]System.Boolean
+		IL_007c: stelem.ref
+		IL_007d: dup
+		IL_007e: ldc.i4.7
+		IL_007f: ldc.i4.1
+		IL_0080: box [System.Runtime]System.Boolean
+		IL_0085: stelem.ref
+		IL_0086: dup
+		IL_0087: ldc.i4.8
+		IL_0088: ldc.i4.0
+		IL_0089: box [System.Runtime]System.Boolean
+		IL_008e: stelem.ref
+		IL_008f: dup
+		IL_0090: ldc.i4.s 9
+		IL_0092: ldloc.s 6
+		IL_0094: stelem.ref
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_009a: pop
+		IL_009b: ldc.i4.1
+		IL_009c: newarr [System.Runtime]System.Object
+		IL_00a1: dup
+		IL_00a2: ldc.i4.0
+		IL_00a3: ldloc.0
 		IL_00a4: stelem.ref
-		IL_00a5: dup
-		IL_00a6: ldc.i4.s 9
-		IL_00a8: ldloc.s 7
-		IL_00aa: stelem.ref
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00b0: pop
-		IL_00b1: ldc.i4.1
-		IL_00b2: newarr [System.Runtime]System.Object
-		IL_00b7: dup
-		IL_00b8: ldc.i4.0
-		IL_00b9: ldloc.0
-		IL_00ba: stelem.ref
-		IL_00bb: stloc.s 7
-		IL_00bd: ldloc.s 5
-		IL_00bf: ldloc.s 7
-		IL_00c1: ldc.r8 0.0
-		IL_00ca: box [System.Runtime]System.Double
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00d4: stloc.s 8
-		IL_00d6: ldloc.s 8
-		IL_00d8: stloc.1
-		IL_00d9: ldc.i4.0
-		IL_00da: newarr [System.Runtime]System.Object
-		IL_00df: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00e4: newobj instance void Modules.Generator_ClassMethod_YieldAssign/Gen::.ctor()
-		IL_00e9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00ee: stloc.2
-		IL_00ef: ldloc.2
-		IL_00f0: ldtoken Modules.Generator_ClassMethod_YieldAssign/Gen
-		IL_00f5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00fa: ldstr "prototype"
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0104: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0109: ldloc.2
-		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Generator_ClassMethod_YieldAssign/Gen>(!!0)
-		IL_010f: stloc.s 9
-		IL_0111: ldloc.s 9
-		IL_0113: ldc.i4.1
-		IL_0114: newarr [System.Runtime]System.Object
-		IL_0119: dup
-		IL_011a: ldc.i4.0
-		IL_011b: ldloc.0
-		IL_011c: stelem.ref
-		IL_011d: ldnull
-		IL_011e: callvirt instance object Modules.Generator_ClassMethod_YieldAssign/Gen::values(object[], object)
-		IL_0123: stloc.3
-		IL_0124: ldnull
+		IL_00a5: stloc.s 6
+		IL_00a7: ldloc.s 5
+		IL_00a9: ldloc.s 6
+		IL_00ab: ldc.r8 0.0
+		IL_00b4: box [System.Runtime]System.Double
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00be: stloc.s 7
+		IL_00c0: ldloc.s 7
+		IL_00c2: stloc.1
+		IL_00c3: ldc.i4.0
+		IL_00c4: newarr [System.Runtime]System.Object
+		IL_00c9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00ce: newobj instance void Modules.Generator_ClassMethod_YieldAssign/Gen::.ctor()
+		IL_00d3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00d8: stloc.2
+		IL_00d9: ldloc.2
+		IL_00da: ldtoken Modules.Generator_ClassMethod_YieldAssign/Gen
+		IL_00df: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00e4: ldstr "prototype"
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00ee: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00f3: ldloc.2
+		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Generator_ClassMethod_YieldAssign/Gen>(!!0)
+		IL_00f9: stloc.s 8
+		IL_00fb: ldloc.s 8
+		IL_00fd: ldc.i4.1
+		IL_00fe: newarr [System.Runtime]System.Object
+		IL_0103: dup
+		IL_0104: ldc.i4.0
+		IL_0105: ldloc.0
+		IL_0106: stelem.ref
+		IL_0107: ldnull
+		IL_0108: callvirt instance object Modules.Generator_ClassMethod_YieldAssign/Gen::values(object[], object)
+		IL_010d: stloc.3
+		IL_010e: ldnull
+		IL_010f: stloc.s 4
+		IL_0111: ldloc.3
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0117: ldstr "next"
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0121: stloc.s 7
+		IL_0123: ldloc.s 7
 		IL_0125: stloc.s 4
-		IL_0127: ldloc.3
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012d: ldstr "next"
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0137: stloc.s 8
-		IL_0139: ldloc.s 8
-		IL_013b: stloc.s 4
-		IL_013d: ldstr "console"
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014c: stloc.s 8
-		IL_014e: ldloc.s 4
-		IL_0150: ldstr "value"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015a: stloc.s 10
-		IL_015c: ldloc.s 4
-		IL_015e: ldstr "done"
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0168: stloc.s 11
-		IL_016a: ldloc.s 8
-		IL_016c: ldstr "log"
-		IL_0171: ldc.i4.4
-		IL_0172: newarr [System.Runtime]System.Object
-		IL_0177: dup
-		IL_0178: ldc.i4.0
-		IL_0179: ldstr "y1:"
-		IL_017e: stelem.ref
-		IL_017f: dup
-		IL_0180: ldc.i4.1
-		IL_0181: ldloc.s 10
-		IL_0183: stelem.ref
-		IL_0184: dup
-		IL_0185: ldc.i4.2
-		IL_0186: ldstr "done:"
-		IL_018b: stelem.ref
-		IL_018c: dup
-		IL_018d: ldc.i4.3
-		IL_018e: ldloc.s 11
-		IL_0190: stelem.ref
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0196: pop
-		IL_0197: ldloc.3
-		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019d: ldstr "next"
-		IL_01a2: ldc.r8 42
-		IL_01ab: box [System.Runtime]System.Double
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b5: stloc.s 8
-		IL_01b7: ldloc.s 8
-		IL_01b9: stloc.s 4
-		IL_01bb: ldstr "console"
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ca: stloc.s 8
-		IL_01cc: ldloc.s 4
-		IL_01ce: ldstr "value"
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01d8: stloc.s 11
-		IL_01da: ldloc.s 4
-		IL_01dc: ldstr "done"
-		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e6: stloc.s 10
-		IL_01e8: ldloc.s 8
-		IL_01ea: ldstr "log"
-		IL_01ef: ldc.i4.4
-		IL_01f0: newarr [System.Runtime]System.Object
-		IL_01f5: dup
-		IL_01f6: ldc.i4.0
-		IL_01f7: ldstr "y2:"
-		IL_01fc: stelem.ref
-		IL_01fd: dup
-		IL_01fe: ldc.i4.1
-		IL_01ff: ldloc.s 11
-		IL_0201: stelem.ref
-		IL_0202: dup
-		IL_0203: ldc.i4.2
-		IL_0204: ldstr "done:"
-		IL_0209: stelem.ref
-		IL_020a: dup
-		IL_020b: ldc.i4.3
-		IL_020c: ldloc.s 10
-		IL_020e: stelem.ref
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0214: pop
-		IL_0215: ldloc.3
-		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021b: ldstr "next"
-		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0225: stloc.s 8
-		IL_0227: ldloc.s 8
-		IL_0229: stloc.s 4
-		IL_022b: ldstr "console"
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023a: stloc.s 8
-		IL_023c: ldloc.s 4
-		IL_023e: ldstr "value"
-		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0248: stloc.s 10
-		IL_024a: ldloc.s 4
-		IL_024c: ldstr "done"
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0256: stloc.s 11
-		IL_0258: ldloc.s 8
-		IL_025a: ldstr "log"
-		IL_025f: ldc.i4.4
-		IL_0260: newarr [System.Runtime]System.Object
-		IL_0265: dup
-		IL_0266: ldc.i4.0
-		IL_0267: ldstr "y3:"
-		IL_026c: stelem.ref
-		IL_026d: dup
-		IL_026e: ldc.i4.1
-		IL_026f: ldloc.s 10
-		IL_0271: stelem.ref
-		IL_0272: dup
-		IL_0273: ldc.i4.2
-		IL_0274: ldstr "done:"
-		IL_0279: stelem.ref
-		IL_027a: dup
-		IL_027b: ldc.i4.3
-		IL_027c: ldloc.s 11
-		IL_027e: stelem.ref
-		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0284: pop
-		IL_0285: ret
+		IL_0127: ldstr "console"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0136: stloc.s 7
+		IL_0138: ldloc.s 4
+		IL_013a: ldstr "value"
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0144: stloc.s 9
+		IL_0146: ldloc.s 4
+		IL_0148: ldstr "done"
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0152: stloc.s 10
+		IL_0154: ldloc.s 7
+		IL_0156: ldstr "log"
+		IL_015b: ldc.i4.4
+		IL_015c: newarr [System.Runtime]System.Object
+		IL_0161: dup
+		IL_0162: ldc.i4.0
+		IL_0163: ldstr "y1:"
+		IL_0168: stelem.ref
+		IL_0169: dup
+		IL_016a: ldc.i4.1
+		IL_016b: ldloc.s 9
+		IL_016d: stelem.ref
+		IL_016e: dup
+		IL_016f: ldc.i4.2
+		IL_0170: ldstr "done:"
+		IL_0175: stelem.ref
+		IL_0176: dup
+		IL_0177: ldc.i4.3
+		IL_0178: ldloc.s 10
+		IL_017a: stelem.ref
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0180: pop
+		IL_0181: ldloc.3
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0187: ldstr "next"
+		IL_018c: ldc.r8 42
+		IL_0195: box [System.Runtime]System.Double
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019f: stloc.s 7
+		IL_01a1: ldloc.s 7
+		IL_01a3: stloc.s 4
+		IL_01a5: ldstr "console"
+		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b4: stloc.s 7
+		IL_01b6: ldloc.s 4
+		IL_01b8: ldstr "value"
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c2: stloc.s 10
+		IL_01c4: ldloc.s 4
+		IL_01c6: ldstr "done"
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d0: stloc.s 9
+		IL_01d2: ldloc.s 7
+		IL_01d4: ldstr "log"
+		IL_01d9: ldc.i4.4
+		IL_01da: newarr [System.Runtime]System.Object
+		IL_01df: dup
+		IL_01e0: ldc.i4.0
+		IL_01e1: ldstr "y2:"
+		IL_01e6: stelem.ref
+		IL_01e7: dup
+		IL_01e8: ldc.i4.1
+		IL_01e9: ldloc.s 10
+		IL_01eb: stelem.ref
+		IL_01ec: dup
+		IL_01ed: ldc.i4.2
+		IL_01ee: ldstr "done:"
+		IL_01f3: stelem.ref
+		IL_01f4: dup
+		IL_01f5: ldc.i4.3
+		IL_01f6: ldloc.s 9
+		IL_01f8: stelem.ref
+		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_01fe: pop
+		IL_01ff: ldloc.3
+		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0205: ldstr "next"
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_020f: stloc.s 7
+		IL_0211: ldloc.s 7
+		IL_0213: stloc.s 4
+		IL_0215: ldstr "console"
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0224: stloc.s 7
+		IL_0226: ldloc.s 4
+		IL_0228: ldstr "value"
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0232: stloc.s 9
+		IL_0234: ldloc.s 4
+		IL_0236: ldstr "done"
+		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0240: stloc.s 10
+		IL_0242: ldloc.s 7
+		IL_0244: ldstr "log"
+		IL_0249: ldc.i4.4
+		IL_024a: newarr [System.Runtime]System.Object
+		IL_024f: dup
+		IL_0250: ldc.i4.0
+		IL_0251: ldstr "y3:"
+		IL_0256: stelem.ref
+		IL_0257: dup
+		IL_0258: ldc.i4.1
+		IL_0259: ldloc.s 9
+		IL_025b: stelem.ref
+		IL_025c: dup
+		IL_025d: ldc.i4.2
+		IL_025e: ldstr "done:"
+		IL_0263: stelem.ref
+		IL_0264: dup
+		IL_0265: ldc.i4.3
+		IL_0266: ldloc.s 10
+		IL_0268: stelem.ref
+		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_026e: pop
+		IL_026f: ret
 	} // end of method Generator_ClassMethod_YieldAssign::__js_module_init__
 
 } // end of class Modules.Generator_ClassMethod_YieldAssign
@@ -674,7 +668,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24b9
+		// Method begins at RVA 0x24a1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Inheritance_SuperIteratorMethod.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Inheritance_SuperIteratorMethod.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2451
+				// Method begins at RVA 0x2425
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245a
+				// Method begins at RVA 0x242e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2475
+				// Method begins at RVA 0x2449
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2484
+				// Method begins at RVA 0x2458
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2487
+				// Method begins at RVA 0x245b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x248a
+				// Method begins at RVA 0x245e
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2496
+				// Method begins at RVA 0x246a
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a2
+				// Method begins at RVA 0x2476
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24aa
+				// Method begins at RVA 0x247e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24ad
+				// Method begins at RVA 0x2481
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x24b0
+				// Method begins at RVA 0x2484
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -209,7 +209,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2256
+			// Method begins at RVA 0x2228
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -228,7 +228,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22fc
+			// Method begins at RVA 0x22d0
 			// Header size: 12
 			// Code size: 320 (0x140)
 			.maxstack 8
@@ -379,7 +379,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2463
+				// Method begins at RVA 0x2437
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -399,7 +399,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x246c
+				// Method begins at RVA 0x2440
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -424,7 +424,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x24d4
+				// Method begins at RVA 0x24a8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -440,7 +440,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24e3
+				// Method begins at RVA 0x24b7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -452,7 +452,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24e6
+				// Method begins at RVA 0x24ba
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -467,7 +467,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x24e9
+				// Method begins at RVA 0x24bd
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -483,7 +483,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x24f5
+				// Method begins at RVA 0x24c9
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -509,7 +509,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x2501
+				// Method begins at RVA 0x24d5
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -528,7 +528,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2517
+				// Method begins at RVA 0x24eb
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -540,7 +540,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x251a
+				// Method begins at RVA 0x24ee
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -552,7 +552,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x251d
+				// Method begins at RVA 0x24f1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -565,7 +565,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x2525
+				// Method begins at RVA 0x24f9
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -581,7 +581,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x252d
+				// Method begins at RVA 0x2501
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -609,7 +609,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x225e
+			// Method begins at RVA 0x2230
 			// Header size: 1
 			// Code size: 13 (0xd)
 			.maxstack 8
@@ -627,7 +627,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x226c
+			// Method begins at RVA 0x2240
 			// Header size: 12
 			// Code size: 131 (0x83)
 			.maxstack 8
@@ -691,7 +691,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2448
+			// Method begins at RVA 0x241c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -717,17 +717,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 506 (0x1fa)
+		// Code size: 460 (0x1cc)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Generator_Inheritance_SuperIteratorMethod/Scope,
 			[1] object,
 			[2] object,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object[],
-			[6] object,
-			[7] class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run
+			[4] object[],
+			[5] object,
+			[6] class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run
 		)
 
 		IL_0000: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Scope::.ctor()
@@ -738,178 +737,168 @@
 		IL_0011: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Base
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Base
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Base
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: pop
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.0
-		IL_0048: stelem.ref
-		IL_0049: stloc.s 5
-		IL_004b: ldc.i4.s 10
-		IL_004d: newarr [System.Runtime]System.Object
-		IL_0052: dup
-		IL_0053: ldc.i4.0
-		IL_0054: ldloc.3
-		IL_0055: stelem.ref
-		IL_0056: dup
-		IL_0057: ldc.i4.1
-		IL_0058: ldstr "values"
-		IL_005d: stelem.ref
-		IL_005e: dup
-		IL_005f: ldc.i4.2
-		IL_0060: ldstr "values"
-		IL_0065: stelem.ref
-		IL_0066: dup
-		IL_0067: ldc.i4.3
-		IL_0068: ldc.r8 0.0
-		IL_0071: box [System.Runtime]System.Double
-		IL_0076: stelem.ref
-		IL_0077: dup
-		IL_0078: ldc.i4.4
-		IL_0079: ldstr "values"
-		IL_007e: stelem.ref
-		IL_007f: dup
-		IL_0080: ldc.i4.5
-		IL_0081: ldc.i4.0
-		IL_0082: box [System.Runtime]System.Boolean
-		IL_0087: stelem.ref
-		IL_0088: dup
-		IL_0089: ldc.i4.6
-		IL_008a: ldc.i4.0
-		IL_008b: box [System.Runtime]System.Boolean
-		IL_0090: stelem.ref
-		IL_0091: dup
-		IL_0092: ldc.i4.7
-		IL_0093: ldc.i4.1
-		IL_0094: box [System.Runtime]System.Boolean
-		IL_0099: stelem.ref
-		IL_009a: dup
-		IL_009b: ldc.i4.8
-		IL_009c: ldc.i4.0
-		IL_009d: box [System.Runtime]System.Boolean
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.s 9
-		IL_00a6: ldloc.s 5
-		IL_00a8: stelem.ref
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00ae: pop
-		IL_00af: ldc.i4.1
-		IL_00b0: newarr [System.Runtime]System.Object
-		IL_00b5: dup
-		IL_00b6: ldc.i4.0
-		IL_00b7: ldloc.0
-		IL_00b8: stelem.ref
-		IL_00b9: stloc.s 5
-		IL_00bb: ldloc.3
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: pop
+		IL_0028: ldc.i4.1
+		IL_0029: newarr [System.Runtime]System.Object
+		IL_002e: dup
+		IL_002f: ldc.i4.0
+		IL_0030: ldloc.0
+		IL_0031: stelem.ref
+		IL_0032: stloc.s 4
+		IL_0034: ldc.i4.s 10
+		IL_0036: newarr [System.Runtime]System.Object
+		IL_003b: dup
+		IL_003c: ldc.i4.0
+		IL_003d: ldloc.3
+		IL_003e: stelem.ref
+		IL_003f: dup
+		IL_0040: ldc.i4.1
+		IL_0041: ldstr "values"
+		IL_0046: stelem.ref
+		IL_0047: dup
+		IL_0048: ldc.i4.2
+		IL_0049: ldstr "values"
+		IL_004e: stelem.ref
+		IL_004f: dup
+		IL_0050: ldc.i4.3
+		IL_0051: ldc.r8 0.0
+		IL_005a: box [System.Runtime]System.Double
+		IL_005f: stelem.ref
+		IL_0060: dup
+		IL_0061: ldc.i4.4
+		IL_0062: ldstr "values"
+		IL_0067: stelem.ref
+		IL_0068: dup
+		IL_0069: ldc.i4.5
+		IL_006a: ldc.i4.0
+		IL_006b: box [System.Runtime]System.Boolean
+		IL_0070: stelem.ref
+		IL_0071: dup
+		IL_0072: ldc.i4.6
+		IL_0073: ldc.i4.0
+		IL_0074: box [System.Runtime]System.Boolean
+		IL_0079: stelem.ref
+		IL_007a: dup
+		IL_007b: ldc.i4.7
+		IL_007c: ldc.i4.1
+		IL_007d: box [System.Runtime]System.Boolean
+		IL_0082: stelem.ref
+		IL_0083: dup
+		IL_0084: ldc.i4.8
+		IL_0085: ldc.i4.0
+		IL_0086: box [System.Runtime]System.Boolean
+		IL_008b: stelem.ref
+		IL_008c: dup
+		IL_008d: ldc.i4.s 9
+		IL_008f: ldloc.s 4
+		IL_0091: stelem.ref
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0097: pop
+		IL_0098: ldc.i4.1
+		IL_0099: newarr [System.Runtime]System.Object
+		IL_009e: dup
+		IL_009f: ldc.i4.0
+		IL_00a0: ldloc.0
+		IL_00a1: stelem.ref
+		IL_00a2: stloc.s 4
+		IL_00a4: ldloc.3
+		IL_00a5: ldloc.s 4
+		IL_00a7: ldc.r8 0.0
+		IL_00b0: box [System.Runtime]System.Double
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00ba: stloc.s 5
 		IL_00bc: ldloc.s 5
-		IL_00be: ldc.r8 0.0
-		IL_00c7: box [System.Runtime]System.Double
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00d1: stloc.s 6
-		IL_00d3: ldloc.s 6
-		IL_00d5: stloc.1
-		IL_00d6: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-		IL_00db: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00e0: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-		IL_00e5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00ea: stloc.3
-		IL_00eb: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-		IL_00f0: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00f5: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-		IL_00fa: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00ff: stloc.s 4
-		IL_0101: ldloc.s 4
-		IL_0103: ldstr "prototype"
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010d: stloc.s 6
-		IL_010f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0114: stloc.s 5
-		IL_0116: ldloc.s 6
-		IL_0118: ldloc.s 5
-		IL_011a: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run::.ctor(class [System.Runtime]System.Object, object[])
-		IL_011f: ldc.i4.0
-		IL_0120: conv.r8
-		IL_0121: ldstr "run"
-		IL_0126: ldc.i4.1
-		IL_0127: ldc.i4.1
-		IL_0128: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0, float64, string, bool, bool)
-		IL_012d: stloc.s 7
-		IL_012f: ldloc.s 7
-		IL_0131: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0)
-		IL_0136: stloc.s 7
-		IL_0138: ldloc.s 6
-		IL_013a: ldstr "run"
-		IL_013f: ldloc.s 7
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0146: pop
-		IL_0147: ldc.i4.1
-		IL_0148: newarr [System.Runtime]System.Object
-		IL_014d: dup
-		IL_014e: ldc.i4.0
-		IL_014f: ldloc.0
-		IL_0150: stelem.ref
-		IL_0151: stloc.s 5
-		IL_0153: ldloc.3
-		IL_0154: ldloc.s 5
-		IL_0156: ldc.r8 0.0
-		IL_015f: box [System.Runtime]System.Double
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0169: stloc.s 6
-		IL_016b: ldloc.s 6
-		IL_016d: ldloc.1
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0173: stloc.s 6
-		IL_0175: ldloc.s 6
-		IL_0177: stloc.2
-		IL_0178: ldc.i4.0
-		IL_0179: newarr [System.Runtime]System.Object
-		IL_017e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0183: ldloc.2
-		IL_0184: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_0189: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_018e: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived::.ctor()
-		IL_0193: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_0198: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_019d: dup
-		IL_019e: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-		IL_01a3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01a8: ldstr "prototype"
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_01b2: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_01b7: stloc.s 6
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_01c3: stloc.s 6
-		IL_01c5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_01ca: ldloc.s 6
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d1: stloc.s 6
-		IL_01d3: ldloc.s 6
-		IL_01d5: isinst Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-		IL_01da: dup
-		IL_01db: brfalse IL_01eb
+		IL_00be: stloc.1
+		IL_00bf: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
+		IL_00c4: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00c9: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
+		IL_00ce: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00d3: stloc.3
+		IL_00d4: ldloc.3
+		IL_00d5: ldstr "prototype"
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00df: stloc.s 5
+		IL_00e1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e6: stloc.s 4
+		IL_00e8: ldloc.s 5
+		IL_00ea: ldloc.s 4
+		IL_00ec: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run::.ctor(class [System.Runtime]System.Object, object[])
+		IL_00f1: ldc.i4.0
+		IL_00f2: conv.r8
+		IL_00f3: ldstr "run"
+		IL_00f8: ldc.i4.1
+		IL_00f9: ldc.i4.1
+		IL_00fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0, float64, string, bool, bool)
+		IL_00ff: stloc.s 6
+		IL_0101: ldloc.s 6
+		IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0)
+		IL_0108: stloc.s 6
+		IL_010a: ldloc.s 5
+		IL_010c: ldstr "run"
+		IL_0111: ldloc.s 6
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0118: pop
+		IL_0119: ldc.i4.1
+		IL_011a: newarr [System.Runtime]System.Object
+		IL_011f: dup
+		IL_0120: ldc.i4.0
+		IL_0121: ldloc.0
+		IL_0122: stelem.ref
+		IL_0123: stloc.s 4
+		IL_0125: ldloc.3
+		IL_0126: ldloc.s 4
+		IL_0128: ldc.r8 0.0
+		IL_0131: box [System.Runtime]System.Double
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_013b: stloc.s 5
+		IL_013d: ldloc.s 5
+		IL_013f: ldloc.1
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_0145: stloc.s 5
+		IL_0147: ldloc.s 5
+		IL_0149: stloc.2
+		IL_014a: ldc.i4.0
+		IL_014b: newarr [System.Runtime]System.Object
+		IL_0150: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0155: ldloc.2
+		IL_0156: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_015b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0160: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived::.ctor()
+		IL_0165: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_016a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_016f: dup
+		IL_0170: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
+		IL_0175: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_017a: ldstr "prototype"
+		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0184: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0189: stloc.s 5
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0195: stloc.s 5
+		IL_0197: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_019c: ldloc.s 5
+		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a3: stloc.s 5
+		IL_01a5: ldloc.s 5
+		IL_01a7: isinst Modules.Generator_Inheritance_SuperIteratorMethod/Derived
+		IL_01ac: dup
+		IL_01ad: brfalse IL_01bd
 
-		IL_01e0: callvirt instance object Modules.Generator_Inheritance_SuperIteratorMethod/Derived::run()
-		IL_01e5: pop
-		IL_01e6: br IL_01f9
+		IL_01b2: callvirt instance object Modules.Generator_Inheritance_SuperIteratorMethod/Derived::run()
+		IL_01b7: pop
+		IL_01b8: br IL_01cb
 
-		IL_01eb: pop
-		IL_01ec: ldloc.s 6
-		IL_01ee: ldstr "run"
-		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01f8: pop
+		IL_01bd: pop
+		IL_01be: ldloc.s 5
+		IL_01c0: ldstr "run"
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01ca: pop
 
-		IL_01f9: ret
+		IL_01cb: ret
 	} // end of method Generator_Inheritance_SuperIteratorMethod::__js_module_init__
 
 } // end of class Modules.Generator_Inheritance_SuperIteratorMethod
@@ -921,7 +910,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2551
+		// Method begins at RVA 0x2525
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_StaticMethod_SimpleYield.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_StaticMethod_SimpleYield.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x233d
+				// Method begins at RVA 0x2325
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2346
+				// Method begins at RVA 0x232e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x234f
+				// Method begins at RVA 0x2337
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x235e
+				// Method begins at RVA 0x2346
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2361
+				// Method begins at RVA 0x2349
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2364
+				// Method begins at RVA 0x234c
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2370
+				// Method begins at RVA 0x2358
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x237c
+				// Method begins at RVA 0x2364
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2384
+				// Method begins at RVA 0x236c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2387
+				// Method begins at RVA 0x236f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x238a
+				// Method begins at RVA 0x2372
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -200,7 +200,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x222e
+			// Method begins at RVA 0x2218
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -219,7 +219,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2238
+			// Method begins at RVA 0x2220
 			// Header size: 12
 			// Code size: 240 (0xf0)
 			.maxstack 8
@@ -333,7 +333,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2334
+			// Method begins at RVA 0x231c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -359,7 +359,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 466 (0x1d2)
+		// Code size: 444 (0x1bc)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Generator_StaticMethod_SimpleYield/Scope,
@@ -367,11 +367,10 @@
 			[2] object,
 			[3] object,
 			[4] class [System.Runtime]System.Type,
-			[5] class [System.Runtime]System.Type,
-			[6] object[],
+			[5] object[],
+			[6] object,
 			[7] object,
-			[8] object,
-			[9] object
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.Generator_StaticMethod_SimpleYield/Scope::.ctor()
@@ -382,182 +381,177 @@
 		IL_0011: ldtoken Modules.Generator_StaticMethod_SimpleYield/Gen
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.s 4
-		IL_001d: ldtoken Modules.Generator_StaticMethod_SimpleYield/Gen
-		IL_0022: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0027: ldtoken Modules.Generator_StaticMethod_SimpleYield/Gen
-		IL_002c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0031: stloc.s 5
-		IL_0033: ldloc.s 5
-		IL_0035: ldstr "prototype"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003f: pop
-		IL_0040: ldc.i4.1
-		IL_0041: newarr [System.Runtime]System.Object
-		IL_0046: dup
-		IL_0047: ldc.i4.0
-		IL_0048: ldloc.0
+		IL_001d: ldloc.s 4
+		IL_001f: ldstr "prototype"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0029: pop
+		IL_002a: ldc.i4.1
+		IL_002b: newarr [System.Runtime]System.Object
+		IL_0030: dup
+		IL_0031: ldc.i4.0
+		IL_0032: ldloc.0
+		IL_0033: stelem.ref
+		IL_0034: stloc.s 5
+		IL_0036: ldc.i4.s 10
+		IL_0038: newarr [System.Runtime]System.Object
+		IL_003d: dup
+		IL_003e: ldc.i4.0
+		IL_003f: ldloc.s 4
+		IL_0041: stelem.ref
+		IL_0042: dup
+		IL_0043: ldc.i4.1
+		IL_0044: ldstr "values"
 		IL_0049: stelem.ref
-		IL_004a: stloc.s 6
-		IL_004c: ldc.i4.s 10
-		IL_004e: newarr [System.Runtime]System.Object
-		IL_0053: dup
-		IL_0054: ldc.i4.0
-		IL_0055: ldloc.s 4
-		IL_0057: stelem.ref
-		IL_0058: dup
-		IL_0059: ldc.i4.1
-		IL_005a: ldstr "values"
-		IL_005f: stelem.ref
-		IL_0060: dup
-		IL_0061: ldc.i4.2
-		IL_0062: ldstr "values"
-		IL_0067: stelem.ref
-		IL_0068: dup
-		IL_0069: ldc.i4.3
-		IL_006a: ldc.r8 0.0
-		IL_0073: box [System.Runtime]System.Double
-		IL_0078: stelem.ref
-		IL_0079: dup
-		IL_007a: ldc.i4.4
-		IL_007b: ldstr "values"
-		IL_0080: stelem.ref
-		IL_0081: dup
-		IL_0082: ldc.i4.5
-		IL_0083: ldc.i4.1
-		IL_0084: box [System.Runtime]System.Boolean
-		IL_0089: stelem.ref
-		IL_008a: dup
-		IL_008b: ldc.i4.6
-		IL_008c: ldc.i4.0
-		IL_008d: box [System.Runtime]System.Boolean
-		IL_0092: stelem.ref
-		IL_0093: dup
-		IL_0094: ldc.i4.7
-		IL_0095: ldc.i4.1
-		IL_0096: box [System.Runtime]System.Boolean
-		IL_009b: stelem.ref
-		IL_009c: dup
-		IL_009d: ldc.i4.8
-		IL_009e: ldc.i4.0
-		IL_009f: box [System.Runtime]System.Boolean
+		IL_004a: dup
+		IL_004b: ldc.i4.2
+		IL_004c: ldstr "values"
+		IL_0051: stelem.ref
+		IL_0052: dup
+		IL_0053: ldc.i4.3
+		IL_0054: ldc.r8 0.0
+		IL_005d: box [System.Runtime]System.Double
+		IL_0062: stelem.ref
+		IL_0063: dup
+		IL_0064: ldc.i4.4
+		IL_0065: ldstr "values"
+		IL_006a: stelem.ref
+		IL_006b: dup
+		IL_006c: ldc.i4.5
+		IL_006d: ldc.i4.1
+		IL_006e: box [System.Runtime]System.Boolean
+		IL_0073: stelem.ref
+		IL_0074: dup
+		IL_0075: ldc.i4.6
+		IL_0076: ldc.i4.0
+		IL_0077: box [System.Runtime]System.Boolean
+		IL_007c: stelem.ref
+		IL_007d: dup
+		IL_007e: ldc.i4.7
+		IL_007f: ldc.i4.1
+		IL_0080: box [System.Runtime]System.Boolean
+		IL_0085: stelem.ref
+		IL_0086: dup
+		IL_0087: ldc.i4.8
+		IL_0088: ldc.i4.0
+		IL_0089: box [System.Runtime]System.Boolean
+		IL_008e: stelem.ref
+		IL_008f: dup
+		IL_0090: ldc.i4.s 9
+		IL_0092: ldloc.s 5
+		IL_0094: stelem.ref
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_009a: pop
+		IL_009b: ldc.i4.1
+		IL_009c: newarr [System.Runtime]System.Object
+		IL_00a1: dup
+		IL_00a2: ldc.i4.0
+		IL_00a3: ldloc.0
 		IL_00a4: stelem.ref
-		IL_00a5: dup
-		IL_00a6: ldc.i4.s 9
-		IL_00a8: ldloc.s 6
-		IL_00aa: stelem.ref
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00b0: pop
-		IL_00b1: ldc.i4.1
-		IL_00b2: newarr [System.Runtime]System.Object
-		IL_00b7: dup
-		IL_00b8: ldc.i4.0
-		IL_00b9: ldloc.0
-		IL_00ba: stelem.ref
-		IL_00bb: stloc.s 6
-		IL_00bd: ldloc.s 4
-		IL_00bf: ldloc.s 6
-		IL_00c1: ldc.r8 0.0
-		IL_00ca: box [System.Runtime]System.Double
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00d4: stloc.s 7
-		IL_00d6: ldloc.s 7
-		IL_00d8: stloc.1
-		IL_00d9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00de: stloc.s 6
-		IL_00e0: ldloc.1
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_00e6: stloc.s 7
-		IL_00e8: ldloc.s 6
-		IL_00ea: ldnull
-		IL_00eb: call object Modules.Generator_StaticMethod_SimpleYield/Gen::values(object[], object)
-		IL_00f0: stloc.s 8
-		IL_00f2: ldloc.s 8
-		IL_00f4: stloc.2
-		IL_00f5: ldnull
-		IL_00f6: stloc.3
-		IL_00f7: ldloc.2
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fd: ldstr "next"
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0107: stloc.s 8
-		IL_0109: ldloc.s 8
-		IL_010b: stloc.3
-		IL_010c: ldstr "console"
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011b: stloc.s 8
-		IL_011d: ldloc.3
-		IL_011e: ldstr "value"
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0128: stloc.s 7
-		IL_012a: ldloc.3
-		IL_012b: ldstr "done"
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0135: stloc.s 9
-		IL_0137: ldloc.s 8
-		IL_0139: ldstr "log"
-		IL_013e: ldc.i4.4
-		IL_013f: newarr [System.Runtime]System.Object
-		IL_0144: dup
-		IL_0145: ldc.i4.0
-		IL_0146: ldstr "s1:"
-		IL_014b: stelem.ref
-		IL_014c: dup
-		IL_014d: ldc.i4.1
-		IL_014e: ldloc.s 7
-		IL_0150: stelem.ref
-		IL_0151: dup
-		IL_0152: ldc.i4.2
-		IL_0153: ldstr "done:"
-		IL_0158: stelem.ref
-		IL_0159: dup
-		IL_015a: ldc.i4.3
-		IL_015b: ldloc.s 9
-		IL_015d: stelem.ref
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0163: pop
-		IL_0164: ldloc.2
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016a: ldstr "next"
-		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0174: stloc.s 8
-		IL_0176: ldloc.s 8
-		IL_0178: stloc.3
-		IL_0179: ldstr "console"
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0188: stloc.s 8
-		IL_018a: ldloc.3
-		IL_018b: ldstr "value"
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0195: stloc.s 9
-		IL_0197: ldloc.3
-		IL_0198: ldstr "done"
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a2: stloc.s 7
-		IL_01a4: ldloc.s 8
-		IL_01a6: ldstr "log"
-		IL_01ab: ldc.i4.4
-		IL_01ac: newarr [System.Runtime]System.Object
-		IL_01b1: dup
-		IL_01b2: ldc.i4.0
-		IL_01b3: ldstr "s2:"
-		IL_01b8: stelem.ref
-		IL_01b9: dup
-		IL_01ba: ldc.i4.1
-		IL_01bb: ldloc.s 9
-		IL_01bd: stelem.ref
-		IL_01be: dup
-		IL_01bf: ldc.i4.2
-		IL_01c0: ldstr "done:"
-		IL_01c5: stelem.ref
-		IL_01c6: dup
-		IL_01c7: ldc.i4.3
-		IL_01c8: ldloc.s 7
-		IL_01ca: stelem.ref
-		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_01d0: pop
-		IL_01d1: ret
+		IL_00a5: stloc.s 5
+		IL_00a7: ldloc.s 4
+		IL_00a9: ldloc.s 5
+		IL_00ab: ldc.r8 0.0
+		IL_00b4: box [System.Runtime]System.Double
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00be: stloc.s 6
+		IL_00c0: ldloc.s 6
+		IL_00c2: stloc.1
+		IL_00c3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00c8: stloc.s 5
+		IL_00ca: ldloc.1
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_00d0: stloc.s 6
+		IL_00d2: ldloc.s 5
+		IL_00d4: ldnull
+		IL_00d5: call object Modules.Generator_StaticMethod_SimpleYield/Gen::values(object[], object)
+		IL_00da: stloc.s 7
+		IL_00dc: ldloc.s 7
+		IL_00de: stloc.2
+		IL_00df: ldnull
+		IL_00e0: stloc.3
+		IL_00e1: ldloc.2
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e7: ldstr "next"
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00f1: stloc.s 7
+		IL_00f3: ldloc.s 7
+		IL_00f5: stloc.3
+		IL_00f6: ldstr "console"
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0105: stloc.s 7
+		IL_0107: ldloc.3
+		IL_0108: ldstr "value"
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0112: stloc.s 6
+		IL_0114: ldloc.3
+		IL_0115: ldstr "done"
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011f: stloc.s 8
+		IL_0121: ldloc.s 7
+		IL_0123: ldstr "log"
+		IL_0128: ldc.i4.4
+		IL_0129: newarr [System.Runtime]System.Object
+		IL_012e: dup
+		IL_012f: ldc.i4.0
+		IL_0130: ldstr "s1:"
+		IL_0135: stelem.ref
+		IL_0136: dup
+		IL_0137: ldc.i4.1
+		IL_0138: ldloc.s 6
+		IL_013a: stelem.ref
+		IL_013b: dup
+		IL_013c: ldc.i4.2
+		IL_013d: ldstr "done:"
+		IL_0142: stelem.ref
+		IL_0143: dup
+		IL_0144: ldc.i4.3
+		IL_0145: ldloc.s 8
+		IL_0147: stelem.ref
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_014d: pop
+		IL_014e: ldloc.2
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0154: ldstr "next"
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_015e: stloc.s 7
+		IL_0160: ldloc.s 7
+		IL_0162: stloc.3
+		IL_0163: ldstr "console"
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0172: stloc.s 7
+		IL_0174: ldloc.3
+		IL_0175: ldstr "value"
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_017f: stloc.s 8
+		IL_0181: ldloc.3
+		IL_0182: ldstr "done"
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018c: stloc.s 6
+		IL_018e: ldloc.s 7
+		IL_0190: ldstr "log"
+		IL_0195: ldc.i4.4
+		IL_0196: newarr [System.Runtime]System.Object
+		IL_019b: dup
+		IL_019c: ldc.i4.0
+		IL_019d: ldstr "s2:"
+		IL_01a2: stelem.ref
+		IL_01a3: dup
+		IL_01a4: ldc.i4.1
+		IL_01a5: ldloc.s 8
+		IL_01a7: stelem.ref
+		IL_01a8: dup
+		IL_01a9: ldc.i4.2
+		IL_01aa: ldstr "done:"
+		IL_01af: stelem.ref
+		IL_01b0: dup
+		IL_01b1: ldc.i4.3
+		IL_01b2: ldloc.s 6
+		IL_01b4: stelem.ref
+		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_01ba: pop
+		IL_01bb: ret
 	} // end of method Generator_StaticMethod_SimpleYield::__js_module_init__
 
 } // end of class Modules.Generator_StaticMethod_SimpleYield
@@ -569,7 +563,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2391
+		// Method begins at RVA 0x2379
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fe7
+						// Method begins at RVA 0x2fcf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fde
+					// Method begins at RVA 0x2fc6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fd5
+				// Method begins at RVA 0x2fbd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 					class Modules.Compile_Performance_PrimeJavaScript/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3301
+				// Method begins at RVA 0x32e9
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -114,7 +114,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3310
+				// Method begins at RVA 0x32f8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3313
+				// Method begins at RVA 0x32fb
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -141,7 +141,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3316
+				// Method begins at RVA 0x32fe
 				// Header size: 1
 				// Code size: 32 (0x20)
 				.maxstack 8
@@ -177,7 +177,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2374
+			// Method begins at RVA 0x235c
 			// Header size: 12
 			// Code size: 235 (0xeb)
 			.maxstack 8
@@ -306,7 +306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ff0
+				// Method begins at RVA 0x2fd8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -331,7 +331,7 @@
 					class Modules.Compile_Performance_PrimeJavaScript/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3337
+				// Method begins at RVA 0x331f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -347,7 +347,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3346
+				// Method begins at RVA 0x332e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -359,7 +359,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3349
+				// Method begins at RVA 0x3331
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -374,7 +374,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x334c
+				// Method begins at RVA 0x3334
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -405,7 +405,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x246c
+			// Method begins at RVA 0x2454
 			// Header size: 12
 			// Code size: 531 (0x213)
 			.maxstack 8
@@ -625,7 +625,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ec7
+				// Method begins at RVA 0x2eaf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -645,7 +645,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ed0
+				// Method begins at RVA 0x2eb8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -665,7 +665,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ed9
+				// Method begins at RVA 0x2ec1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -693,7 +693,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ef4
+						// Method begins at RVA 0x2edc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -717,7 +717,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2f06
+							// Method begins at RVA 0x2eee
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -735,7 +735,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2efd
+						// Method begins at RVA 0x2ee5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -753,7 +753,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2eeb
+					// Method begins at RVA 0x2ed3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -781,7 +781,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2f21
+							// Method begins at RVA 0x2f09
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -799,7 +799,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2f18
+						// Method begins at RVA 0x2f00
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -817,7 +817,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f0f
+					// Method begins at RVA 0x2ef7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -841,7 +841,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2f33
+						// Method begins at RVA 0x2f1b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -859,7 +859,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f2a
+					// Method begins at RVA 0x2f12
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -877,7 +877,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ee2
+				// Method begins at RVA 0x2eca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -897,7 +897,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f3c
+				// Method begins at RVA 0x2f24
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -921,7 +921,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f4e
+					// Method begins at RVA 0x2f36
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -939,7 +939,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f45
+				// Method begins at RVA 0x2f2d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -964,7 +964,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3075
+				// Method begins at RVA 0x305d
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -980,7 +980,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3084
+				// Method begins at RVA 0x306c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -992,7 +992,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3087
+				// Method begins at RVA 0x306f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1007,7 +1007,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x308a
+				// Method begins at RVA 0x3072
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1023,7 +1023,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3096
+				// Method begins at RVA 0x307e
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1042,7 +1042,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30a2
+				// Method begins at RVA 0x308a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1055,7 +1055,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x30aa
+				// Method begins at RVA 0x3092
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1067,7 +1067,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x30ad
+				// Method begins at RVA 0x3095
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1082,7 +1082,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x30b0
+				// Method begins at RVA 0x3098
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -1118,7 +1118,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x30e0
+				// Method begins at RVA 0x30c8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1134,7 +1134,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x30ef
+				// Method begins at RVA 0x30d7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1146,7 +1146,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x30f2
+				// Method begins at RVA 0x30da
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1161,7 +1161,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x30f8
+				// Method begins at RVA 0x30e0
 				// Header size: 12
 				// Code size: 71 (0x47)
 				.maxstack 8
@@ -1200,7 +1200,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x314b
+				// Method begins at RVA 0x3133
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1213,7 +1213,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3153
+				// Method begins at RVA 0x313b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1225,7 +1225,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3156
+				// Method begins at RVA 0x313e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1240,7 +1240,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3159
+				// Method begins at RVA 0x3141
 				// Header size: 1
 				// Code size: 52 (0x34)
 				.maxstack 8
@@ -1272,7 +1272,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x318e
+				// Method begins at RVA 0x3176
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1285,7 +1285,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3196
+				// Method begins at RVA 0x317e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1297,7 +1297,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3199
+				// Method begins at RVA 0x3181
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1312,7 +1312,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x319c
+				// Method begins at RVA 0x3184
 				// Header size: 1
 				// Code size: 52 (0x34)
 				.maxstack 8
@@ -1352,7 +1352,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26f0
+			// Method begins at RVA 0x26d8
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -1400,7 +1400,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x295c
+			// Method begins at RVA 0x2944
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -1464,7 +1464,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2774
+			// Method begins at RVA 0x275c
 			// Header size: 12
 			// Code size: 475 (0x1db)
 			.maxstack 8
@@ -1731,7 +1731,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29bc
+			// Method begins at RVA 0x29a4
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -1788,7 +1788,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x273c
+			// Method begins at RVA 0x2724
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1833,7 +1833,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f57
+				// Method begins at RVA 0x2f3f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1853,7 +1853,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f60
+				// Method begins at RVA 0x2f48
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1877,7 +1877,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f72
+					// Method begins at RVA 0x2f5a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1895,7 +1895,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f69
+				// Method begins at RVA 0x2f51
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1915,7 +1915,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f7b
+				// Method begins at RVA 0x2f63
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1943,7 +1943,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2f96
+						// Method begins at RVA 0x2f7e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1961,7 +1961,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f8d
+					// Method begins at RVA 0x2f75
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1979,7 +1979,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f84
+				// Method begins at RVA 0x2f6c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2003,7 +2003,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fa8
+					// Method begins at RVA 0x2f90
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2027,7 +2027,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fba
+						// Method begins at RVA 0x2fa2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2045,7 +2045,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fb1
+					// Method begins at RVA 0x2f99
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2063,7 +2063,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f9f
+				// Method begins at RVA 0x2f87
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2087,7 +2087,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fcc
+					// Method begins at RVA 0x2fb4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2105,7 +2105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fc3
+				// Method begins at RVA 0x2fab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2132,7 +2132,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x31d1
+				// Method begins at RVA 0x31b9
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -2151,7 +2151,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x31e7
+				// Method begins at RVA 0x31cf
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2163,7 +2163,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x31ea
+				// Method begins at RVA 0x31d2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2178,7 +2178,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x31ed
+				// Method begins at RVA 0x31d5
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -2194,7 +2194,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x31f9
+				// Method begins at RVA 0x31e1
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -2218,7 +2218,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3205
+				// Method begins at RVA 0x31ed
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2234,7 +2234,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3214
+				// Method begins at RVA 0x31fc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2246,7 +2246,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3217
+				// Method begins at RVA 0x31ff
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2261,7 +2261,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x321a
+				// Method begins at RVA 0x3202
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -2293,7 +2293,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x323e
+				// Method begins at RVA 0x3226
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2309,7 +2309,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x324d
+				// Method begins at RVA 0x3235
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2321,7 +2321,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3250
+				// Method begins at RVA 0x3238
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2336,7 +2336,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3253
+				// Method begins at RVA 0x323b
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -2369,7 +2369,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x327c
+				// Method begins at RVA 0x3264
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2385,7 +2385,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x328b
+				// Method begins at RVA 0x3273
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2397,7 +2397,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x328e
+				// Method begins at RVA 0x3276
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2412,7 +2412,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3291
+				// Method begins at RVA 0x3279
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -2447,7 +2447,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x32bc
+				// Method begins at RVA 0x32a4
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2463,7 +2463,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x32cb
+				// Method begins at RVA 0x32b3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2475,7 +2475,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x32ce
+				// Method begins at RVA 0x32b6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2490,7 +2490,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x32d1
+				// Method begins at RVA 0x32b9
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -2531,7 +2531,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x268c
+			// Method begins at RVA 0x2674
 			// Header size: 12
 			// Code size: 85 (0x55)
 			.maxstack 8
@@ -2587,7 +2587,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a0c
+			// Method begins at RVA 0x29f4
 			// Header size: 12
 			// Code size: 168 (0xa8)
 			.maxstack 8
@@ -2675,7 +2675,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d60
+			// Method begins at RVA 0x2d48
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -2740,7 +2740,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2dd8
+			// Method begins at RVA 0x2dc0
 			// Header size: 12
 			// Code size: 218 (0xda)
 			.maxstack 8
@@ -2848,7 +2848,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ac0
+			// Method begins at RVA 0x2aa8
 			// Header size: 12
 			// Code size: 658 (0x292)
 			.maxstack 8
@@ -3082,7 +3082,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2ebe
+			// Method begins at RVA 0x2ea6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3112,7 +3112,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ff9
+				// Method begins at RVA 0x2fe1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3125,7 +3125,7 @@
 			.method public hidebysig 
 				instance float64 get_sieveSize () cil managed 
 			{
-				// Method begins at RVA 0x3001
+				// Method begins at RVA 0x2fe9
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3140,7 +3140,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3009
+				// Method begins at RVA 0x2ff1
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3158,7 +3158,7 @@
 			.method public hidebysig 
 				instance float64 get_timeLimitSeconds () cil managed 
 			{
-				// Method begins at RVA 0x301e
+				// Method begins at RVA 0x3006
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3173,7 +3173,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3026
+				// Method begins at RVA 0x300e
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3191,7 +3191,7 @@
 			.method public hidebysig 
 				instance object get_verbose () cil managed 
 			{
-				// Method begins at RVA 0x303b
+				// Method begins at RVA 0x3023
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3206,7 +3206,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3043
+				// Method begins at RVA 0x302b
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3224,7 +3224,7 @@
 			.method public hidebysig 
 				instance object get_runtime () cil managed 
 			{
-				// Method begins at RVA 0x3058
+				// Method begins at RVA 0x3040
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3239,7 +3239,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3060
+				// Method begins at RVA 0x3048
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3272,7 +3272,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 790 (0x316)
+		// Code size: 768 (0x300)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_PrimeJavaScript/Scope,
@@ -3285,14 +3285,13 @@
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[8] float64,
 			[9] class [System.Runtime]System.Type,
-			[10] class [System.Runtime]System.Type,
-			[11] object[],
-			[12] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue,
-			[13] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue,
-			[14] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue,
-			[15] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse,
-			[16] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject,
-			[17] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject
+			[10] object[],
+			[11] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue,
+			[12] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue,
+			[13] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue,
+			[14] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse,
+			[15] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject,
+			[16] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Performance_PrimeJavaScript/Scope::.ctor()
@@ -3393,168 +3392,163 @@
 		IL_0151: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
 		IL_0156: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_015b: stloc.s 9
-		IL_015d: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0162: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0167: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_016c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0171: stloc.s 10
-		IL_0173: ldloc.s 10
-		IL_0175: ldstr "prototype"
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017f: stloc.s 6
-		IL_0181: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0186: stloc.s 11
-		IL_0188: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::.ctor()
-		IL_018d: ldc.i4.1
-		IL_018e: conv.r8
-		IL_018f: ldstr "setBitTrue"
-		IL_0194: ldc.i4.1
-		IL_0195: ldc.i4.1
-		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
-		IL_019b: stloc.s 12
-		IL_019d: ldloc.s 12
-		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0)
-		IL_01a4: stloc.s 12
-		IL_01a6: ldloc.s 6
-		IL_01a8: ldstr "setBitTrue"
-		IL_01ad: ldloc.s 12
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01b4: pop
-		IL_01b5: ldc.i4.1
-		IL_01b6: newarr [System.Runtime]System.Object
-		IL_01bb: dup
-		IL_01bc: ldc.i4.0
-		IL_01bd: ldloc.0
-		IL_01be: stelem.ref
-		IL_01bf: stloc.s 11
-		IL_01c1: ldloc.s 11
-		IL_01c3: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::.ctor(object[])
-		IL_01c8: ldc.i4.3
-		IL_01c9: conv.r8
-		IL_01ca: ldstr "setBitsTrue"
-		IL_01cf: ldc.i4.1
-		IL_01d0: ldc.i4.1
-		IL_01d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_01d6: stloc.s 13
-		IL_01d8: ldloc.s 13
-		IL_01da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0)
-		IL_01df: stloc.s 13
-		IL_01e1: ldloc.s 6
-		IL_01e3: ldstr "setBitsTrue"
-		IL_01e8: ldloc.s 13
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01ef: pop
-		IL_01f0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01f5: stloc.s 11
-		IL_01f7: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::.ctor()
-		IL_01fc: ldc.i4.1
-		IL_01fd: conv.r8
-		IL_01fe: ldstr "testBitTrue"
-		IL_0203: ldc.i4.1
-		IL_0204: ldc.i4.1
-		IL_0205: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
-		IL_020a: stloc.s 14
-		IL_020c: ldloc.s 14
-		IL_020e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0)
-		IL_0213: stloc.s 14
-		IL_0215: ldloc.s 6
-		IL_0217: ldstr "testBitTrue"
-		IL_021c: ldloc.s 14
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0223: pop
-		IL_0224: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0229: stloc.s 11
-		IL_022b: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::.ctor()
-		IL_0230: ldc.i4.1
-		IL_0231: conv.r8
-		IL_0232: ldstr "searchBitFalse"
-		IL_0237: ldc.i4.1
-		IL_0238: ldc.i4.1
-		IL_0239: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
-		IL_023e: stloc.s 15
-		IL_0240: ldloc.s 15
-		IL_0242: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0)
-		IL_0247: stloc.s 15
-		IL_0249: ldloc.s 6
-		IL_024b: ldstr "searchBitFalse"
-		IL_0250: ldloc.s 15
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0257: pop
-		IL_0258: ldc.i4.1
-		IL_0259: newarr [System.Runtime]System.Object
-		IL_025e: dup
-		IL_025f: ldc.i4.0
-		IL_0260: ldloc.0
-		IL_0261: stelem.ref
-		IL_0262: stloc.s 11
-		IL_0264: ldloc.s 9
-		IL_0266: ldloc.s 11
-		IL_0268: ldc.r8 1
-		IL_0271: box [System.Runtime]System.Double
-		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_027b: stloc.s 6
-		IL_027d: ldloc.0
-		IL_027e: ldloc.s 6
-		IL_0280: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
-		IL_0285: nop
-		IL_0286: ldc.i4.1
-		IL_0287: newarr [System.Runtime]System.Object
-		IL_028c: dup
-		IL_028d: ldc.i4.0
-		IL_028e: ldloc.0
-		IL_028f: stelem.ref
-		IL_0290: stloc.s 11
-		IL_0292: ldloc.s 11
-		IL_0294: ldc.i4.0
-		IL_0295: ldelem.ref
-		IL_0296: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_029b: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
-		IL_02a0: ldc.i4.1
-		IL_02a1: conv.r8
-		IL_02a2: ldstr ""
-		IL_02a7: ldc.i4.0
-		IL_02a8: ldc.i4.0
-		IL_02a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0)
-		IL_02b3: stloc.s 16
-		IL_02b5: ldloc.s 16
-		IL_02b7: ldstr "runSieveBatch"
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_02c1: stloc.s 6
-		IL_02c3: ldloc.0
-		IL_02c4: ldloc.s 6
-		IL_02c6: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-		IL_02cb: ldc.i4.1
-		IL_02cc: newarr [System.Runtime]System.Object
-		IL_02d1: dup
-		IL_02d2: ldc.i4.0
-		IL_02d3: ldloc.0
-		IL_02d4: stelem.ref
-		IL_02d5: stloc.s 11
-		IL_02d7: ldloc.s 11
-		IL_02d9: ldc.i4.0
-		IL_02da: ldelem.ref
-		IL_02db: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_02e0: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
-		IL_02e5: ldc.i4.1
-		IL_02e6: conv.r8
-		IL_02e7: ldstr ""
-		IL_02ec: ldc.i4.0
-		IL_02ed: ldc.i4.0
-		IL_02ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject>(!!0)
-		IL_02f8: stloc.s 17
-		IL_02fa: ldloc.s 17
-		IL_02fc: ldstr "main"
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0306: stloc.3
-		IL_0307: ldloc.0
-		IL_0308: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_030d: ldnull
-		IL_030e: ldloc.1
-		IL_030f: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_0314: pop
-		IL_0315: ret
+		IL_015d: ldloc.s 9
+		IL_015f: ldstr "prototype"
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0169: stloc.s 6
+		IL_016b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0170: stloc.s 10
+		IL_0172: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::.ctor()
+		IL_0177: ldc.i4.1
+		IL_0178: conv.r8
+		IL_0179: ldstr "setBitTrue"
+		IL_017e: ldc.i4.1
+		IL_017f: ldc.i4.1
+		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
+		IL_0185: stloc.s 11
+		IL_0187: ldloc.s 11
+		IL_0189: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0)
+		IL_018e: stloc.s 11
+		IL_0190: ldloc.s 6
+		IL_0192: ldstr "setBitTrue"
+		IL_0197: ldloc.s 11
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_019e: pop
+		IL_019f: ldc.i4.1
+		IL_01a0: newarr [System.Runtime]System.Object
+		IL_01a5: dup
+		IL_01a6: ldc.i4.0
+		IL_01a7: ldloc.0
+		IL_01a8: stelem.ref
+		IL_01a9: stloc.s 10
+		IL_01ab: ldloc.s 10
+		IL_01ad: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::.ctor(object[])
+		IL_01b2: ldc.i4.3
+		IL_01b3: conv.r8
+		IL_01b4: ldstr "setBitsTrue"
+		IL_01b9: ldc.i4.1
+		IL_01ba: ldc.i4.1
+		IL_01bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
+		IL_01c0: stloc.s 12
+		IL_01c2: ldloc.s 12
+		IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0)
+		IL_01c9: stloc.s 12
+		IL_01cb: ldloc.s 6
+		IL_01cd: ldstr "setBitsTrue"
+		IL_01d2: ldloc.s 12
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01d9: pop
+		IL_01da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01df: stloc.s 10
+		IL_01e1: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::.ctor()
+		IL_01e6: ldc.i4.1
+		IL_01e7: conv.r8
+		IL_01e8: ldstr "testBitTrue"
+		IL_01ed: ldc.i4.1
+		IL_01ee: ldc.i4.1
+		IL_01ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
+		IL_01f4: stloc.s 13
+		IL_01f6: ldloc.s 13
+		IL_01f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0)
+		IL_01fd: stloc.s 13
+		IL_01ff: ldloc.s 6
+		IL_0201: ldstr "testBitTrue"
+		IL_0206: ldloc.s 13
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_020d: pop
+		IL_020e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0213: stloc.s 10
+		IL_0215: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::.ctor()
+		IL_021a: ldc.i4.1
+		IL_021b: conv.r8
+		IL_021c: ldstr "searchBitFalse"
+		IL_0221: ldc.i4.1
+		IL_0222: ldc.i4.1
+		IL_0223: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
+		IL_0228: stloc.s 14
+		IL_022a: ldloc.s 14
+		IL_022c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0)
+		IL_0231: stloc.s 14
+		IL_0233: ldloc.s 6
+		IL_0235: ldstr "searchBitFalse"
+		IL_023a: ldloc.s 14
+		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0241: pop
+		IL_0242: ldc.i4.1
+		IL_0243: newarr [System.Runtime]System.Object
+		IL_0248: dup
+		IL_0249: ldc.i4.0
+		IL_024a: ldloc.0
+		IL_024b: stelem.ref
+		IL_024c: stloc.s 10
+		IL_024e: ldloc.s 9
+		IL_0250: ldloc.s 10
+		IL_0252: ldc.r8 1
+		IL_025b: box [System.Runtime]System.Double
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0265: stloc.s 6
+		IL_0267: ldloc.0
+		IL_0268: ldloc.s 6
+		IL_026a: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
+		IL_026f: nop
+		IL_0270: ldc.i4.1
+		IL_0271: newarr [System.Runtime]System.Object
+		IL_0276: dup
+		IL_0277: ldc.i4.0
+		IL_0278: ldloc.0
+		IL_0279: stelem.ref
+		IL_027a: stloc.s 10
+		IL_027c: ldloc.s 10
+		IL_027e: ldc.i4.0
+		IL_027f: ldelem.ref
+		IL_0280: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_0285: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
+		IL_028a: ldc.i4.1
+		IL_028b: conv.r8
+		IL_028c: ldstr ""
+		IL_0291: ldc.i4.0
+		IL_0292: ldc.i4.0
+		IL_0293: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0298: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0)
+		IL_029d: stloc.s 15
+		IL_029f: ldloc.s 15
+		IL_02a1: ldstr "runSieveBatch"
+		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_02ab: stloc.s 6
+		IL_02ad: ldloc.0
+		IL_02ae: ldloc.s 6
+		IL_02b0: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+		IL_02b5: ldc.i4.1
+		IL_02b6: newarr [System.Runtime]System.Object
+		IL_02bb: dup
+		IL_02bc: ldc.i4.0
+		IL_02bd: ldloc.0
+		IL_02be: stelem.ref
+		IL_02bf: stloc.s 10
+		IL_02c1: ldloc.s 10
+		IL_02c3: ldc.i4.0
+		IL_02c4: ldelem.ref
+		IL_02c5: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_02ca: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
+		IL_02cf: ldc.i4.1
+		IL_02d0: conv.r8
+		IL_02d1: ldstr ""
+		IL_02d6: ldc.i4.0
+		IL_02d7: ldc.i4.0
+		IL_02d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject>(!!0)
+		IL_02e2: stloc.s 16
+		IL_02e4: ldloc.s 16
+		IL_02e6: ldstr "main"
+		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_02f0: stloc.3
+		IL_02f1: ldloc.0
+		IL_02f2: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_02f7: ldnull
+		IL_02f8: ldloc.1
+		IL_02f9: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_02fe: pop
+		IL_02ff: ret
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript
@@ -3566,7 +3560,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3361
+		// Method begins at RVA 0x3349
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30bb
+						// Method begins at RVA 0x308f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30b2
+					// Method begins at RVA 0x3086
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30a9
+				// Method begins at RVA 0x307d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 					class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x33d5
+				// Method begins at RVA 0x33a9
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -114,7 +114,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x33e4
+				// Method begins at RVA 0x33b8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x33e7
+				// Method begins at RVA 0x33bb
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -141,7 +141,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x33ea
+				// Method begins at RVA 0x33be
 				// Header size: 1
 				// Code size: 27 (0x1b)
 				.maxstack 8
@@ -176,7 +176,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x24bc
+			// Method begins at RVA 0x2490
 			// Header size: 12
 			// Code size: 230 (0xe6)
 			.maxstack 8
@@ -304,7 +304,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30c4
+				// Method begins at RVA 0x3098
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -329,7 +329,7 @@
 					class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3406
+				// Method begins at RVA 0x33da
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -345,7 +345,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3415
+				// Method begins at RVA 0x33e9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -357,7 +357,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3418
+				// Method begins at RVA 0x33ec
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -372,7 +372,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x341b
+				// Method begins at RVA 0x33ef
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -403,7 +403,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x25b0
+			// Method begins at RVA 0x2584
 			// Header size: 12
 			// Code size: 431 (0x1af)
 			.maxstack 8
@@ -578,7 +578,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f9b
+				// Method begins at RVA 0x2f6f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -598,7 +598,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fa4
+				// Method begins at RVA 0x2f78
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -618,7 +618,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fad
+				// Method begins at RVA 0x2f81
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -646,7 +646,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fc8
+						// Method begins at RVA 0x2f9c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -670,7 +670,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2fda
+							// Method begins at RVA 0x2fae
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -688,7 +688,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fd1
+						// Method begins at RVA 0x2fa5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -706,7 +706,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fbf
+					// Method begins at RVA 0x2f93
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -734,7 +734,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2ff5
+							// Method begins at RVA 0x2fc9
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -752,7 +752,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fec
+						// Method begins at RVA 0x2fc0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -770,7 +770,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fe3
+					// Method begins at RVA 0x2fb7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -794,7 +794,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3007
+						// Method begins at RVA 0x2fdb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -812,7 +812,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ffe
+					// Method begins at RVA 0x2fd2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -830,7 +830,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fb6
+				// Method begins at RVA 0x2f8a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -850,7 +850,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3010
+				// Method begins at RVA 0x2fe4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -874,7 +874,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3022
+					// Method begins at RVA 0x2ff6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -892,7 +892,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3019
+				// Method begins at RVA 0x2fed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -917,7 +917,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3149
+				// Method begins at RVA 0x311d
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -933,7 +933,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3158
+				// Method begins at RVA 0x312c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -945,7 +945,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x315b
+				// Method begins at RVA 0x312f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -960,7 +960,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x315e
+				// Method begins at RVA 0x3132
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -976,7 +976,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x316a
+				// Method begins at RVA 0x313e
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -995,7 +995,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3176
+				// Method begins at RVA 0x314a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1008,7 +1008,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x317e
+				// Method begins at RVA 0x3152
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1020,7 +1020,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3181
+				// Method begins at RVA 0x3155
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1035,7 +1035,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3184
+				// Method begins at RVA 0x3158
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -1071,7 +1071,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x31b4
+				// Method begins at RVA 0x3188
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1087,7 +1087,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x31c3
+				// Method begins at RVA 0x3197
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1099,7 +1099,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x31c6
+				// Method begins at RVA 0x319a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1114,7 +1114,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x31cc
+				// Method begins at RVA 0x31a0
 				// Header size: 12
 				// Code size: 71 (0x47)
 				.maxstack 8
@@ -1153,7 +1153,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x321f
+				// Method begins at RVA 0x31f3
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1166,7 +1166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3227
+				// Method begins at RVA 0x31fb
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1178,7 +1178,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x322a
+				// Method begins at RVA 0x31fe
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1193,7 +1193,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x322d
+				// Method begins at RVA 0x3201
 				// Header size: 1
 				// Code size: 52 (0x34)
 				.maxstack 8
@@ -1225,7 +1225,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3262
+				// Method begins at RVA 0x3236
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1238,7 +1238,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x326a
+				// Method begins at RVA 0x323e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1250,7 +1250,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x326d
+				// Method begins at RVA 0x3241
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1265,7 +1265,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3270
+				// Method begins at RVA 0x3244
 				// Header size: 1
 				// Code size: 52 (0x34)
 				.maxstack 8
@@ -1305,7 +1305,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27d4
+			// Method begins at RVA 0x27a8
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -1353,7 +1353,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a40
+			// Method begins at RVA 0x2a14
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -1417,7 +1417,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2858
+			// Method begins at RVA 0x282c
 			// Header size: 12
 			// Code size: 475 (0x1db)
 			.maxstack 8
@@ -1684,7 +1684,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2aa0
+			// Method begins at RVA 0x2a74
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -1741,7 +1741,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2820
+			// Method begins at RVA 0x27f4
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1786,7 +1786,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x302b
+				// Method begins at RVA 0x2fff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1806,7 +1806,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3034
+				// Method begins at RVA 0x3008
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1830,7 +1830,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3046
+					// Method begins at RVA 0x301a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1848,7 +1848,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x303d
+				// Method begins at RVA 0x3011
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1868,7 +1868,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x304f
+				// Method begins at RVA 0x3023
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1896,7 +1896,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x306a
+						// Method begins at RVA 0x303e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1914,7 +1914,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3061
+					// Method begins at RVA 0x3035
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1932,7 +1932,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3058
+				// Method begins at RVA 0x302c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1956,7 +1956,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x307c
+					// Method begins at RVA 0x3050
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1980,7 +1980,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x308e
+						// Method begins at RVA 0x3062
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1998,7 +1998,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3085
+					// Method begins at RVA 0x3059
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2016,7 +2016,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3073
+				// Method begins at RVA 0x3047
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2040,7 +2040,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30a0
+					// Method begins at RVA 0x3074
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2058,7 +2058,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3097
+				// Method begins at RVA 0x306b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2085,7 +2085,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x32a5
+				// Method begins at RVA 0x3279
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -2104,7 +2104,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x32bb
+				// Method begins at RVA 0x328f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2116,7 +2116,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x32be
+				// Method begins at RVA 0x3292
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2131,7 +2131,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x32c1
+				// Method begins at RVA 0x3295
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -2147,7 +2147,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x32cd
+				// Method begins at RVA 0x32a1
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -2171,7 +2171,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x32d9
+				// Method begins at RVA 0x32ad
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2187,7 +2187,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x32e8
+				// Method begins at RVA 0x32bc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2199,7 +2199,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x32eb
+				// Method begins at RVA 0x32bf
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2214,7 +2214,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x32ee
+				// Method begins at RVA 0x32c2
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -2246,7 +2246,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3312
+				// Method begins at RVA 0x32e6
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2262,7 +2262,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3321
+				// Method begins at RVA 0x32f5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2274,7 +2274,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3324
+				// Method begins at RVA 0x32f8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2289,7 +2289,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3327
+				// Method begins at RVA 0x32fb
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -2322,7 +2322,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3350
+				// Method begins at RVA 0x3324
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2338,7 +2338,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x335f
+				// Method begins at RVA 0x3333
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2350,7 +2350,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3362
+				// Method begins at RVA 0x3336
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2365,7 +2365,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3365
+				// Method begins at RVA 0x3339
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -2400,7 +2400,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3390
+				// Method begins at RVA 0x3364
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2416,7 +2416,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x339f
+				// Method begins at RVA 0x3373
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2428,7 +2428,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x33a2
+				// Method begins at RVA 0x3376
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2443,7 +2443,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x33a5
+				// Method begins at RVA 0x3379
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -2484,7 +2484,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x276c
+			// Method begins at RVA 0x2740
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -2543,7 +2543,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2af0
+			// Method begins at RVA 0x2ac4
 			// Header size: 12
 			// Code size: 168 (0xa8)
 			.maxstack 8
@@ -2631,7 +2631,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e34
+			// Method begins at RVA 0x2e08
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -2696,7 +2696,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2eac
+			// Method begins at RVA 0x2e80
 			// Header size: 12
 			// Code size: 218 (0xda)
 			.maxstack 8
@@ -2804,7 +2804,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ba4
+			// Method begins at RVA 0x2b78
 			// Header size: 12
 			// Code size: 643 (0x283)
 			.maxstack 8
@@ -3033,7 +3033,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2f92
+			// Method begins at RVA 0x2f66
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3063,7 +3063,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30cd
+				// Method begins at RVA 0x30a1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3076,7 +3076,7 @@
 			.method public hidebysig 
 				instance float64 get_sieveSize () cil managed 
 			{
-				// Method begins at RVA 0x30d5
+				// Method begins at RVA 0x30a9
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3091,7 +3091,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x30dd
+				// Method begins at RVA 0x30b1
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3109,7 +3109,7 @@
 			.method public hidebysig 
 				instance float64 get_timeLimitSeconds () cil managed 
 			{
-				// Method begins at RVA 0x30f2
+				// Method begins at RVA 0x30c6
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3124,7 +3124,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x30fa
+				// Method begins at RVA 0x30ce
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3142,7 +3142,7 @@
 			.method public hidebysig 
 				instance object get_verbose () cil managed 
 			{
-				// Method begins at RVA 0x310f
+				// Method begins at RVA 0x30e3
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3157,7 +3157,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3117
+				// Method begins at RVA 0x30eb
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3175,7 +3175,7 @@
 			.method public hidebysig 
 				instance object get_runtime () cil managed 
 			{
-				// Method begins at RVA 0x312c
+				// Method begins at RVA 0x3100
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3190,7 +3190,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3134
+				// Method begins at RVA 0x3108
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3223,7 +3223,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1120 (0x460)
+		// Code size: 1076 (0x434)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope,
@@ -3237,18 +3237,17 @@
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[9] float64,
 			[10] class [System.Runtime]System.Type,
-			[11] class [System.Runtime]System.Type,
-			[12] object[],
-			[13] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue,
-			[14] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue,
-			[15] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue,
-			[16] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse,
-			[17] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve,
-			[18] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes,
-			[19] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes,
-			[20] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount,
-			[21] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject,
-			[22] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject
+			[11] object[],
+			[12] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue,
+			[13] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue,
+			[14] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue,
+			[15] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse,
+			[16] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve,
+			[17] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes,
+			[18] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes,
+			[19] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount,
+			[20] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject,
+			[21] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::.ctor()
@@ -3349,290 +3348,280 @@
 		IL_0151: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
 		IL_0156: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_015b: stloc.s 10
-		IL_015d: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0162: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0167: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_016c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0171: stloc.s 11
-		IL_0173: ldloc.s 11
-		IL_0175: ldstr "prototype"
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017f: stloc.s 7
-		IL_0181: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0186: stloc.s 12
-		IL_0188: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::.ctor()
-		IL_018d: ldc.i4.1
-		IL_018e: conv.r8
-		IL_018f: ldstr "setBitTrue"
-		IL_0194: ldc.i4.1
-		IL_0195: ldc.i4.1
-		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
-		IL_019b: stloc.s 13
-		IL_019d: ldloc.s 13
-		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0)
-		IL_01a4: stloc.s 13
-		IL_01a6: ldloc.s 7
-		IL_01a8: ldstr "setBitTrue"
-		IL_01ad: ldloc.s 13
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01b4: pop
-		IL_01b5: ldc.i4.1
-		IL_01b6: newarr [System.Runtime]System.Object
-		IL_01bb: dup
-		IL_01bc: ldc.i4.0
-		IL_01bd: ldloc.0
-		IL_01be: stelem.ref
-		IL_01bf: stloc.s 12
-		IL_01c1: ldloc.s 12
-		IL_01c3: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::.ctor(object[])
-		IL_01c8: ldc.i4.3
-		IL_01c9: conv.r8
-		IL_01ca: ldstr "setBitsTrue"
-		IL_01cf: ldc.i4.1
-		IL_01d0: ldc.i4.1
-		IL_01d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_01d6: stloc.s 14
-		IL_01d8: ldloc.s 14
-		IL_01da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0)
-		IL_01df: stloc.s 14
-		IL_01e1: ldloc.s 7
-		IL_01e3: ldstr "setBitsTrue"
-		IL_01e8: ldloc.s 14
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01ef: pop
-		IL_01f0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01f5: stloc.s 12
-		IL_01f7: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::.ctor()
-		IL_01fc: ldc.i4.1
-		IL_01fd: conv.r8
-		IL_01fe: ldstr "testBitTrue"
-		IL_0203: ldc.i4.1
-		IL_0204: ldc.i4.1
-		IL_0205: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
-		IL_020a: stloc.s 15
-		IL_020c: ldloc.s 15
-		IL_020e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0)
-		IL_0213: stloc.s 15
-		IL_0215: ldloc.s 7
-		IL_0217: ldstr "testBitTrue"
-		IL_021c: ldloc.s 15
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0223: pop
-		IL_0224: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0229: stloc.s 12
-		IL_022b: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::.ctor()
-		IL_0230: ldc.i4.1
-		IL_0231: conv.r8
-		IL_0232: ldstr "searchBitFalse"
-		IL_0237: ldc.i4.1
-		IL_0238: ldc.i4.1
-		IL_0239: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
-		IL_023e: stloc.s 16
-		IL_0240: ldloc.s 16
-		IL_0242: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0)
-		IL_0247: stloc.s 16
-		IL_0249: ldloc.s 7
-		IL_024b: ldstr "searchBitFalse"
-		IL_0250: ldloc.s 16
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0257: pop
-		IL_0258: ldc.i4.1
-		IL_0259: newarr [System.Runtime]System.Object
-		IL_025e: dup
-		IL_025f: ldc.i4.0
-		IL_0260: ldloc.0
-		IL_0261: stelem.ref
-		IL_0262: stloc.s 12
-		IL_0264: ldloc.s 10
-		IL_0266: ldloc.s 12
-		IL_0268: ldc.r8 1
-		IL_0271: box [System.Runtime]System.Double
-		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_027b: stloc.s 7
-		IL_027d: ldloc.0
-		IL_027e: ldloc.s 7
-		IL_0280: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
-		IL_0285: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_028a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_028f: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0294: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0299: stloc.s 10
-		IL_029b: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_02a0: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_02a5: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_02aa: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_02af: stloc.s 11
-		IL_02b1: ldloc.s 11
-		IL_02b3: ldstr "prototype"
-		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02bd: stloc.s 7
-		IL_02bf: ldc.i4.1
-		IL_02c0: newarr [System.Runtime]System.Object
-		IL_02c5: dup
-		IL_02c6: ldc.i4.0
-		IL_02c7: ldloc.0
-		IL_02c8: stelem.ref
-		IL_02c9: stloc.s 12
-		IL_02cb: ldloc.s 12
-		IL_02cd: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::.ctor(object[])
-		IL_02d2: ldc.i4.0
-		IL_02d3: conv.r8
-		IL_02d4: ldstr "runSieve"
-		IL_02d9: ldc.i4.1
-		IL_02da: ldc.i4.1
-		IL_02db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0, float64, string, bool, bool)
-		IL_02e0: stloc.s 17
-		IL_02e2: ldloc.s 17
-		IL_02e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0)
-		IL_02e9: stloc.s 17
-		IL_02eb: ldloc.s 7
-		IL_02ed: ldstr "runSieve"
-		IL_02f2: ldloc.s 17
-		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02f9: pop
-		IL_02fa: ldc.i4.1
-		IL_02fb: newarr [System.Runtime]System.Object
-		IL_0300: dup
-		IL_0301: ldc.i4.0
-		IL_0302: ldloc.0
-		IL_0303: stelem.ref
-		IL_0304: stloc.s 12
-		IL_0306: ldloc.s 12
-		IL_0308: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::.ctor(object[])
-		IL_030d: ldc.i4.0
-		IL_030e: conv.r8
-		IL_030f: ldstr "countPrimes"
-		IL_0314: ldc.i4.1
-		IL_0315: ldc.i4.1
-		IL_0316: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0, float64, string, bool, bool)
-		IL_031b: stloc.s 18
-		IL_031d: ldloc.s 18
-		IL_031f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0)
-		IL_0324: stloc.s 18
-		IL_0326: ldloc.s 7
-		IL_0328: ldstr "countPrimes"
-		IL_032d: ldloc.s 18
-		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0334: pop
-		IL_0335: ldc.i4.1
-		IL_0336: newarr [System.Runtime]System.Object
-		IL_033b: dup
-		IL_033c: ldc.i4.0
-		IL_033d: ldloc.0
-		IL_033e: stelem.ref
-		IL_033f: stloc.s 12
-		IL_0341: ldloc.s 12
-		IL_0343: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::.ctor(object[])
-		IL_0348: ldc.i4.0
-		IL_0349: conv.r8
-		IL_034a: ldstr "getPrimes"
-		IL_034f: ldc.i4.1
-		IL_0350: ldc.i4.1
-		IL_0351: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0, float64, string, bool, bool)
-		IL_0356: stloc.s 19
-		IL_0358: ldloc.s 19
-		IL_035a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0)
-		IL_035f: stloc.s 19
-		IL_0361: ldloc.s 7
-		IL_0363: ldstr "getPrimes"
-		IL_0368: ldloc.s 19
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_036f: pop
-		IL_0370: ldc.i4.1
-		IL_0371: newarr [System.Runtime]System.Object
-		IL_0376: dup
-		IL_0377: ldc.i4.0
-		IL_0378: ldloc.0
-		IL_0379: stelem.ref
-		IL_037a: stloc.s 12
-		IL_037c: ldloc.s 12
-		IL_037e: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::.ctor(object[])
-		IL_0383: ldc.i4.1
-		IL_0384: conv.r8
-		IL_0385: ldstr "validatePrimeCount"
-		IL_038a: ldc.i4.1
-		IL_038b: ldc.i4.1
-		IL_038c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0, float64, string, bool, bool)
-		IL_0391: stloc.s 20
-		IL_0393: ldloc.s 20
-		IL_0395: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0)
-		IL_039a: stloc.s 20
-		IL_039c: ldloc.s 7
-		IL_039e: ldstr "validatePrimeCount"
-		IL_03a3: ldloc.s 20
-		IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_03aa: pop
-		IL_03ab: ldc.i4.1
-		IL_03ac: newarr [System.Runtime]System.Object
-		IL_03b1: dup
-		IL_03b2: ldc.i4.0
-		IL_03b3: ldloc.0
-		IL_03b4: stelem.ref
-		IL_03b5: stloc.s 12
-		IL_03b7: ldloc.s 10
-		IL_03b9: ldloc.s 12
-		IL_03bb: ldc.r8 1
-		IL_03c4: box [System.Runtime]System.Double
-		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_03ce: stloc.s 7
-		IL_03d0: ldloc.0
-		IL_03d1: ldloc.s 7
-		IL_03d3: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
-		IL_03d8: ldc.i4.1
-		IL_03d9: newarr [System.Runtime]System.Object
-		IL_03de: dup
-		IL_03df: ldc.i4.0
-		IL_03e0: ldloc.0
-		IL_03e1: stelem.ref
-		IL_03e2: stloc.s 12
-		IL_03e4: ldloc.s 12
-		IL_03e6: ldc.i4.0
-		IL_03e7: ldelem.ref
-		IL_03e8: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_03ed: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope)
-		IL_03f2: ldc.i4.1
-		IL_03f3: conv.r8
-		IL_03f4: ldstr ""
-		IL_03f9: ldc.i4.0
-		IL_03fa: ldc.i4.0
-		IL_03fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0400: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject>(!!0)
-		IL_0405: stloc.s 21
-		IL_0407: ldloc.s 21
-		IL_0409: ldstr "runSieveBatch"
-		IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0413: stloc.3
-		IL_0414: ldc.i4.1
-		IL_0415: newarr [System.Runtime]System.Object
-		IL_041a: dup
-		IL_041b: ldc.i4.0
-		IL_041c: ldloc.0
-		IL_041d: stelem.ref
-		IL_041e: stloc.s 12
-		IL_0420: ldloc.s 12
-		IL_0422: ldc.i4.0
-		IL_0423: ldelem.ref
-		IL_0424: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0429: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope)
-		IL_042e: ldc.i4.1
-		IL_042f: conv.r8
-		IL_0430: ldstr ""
-		IL_0435: ldc.i4.0
-		IL_0436: ldc.i4.0
-		IL_0437: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_043c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject>(!!0)
-		IL_0441: stloc.s 22
-		IL_0443: ldloc.s 22
-		IL_0445: ldstr "main"
-		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_044f: stloc.s 4
-		IL_0451: ldloc.0
-		IL_0452: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0457: ldnull
-		IL_0458: ldloc.1
-		IL_0459: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_045e: pop
-		IL_045f: ret
+		IL_015d: ldloc.s 10
+		IL_015f: ldstr "prototype"
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0169: stloc.s 7
+		IL_016b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0170: stloc.s 11
+		IL_0172: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::.ctor()
+		IL_0177: ldc.i4.1
+		IL_0178: conv.r8
+		IL_0179: ldstr "setBitTrue"
+		IL_017e: ldc.i4.1
+		IL_017f: ldc.i4.1
+		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
+		IL_0185: stloc.s 12
+		IL_0187: ldloc.s 12
+		IL_0189: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0)
+		IL_018e: stloc.s 12
+		IL_0190: ldloc.s 7
+		IL_0192: ldstr "setBitTrue"
+		IL_0197: ldloc.s 12
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_019e: pop
+		IL_019f: ldc.i4.1
+		IL_01a0: newarr [System.Runtime]System.Object
+		IL_01a5: dup
+		IL_01a6: ldc.i4.0
+		IL_01a7: ldloc.0
+		IL_01a8: stelem.ref
+		IL_01a9: stloc.s 11
+		IL_01ab: ldloc.s 11
+		IL_01ad: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::.ctor(object[])
+		IL_01b2: ldc.i4.3
+		IL_01b3: conv.r8
+		IL_01b4: ldstr "setBitsTrue"
+		IL_01b9: ldc.i4.1
+		IL_01ba: ldc.i4.1
+		IL_01bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
+		IL_01c0: stloc.s 13
+		IL_01c2: ldloc.s 13
+		IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0)
+		IL_01c9: stloc.s 13
+		IL_01cb: ldloc.s 7
+		IL_01cd: ldstr "setBitsTrue"
+		IL_01d2: ldloc.s 13
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01d9: pop
+		IL_01da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01df: stloc.s 11
+		IL_01e1: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::.ctor()
+		IL_01e6: ldc.i4.1
+		IL_01e7: conv.r8
+		IL_01e8: ldstr "testBitTrue"
+		IL_01ed: ldc.i4.1
+		IL_01ee: ldc.i4.1
+		IL_01ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
+		IL_01f4: stloc.s 14
+		IL_01f6: ldloc.s 14
+		IL_01f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0)
+		IL_01fd: stloc.s 14
+		IL_01ff: ldloc.s 7
+		IL_0201: ldstr "testBitTrue"
+		IL_0206: ldloc.s 14
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_020d: pop
+		IL_020e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0213: stloc.s 11
+		IL_0215: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::.ctor()
+		IL_021a: ldc.i4.1
+		IL_021b: conv.r8
+		IL_021c: ldstr "searchBitFalse"
+		IL_0221: ldc.i4.1
+		IL_0222: ldc.i4.1
+		IL_0223: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
+		IL_0228: stloc.s 15
+		IL_022a: ldloc.s 15
+		IL_022c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0)
+		IL_0231: stloc.s 15
+		IL_0233: ldloc.s 7
+		IL_0235: ldstr "searchBitFalse"
+		IL_023a: ldloc.s 15
+		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0241: pop
+		IL_0242: ldc.i4.1
+		IL_0243: newarr [System.Runtime]System.Object
+		IL_0248: dup
+		IL_0249: ldc.i4.0
+		IL_024a: ldloc.0
+		IL_024b: stelem.ref
+		IL_024c: stloc.s 11
+		IL_024e: ldloc.s 10
+		IL_0250: ldloc.s 11
+		IL_0252: ldc.r8 1
+		IL_025b: box [System.Runtime]System.Double
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0265: stloc.s 7
+		IL_0267: ldloc.0
+		IL_0268: ldloc.s 7
+		IL_026a: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
+		IL_026f: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_0274: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0279: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_027e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0283: stloc.s 10
+		IL_0285: ldloc.s 10
+		IL_0287: ldstr "prototype"
+		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0291: stloc.s 7
+		IL_0293: ldc.i4.1
+		IL_0294: newarr [System.Runtime]System.Object
+		IL_0299: dup
+		IL_029a: ldc.i4.0
+		IL_029b: ldloc.0
+		IL_029c: stelem.ref
+		IL_029d: stloc.s 11
+		IL_029f: ldloc.s 11
+		IL_02a1: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::.ctor(object[])
+		IL_02a6: ldc.i4.0
+		IL_02a7: conv.r8
+		IL_02a8: ldstr "runSieve"
+		IL_02ad: ldc.i4.1
+		IL_02ae: ldc.i4.1
+		IL_02af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0, float64, string, bool, bool)
+		IL_02b4: stloc.s 16
+		IL_02b6: ldloc.s 16
+		IL_02b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0)
+		IL_02bd: stloc.s 16
+		IL_02bf: ldloc.s 7
+		IL_02c1: ldstr "runSieve"
+		IL_02c6: ldloc.s 16
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02cd: pop
+		IL_02ce: ldc.i4.1
+		IL_02cf: newarr [System.Runtime]System.Object
+		IL_02d4: dup
+		IL_02d5: ldc.i4.0
+		IL_02d6: ldloc.0
+		IL_02d7: stelem.ref
+		IL_02d8: stloc.s 11
+		IL_02da: ldloc.s 11
+		IL_02dc: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::.ctor(object[])
+		IL_02e1: ldc.i4.0
+		IL_02e2: conv.r8
+		IL_02e3: ldstr "countPrimes"
+		IL_02e8: ldc.i4.1
+		IL_02e9: ldc.i4.1
+		IL_02ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0, float64, string, bool, bool)
+		IL_02ef: stloc.s 17
+		IL_02f1: ldloc.s 17
+		IL_02f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0)
+		IL_02f8: stloc.s 17
+		IL_02fa: ldloc.s 7
+		IL_02fc: ldstr "countPrimes"
+		IL_0301: ldloc.s 17
+		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0308: pop
+		IL_0309: ldc.i4.1
+		IL_030a: newarr [System.Runtime]System.Object
+		IL_030f: dup
+		IL_0310: ldc.i4.0
+		IL_0311: ldloc.0
+		IL_0312: stelem.ref
+		IL_0313: stloc.s 11
+		IL_0315: ldloc.s 11
+		IL_0317: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::.ctor(object[])
+		IL_031c: ldc.i4.0
+		IL_031d: conv.r8
+		IL_031e: ldstr "getPrimes"
+		IL_0323: ldc.i4.1
+		IL_0324: ldc.i4.1
+		IL_0325: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0, float64, string, bool, bool)
+		IL_032a: stloc.s 18
+		IL_032c: ldloc.s 18
+		IL_032e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0)
+		IL_0333: stloc.s 18
+		IL_0335: ldloc.s 7
+		IL_0337: ldstr "getPrimes"
+		IL_033c: ldloc.s 18
+		IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0343: pop
+		IL_0344: ldc.i4.1
+		IL_0345: newarr [System.Runtime]System.Object
+		IL_034a: dup
+		IL_034b: ldc.i4.0
+		IL_034c: ldloc.0
+		IL_034d: stelem.ref
+		IL_034e: stloc.s 11
+		IL_0350: ldloc.s 11
+		IL_0352: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::.ctor(object[])
+		IL_0357: ldc.i4.1
+		IL_0358: conv.r8
+		IL_0359: ldstr "validatePrimeCount"
+		IL_035e: ldc.i4.1
+		IL_035f: ldc.i4.1
+		IL_0360: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0, float64, string, bool, bool)
+		IL_0365: stloc.s 19
+		IL_0367: ldloc.s 19
+		IL_0369: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0)
+		IL_036e: stloc.s 19
+		IL_0370: ldloc.s 7
+		IL_0372: ldstr "validatePrimeCount"
+		IL_0377: ldloc.s 19
+		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_037e: pop
+		IL_037f: ldc.i4.1
+		IL_0380: newarr [System.Runtime]System.Object
+		IL_0385: dup
+		IL_0386: ldc.i4.0
+		IL_0387: ldloc.0
+		IL_0388: stelem.ref
+		IL_0389: stloc.s 11
+		IL_038b: ldloc.s 10
+		IL_038d: ldloc.s 11
+		IL_038f: ldc.r8 1
+		IL_0398: box [System.Runtime]System.Double
+		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_03a2: stloc.s 7
+		IL_03a4: ldloc.0
+		IL_03a5: ldloc.s 7
+		IL_03a7: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
+		IL_03ac: ldc.i4.1
+		IL_03ad: newarr [System.Runtime]System.Object
+		IL_03b2: dup
+		IL_03b3: ldc.i4.0
+		IL_03b4: ldloc.0
+		IL_03b5: stelem.ref
+		IL_03b6: stloc.s 11
+		IL_03b8: ldloc.s 11
+		IL_03ba: ldc.i4.0
+		IL_03bb: ldelem.ref
+		IL_03bc: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_03c1: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope)
+		IL_03c6: ldc.i4.1
+		IL_03c7: conv.r8
+		IL_03c8: ldstr ""
+		IL_03cd: ldc.i4.0
+		IL_03ce: ldc.i4.0
+		IL_03cf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject>(!!0)
+		IL_03d9: stloc.s 20
+		IL_03db: ldloc.s 20
+		IL_03dd: ldstr "runSieveBatch"
+		IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_03e7: stloc.3
+		IL_03e8: ldc.i4.1
+		IL_03e9: newarr [System.Runtime]System.Object
+		IL_03ee: dup
+		IL_03ef: ldc.i4.0
+		IL_03f0: ldloc.0
+		IL_03f1: stelem.ref
+		IL_03f2: stloc.s 11
+		IL_03f4: ldloc.s 11
+		IL_03f6: ldc.i4.0
+		IL_03f7: ldelem.ref
+		IL_03f8: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_03fd: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope)
+		IL_0402: ldc.i4.1
+		IL_0403: conv.r8
+		IL_0404: ldstr ""
+		IL_0409: ldc.i4.0
+		IL_040a: ldc.i4.0
+		IL_040b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0410: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject>(!!0)
+		IL_0415: stloc.s 21
+		IL_0417: ldloc.s 21
+		IL_0419: ldstr "main"
+		IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0423: stloc.s 4
+		IL_0425: ldloc.0
+		IL_0426: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_042b: ldnull
+		IL_042c: ldloc.1
+		IL_042d: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_0432: pop
+		IL_0433: ret
 	} // end of method Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes::__js_module_init__
 
 } // end of class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
@@ -3644,7 +3633,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3430
+		// Method begins at RVA 0x3404
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.BeanCounter_Class_Index_Assign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.BeanCounter_Class_Index_Assign.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21db
+				// Method begins at RVA 0x21c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e4
+				// Method begins at RVA 0x21cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ed
+				// Method begins at RVA 0x21d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x21f6
+				// Method begins at RVA 0x21de
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2205
+				// Method begins at RVA 0x21ed
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2208
+				// Method begins at RVA 0x21f0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x220b
+				// Method begins at RVA 0x21f3
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -142,7 +142,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2217
+				// Method begins at RVA 0x21ff
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2223
+				// Method begins at RVA 0x220b
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -174,7 +174,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x222b
+				// Method begins at RVA 0x2213
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -186,7 +186,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x222e
+				// Method begins at RVA 0x2216
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -201,7 +201,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2231
+				// Method begins at RVA 0x2219
 				// Header size: 1
 				// Code size: 49 (0x31)
 				.maxstack 8
@@ -238,7 +238,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2194
+			// Method begins at RVA 0x217c
 			// Header size: 12
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -265,7 +265,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21c0
+			// Method begins at RVA 0x21a8
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -290,7 +290,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d2
+			// Method begins at RVA 0x21ba
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -316,19 +316,18 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 311 (0x137)
+		// Code size: 288 (0x120)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BeanCounter_Class_Index_Assign/Scope,
 			[1] object,
 			[2] class Modules.BeanCounter_Class_Index_Assign/BeanCounter,
 			[3] class [System.Runtime]System.Type,
-			[4] class [System.Runtime]System.Type,
-			[5] object,
-			[6] object[],
-			[7] class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount,
-			[8] class Modules.BeanCounter_Class_Index_Assign/BeanCounter,
-			[9] object
+			[4] object,
+			[5] object[],
+			[6] class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount,
+			[7] class Modules.BeanCounter_Class_Index_Assign/BeanCounter,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.BeanCounter_Class_Index_Assign/Scope::.ctor()
@@ -339,88 +338,83 @@
 		IL_0011: ldtoken Modules.BeanCounter_Class_Index_Assign/BeanCounter
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.3
-		IL_001c: ldtoken Modules.BeanCounter_Class_Index_Assign/BeanCounter
-		IL_0021: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0026: ldtoken Modules.BeanCounter_Class_Index_Assign/BeanCounter
-		IL_002b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: stloc.s 5
-		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0045: stloc.s 6
-		IL_0047: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::.ctor()
-		IL_004c: ldc.i4.2
-		IL_004d: conv.r8
-		IL_004e: ldstr "setBeanCount"
-		IL_0053: ldc.i4.1
-		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0, float64, string, bool, bool)
-		IL_005a: stloc.s 7
-		IL_005c: ldloc.s 7
-		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0)
-		IL_0063: stloc.s 7
-		IL_0065: ldloc.s 5
-		IL_0067: ldstr "setBeanCount"
-		IL_006c: ldloc.s 7
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0073: pop
-		IL_0074: ldc.i4.1
-		IL_0075: newarr [System.Runtime]System.Object
-		IL_007a: dup
-		IL_007b: ldc.i4.0
-		IL_007c: ldloc.0
-		IL_007d: stelem.ref
-		IL_007e: stloc.s 6
-		IL_0080: ldloc.3
-		IL_0081: ldloc.s 6
-		IL_0083: ldc.r8 0.0
-		IL_008c: box [System.Runtime]System.Double
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0096: stloc.s 5
-		IL_0098: ldloc.s 5
-		IL_009a: stloc.1
-		IL_009b: ldc.i4.0
-		IL_009c: newarr [System.Runtime]System.Object
-		IL_00a1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00a6: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter::.ctor()
-		IL_00ab: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00b0: stloc.2
-		IL_00b1: ldloc.2
-		IL_00b2: ldtoken Modules.BeanCounter_Class_Index_Assign/BeanCounter
-		IL_00b7: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00bc: ldstr "prototype"
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00c6: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00cb: ldloc.2
-		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.BeanCounter_Class_Index_Assign/BeanCounter>(!!0)
-		IL_00d1: stloc.s 8
-		IL_00d3: ldloc.s 8
-		IL_00d5: ldc.r8 1
-		IL_00de: box [System.Runtime]System.Double
-		IL_00e3: ldc.r8 42
-		IL_00ec: box [System.Runtime]System.Double
-		IL_00f1: callvirt instance object Modules.BeanCounter_Class_Index_Assign/BeanCounter::setBeanCount(object, object)
-		IL_00f6: pop
-		IL_00f7: ldstr "console"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0106: stloc.s 5
-		IL_0108: ldloc.2
-		IL_0109: ldstr "beanCounts"
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0113: stloc.s 9
-		IL_0115: ldloc.s 9
-		IL_0117: ldc.r8 1
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0125: stloc.s 9
-		IL_0127: ldloc.s 5
-		IL_0129: ldstr "log"
-		IL_012e: ldloc.s 9
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0135: pop
-		IL_0136: ret
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: stloc.s 4
+		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002e: stloc.s 5
+		IL_0030: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::.ctor()
+		IL_0035: ldc.i4.2
+		IL_0036: conv.r8
+		IL_0037: ldstr "setBeanCount"
+		IL_003c: ldc.i4.1
+		IL_003d: ldc.i4.1
+		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0, float64, string, bool, bool)
+		IL_0043: stloc.s 6
+		IL_0045: ldloc.s 6
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0)
+		IL_004c: stloc.s 6
+		IL_004e: ldloc.s 4
+		IL_0050: ldstr "setBeanCount"
+		IL_0055: ldloc.s 6
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005c: pop
+		IL_005d: ldc.i4.1
+		IL_005e: newarr [System.Runtime]System.Object
+		IL_0063: dup
+		IL_0064: ldc.i4.0
+		IL_0065: ldloc.0
+		IL_0066: stelem.ref
+		IL_0067: stloc.s 5
+		IL_0069: ldloc.3
+		IL_006a: ldloc.s 5
+		IL_006c: ldc.r8 0.0
+		IL_0075: box [System.Runtime]System.Double
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_007f: stloc.s 4
+		IL_0081: ldloc.s 4
+		IL_0083: stloc.1
+		IL_0084: ldc.i4.0
+		IL_0085: newarr [System.Runtime]System.Object
+		IL_008a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_008f: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter::.ctor()
+		IL_0094: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0099: stloc.2
+		IL_009a: ldloc.2
+		IL_009b: ldtoken Modules.BeanCounter_Class_Index_Assign/BeanCounter
+		IL_00a0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00a5: ldstr "prototype"
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00af: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00b4: ldloc.2
+		IL_00b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.BeanCounter_Class_Index_Assign/BeanCounter>(!!0)
+		IL_00ba: stloc.s 7
+		IL_00bc: ldloc.s 7
+		IL_00be: ldc.r8 1
+		IL_00c7: box [System.Runtime]System.Double
+		IL_00cc: ldc.r8 42
+		IL_00d5: box [System.Runtime]System.Double
+		IL_00da: callvirt instance object Modules.BeanCounter_Class_Index_Assign/BeanCounter::setBeanCount(object, object)
+		IL_00df: pop
+		IL_00e0: ldstr "console"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ef: stloc.s 4
+		IL_00f1: ldloc.2
+		IL_00f2: ldstr "beanCounts"
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00fc: stloc.s 8
+		IL_00fe: ldloc.s 8
+		IL_0100: ldc.r8 1
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_010e: stloc.s 8
+		IL_0110: ldloc.s 4
+		IL_0112: ldstr "log"
+		IL_0117: ldloc.s 8
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011e: pop
+		IL_011f: ret
 	} // end of method BeanCounter_Class_Index_Assign::__js_module_init__
 
 } // end of class Modules.BeanCounter_Class_Index_Assign
@@ -432,7 +426,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2263
+		// Method begins at RVA 0x224b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a3e
+				// Method begins at RVA 0x2a2a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a47
+				// Method begins at RVA 0x2a33
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a59
+					// Method begins at RVA 0x2a45
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a50
+				// Method begins at RVA 0x2a3c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a74
+						// Method begins at RVA 0x2a60
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -132,7 +132,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2a86
+							// Method begins at RVA 0x2a72
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -150,7 +150,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a7d
+						// Method begins at RVA 0x2a69
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -168,7 +168,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a6b
+					// Method begins at RVA 0x2a57
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -196,7 +196,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2aa1
+							// Method begins at RVA 0x2a8d
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -214,7 +214,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a98
+						// Method begins at RVA 0x2a84
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -232,7 +232,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a8f
+					// Method begins at RVA 0x2a7b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a62
+				// Method begins at RVA 0x2a4e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +274,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ab3
+					// Method begins at RVA 0x2a9f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -292,7 +292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aaa
+				// Method begins at RVA 0x2a96
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -312,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2abc
+				// Method begins at RVA 0x2aa8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -336,7 +336,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ace
+					// Method begins at RVA 0x2aba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -354,7 +354,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac5
+				// Method begins at RVA 0x2ab1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -379,7 +379,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2afb
+				// Method begins at RVA 0x2ae7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -395,7 +395,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2b0a
+				// Method begins at RVA 0x2af6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -407,7 +407,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2b0d
+				// Method begins at RVA 0x2af9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -422,7 +422,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b10
+				// Method begins at RVA 0x2afc
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -438,7 +438,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b1c
+				// Method begins at RVA 0x2b08
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -457,7 +457,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b28
+				// Method begins at RVA 0x2b14
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -470,7 +470,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2b30
+				// Method begins at RVA 0x2b1c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -482,7 +482,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2b33
+				// Method begins at RVA 0x2b1f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -497,7 +497,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b36
+				// Method begins at RVA 0x2b22
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -533,7 +533,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b66
+				// Method begins at RVA 0x2b52
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -549,7 +549,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2b75
+				// Method begins at RVA 0x2b61
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -561,7 +561,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2b78
+				// Method begins at RVA 0x2b64
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -576,7 +576,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b7b
+				// Method begins at RVA 0x2b67
 				// Header size: 1
 				// Code size: 56 (0x38)
 				.maxstack 8
@@ -617,7 +617,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bb4
+				// Method begins at RVA 0x2ba0
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -633,7 +633,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2bc3
+				// Method begins at RVA 0x2baf
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -645,7 +645,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2bc6
+				// Method begins at RVA 0x2bb2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -660,7 +660,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bc9
+				// Method begins at RVA 0x2bb5
 				// Header size: 1
 				// Code size: 56 (0x38)
 				.maxstack 8
@@ -704,7 +704,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2704
+			// Method begins at RVA 0x26f0
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -752,7 +752,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2958
+			// Method begins at RVA 0x2944
 			// Header size: 12
 			// Code size: 165 (0xa5)
 			.maxstack 8
@@ -849,7 +849,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2750
+			// Method begins at RVA 0x273c
 			// Header size: 12
 			// Code size: 391 (0x187)
 			.maxstack 8
@@ -1061,7 +1061,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28e4
+			// Method begins at RVA 0x28d0
 			// Header size: 12
 			// Code size: 102 (0x66)
 			.maxstack 8
@@ -1147,7 +1147,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2af2
+				// Method begins at RVA 0x2ade
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1171,7 +1171,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a09
+			// Method begins at RVA 0x29f5
 			// Header size: 1
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -1211,7 +1211,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ae9
+					// Method begins at RVA 0x2ad5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1229,7 +1229,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae0
+				// Method begins at RVA 0x2acc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1247,7 +1247,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2ad7
+			// Method begins at RVA 0x2ac3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1273,7 +1273,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1704 (0x6a8)
+		// Code size: 1682 (0x692)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope,
@@ -1284,22 +1284,21 @@
 			[5] object,
 			[6] float64,
 			[7] class [System.Runtime]System.Type,
-			[8] class [System.Runtime]System.Type,
-			[9] object,
-			[10] object[],
-			[11] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue,
-			[12] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue,
-			[13] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive,
-			[14] object,
+			[8] object,
+			[9] object[],
+			[10] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue,
+			[11] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue,
+			[12] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive,
+			[13] object,
+			[14] string,
 			[15] string,
-			[16] string,
-			[17] object,
-			[18] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray,
+			[16] object,
+			[17] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray,
+			[18] float64,
 			[19] float64,
-			[20] float64,
-			[21] bool,
-			[22] object,
-			[23] object
+			[20] bool,
+			[21] object,
+			[22] object
 		)
 
 		IL_0000: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::.ctor()
@@ -1310,533 +1309,528 @@
 		IL_0011: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.s 7
-		IL_001d: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0022: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0027: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_002c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0031: stloc.s 8
-		IL_0033: ldloc.s 8
-		IL_0035: ldstr "prototype"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003f: stloc.s 9
-		IL_0041: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0046: stloc.s 10
-		IL_0048: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::.ctor()
-		IL_004d: ldc.i4.1
-		IL_004e: conv.r8
-		IL_004f: ldstr "setBitTrue"
-		IL_0054: ldc.i4.1
-		IL_0055: ldc.i4.1
-		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
-		IL_005b: stloc.s 11
-		IL_005d: ldloc.s 11
-		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0)
-		IL_0064: stloc.s 11
-		IL_0066: ldloc.s 9
-		IL_0068: ldstr "setBitTrue"
-		IL_006d: ldloc.s 11
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0074: pop
-		IL_0075: ldc.i4.1
-		IL_0076: newarr [System.Runtime]System.Object
-		IL_007b: dup
-		IL_007c: ldc.i4.0
-		IL_007d: ldloc.0
-		IL_007e: stelem.ref
-		IL_007f: stloc.s 10
-		IL_0081: ldloc.s 10
-		IL_0083: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::.ctor(object[])
-		IL_0088: ldc.i4.3
-		IL_0089: conv.r8
-		IL_008a: ldstr "setBitsTrue"
-		IL_008f: ldc.i4.1
-		IL_0090: ldc.i4.1
-		IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_0096: stloc.s 12
-		IL_0098: ldloc.s 12
-		IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0)
-		IL_009f: stloc.s 12
-		IL_00a1: ldloc.s 9
-		IL_00a3: ldstr "setBitsTrue"
-		IL_00a8: ldloc.s 12
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00af: pop
-		IL_00b0: ldc.i4.1
-		IL_00b1: newarr [System.Runtime]System.Object
-		IL_00b6: dup
-		IL_00b7: ldc.i4.0
-		IL_00b8: ldloc.0
-		IL_00b9: stelem.ref
-		IL_00ba: stloc.s 10
-		IL_00bc: ldloc.s 10
-		IL_00be: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::.ctor(object[])
-		IL_00c3: ldc.i4.3
-		IL_00c4: conv.r8
-		IL_00c5: ldstr "setBitsTrue_Naive"
-		IL_00ca: ldc.i4.1
-		IL_00cb: ldc.i4.1
-		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0, float64, string, bool, bool)
-		IL_00d1: stloc.s 13
-		IL_00d3: ldloc.s 13
-		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0)
-		IL_00da: stloc.s 13
-		IL_00dc: ldloc.s 9
-		IL_00de: ldstr "setBitsTrue_Naive"
-		IL_00e3: ldloc.s 13
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00ea: pop
-		IL_00eb: ldc.i4.1
-		IL_00ec: newarr [System.Runtime]System.Object
-		IL_00f1: dup
-		IL_00f2: ldc.i4.0
-		IL_00f3: ldloc.0
-		IL_00f4: stelem.ref
-		IL_00f5: stloc.s 10
-		IL_00f7: ldloc.s 7
-		IL_00f9: ldloc.s 10
-		IL_00fb: ldc.r8 1
-		IL_0104: box [System.Runtime]System.Double
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_010e: stloc.s 9
-		IL_0110: ldloc.s 9
-		IL_0112: stloc.1
-		IL_0113: ldloc.0
-		IL_0114: ldc.r8 2048
-		IL_011d: box [System.Runtime]System.Double
-		IL_0122: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_0127: ldloc.0
-		IL_0128: ldc.r8 1
-		IL_0131: box [System.Runtime]System.Double
-		IL_0136: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_013b: ldloc.0
-		IL_013c: ldc.r8 17
-		IL_0145: box [System.Runtime]System.Double
-		IL_014a: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_014f: ldloc.0
-		IL_0150: ldc.r8 600
-		IL_0159: box [System.Runtime]System.Double
-		IL_015e: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_0163: ldc.i4.1
-		IL_0164: newarr [System.Runtime]System.Object
-		IL_0169: dup
-		IL_016a: ldc.i4.0
-		IL_016b: ldloc.0
-		IL_016c: stelem.ref
-		IL_016d: stloc.s 10
-		IL_016f: ldloc.0
-		IL_0170: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_0175: ldstr "Cannot access 'size' before initialization"
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_017f: stloc.s 9
-		IL_0181: ldloc.s 10
-		IL_0183: ldc.i4.1
-		IL_0184: newarr [System.Runtime]System.Object
-		IL_0189: dup
-		IL_018a: ldc.i4.0
-		IL_018b: ldloc.s 9
-		IL_018d: stelem.ref
-		IL_018e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0193: ldloc.s 9
-		IL_0195: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_019a: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
-		IL_019f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_01a4: stloc.2
-		IL_01a5: ldloc.2
-		IL_01a6: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_01ab: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01b0: ldstr "prototype"
-		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_01ba: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_01bf: ldc.i4.1
-		IL_01c0: newarr [System.Runtime]System.Object
-		IL_01c5: dup
-		IL_01c6: ldc.i4.0
-		IL_01c7: ldloc.0
-		IL_01c8: stelem.ref
-		IL_01c9: stloc.s 10
-		IL_01cb: ldloc.0
-		IL_01cc: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_01d1: ldstr "Cannot access 'size' before initialization"
-		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01db: stloc.s 9
-		IL_01dd: ldloc.s 10
-		IL_01df: ldc.i4.1
-		IL_01e0: newarr [System.Runtime]System.Object
-		IL_01e5: dup
-		IL_01e6: ldc.i4.0
-		IL_01e7: ldloc.s 9
-		IL_01e9: stelem.ref
-		IL_01ea: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_01ef: ldloc.s 9
-		IL_01f1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_01f6: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
-		IL_01fb: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0200: stloc.3
-		IL_0201: ldloc.3
-		IL_0202: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0207: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_020c: ldstr "prototype"
-		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0216: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_021b: ldstr "console"
-		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022a: stloc.s 9
-		IL_022c: ldloc.2
+		IL_001d: ldloc.s 7
+		IL_001f: ldstr "prototype"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0029: stloc.s 8
+		IL_002b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0030: stloc.s 9
+		IL_0032: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::.ctor()
+		IL_0037: ldc.i4.1
+		IL_0038: conv.r8
+		IL_0039: ldstr "setBitTrue"
+		IL_003e: ldc.i4.1
+		IL_003f: ldc.i4.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.s 10
+		IL_0047: ldloc.s 10
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0)
+		IL_004e: stloc.s 10
+		IL_0050: ldloc.s 8
+		IL_0052: ldstr "setBitTrue"
+		IL_0057: ldloc.s 10
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005e: pop
+		IL_005f: ldc.i4.1
+		IL_0060: newarr [System.Runtime]System.Object
+		IL_0065: dup
+		IL_0066: ldc.i4.0
+		IL_0067: ldloc.0
+		IL_0068: stelem.ref
+		IL_0069: stloc.s 9
+		IL_006b: ldloc.s 9
+		IL_006d: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::.ctor(object[])
+		IL_0072: ldc.i4.3
+		IL_0073: conv.r8
+		IL_0074: ldstr "setBitsTrue"
+		IL_0079: ldc.i4.1
+		IL_007a: ldc.i4.1
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
+		IL_0080: stloc.s 11
+		IL_0082: ldloc.s 11
+		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0)
+		IL_0089: stloc.s 11
+		IL_008b: ldloc.s 8
+		IL_008d: ldstr "setBitsTrue"
+		IL_0092: ldloc.s 11
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0099: pop
+		IL_009a: ldc.i4.1
+		IL_009b: newarr [System.Runtime]System.Object
+		IL_00a0: dup
+		IL_00a1: ldc.i4.0
+		IL_00a2: ldloc.0
+		IL_00a3: stelem.ref
+		IL_00a4: stloc.s 9
+		IL_00a6: ldloc.s 9
+		IL_00a8: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::.ctor(object[])
+		IL_00ad: ldc.i4.3
+		IL_00ae: conv.r8
+		IL_00af: ldstr "setBitsTrue_Naive"
+		IL_00b4: ldc.i4.1
+		IL_00b5: ldc.i4.1
+		IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0, float64, string, bool, bool)
+		IL_00bb: stloc.s 12
+		IL_00bd: ldloc.s 12
+		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0)
+		IL_00c4: stloc.s 12
+		IL_00c6: ldloc.s 8
+		IL_00c8: ldstr "setBitsTrue_Naive"
+		IL_00cd: ldloc.s 12
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00d4: pop
+		IL_00d5: ldc.i4.1
+		IL_00d6: newarr [System.Runtime]System.Object
+		IL_00db: dup
+		IL_00dc: ldc.i4.0
+		IL_00dd: ldloc.0
+		IL_00de: stelem.ref
+		IL_00df: stloc.s 9
+		IL_00e1: ldloc.s 7
+		IL_00e3: ldloc.s 9
+		IL_00e5: ldc.r8 1
+		IL_00ee: box [System.Runtime]System.Double
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00f8: stloc.s 8
+		IL_00fa: ldloc.s 8
+		IL_00fc: stloc.1
+		IL_00fd: ldloc.0
+		IL_00fe: ldc.r8 2048
+		IL_0107: box [System.Runtime]System.Double
+		IL_010c: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_0111: ldloc.0
+		IL_0112: ldc.r8 1
+		IL_011b: box [System.Runtime]System.Double
+		IL_0120: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_0125: ldloc.0
+		IL_0126: ldc.r8 17
+		IL_012f: box [System.Runtime]System.Double
+		IL_0134: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_0139: ldloc.0
+		IL_013a: ldc.r8 600
+		IL_0143: box [System.Runtime]System.Double
+		IL_0148: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_014d: ldc.i4.1
+		IL_014e: newarr [System.Runtime]System.Object
+		IL_0153: dup
+		IL_0154: ldc.i4.0
+		IL_0155: ldloc.0
+		IL_0156: stelem.ref
+		IL_0157: stloc.s 9
+		IL_0159: ldloc.0
+		IL_015a: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_015f: ldstr "Cannot access 'size' before initialization"
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0169: stloc.s 8
+		IL_016b: ldloc.s 9
+		IL_016d: ldc.i4.1
+		IL_016e: newarr [System.Runtime]System.Object
+		IL_0173: dup
+		IL_0174: ldc.i4.0
+		IL_0175: ldloc.s 8
+		IL_0177: stelem.ref
+		IL_0178: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_017d: ldloc.s 8
+		IL_017f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0184: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
+		IL_0189: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_018e: stloc.2
+		IL_018f: ldloc.2
+		IL_0190: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_0195: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_019a: ldstr "prototype"
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_01a4: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_01a9: ldc.i4.1
+		IL_01aa: newarr [System.Runtime]System.Object
+		IL_01af: dup
+		IL_01b0: ldc.i4.0
+		IL_01b1: ldloc.0
+		IL_01b2: stelem.ref
+		IL_01b3: stloc.s 9
+		IL_01b5: ldloc.0
+		IL_01b6: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_01bb: ldstr "Cannot access 'size' before initialization"
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_01c5: stloc.s 8
+		IL_01c7: ldloc.s 9
+		IL_01c9: ldc.i4.1
+		IL_01ca: newarr [System.Runtime]System.Object
+		IL_01cf: dup
+		IL_01d0: ldc.i4.0
+		IL_01d1: ldloc.s 8
+		IL_01d3: stelem.ref
+		IL_01d4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_01d9: ldloc.s 8
+		IL_01db: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_01e0: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
+		IL_01e5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_01ea: stloc.3
+		IL_01eb: ldloc.3
+		IL_01ec: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_01f1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_01f6: ldstr "prototype"
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0200: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0205: ldstr "console"
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0214: stloc.s 8
+		IL_0216: ldloc.2
+		IL_0217: ldstr "wordArray"
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0221: stloc.s 13
+		IL_0223: ldloc.s 13
+		IL_0225: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_022a: stloc.s 14
+		IL_022c: ldloc.3
 		IL_022d: ldstr "wordArray"
 		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0237: stloc.s 14
-		IL_0239: ldloc.s 14
+		IL_0237: stloc.s 13
+		IL_0239: ldloc.s 13
 		IL_023b: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 		IL_0240: stloc.s 15
-		IL_0242: ldloc.3
-		IL_0243: ldstr "wordArray"
-		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_024d: stloc.s 14
-		IL_024f: ldloc.s 14
-		IL_0251: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0256: stloc.s 16
-		IL_0258: ldloc.s 9
-		IL_025a: ldstr "log"
-		IL_025f: ldstr "types"
-		IL_0264: ldloc.s 15
-		IL_0266: ldloc.s 16
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_026d: pop
-		IL_026e: ldstr "console"
-		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027d: stloc.s 9
-		IL_027f: ldloc.2
-		IL_0280: ldstr "wordArray"
-		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_028a: stloc.s 14
-		IL_028c: ldloc.s 14
-		IL_028e: ldstr "length"
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0298: stloc.s 14
-		IL_029a: ldloc.3
-		IL_029b: ldstr "wordArray"
-		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a5: stloc.s 17
-		IL_02a7: ldloc.s 17
-		IL_02a9: ldstr "length"
-		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b3: stloc.s 17
-		IL_02b5: ldloc.s 9
-		IL_02b7: ldstr "log"
-		IL_02bc: ldstr "lens"
-		IL_02c1: ldloc.s 14
-		IL_02c3: ldloc.s 17
-		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_02ca: pop
-		IL_02cb: ldloc.2
-		IL_02cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
-		IL_02d1: stloc.s 18
-		IL_02d3: ldloc.0
-		IL_02d4: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_02d9: ldstr "Cannot access 'range_start' before initialization"
-		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02e3: stloc.s 17
-		IL_02e5: ldloc.0
-		IL_02e6: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_02eb: ldstr "Cannot access 'step' before initialization"
-		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02f5: stloc.s 14
-		IL_02f7: ldloc.0
-		IL_02f8: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_02fd: ldstr "Cannot access 'range_stop' before initialization"
-		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0307: stloc.s 9
-		IL_0309: ldloc.s 18
-		IL_030b: ldloc.s 17
-		IL_030d: ldloc.s 14
-		IL_030f: ldloc.s 9
-		IL_0311: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
-		IL_0316: pop
-		IL_0317: ldloc.3
-		IL_0318: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
-		IL_031d: stloc.s 18
-		IL_031f: ldloc.0
-		IL_0320: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_0325: ldstr "Cannot access 'range_start' before initialization"
-		IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_032f: stloc.s 9
-		IL_0331: ldloc.0
-		IL_0332: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_0337: ldstr "Cannot access 'step' before initialization"
-		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0341: stloc.s 14
-		IL_0343: ldloc.0
-		IL_0344: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_0349: ldstr "Cannot access 'range_stop' before initialization"
-		IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0353: stloc.s 17
-		IL_0355: ldloc.s 18
-		IL_0357: ldloc.s 9
-		IL_0359: ldloc.s 14
-		IL_035b: ldloc.s 17
-		IL_035d: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
-		IL_0362: pop
-		IL_0363: ldc.r8 0.0
-		IL_036c: stloc.s 4
-		IL_036e: ldc.r8 1
-		IL_0377: neg
-		IL_0378: stloc.s 19
-		IL_037a: ldloc.s 19
-		IL_037c: box [System.Runtime]System.Double
-		IL_0381: stloc.s 5
-		IL_0383: ldc.r8 0.0
-		IL_038c: stloc.s 6
-		// loop start (head: IL_038e)
-			IL_038e: ldloc.s 6
-			IL_0390: stloc.s 19
-			IL_0392: ldloc.2
-			IL_0393: ldstr "wordArray"
-			IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_039d: stloc.s 17
-			IL_039f: ldloc.s 17
-			IL_03a1: ldstr "length"
-			IL_03a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_03ab: stloc.s 20
-			IL_03ad: ldloc.s 19
-			IL_03af: ldloc.s 20
-			IL_03b1: clt
-			IL_03b3: brfalse IL_0453
+		IL_0242: ldloc.s 8
+		IL_0244: ldstr "log"
+		IL_0249: ldstr "types"
+		IL_024e: ldloc.s 14
+		IL_0250: ldloc.s 15
+		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0257: pop
+		IL_0258: ldstr "console"
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0267: stloc.s 8
+		IL_0269: ldloc.2
+		IL_026a: ldstr "wordArray"
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0274: stloc.s 13
+		IL_0276: ldloc.s 13
+		IL_0278: ldstr "length"
+		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0282: stloc.s 13
+		IL_0284: ldloc.3
+		IL_0285: ldstr "wordArray"
+		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_028f: stloc.s 16
+		IL_0291: ldloc.s 16
+		IL_0293: ldstr "length"
+		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_029d: stloc.s 16
+		IL_029f: ldloc.s 8
+		IL_02a1: ldstr "log"
+		IL_02a6: ldstr "lens"
+		IL_02ab: ldloc.s 13
+		IL_02ad: ldloc.s 16
+		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_02b4: pop
+		IL_02b5: ldloc.2
+		IL_02b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
+		IL_02bb: stloc.s 17
+		IL_02bd: ldloc.0
+		IL_02be: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_02c3: ldstr "Cannot access 'range_start' before initialization"
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_02cd: stloc.s 16
+		IL_02cf: ldloc.0
+		IL_02d0: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_02d5: ldstr "Cannot access 'step' before initialization"
+		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_02df: stloc.s 13
+		IL_02e1: ldloc.0
+		IL_02e2: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_02e7: ldstr "Cannot access 'range_stop' before initialization"
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_02f1: stloc.s 8
+		IL_02f3: ldloc.s 17
+		IL_02f5: ldloc.s 16
+		IL_02f7: ldloc.s 13
+		IL_02f9: ldloc.s 8
+		IL_02fb: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
+		IL_0300: pop
+		IL_0301: ldloc.3
+		IL_0302: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
+		IL_0307: stloc.s 17
+		IL_0309: ldloc.0
+		IL_030a: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_030f: ldstr "Cannot access 'range_start' before initialization"
+		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0319: stloc.s 8
+		IL_031b: ldloc.0
+		IL_031c: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_0321: ldstr "Cannot access 'step' before initialization"
+		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_032b: stloc.s 13
+		IL_032d: ldloc.0
+		IL_032e: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_0333: ldstr "Cannot access 'range_stop' before initialization"
+		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_033d: stloc.s 16
+		IL_033f: ldloc.s 17
+		IL_0341: ldloc.s 8
+		IL_0343: ldloc.s 13
+		IL_0345: ldloc.s 16
+		IL_0347: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
+		IL_034c: pop
+		IL_034d: ldc.r8 0.0
+		IL_0356: stloc.s 4
+		IL_0358: ldc.r8 1
+		IL_0361: neg
+		IL_0362: stloc.s 18
+		IL_0364: ldloc.s 18
+		IL_0366: box [System.Runtime]System.Double
+		IL_036b: stloc.s 5
+		IL_036d: ldc.r8 0.0
+		IL_0376: stloc.s 6
+		// loop start (head: IL_0378)
+			IL_0378: ldloc.s 6
+			IL_037a: stloc.s 18
+			IL_037c: ldloc.2
+			IL_037d: ldstr "wordArray"
+			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0387: stloc.s 16
+			IL_0389: ldloc.s 16
+			IL_038b: ldstr "length"
+			IL_0390: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_0395: stloc.s 19
+			IL_0397: ldloc.s 18
+			IL_0399: ldloc.s 19
+			IL_039b: clt
+			IL_039d: brfalse IL_043d
 
-			IL_03b8: ldloc.2
-			IL_03b9: ldstr "wordArray"
-			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03c3: stloc.s 17
-			IL_03c5: ldloc.s 17
-			IL_03c7: ldloc.s 6
-			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03ce: stloc.s 17
-			IL_03d0: ldloc.3
-			IL_03d1: ldstr "wordArray"
-			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03db: stloc.s 14
-			IL_03dd: ldloc.s 14
-			IL_03df: ldloc.s 6
-			IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03e6: stloc.s 14
-			IL_03e8: ldloc.s 17
-			IL_03ea: ldloc.s 14
-			IL_03ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_03f1: stloc.s 21
-			IL_03f3: ldloc.s 21
-			IL_03f5: brfalse IL_0440
+			IL_03a2: ldloc.2
+			IL_03a3: ldstr "wordArray"
+			IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03ad: stloc.s 16
+			IL_03af: ldloc.s 16
+			IL_03b1: ldloc.s 6
+			IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_03b8: stloc.s 16
+			IL_03ba: ldloc.3
+			IL_03bb: ldstr "wordArray"
+			IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c5: stloc.s 13
+			IL_03c7: ldloc.s 13
+			IL_03c9: ldloc.s 6
+			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_03d0: stloc.s 13
+			IL_03d2: ldloc.s 16
+			IL_03d4: ldloc.s 13
+			IL_03d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_03db: stloc.s 20
+			IL_03dd: ldloc.s 20
+			IL_03df: brfalse IL_042a
 
-			IL_03fa: ldloc.s 4
-			IL_03fc: ldc.r8 1
-			IL_0405: add
-			IL_0406: stloc.s 4
-			IL_0408: ldloc.s 5
-			IL_040a: stloc.s 22
-			IL_040c: ldc.r8 1
-			IL_0415: neg
-			IL_0416: stloc.s 20
-			IL_0418: ldloc.s 20
-			IL_041a: box [System.Runtime]System.Double
-			IL_041f: stloc.s 23
-			IL_0421: ldloc.s 22
-			IL_0423: ldloc.s 23
-			IL_0425: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_042a: stloc.s 21
-			IL_042c: ldloc.s 21
-			IL_042e: brfalse IL_0440
+			IL_03e4: ldloc.s 4
+			IL_03e6: ldc.r8 1
+			IL_03ef: add
+			IL_03f0: stloc.s 4
+			IL_03f2: ldloc.s 5
+			IL_03f4: stloc.s 21
+			IL_03f6: ldc.r8 1
+			IL_03ff: neg
+			IL_0400: stloc.s 19
+			IL_0402: ldloc.s 19
+			IL_0404: box [System.Runtime]System.Double
+			IL_0409: stloc.s 22
+			IL_040b: ldloc.s 21
+			IL_040d: ldloc.s 22
+			IL_040f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0414: stloc.s 20
+			IL_0416: ldloc.s 20
+			IL_0418: brfalse IL_042a
 
-			IL_0433: ldloc.s 6
-			IL_0435: box [System.Runtime]System.Double
-			IL_043a: stloc.s 23
-			IL_043c: ldloc.s 23
-			IL_043e: stloc.s 5
+			IL_041d: ldloc.s 6
+			IL_041f: box [System.Runtime]System.Double
+			IL_0424: stloc.s 22
+			IL_0426: ldloc.s 22
+			IL_0428: stloc.s 5
 
-			IL_0440: ldloc.s 6
-			IL_0442: ldc.r8 1
-			IL_044b: add
-			IL_044c: stloc.s 6
-			IL_044e: br IL_038e
+			IL_042a: ldloc.s 6
+			IL_042c: ldc.r8 1
+			IL_0435: add
+			IL_0436: stloc.s 6
+			IL_0438: br IL_0378
 		// end loop
 
-		IL_0453: ldstr "console"
-		IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0462: ldloc.s 4
-		IL_0464: box [System.Runtime]System.Double
-		IL_0469: stloc.s 23
-		IL_046b: ldstr "log"
-		IL_0470: ldstr "diffs"
-		IL_0475: ldloc.s 23
-		IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_047c: pop
-		IL_047d: ldloc.s 5
-		IL_047f: stloc.s 23
-		IL_0481: ldc.r8 1
-		IL_048a: neg
-		IL_048b: stloc.s 20
-		IL_048d: ldloc.s 20
-		IL_048f: box [System.Runtime]System.Double
-		IL_0494: stloc.s 22
-		IL_0496: ldloc.s 23
-		IL_0498: ldloc.s 22
-		IL_049a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_049f: stloc.s 21
-		IL_04a1: ldloc.s 21
-		IL_04a3: brfalse IL_0513
+		IL_043d: ldstr "console"
+		IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_044c: ldloc.s 4
+		IL_044e: box [System.Runtime]System.Double
+		IL_0453: stloc.s 22
+		IL_0455: ldstr "log"
+		IL_045a: ldstr "diffs"
+		IL_045f: ldloc.s 22
+		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0466: pop
+		IL_0467: ldloc.s 5
+		IL_0469: stloc.s 22
+		IL_046b: ldc.r8 1
+		IL_0474: neg
+		IL_0475: stloc.s 19
+		IL_0477: ldloc.s 19
+		IL_0479: box [System.Runtime]System.Double
+		IL_047e: stloc.s 21
+		IL_0480: ldloc.s 22
+		IL_0482: ldloc.s 21
+		IL_0484: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0489: stloc.s 20
+		IL_048b: ldloc.s 20
+		IL_048d: brfalse IL_04fd
 
-		IL_04a8: ldstr "console"
-		IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b7: stloc.s 14
-		IL_04b9: ldloc.2
-		IL_04ba: ldstr "wordArray"
-		IL_04bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04c4: stloc.s 17
-		IL_04c6: ldloc.s 17
-		IL_04c8: ldloc.s 5
-		IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_04cf: stloc.s 17
-		IL_04d1: ldloc.3
-		IL_04d2: ldstr "wordArray"
-		IL_04d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04dc: stloc.s 9
-		IL_04de: ldloc.s 9
-		IL_04e0: ldloc.s 5
-		IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_04e7: stloc.s 9
-		IL_04e9: ldloc.s 14
-		IL_04eb: ldstr "log"
-		IL_04f0: ldc.i4.4
-		IL_04f1: newarr [System.Runtime]System.Object
-		IL_04f6: dup
-		IL_04f7: ldc.i4.0
-		IL_04f8: ldstr "first"
-		IL_04fd: stelem.ref
-		IL_04fe: dup
-		IL_04ff: ldc.i4.1
-		IL_0500: ldloc.s 5
-		IL_0502: stelem.ref
-		IL_0503: dup
-		IL_0504: ldc.i4.2
-		IL_0505: ldloc.s 17
-		IL_0507: stelem.ref
-		IL_0508: dup
-		IL_0509: ldc.i4.3
-		IL_050a: ldloc.s 9
-		IL_050c: stelem.ref
-		IL_050d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0512: pop
+		IL_0492: ldstr "console"
+		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04a1: stloc.s 13
+		IL_04a3: ldloc.2
+		IL_04a4: ldstr "wordArray"
+		IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04ae: stloc.s 16
+		IL_04b0: ldloc.s 16
+		IL_04b2: ldloc.s 5
+		IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_04b9: stloc.s 16
+		IL_04bb: ldloc.3
+		IL_04bc: ldstr "wordArray"
+		IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04c6: stloc.s 8
+		IL_04c8: ldloc.s 8
+		IL_04ca: ldloc.s 5
+		IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_04d1: stloc.s 8
+		IL_04d3: ldloc.s 13
+		IL_04d5: ldstr "log"
+		IL_04da: ldc.i4.4
+		IL_04db: newarr [System.Runtime]System.Object
+		IL_04e0: dup
+		IL_04e1: ldc.i4.0
+		IL_04e2: ldstr "first"
+		IL_04e7: stelem.ref
+		IL_04e8: dup
+		IL_04e9: ldc.i4.1
+		IL_04ea: ldloc.s 5
+		IL_04ec: stelem.ref
+		IL_04ed: dup
+		IL_04ee: ldc.i4.2
+		IL_04ef: ldloc.s 16
+		IL_04f1: stelem.ref
+		IL_04f2: dup
+		IL_04f3: ldc.i4.3
+		IL_04f4: ldloc.s 8
+		IL_04f6: stelem.ref
+		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_04fc: pop
 
-		IL_0513: ldstr "console"
-		IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0522: stloc.s 14
-		IL_0524: ldloc.2
-		IL_0525: ldstr "wordArray"
-		IL_052a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_052f: stloc.s 9
-		IL_0531: ldloc.s 9
-		IL_0533: ldc.r8 0.0
-		IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0541: stloc.s 9
-		IL_0543: ldloc.3
-		IL_0544: ldstr "wordArray"
-		IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_054e: stloc.s 17
-		IL_0550: ldloc.s 17
-		IL_0552: ldc.r8 0.0
-		IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0560: stloc.s 17
-		IL_0562: ldloc.s 14
-		IL_0564: ldstr "log"
-		IL_0569: ldstr "w0"
-		IL_056e: ldloc.s 9
-		IL_0570: ldloc.s 17
-		IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0577: pop
-		IL_0578: ldstr "console"
-		IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0587: stloc.s 17
-		IL_0589: ldloc.2
-		IL_058a: ldstr "wordArray"
-		IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0594: stloc.s 9
-		IL_0596: ldloc.s 9
-		IL_0598: ldc.r8 1
-		IL_05a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05a6: stloc.s 9
-		IL_05a8: ldloc.3
-		IL_05a9: ldstr "wordArray"
-		IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05b3: stloc.s 14
-		IL_05b5: ldloc.s 14
-		IL_05b7: ldc.r8 1
-		IL_05c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05c5: stloc.s 14
-		IL_05c7: ldloc.s 17
-		IL_05c9: ldstr "log"
-		IL_05ce: ldstr "w1"
-		IL_05d3: ldloc.s 9
-		IL_05d5: ldloc.s 14
-		IL_05d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_05dc: pop
-		IL_05dd: ldstr "console"
-		IL_05e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05ec: stloc.s 14
-		IL_05ee: ldloc.2
-		IL_05ef: ldstr "wordArray"
-		IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05f9: stloc.s 9
-		IL_05fb: ldloc.s 9
-		IL_05fd: ldc.r8 2
-		IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_060b: stloc.s 9
-		IL_060d: ldloc.3
-		IL_060e: ldstr "wordArray"
-		IL_0613: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0618: stloc.s 17
-		IL_061a: ldloc.s 17
-		IL_061c: ldc.r8 2
-		IL_0625: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_062a: stloc.s 17
-		IL_062c: ldloc.s 14
-		IL_062e: ldstr "log"
-		IL_0633: ldstr "w2"
-		IL_0638: ldloc.s 9
-		IL_063a: ldloc.s 17
-		IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0641: pop
-		IL_0642: ldstr "console"
-		IL_0647: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_064c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0651: stloc.s 17
-		IL_0653: ldloc.2
-		IL_0654: ldstr "wordArray"
-		IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_065e: stloc.s 9
-		IL_0660: ldloc.s 9
-		IL_0662: ldc.r8 3
-		IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0670: stloc.s 9
-		IL_0672: ldloc.3
-		IL_0673: ldstr "wordArray"
-		IL_0678: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_067d: stloc.s 14
-		IL_067f: ldloc.s 14
-		IL_0681: ldc.r8 3
-		IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_068f: stloc.s 14
-		IL_0691: ldloc.s 17
-		IL_0693: ldstr "log"
-		IL_0698: ldstr "w3"
-		IL_069d: ldloc.s 9
-		IL_069f: ldloc.s 14
-		IL_06a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_06a6: pop
-		IL_06a7: ret
+		IL_04fd: ldstr "console"
+		IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_050c: stloc.s 13
+		IL_050e: ldloc.2
+		IL_050f: ldstr "wordArray"
+		IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0519: stloc.s 8
+		IL_051b: ldloc.s 8
+		IL_051d: ldc.r8 0.0
+		IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_052b: stloc.s 8
+		IL_052d: ldloc.3
+		IL_052e: ldstr "wordArray"
+		IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0538: stloc.s 16
+		IL_053a: ldloc.s 16
+		IL_053c: ldc.r8 0.0
+		IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_054a: stloc.s 16
+		IL_054c: ldloc.s 13
+		IL_054e: ldstr "log"
+		IL_0553: ldstr "w0"
+		IL_0558: ldloc.s 8
+		IL_055a: ldloc.s 16
+		IL_055c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0561: pop
+		IL_0562: ldstr "console"
+		IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0571: stloc.s 16
+		IL_0573: ldloc.2
+		IL_0574: ldstr "wordArray"
+		IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_057e: stloc.s 8
+		IL_0580: ldloc.s 8
+		IL_0582: ldc.r8 1
+		IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0590: stloc.s 8
+		IL_0592: ldloc.3
+		IL_0593: ldstr "wordArray"
+		IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_059d: stloc.s 13
+		IL_059f: ldloc.s 13
+		IL_05a1: ldc.r8 1
+		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05af: stloc.s 13
+		IL_05b1: ldloc.s 16
+		IL_05b3: ldstr "log"
+		IL_05b8: ldstr "w1"
+		IL_05bd: ldloc.s 8
+		IL_05bf: ldloc.s 13
+		IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_05c6: pop
+		IL_05c7: ldstr "console"
+		IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05d6: stloc.s 13
+		IL_05d8: ldloc.2
+		IL_05d9: ldstr "wordArray"
+		IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05e3: stloc.s 8
+		IL_05e5: ldloc.s 8
+		IL_05e7: ldc.r8 2
+		IL_05f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05f5: stloc.s 8
+		IL_05f7: ldloc.3
+		IL_05f8: ldstr "wordArray"
+		IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0602: stloc.s 16
+		IL_0604: ldloc.s 16
+		IL_0606: ldc.r8 2
+		IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0614: stloc.s 16
+		IL_0616: ldloc.s 13
+		IL_0618: ldstr "log"
+		IL_061d: ldstr "w2"
+		IL_0622: ldloc.s 8
+		IL_0624: ldloc.s 16
+		IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_062b: pop
+		IL_062c: ldstr "console"
+		IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0636: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_063b: stloc.s 16
+		IL_063d: ldloc.2
+		IL_063e: ldstr "wordArray"
+		IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0648: stloc.s 8
+		IL_064a: ldloc.s 8
+		IL_064c: ldc.r8 3
+		IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_065a: stloc.s 8
+		IL_065c: ldloc.3
+		IL_065d: ldstr "wordArray"
+		IL_0662: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0667: stloc.s 13
+		IL_0669: ldloc.s 13
+		IL_066b: ldc.r8 3
+		IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0679: stloc.s 13
+		IL_067b: ldloc.s 16
+		IL_067d: ldstr "log"
+		IL_0682: ldstr "w3"
+		IL_0687: ldloc.s 8
+		IL_0689: ldloc.s 13
+		IL_068b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0690: pop
+		IL_0691: ret
 	} // end of method Prime_SetBitsTrue_LargeStep_OptimizedVsNaive::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive
@@ -1848,7 +1842,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2c02
+		// Method begins at RVA 0x2bee
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2948
+				// Method begins at RVA 0x2930
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2951
+				// Method begins at RVA 0x2939
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x295a
+				// Method begins at RVA 0x2942
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x296c
+					// Method begins at RVA 0x2954
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x297e
+						// Method begins at RVA 0x2966
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2987
+						// Method begins at RVA 0x296f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -144,7 +144,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2975
+					// Method begins at RVA 0x295d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2963
+				// Method begins at RVA 0x294b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2990
+				// Method begins at RVA 0x2978
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -207,7 +207,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2999
+				// Method begins at RVA 0x2981
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -223,7 +223,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x29a8
+				// Method begins at RVA 0x2990
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -235,7 +235,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x29ab
+				// Method begins at RVA 0x2993
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -250,7 +250,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x29ae
+				// Method begins at RVA 0x2996
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -266,7 +266,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x29ba
+				// Method begins at RVA 0x29a2
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -285,7 +285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29c6
+				// Method begins at RVA 0x29ae
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -298,7 +298,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x29ce
+				// Method begins at RVA 0x29b6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -310,7 +310,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x29d1
+				// Method begins at RVA 0x29b9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -325,7 +325,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x29d4
+				// Method begins at RVA 0x29bc
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -360,7 +360,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x29ff
+				// Method begins at RVA 0x29e7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -376,7 +376,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2a0e
+				// Method begins at RVA 0x29f6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -388,7 +388,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2a11
+				// Method begins at RVA 0x29f9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -403,7 +403,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a14
+				// Method begins at RVA 0x29fc
 				// Header size: 1
 				// Code size: 56 (0x38)
 				.maxstack 8
@@ -439,7 +439,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a4d
+				// Method begins at RVA 0x2a35
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -452,7 +452,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2a55
+				// Method begins at RVA 0x2a3d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -464,7 +464,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2a58
+				// Method begins at RVA 0x2a40
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -479,7 +479,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a5b
+				// Method begins at RVA 0x2a43
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -518,7 +518,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24d0
+			// Method begins at RVA 0x24b8
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -566,7 +566,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x251c
+			// Method begins at RVA 0x2504
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -633,7 +633,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2580
+			// Method begins at RVA 0x2568
 			// Header size: 12
 			// Code size: 858 (0x35a)
 			.maxstack 8
@@ -1005,7 +1005,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28e8
+			// Method begins at RVA 0x28d0
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -1066,7 +1066,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x293f
+			// Method begins at RVA 0x2927
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1092,7 +1092,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1138 (0x472)
+		// Code size: 1116 (0x45c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope,
@@ -1105,17 +1105,16 @@
 			[7] object,
 			[8] object,
 			[9] class [System.Runtime]System.Type,
-			[10] class [System.Runtime]System.Type,
-			[11] object,
-			[12] object[],
-			[13] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue,
-			[14] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue,
-			[15] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue,
-			[16] object,
-			[17] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray,
-			[18] float64,
-			[19] bool,
-			[20] object
+			[10] object,
+			[11] object[],
+			[12] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue,
+			[13] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue,
+			[14] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue,
+			[15] object,
+			[16] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray,
+			[17] float64,
+			[18] bool,
+			[19] object
 		)
 
 		IL_0000: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::.ctor()
@@ -1126,320 +1125,315 @@
 		IL_0011: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
 		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_001b: stloc.s 9
-		IL_001d: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_0022: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0027: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_002c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0031: stloc.s 10
-		IL_0033: ldloc.s 10
-		IL_0035: ldstr "prototype"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003f: stloc.s 11
-		IL_0041: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0046: stloc.s 12
-		IL_0048: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::.ctor()
-		IL_004d: ldc.i4.1
-		IL_004e: conv.r8
-		IL_004f: ldstr "setBitTrue"
-		IL_0054: ldc.i4.1
-		IL_0055: ldc.i4.1
-		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
-		IL_005b: stloc.s 13
-		IL_005d: ldloc.s 13
-		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0)
-		IL_0064: stloc.s 13
-		IL_0066: ldloc.s 11
-		IL_0068: ldstr "setBitTrue"
-		IL_006d: ldloc.s 13
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0074: pop
-		IL_0075: ldc.i4.1
-		IL_0076: newarr [System.Runtime]System.Object
-		IL_007b: dup
-		IL_007c: ldc.i4.0
-		IL_007d: ldloc.0
-		IL_007e: stelem.ref
-		IL_007f: stloc.s 12
-		IL_0081: ldloc.s 12
-		IL_0083: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::.ctor(object[])
-		IL_0088: ldc.i4.3
-		IL_0089: conv.r8
-		IL_008a: ldstr "setBitsTrue"
-		IL_008f: ldc.i4.1
-		IL_0090: ldc.i4.1
-		IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_0096: stloc.s 14
-		IL_0098: ldloc.s 14
-		IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0)
-		IL_009f: stloc.s 14
-		IL_00a1: ldloc.s 11
-		IL_00a3: ldstr "setBitsTrue"
-		IL_00a8: ldloc.s 14
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00af: pop
-		IL_00b0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00b5: stloc.s 12
-		IL_00b7: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::.ctor()
-		IL_00bc: ldc.i4.1
-		IL_00bd: conv.r8
-		IL_00be: ldstr "testBitTrue"
-		IL_00c3: ldc.i4.1
-		IL_00c4: ldc.i4.1
-		IL_00c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
-		IL_00ca: stloc.s 15
-		IL_00cc: ldloc.s 15
-		IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0)
-		IL_00d3: stloc.s 15
-		IL_00d5: ldloc.s 11
-		IL_00d7: ldstr "testBitTrue"
-		IL_00dc: ldloc.s 15
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00e3: pop
-		IL_00e4: ldc.i4.1
-		IL_00e5: newarr [System.Runtime]System.Object
-		IL_00ea: dup
-		IL_00eb: ldc.i4.0
-		IL_00ec: ldloc.0
-		IL_00ed: stelem.ref
-		IL_00ee: stloc.s 12
-		IL_00f0: ldloc.s 9
-		IL_00f2: ldloc.s 12
-		IL_00f4: ldc.r8 1
-		IL_00fd: box [System.Runtime]System.Double
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0107: stloc.s 11
-		IL_0109: ldloc.s 11
-		IL_010b: stloc.1
-		IL_010c: ldc.i4.1
-		IL_010d: newarr [System.Runtime]System.Object
-		IL_0112: dup
-		IL_0113: ldc.i4.0
-		IL_0114: ldloc.0
-		IL_0115: stelem.ref
-		IL_0116: stloc.s 12
-		IL_0118: ldloc.s 12
-		IL_011a: ldc.i4.1
-		IL_011b: newarr [System.Runtime]System.Object
-		IL_0120: dup
-		IL_0121: ldc.i4.0
-		IL_0122: ldc.r8 64
-		IL_012b: box [System.Runtime]System.Double
-		IL_0130: stelem.ref
-		IL_0131: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0136: ldc.r8 64
-		IL_013f: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::.ctor(object[], float64)
-		IL_0144: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0149: stloc.2
-		IL_014a: ldloc.2
-		IL_014b: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_0150: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0155: ldstr "prototype"
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_015f: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0164: ldc.r8 3
-		IL_016d: box [System.Runtime]System.Double
-		IL_0172: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_0177: stloc.3
-		IL_0178: ldc.r8 0.0
-		IL_0181: stloc.s 4
-		IL_0183: ldloc.3
-		IL_0184: ldloc.s 4
-		IL_0186: ldc.r8 16
-		IL_018f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-		IL_0194: ldstr "console"
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a3: ldloc.3
-		IL_01a4: ldc.r8 0.0
-		IL_01ad: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_01b2: box [System.Runtime]System.Double
-		IL_01b7: stloc.s 16
-		IL_01b9: ldstr "log"
-		IL_01be: ldstr "varIndexSet"
-		IL_01c3: ldloc.s 16
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01ca: pop
-		IL_01cb: ldloc.2
-		IL_01cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_01d1: stloc.s 17
-		IL_01d3: ldloc.s 17
-		IL_01d5: ldc.r8 4
-		IL_01de: box [System.Runtime]System.Double
-		IL_01e3: ldc.r8 3
-		IL_01ec: box [System.Runtime]System.Double
-		IL_01f1: ldc.r8 64
-		IL_01fa: box [System.Runtime]System.Double
-		IL_01ff: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
-		IL_0204: pop
-		IL_0205: ldstr "console"
-		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0214: stloc.s 11
-		IL_0216: ldloc.2
-		IL_0217: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_021c: stloc.s 17
-		IL_021e: ldloc.s 17
-		IL_0220: ldc.r8 4
-		IL_0229: box [System.Runtime]System.Double
-		IL_022e: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_0233: stloc.s 18
-		IL_0235: ldloc.s 18
-		IL_0237: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_023c: stloc.s 19
-		IL_023e: ldloc.s 19
-		IL_0240: brfalse IL_025a
+		IL_001d: ldloc.s 9
+		IL_001f: ldstr "prototype"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0029: stloc.s 10
+		IL_002b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0030: stloc.s 11
+		IL_0032: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::.ctor()
+		IL_0037: ldc.i4.1
+		IL_0038: conv.r8
+		IL_0039: ldstr "setBitTrue"
+		IL_003e: ldc.i4.1
+		IL_003f: ldc.i4.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.s 12
+		IL_0047: ldloc.s 12
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0)
+		IL_004e: stloc.s 12
+		IL_0050: ldloc.s 10
+		IL_0052: ldstr "setBitTrue"
+		IL_0057: ldloc.s 12
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005e: pop
+		IL_005f: ldc.i4.1
+		IL_0060: newarr [System.Runtime]System.Object
+		IL_0065: dup
+		IL_0066: ldc.i4.0
+		IL_0067: ldloc.0
+		IL_0068: stelem.ref
+		IL_0069: stloc.s 11
+		IL_006b: ldloc.s 11
+		IL_006d: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::.ctor(object[])
+		IL_0072: ldc.i4.3
+		IL_0073: conv.r8
+		IL_0074: ldstr "setBitsTrue"
+		IL_0079: ldc.i4.1
+		IL_007a: ldc.i4.1
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
+		IL_0080: stloc.s 13
+		IL_0082: ldloc.s 13
+		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0)
+		IL_0089: stloc.s 13
+		IL_008b: ldloc.s 10
+		IL_008d: ldstr "setBitsTrue"
+		IL_0092: ldloc.s 13
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0099: pop
+		IL_009a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_009f: stloc.s 11
+		IL_00a1: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::.ctor()
+		IL_00a6: ldc.i4.1
+		IL_00a7: conv.r8
+		IL_00a8: ldstr "testBitTrue"
+		IL_00ad: ldc.i4.1
+		IL_00ae: ldc.i4.1
+		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
+		IL_00b4: stloc.s 14
+		IL_00b6: ldloc.s 14
+		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0)
+		IL_00bd: stloc.s 14
+		IL_00bf: ldloc.s 10
+		IL_00c1: ldstr "testBitTrue"
+		IL_00c6: ldloc.s 14
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00cd: pop
+		IL_00ce: ldc.i4.1
+		IL_00cf: newarr [System.Runtime]System.Object
+		IL_00d4: dup
+		IL_00d5: ldc.i4.0
+		IL_00d6: ldloc.0
+		IL_00d7: stelem.ref
+		IL_00d8: stloc.s 11
+		IL_00da: ldloc.s 9
+		IL_00dc: ldloc.s 11
+		IL_00de: ldc.r8 1
+		IL_00e7: box [System.Runtime]System.Double
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00f1: stloc.s 10
+		IL_00f3: ldloc.s 10
+		IL_00f5: stloc.1
+		IL_00f6: ldc.i4.1
+		IL_00f7: newarr [System.Runtime]System.Object
+		IL_00fc: dup
+		IL_00fd: ldc.i4.0
+		IL_00fe: ldloc.0
+		IL_00ff: stelem.ref
+		IL_0100: stloc.s 11
+		IL_0102: ldloc.s 11
+		IL_0104: ldc.i4.1
+		IL_0105: newarr [System.Runtime]System.Object
+		IL_010a: dup
+		IL_010b: ldc.i4.0
+		IL_010c: ldc.r8 64
+		IL_0115: box [System.Runtime]System.Double
+		IL_011a: stelem.ref
+		IL_011b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0120: ldc.r8 64
+		IL_0129: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::.ctor(object[], float64)
+		IL_012e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0133: stloc.2
+		IL_0134: ldloc.2
+		IL_0135: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_013a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_013f: ldstr "prototype"
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0149: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_014e: ldc.r8 3
+		IL_0157: box [System.Runtime]System.Double
+		IL_015c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_0161: stloc.3
+		IL_0162: ldc.r8 0.0
+		IL_016b: stloc.s 4
+		IL_016d: ldloc.3
+		IL_016e: ldloc.s 4
+		IL_0170: ldc.r8 16
+		IL_0179: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+		IL_017e: ldstr "console"
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018d: ldloc.3
+		IL_018e: ldc.r8 0.0
+		IL_0197: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_019c: box [System.Runtime]System.Double
+		IL_01a1: stloc.s 15
+		IL_01a3: ldstr "log"
+		IL_01a8: ldstr "varIndexSet"
+		IL_01ad: ldloc.s 15
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01b4: pop
+		IL_01b5: ldloc.2
+		IL_01b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_01bb: stloc.s 16
+		IL_01bd: ldloc.s 16
+		IL_01bf: ldc.r8 4
+		IL_01c8: box [System.Runtime]System.Double
+		IL_01cd: ldc.r8 3
+		IL_01d6: box [System.Runtime]System.Double
+		IL_01db: ldc.r8 64
+		IL_01e4: box [System.Runtime]System.Double
+		IL_01e9: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
+		IL_01ee: pop
+		IL_01ef: ldstr "console"
+		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01fe: stloc.s 10
+		IL_0200: ldloc.2
+		IL_0201: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0206: stloc.s 16
+		IL_0208: ldloc.s 16
+		IL_020a: ldc.r8 4
+		IL_0213: box [System.Runtime]System.Double
+		IL_0218: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_021d: stloc.s 17
+		IL_021f: ldloc.s 17
+		IL_0221: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_0226: stloc.s 18
+		IL_0228: ldloc.s 18
+		IL_022a: brfalse IL_0244
 
-		IL_0245: ldc.r8 1
-		IL_024e: box [System.Runtime]System.Double
-		IL_0253: stloc.s 5
-		IL_0255: br IL_026a
+		IL_022f: ldc.r8 1
+		IL_0238: box [System.Runtime]System.Double
+		IL_023d: stloc.s 5
+		IL_023f: br IL_0254
 
-		IL_025a: ldc.r8 0.0
-		IL_0263: box [System.Runtime]System.Double
-		IL_0268: stloc.s 5
+		IL_0244: ldc.r8 0.0
+		IL_024d: box [System.Runtime]System.Double
+		IL_0252: stloc.s 5
 
-		IL_026a: ldloc.s 11
-		IL_026c: ldstr "log"
-		IL_0271: ldstr "bit4"
-		IL_0276: ldloc.s 5
-		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_027d: pop
-		IL_027e: ldstr "console"
-		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028d: stloc.s 11
-		IL_028f: ldloc.2
-		IL_0290: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_0295: stloc.s 17
-		IL_0297: ldloc.s 17
-		IL_0299: ldc.r8 7
-		IL_02a2: box [System.Runtime]System.Double
-		IL_02a7: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_02ac: stloc.s 18
-		IL_02ae: ldloc.s 18
-		IL_02b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_02b5: stloc.s 19
-		IL_02b7: ldloc.s 19
-		IL_02b9: brfalse IL_02d3
+		IL_0254: ldloc.s 10
+		IL_0256: ldstr "log"
+		IL_025b: ldstr "bit4"
+		IL_0260: ldloc.s 5
+		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0267: pop
+		IL_0268: ldstr "console"
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0277: stloc.s 10
+		IL_0279: ldloc.2
+		IL_027a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_027f: stloc.s 16
+		IL_0281: ldloc.s 16
+		IL_0283: ldc.r8 7
+		IL_028c: box [System.Runtime]System.Double
+		IL_0291: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0296: stloc.s 17
+		IL_0298: ldloc.s 17
+		IL_029a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_029f: stloc.s 18
+		IL_02a1: ldloc.s 18
+		IL_02a3: brfalse IL_02bd
 
-		IL_02be: ldc.r8 1
-		IL_02c7: box [System.Runtime]System.Double
-		IL_02cc: stloc.s 6
-		IL_02ce: br IL_02e3
+		IL_02a8: ldc.r8 1
+		IL_02b1: box [System.Runtime]System.Double
+		IL_02b6: stloc.s 6
+		IL_02b8: br IL_02cd
 
-		IL_02d3: ldc.r8 0.0
-		IL_02dc: box [System.Runtime]System.Double
-		IL_02e1: stloc.s 6
+		IL_02bd: ldc.r8 0.0
+		IL_02c6: box [System.Runtime]System.Double
+		IL_02cb: stloc.s 6
 
-		IL_02e3: ldloc.s 11
-		IL_02e5: ldstr "log"
-		IL_02ea: ldstr "bit7"
-		IL_02ef: ldloc.s 6
-		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02f6: pop
-		IL_02f7: ldstr "console"
-		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0306: stloc.s 11
-		IL_0308: ldloc.2
-		IL_0309: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_030e: stloc.s 17
-		IL_0310: ldloc.s 17
-		IL_0312: ldc.r8 31
-		IL_031b: box [System.Runtime]System.Double
-		IL_0320: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_0325: stloc.s 18
-		IL_0327: ldloc.s 18
-		IL_0329: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_032e: stloc.s 19
-		IL_0330: ldloc.s 19
-		IL_0332: brfalse IL_034c
+		IL_02cd: ldloc.s 10
+		IL_02cf: ldstr "log"
+		IL_02d4: ldstr "bit7"
+		IL_02d9: ldloc.s 6
+		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02e0: pop
+		IL_02e1: ldstr "console"
+		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f0: stloc.s 10
+		IL_02f2: ldloc.2
+		IL_02f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_02f8: stloc.s 16
+		IL_02fa: ldloc.s 16
+		IL_02fc: ldc.r8 31
+		IL_0305: box [System.Runtime]System.Double
+		IL_030a: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_030f: stloc.s 17
+		IL_0311: ldloc.s 17
+		IL_0313: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_0318: stloc.s 18
+		IL_031a: ldloc.s 18
+		IL_031c: brfalse IL_0336
 
-		IL_0337: ldc.r8 1
-		IL_0340: box [System.Runtime]System.Double
-		IL_0345: stloc.s 7
-		IL_0347: br IL_035c
+		IL_0321: ldc.r8 1
+		IL_032a: box [System.Runtime]System.Double
+		IL_032f: stloc.s 7
+		IL_0331: br IL_0346
 
-		IL_034c: ldc.r8 0.0
-		IL_0355: box [System.Runtime]System.Double
-		IL_035a: stloc.s 7
+		IL_0336: ldc.r8 0.0
+		IL_033f: box [System.Runtime]System.Double
+		IL_0344: stloc.s 7
 
-		IL_035c: ldloc.s 11
-		IL_035e: ldstr "log"
-		IL_0363: ldstr "bit31"
-		IL_0368: ldloc.s 7
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_036f: pop
-		IL_0370: ldstr "console"
-		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_037f: stloc.s 11
-		IL_0381: ldloc.2
-		IL_0382: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_0387: stloc.s 17
-		IL_0389: ldloc.s 17
-		IL_038b: ldc.r8 5
-		IL_0394: box [System.Runtime]System.Double
-		IL_0399: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_039e: stloc.s 18
-		IL_03a0: ldloc.s 18
-		IL_03a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_03a7: stloc.s 19
-		IL_03a9: ldloc.s 19
-		IL_03ab: brfalse IL_03c5
+		IL_0346: ldloc.s 10
+		IL_0348: ldstr "log"
+		IL_034d: ldstr "bit31"
+		IL_0352: ldloc.s 7
+		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0359: pop
+		IL_035a: ldstr "console"
+		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0369: stloc.s 10
+		IL_036b: ldloc.2
+		IL_036c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0371: stloc.s 16
+		IL_0373: ldloc.s 16
+		IL_0375: ldc.r8 5
+		IL_037e: box [System.Runtime]System.Double
+		IL_0383: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0388: stloc.s 17
+		IL_038a: ldloc.s 17
+		IL_038c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_0391: stloc.s 18
+		IL_0393: ldloc.s 18
+		IL_0395: brfalse IL_03af
 
-		IL_03b0: ldc.r8 1
-		IL_03b9: box [System.Runtime]System.Double
-		IL_03be: stloc.s 8
-		IL_03c0: br IL_03d5
+		IL_039a: ldc.r8 1
+		IL_03a3: box [System.Runtime]System.Double
+		IL_03a8: stloc.s 8
+		IL_03aa: br IL_03bf
 
-		IL_03c5: ldc.r8 0.0
-		IL_03ce: box [System.Runtime]System.Double
-		IL_03d3: stloc.s 8
+		IL_03af: ldc.r8 0.0
+		IL_03b8: box [System.Runtime]System.Double
+		IL_03bd: stloc.s 8
 
-		IL_03d5: ldloc.s 11
-		IL_03d7: ldstr "log"
-		IL_03dc: ldstr "bit5"
-		IL_03e1: ldloc.s 8
-		IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03e8: pop
-		IL_03e9: ldstr "console"
-		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03f8: stloc.s 11
-		IL_03fa: ldloc.2
-		IL_03fb: ldstr "wordArray"
-		IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0405: stloc.s 20
-		IL_0407: ldloc.s 20
-		IL_0409: ldc.r8 0.0
-		IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0417: stloc.s 20
-		IL_0419: ldloc.s 11
-		IL_041b: ldstr "log"
-		IL_0420: ldstr "word0"
-		IL_0425: ldloc.s 20
-		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_042c: pop
-		IL_042d: ldstr "console"
-		IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_043c: stloc.s 20
-		IL_043e: ldloc.2
-		IL_043f: ldstr "wordArray"
-		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0449: stloc.s 11
-		IL_044b: ldloc.s 11
-		IL_044d: ldc.r8 1
-		IL_0456: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_045b: stloc.s 11
-		IL_045d: ldloc.s 20
-		IL_045f: ldstr "log"
-		IL_0464: ldstr "word1"
-		IL_0469: ldloc.s 11
-		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0470: pop
-		IL_0471: ret
+		IL_03bf: ldloc.s 10
+		IL_03c1: ldstr "log"
+		IL_03c6: ldstr "bit5"
+		IL_03cb: ldloc.s 8
+		IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03d2: pop
+		IL_03d3: ldstr "console"
+		IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03e2: stloc.s 10
+		IL_03e4: ldloc.2
+		IL_03e5: ldstr "wordArray"
+		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03ef: stloc.s 19
+		IL_03f1: ldloc.s 19
+		IL_03f3: ldc.r8 0.0
+		IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0401: stloc.s 19
+		IL_0403: ldloc.s 10
+		IL_0405: ldstr "log"
+		IL_040a: ldstr "word0"
+		IL_040f: ldloc.s 19
+		IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0416: pop
+		IL_0417: ldstr "console"
+		IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0426: stloc.s 19
+		IL_0428: ldloc.2
+		IL_0429: ldstr "wordArray"
+		IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0433: stloc.s 10
+		IL_0435: ldloc.s 10
+		IL_0437: ldc.r8 1
+		IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0445: stloc.s 10
+		IL_0447: ldloc.s 19
+		IL_0449: ldstr "log"
+		IL_044e: ldstr "word1"
+		IL_0453: ldloc.s 10
+		IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_045a: pop
+		IL_045b: ret
 	} // end of method Prime_SetBitsTrue_SmallStep_WordValueOrAssign::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign
@@ -1451,7 +1445,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a8b
+		// Method begins at RVA 0x2a73
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary

- reuse a class type across its straight-line method and private-accessor metadata initialization
- avoid repeated `RuntimeHelpers.RunClassConstructor` calls while preserving the first initialization point and class element order
- use the existing `Classes_ClassPrivateAccessor_EdgeCases_Log` generator snapshot as regression coverage

Closes #1740