### PR TITLE
perf(il): fuse generated callable installation chains

### DIFF
--- a/docs/compiler/InstructionChaining.md
+++ b/docs/compiler/InstructionChaining.md
@@ -1,0 +1,181 @@
+# Instruction chaining
+
+Instruction chaining lets JROC pass a value directly from one generated IL
+instruction to the next instead of storing that value in a temporary local and
+loading it again. It is an IL-backend optimization: it changes neither the
+JavaScript operation order nor the values the program can observe.
+
+## Part 1: a simple illustration
+
+Consider installing a generated class method:
+
+```js
+class Counter {
+    increment() {}
+}
+```
+
+The compiler creates a concrete function-object wrapper, gives that wrapper
+its JavaScript function metadata, marks its `prototype` as `undefined`, and
+installs it under `"increment"`.
+
+Without chaining, each intermediate result goes through a CLR local:
+
+```text
+create wrapper
+  -> local method
+initialize method
+  -> local initializedMethod
+mark initializedMethod as non-constructible
+  -> local callable
+install "increment" with callable
+```
+
+The equivalent IL shape is:
+
+```il
+newobj FunctionObject_Counter_increment::.ctor()
+call !!T Function::InitializeFunctionInstance<T>(!!T, ...)
+stloc methodObject
+
+ldloc methodObject
+call !!T Function::MarkUndefinedPrototype<T>(!!T)
+stloc markedMethodObject
+
+ldloc prototype
+ldstr "increment"
+ldloc markedMethodObject
+call ObjectRuntime::DefineClassElementDataProperty
+pop
+```
+
+With instruction chaining, the wrapper result stays on the CLR evaluation
+stack until property installation consumes it:
+
+```text
+load target and key
+  -> create wrapper
+  -> initialize wrapper
+  -> mark wrapper as non-constructible
+  -> install property
+```
+
+```il
+ldloc prototype
+ldstr "increment"
+newobj FunctionObject_Counter_increment::.ctor()
+call !!T Function::InitializeFunctionInstance<T>(!!T, ...)
+call !!T Function::MarkUndefinedPrototype<T>(!!T)
+call ObjectRuntime::DefineClassElementDataProperty
+pop
+```
+
+Both versions create exactly one function object and install the same object.
+The chained form removes the short-lived typed local and its `stloc`/`ldloc`
+traffic while retaining `FunctionObject_Counter_increment` as `T` through the
+generic runtime calls.
+
+## Part 2: scheduler and emission details
+
+### Where chaining happens
+
+`LIRStackScheduler` runs after LIR normalization and before local allocation
+and IL emission. It is the owner of non-identity instruction ordering and
+residency decisions:
+
+```text
+normalized MethodBodyIR
+  -> LIRStackScheduler
+  -> TempMaterializationPlan
+  -> TempLocalAllocator
+  -> LIRToILCompiler
+```
+
+For generated callable installation, the `GeneralRegions` mode recognizes
+these consumer roots:
+
+- `ObjectRuntime.DefineClassElementDataProperty`
+- `ObjectRuntime.DefineClassElementAccessorProperty`
+- `ObjectRuntime.DefineObjectLiteralDataProperty`
+- `ObjectRuntime.DefineObjectLiteralAccessorProperty`
+
+Starting at a callable operand of one of those roots, it walks backwards
+through a contiguous producer chain:
+
+```text
+LIRCreateBoundArrowFunction
+  or LIRCreateBoundFunctionExpression
+  -> Function.MarkUndefinedPrototype<T>
+  -> optional Function.SetAccessorNameIfAnonymous
+  -> descriptor installation
+```
+
+The scheduler moves the descriptor-installation operation before that
+contiguous producer suffix. Its ordinary argument emission then loads the
+target and key first, followed by the callable chain as the final value
+argument. This is the CLR stack order required by an installation call such
+as `DefineClassElementDataProperty(target, key, value)`.
+
+### Eligibility rules
+
+The optimization is deliberately narrow. Every callable-chain result must:
+
+1. have exactly one LIR definition and one use;
+2. be defined immediately before its consumer in the chain;
+3. stay within one scheduler region;
+4. have no assigned variable-slot storage; and
+5. terminate at one of the supported descriptor-installation roots.
+
+The scheduler rejects the chain when any condition fails. It then leaves the
+original source-order operations and materialized locals unchanged. This
+covers callable values that are reused, cross sequence points or control-flow
+boundaries, or need storage for a different backend feature.
+
+Only the callable-result chain is moved. Captured scope arrays, home objects,
+private brands, object-literal targets, computed keys, and the missing
+getter/setter value remain normal materialized inputs. Therefore:
+
+- computed keys still run before their method/accessor values;
+- capture reads and allocation happen once at their original evaluation point;
+- abrupt completion from a target, key, capture, constructor, initialization,
+  naming, or descriptor operation retains its original relative order; and
+- descriptor installation still receives the exact generated function object.
+
+For object-literal accessors, the lowerer creates the missing getter or setter
+before lowering the generated callable chain. That places the non-callable
+argument on the evaluation stack before the callable argument and avoids
+moving an observable operation across callable construction.
+
+### Ownership and validation
+
+The schedule records every selected producer as
+`TempResidency.ScheduledInline` and marks it scheduler-owned.
+`TempMaterializationPlan` respects that ownership, so it cannot independently
+rematerialize or allocate the same temporary. `LIRStackScheduleValidator`
+checks def/use counts, supported producer/root shapes, region ownership, and
+the resulting stack behavior before IL emission.
+
+`LIRToILCompiler` skips a scheduled-inline definition at its original LIR
+position. When the reordered root emits its arguments, loading the callable
+temp recursively emits the concrete wrapper construction and generic runtime
+calls inline. No wrapper value is widened to `object` merely to avoid a local.
+
+This is distinct from rematerialization. Rematerialization suppresses a cheap,
+stable producer and reproduces it at a use; instruction chaining emits an
+allocation or call exactly once and carries its result to the consumer on the
+evaluation stack.
+
+## Related code and tests
+
+- `src/Compiler/IL/LIRStackScheduler.cs` selects and reorders eligible chains.
+- `src/Compiler/IL/LIRStackScheduleValidator.cs` validates scheduler ownership.
+- `src/Compiler/IL/LIRToILCompiler.GeneratedFunctionObjects.cs` emits the
+  concrete generated wrapper and generic initialization calls.
+- `src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.ClassDefinitions.cs`
+  and `...ArrayObject.cs` preserve accessor argument order during lowering.
+- `tests/Jroc.Tests/Classes/JavaScript/Classes_GeneratedMethodFunctionObjects.js`
+  and `tests/Jroc.Tests/Object/JavaScript/ObjectLiteral_GeneratedMethodFunctionObjects.js`
+  cover class and object-literal method/object identity behavior.
+
+For the scheduler's broader model, modes, and validation boundaries, see
+[LIR stack scheduler](LIRStackScheduler.md).

--- a/docs/compiler/LIRStackScheduler.md
+++ b/docs/compiler/LIRStackScheduler.md
@@ -28,6 +28,9 @@ validated identity foundation:
 
 All unsupported shapes retain source-order, materialized behavior.
 
+For a visual introduction to stack-resident chains and the generated-callable
+installation rules, see [Instruction chaining](InstructionChaining.md).
+
 ## Why a scheduler is needed
 
 JROC LIR names intermediate values with `TempVariable` instances. A direct IL

--- a/src/Compiler/IL/LIRStackScheduler.cs
+++ b/src/Compiler/IL/LIRStackScheduler.cs
@@ -1098,23 +1098,40 @@ internal static class LIRStackScheduler
             var selectedDefinitions = new HashSet<int>();
             var emittedDefinitionOrder = new List<int>();
             var safe = true;
-            foreach (var operand in CollectUsedTemps(root))
+            if (IsGeneratedCallableInstallationRoot(root))
             {
-                if (!TrySelectGeneralProducerTree(
-                        methodBody,
-                        operand,
-                        rootIndex,
-                        rootRegion,
-                        definitionIndex,
-                        definitionCount,
-                        useCount,
-                        regionByLirIndex,
-                        selectedDefinitions,
-                        emittedDefinitionOrder,
-                        ref analysisBudget))
+                safe = TrySelectGeneratedCallableInstallationChain(
+                    methodBody,
+                    root,
+                    rootIndex,
+                    rootRegion,
+                    definitionIndex,
+                    definitionCount,
+                    useCount,
+                    regionByLirIndex,
+                    selectedDefinitions,
+                    emittedDefinitionOrder);
+            }
+            else
+            {
+                foreach (var operand in CollectUsedTemps(root))
                 {
-                    safe = false;
-                    break;
+                    if (!TrySelectGeneralProducerTree(
+                            methodBody,
+                            operand,
+                            rootIndex,
+                            rootRegion,
+                            definitionIndex,
+                            definitionCount,
+                            useCount,
+                            regionByLirIndex,
+                            selectedDefinitions,
+                            emittedDefinitionOrder,
+                            ref analysisBudget))
+                    {
+                        safe = false;
+                        break;
+                    }
                 }
             }
 
@@ -1233,7 +1250,149 @@ internal static class LIRStackScheduler
 
     private static bool IsGeneralSchedulingRoot(LIRInstruction instruction)
         => IsSupportedConstruction(instruction)
-            || IsSupportedArgumentBundle(instruction);
+            || IsSupportedArgumentBundle(instruction)
+            || IsGeneratedCallableInstallationRoot(instruction);
+
+    private static bool TrySelectGeneratedCallableInstallationChain(
+        MethodBodyIR methodBody,
+        LIRInstruction root,
+        int rootIndex,
+        int rootRegion,
+        int[] definitionIndex,
+        int[] definitionCount,
+        int[] useCount,
+        int[] regionByLirIndex,
+        HashSet<int> selectedDefinitions,
+        List<int> emittedDefinitionOrder)
+    {
+        var callableResult = CollectUsedTemps(root)
+            .FirstOrDefault(temp => IsGeneratedCallableChainResult(
+                methodBody,
+                temp,
+                definitionIndex));
+        if (!IsGeneratedCallableChainResult(
+                methodBody,
+                callableResult,
+                definitionIndex))
+        {
+            return false;
+        }
+
+        var expectedDefinitionIndex = rootIndex - 1;
+        var current = callableResult;
+        while (true)
+        {
+            if ((uint)current.Index >= (uint)definitionIndex.Length)
+            {
+                return false;
+            }
+
+            var producerIndex = definitionIndex[current.Index];
+            if (producerIndex != expectedDefinitionIndex
+                || definitionCount[current.Index] != 1
+                || useCount[current.Index] != 1
+                || regionByLirIndex[producerIndex] != rootRegion
+                || current.Index < methodBody.TempVariableSlots.Count
+                    && methodBody.TempVariableSlots[current.Index] >= 0)
+            {
+                return false;
+            }
+
+            var producer = methodBody.Instructions[producerIndex];
+            if (!selectedDefinitions.Add(producerIndex))
+            {
+                return false;
+            }
+
+            emittedDefinitionOrder.Insert(0, producerIndex);
+            if (IsGeneratedFunctionObjectCreation(producer))
+            {
+                return true;
+            }
+
+            if (!TryGetGeneratedCallableInput(producer, out current))
+            {
+                return false;
+            }
+
+            expectedDefinitionIndex--;
+        }
+    }
+
+    private static bool IsGeneratedCallableInstallationRoot(
+        LIRInstruction instruction)
+        => instruction is LIRCallIntrinsicStatic
+        {
+            IntrinsicName: nameof(JavaScriptRuntime.ObjectRuntime),
+            MethodName: nameof(
+                JavaScriptRuntime.ObjectRuntime.DefineClassElementDataProperty)
+                or nameof(
+                    JavaScriptRuntime.ObjectRuntime.DefineClassElementAccessorProperty)
+                or "DefineObjectLiteralDataProperty"
+                or "DefineObjectLiteralAccessorProperty"
+        };
+
+    private static bool IsGeneratedCallableChainResult(
+        MethodBodyIR methodBody,
+        TempVariable temp,
+        int[] definitionIndex)
+    {
+        while ((uint)temp.Index < (uint)definitionIndex.Length)
+        {
+            var definitionIndexForTemp = definitionIndex[temp.Index];
+            if (definitionIndexForTemp < 0)
+            {
+                return false;
+            }
+
+            var definition = methodBody.Instructions[definitionIndexForTemp];
+            if (definition is LIRCreateBoundArrowFunction
+                or LIRCreateBoundFunctionExpression)
+            {
+                return true;
+            }
+
+            if (!TryGetGeneratedCallableInput(definition, out temp))
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetGeneratedCallableInput(
+        LIRInstruction instruction,
+        out TempVariable callableInput)
+    {
+        switch (instruction)
+        {
+            case LIRCallIntrinsicStatic
+            {
+                IntrinsicName: nameof(JavaScriptRuntime.Function),
+                MethodName: nameof(
+                    JavaScriptRuntime.Function.MarkUndefinedPrototype),
+                GenericTypeArgument: not null,
+                Arguments: [var argument]
+            }:
+                callableInput = argument;
+                return true;
+
+            case LIRCallIntrinsicStatic
+            {
+                IntrinsicName: nameof(JavaScriptRuntime.Function),
+                MethodName: nameof(
+                    JavaScriptRuntime.Function.SetAccessorNameIfAnonymous),
+                Arguments: [var argument, ..]
+            }:
+                callableInput = argument;
+                return true;
+
+            default:
+                callableInput = default;
+                return false;
+        }
+    }
 
     private static void ClaimInlineCallArrays(
         MethodBodyIR methodBody,
@@ -1435,6 +1594,11 @@ internal static class LIRStackScheduler
     private static bool IsGeneralInlineProducer(LIRInstruction instruction)
         => IsSupportedScheduledInlineProducer(instruction)
             || IsSupportedCallResultDefinition(instruction);
+
+    private static bool IsGeneratedFunctionObjectCreation(
+        LIRInstruction instruction)
+        => instruction is LIRCreateBoundArrowFunction
+            or LIRCreateBoundFunctionExpression;
 
     private static bool PreservesSelectedEffectOrder(
         MethodBodyIR methodBody,
@@ -1643,7 +1807,15 @@ internal static class LIRStackScheduler
 
     internal static bool IsSupportedScheduledInlineCallProducer(
         LIRInstruction instruction)
-        => IsSupportedCallResultDefinition(instruction);
+        => IsSupportedCallResultDefinition(instruction)
+            || IsGeneratedFunctionObjectCreation(instruction)
+            || instruction is LIRCallIntrinsicStatic
+            {
+                IntrinsicName: nameof(JavaScriptRuntime.Function),
+                MethodName: nameof(
+                    JavaScriptRuntime.Function.MarkUndefinedPrototype),
+                GenericTypeArgument: not null
+            };
 
     private static bool IsSupportedCallResultConsumer(
         MethodBodyIR methodBody,
@@ -1763,6 +1935,7 @@ internal static class LIRStackScheduler
         LIRInstruction instruction)
         => IsSupportedConstruction(instruction)
             || IsSupportedArgumentBundle(instruction)
+            || IsGeneratedCallableInstallationRoot(instruction)
             || IsSupportedInlineCallArrayRoot(instruction);
 
     private static bool IsSupportedConstructionConsumer(

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.ArrayObject.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.ArrayObject.cs
@@ -478,6 +478,10 @@ public sealed partial class HIRToLIRLowerer
             return true;
         }
 
+        var prefixTemp = CreateTempVariable();
+        _methodBodyIR.Instructions.Add(new LIRConstString(prefix, prefixTemp));
+        DefineTempStorage(prefixTemp, new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+
         if (!TryLowerObjectLiteralMemberValue(
                 accessorExpression,
                 targetTemp,
@@ -487,9 +491,6 @@ public sealed partial class HIRToLIRLowerer
         }
 
         accessorTemp = EmitMarkUndefinedPrototype(accessorTemp);
-        var prefixTemp = CreateTempVariable();
-        _methodBodyIR.Instructions.Add(new LIRConstString(prefix, prefixTemp));
-        DefineTempStorage(prefixTemp, new ValueStorage(ValueStorageKind.Reference, typeof(string)));
         var namedAccessor = CreateTempVariable();
         _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStatic(
             IntrinsicName: nameof(JavaScriptRuntime.Function),

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.ClassDefinitions.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.ClassDefinitions.cs
@@ -135,17 +135,17 @@ public sealed partial class HIRToLIRLowerer
 
         if (!expression.IsGenerator && !expression.IsAsync)
         {
+            var undefinedAccessor = CreateTempVariable();
+            _methodBodyIR.Instructions.Add(new LIRConstUndefined(undefinedAccessor));
+            DefineTempStorage(
+                undefinedAccessor,
+                new ValueStorage(ValueStorageKind.Reference, typeof(object)));
             var functionObject = EmitGeneratedClassMethodObject(
                 expression.CallableId,
                 scopesTemp,
                 targetTemp,
                 ownerTemp,
                 expression.FunctionName);
-            var undefinedAccessor = CreateTempVariable();
-            _methodBodyIR.Instructions.Add(new LIRConstUndefined(undefinedAccessor));
-            DefineTempStorage(
-                undefinedAccessor,
-                new ValueStorage(ValueStorageKind.Reference, typeof(object)));
 
             resultTempVar = CreateTempVariable();
             _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStatic(

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalSuper_MethodAndConstructor.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalSuper_MethodAndConstructor.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2435
+				// Method begins at RVA 0x2425
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,7 +47,7 @@
 					object[] capture2
 				) cil managed 
 			{
-				// Method begins at RVA 0x2533
+				// Method begins at RVA 0x2523
 				// Header size: 1
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -69,7 +69,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2550
+				// Method begins at RVA 0x2540
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -81,7 +81,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2553
+				// Method begins at RVA 0x2543
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -95,7 +95,7 @@
 					object thisArgument
 				) cil managed 
 			{
-				// Method begins at RVA 0x2556
+				// Method begins at RVA 0x2546
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -108,7 +108,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x255e
+				// Method begins at RVA 0x254e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -121,7 +121,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x2566
+				// Method begins at RVA 0x2556
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -137,7 +137,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x256e
+				// Method begins at RVA 0x255e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -159,7 +159,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22c8
+			// Method begins at RVA 0x22b8
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -188,7 +188,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2447
+				// Method begins at RVA 0x2437
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -217,7 +217,7 @@
 					object[] capture2
 				) cil managed 
 			{
-				// Method begins at RVA 0x2576
+				// Method begins at RVA 0x2566
 				// Header size: 1
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2593
+				// Method begins at RVA 0x2583
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -251,7 +251,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2596
+				// Method begins at RVA 0x2586
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -265,7 +265,7 @@
 					object thisArgument
 				) cil managed 
 			{
-				// Method begins at RVA 0x2599
+				// Method begins at RVA 0x2589
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -278,7 +278,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x25a1
+				// Method begins at RVA 0x2591
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -291,7 +291,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x25a9
+				// Method begins at RVA 0x2599
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -307,7 +307,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x25b1
+				// Method begins at RVA 0x25a1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -329,7 +329,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22e8
+			// Method begins at RVA 0x22d8
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -358,7 +358,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2408
+				// Method begins at RVA 0x23f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -378,7 +378,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2411
+				// Method begins at RVA 0x2401
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -398,7 +398,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x241a
+				// Method begins at RVA 0x240a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -423,7 +423,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2450
+				// Method begins at RVA 0x2440
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -439,7 +439,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x245f
+				// Method begins at RVA 0x244f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -451,7 +451,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2462
+				// Method begins at RVA 0x2452
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -466,7 +466,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2465
+				// Method begins at RVA 0x2455
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -482,7 +482,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2471
+				// Method begins at RVA 0x2461
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -501,7 +501,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x247d
+				// Method begins at RVA 0x246d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -514,7 +514,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2485
+				// Method begins at RVA 0x2475
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -526,7 +526,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2488
+				// Method begins at RVA 0x2478
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -541,7 +541,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x248b
+				// Method begins at RVA 0x247b
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -574,7 +574,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2306
+			// Method begins at RVA 0x22f6
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -593,7 +593,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23b9
+			// Method begins at RVA 0x23a9
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -616,7 +616,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2423
+				// Method begins at RVA 0x2413
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -636,7 +636,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x242c
+				// Method begins at RVA 0x241c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -656,7 +656,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243e
+				// Method begins at RVA 0x242e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -685,7 +685,7 @@
 					object[] capture2
 				) cil managed 
 			{
-				// Method begins at RVA 0x24af
+				// Method begins at RVA 0x249f
 				// Header size: 1
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -707,7 +707,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24cc
+				// Method begins at RVA 0x24bc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -719,7 +719,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24cf
+				// Method begins at RVA 0x24bf
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -731,7 +731,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x24d2
+				// Method begins at RVA 0x24c2
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -744,7 +744,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x24da
+				// Method begins at RVA 0x24ca
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -760,7 +760,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x24e2
+				// Method begins at RVA 0x24d2
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -776,7 +776,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x24ee
+				// Method begins at RVA 0x24de
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -800,7 +800,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x24fa
+				// Method begins at RVA 0x24ea
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -816,7 +816,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2509
+				// Method begins at RVA 0x24f9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -828,7 +828,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x250c
+				// Method begins at RVA 0x24fc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -843,7 +843,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x250f
+				// Method begins at RVA 0x24ff
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -878,7 +878,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2318
+			// Method begins at RVA 0x2308
 			// Header size: 12
 			// Code size: 149 (0x95)
 			.maxstack 8
@@ -956,7 +956,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23c4
+			// Method begins at RVA 0x23b4
 			// Header size: 12
 			// Code size: 47 (0x2f)
 			.maxstack 8
@@ -996,7 +996,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23ff
+			// Method begins at RVA 0x23ef
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1022,7 +1022,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 617 (0x269)
+		// Code size: 601 (0x259)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Scope,
@@ -1034,10 +1034,8 @@
 			[6] class [System.Runtime]System.Type,
 			[7] object,
 			[8] object[],
-			[9] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read,
-			[10] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader,
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[12] object
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Scope::.ctor()
@@ -1054,183 +1052,175 @@
 		IL_0029: stloc.s 7
 		IL_002b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0030: stloc.s 8
-		IL_0032: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read::.ctor()
-		IL_0037: ldc.i4.0
-		IL_0038: conv.r8
-		IL_0039: ldstr "read"
-		IL_003e: ldc.i4.1
-		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0, float64, string, bool, bool)
-		IL_0045: stloc.s 9
-		IL_0047: ldloc.s 9
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0)
-		IL_004e: stloc.s 9
-		IL_0050: ldloc.s 7
-		IL_0052: ldstr "read"
-		IL_0057: ldloc.s 9
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005e: pop
-		IL_005f: ldc.i4.1
-		IL_0060: newarr [System.Runtime]System.Object
-		IL_0065: dup
-		IL_0066: ldc.i4.0
-		IL_0067: ldloc.0
-		IL_0068: stelem.ref
-		IL_0069: stloc.s 8
-		IL_006b: ldloc.s 6
-		IL_006d: ldloc.s 8
-		IL_006f: ldc.r8 1
-		IL_0078: box [System.Runtime]System.Double
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0082: stloc.s 7
-		IL_0084: ldloc.s 7
-		IL_0086: stloc.1
-		IL_0087: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_008c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0091: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_0096: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_009b: stloc.s 6
-		IL_009d: ldloc.s 6
-		IL_009f: ldstr "prototype"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a9: stloc.s 7
-		IL_00ab: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00b0: stloc.s 8
-		IL_00b2: ldloc.s 8
-		IL_00b4: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader::.ctor(object[])
-		IL_00b9: ldc.i4.0
-		IL_00ba: conv.r8
-		IL_00bb: ldstr "makeReader"
-		IL_00c0: ldc.i4.0
-		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0, float64, string, bool, bool)
-		IL_00c7: stloc.s 10
-		IL_00c9: ldloc.s 10
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0)
-		IL_00d0: stloc.s 10
-		IL_00d2: ldloc.s 7
-		IL_00d4: ldstr "makeReader"
-		IL_00d9: ldloc.s 10
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00e0: pop
-		IL_00e1: ldc.i4.1
-		IL_00e2: newarr [System.Runtime]System.Object
-		IL_00e7: dup
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldloc.0
-		IL_00ea: stelem.ref
-		IL_00eb: stloc.s 8
-		IL_00ed: ldloc.s 6
-		IL_00ef: ldloc.s 8
-		IL_00f1: ldc.r8 1
-		IL_00fa: box [System.Runtime]System.Double
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0104: stloc.s 7
-		IL_0106: ldloc.s 7
-		IL_0108: ldloc.1
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_010e: stloc.s 7
-		IL_0110: ldloc.s 7
-		IL_0112: stloc.2
-		IL_0113: ldc.i4.1
-		IL_0114: newarr [System.Runtime]System.Object
-		IL_0119: dup
-		IL_011a: ldc.i4.0
-		IL_011b: ldloc.0
-		IL_011c: stelem.ref
-		IL_011d: stloc.s 8
-		IL_011f: ldloc.s 8
-		IL_0121: ldc.i4.1
-		IL_0122: newarr [System.Runtime]System.Object
-		IL_0127: dup
-		IL_0128: ldc.i4.0
-		IL_0129: ldc.r8 11
-		IL_0132: box [System.Runtime]System.Double
-		IL_0137: stelem.ref
-		IL_0138: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_013d: ldloc.2
-		IL_013e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_0143: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0148: ldc.r8 11
-		IL_0151: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::.ctor(object[], float64)
-		IL_0156: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_015b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0160: dup
-		IL_0161: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_0166: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_016b: ldstr "prototype"
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0175: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_017a: stloc.3
-		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_0185: stloc.3
-		IL_0186: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_018b: ldloc.3
-		IL_018c: ldstr "fromConstructor"
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0196: stloc.s 4
-		IL_0198: ldloc.3
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019e: stloc.s 7
-		IL_01a0: ldloc.s 7
-		IL_01a2: isinst Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_01a7: dup
-		IL_01a8: brfalse IL_01b9
+		IL_0032: ldloc.s 7
+		IL_0034: ldstr "read"
+		IL_0039: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read::.ctor()
+		IL_003e: ldc.i4.0
+		IL_003f: conv.r8
+		IL_0040: ldstr "read"
+		IL_0045: ldc.i4.1
+		IL_0046: ldc.i4.1
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0)
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0056: pop
+		IL_0057: ldc.i4.1
+		IL_0058: newarr [System.Runtime]System.Object
+		IL_005d: dup
+		IL_005e: ldc.i4.0
+		IL_005f: ldloc.0
+		IL_0060: stelem.ref
+		IL_0061: stloc.s 8
+		IL_0063: ldloc.s 6
+		IL_0065: ldloc.s 8
+		IL_0067: ldc.r8 1
+		IL_0070: box [System.Runtime]System.Double
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_007a: stloc.s 7
+		IL_007c: ldloc.s 7
+		IL_007e: stloc.1
+		IL_007f: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+		IL_0084: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0089: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+		IL_008e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0093: stloc.s 6
+		IL_0095: ldloc.s 6
+		IL_0097: ldstr "prototype"
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a1: stloc.s 7
+		IL_00a3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a8: stloc.s 8
+		IL_00aa: ldloc.s 7
+		IL_00ac: ldstr "makeReader"
+		IL_00b1: ldloc.s 8
+		IL_00b3: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader::.ctor(object[])
+		IL_00b8: ldc.i4.0
+		IL_00b9: conv.r8
+		IL_00ba: ldstr "makeReader"
+		IL_00bf: ldc.i4.0
+		IL_00c0: ldc.i4.1
+		IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0, float64, string, bool, bool)
+		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0)
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00d0: pop
+		IL_00d1: ldc.i4.1
+		IL_00d2: newarr [System.Runtime]System.Object
+		IL_00d7: dup
+		IL_00d8: ldc.i4.0
+		IL_00d9: ldloc.0
+		IL_00da: stelem.ref
+		IL_00db: stloc.s 8
+		IL_00dd: ldloc.s 6
+		IL_00df: ldloc.s 8
+		IL_00e1: ldc.r8 1
+		IL_00ea: box [System.Runtime]System.Double
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00f4: stloc.s 7
+		IL_00f6: ldloc.s 7
+		IL_00f8: ldloc.1
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_00fe: stloc.s 7
+		IL_0100: ldloc.s 7
+		IL_0102: stloc.2
+		IL_0103: ldc.i4.1
+		IL_0104: newarr [System.Runtime]System.Object
+		IL_0109: dup
+		IL_010a: ldc.i4.0
+		IL_010b: ldloc.0
+		IL_010c: stelem.ref
+		IL_010d: stloc.s 8
+		IL_010f: ldloc.s 8
+		IL_0111: ldc.i4.1
+		IL_0112: newarr [System.Runtime]System.Object
+		IL_0117: dup
+		IL_0118: ldc.i4.0
+		IL_0119: ldc.r8 11
+		IL_0122: box [System.Runtime]System.Double
+		IL_0127: stelem.ref
+		IL_0128: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_012d: ldloc.2
+		IL_012e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0133: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0138: ldc.r8 11
+		IL_0141: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::.ctor(object[], float64)
+		IL_0146: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_014b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0150: dup
+		IL_0151: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+		IL_0156: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_015b: ldstr "prototype"
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0165: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_016a: stloc.3
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0175: stloc.3
+		IL_0176: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_017b: ldloc.3
+		IL_017c: ldstr "fromConstructor"
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0186: stloc.s 4
+		IL_0188: ldloc.3
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018e: stloc.s 7
+		IL_0190: ldloc.s 7
+		IL_0192: isinst Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+		IL_0197: dup
+		IL_0198: brfalse IL_01a9
 
-		IL_01ad: callvirt instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::makeReader()
-		IL_01b2: stloc.s 5
-		IL_01b4: br IL_01c8
+		IL_019d: callvirt instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::makeReader()
+		IL_01a2: stloc.s 5
+		IL_01a4: br IL_01b8
 
-		IL_01b9: pop
-		IL_01ba: ldloc.s 7
-		IL_01bc: ldstr "makeReader"
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01c6: stloc.s 5
+		IL_01a9: pop
+		IL_01aa: ldloc.s 7
+		IL_01ac: ldstr "makeReader"
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01b6: stloc.s 5
 
-		IL_01c8: ldstr "console"
-		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d7: stloc.s 7
-		IL_01d9: ldloc.s 4
-		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01e5: dup
-		IL_01e6: ldstr "value"
-		IL_01eb: ldc.r8 99
-		IL_01f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_01f9: stloc.s 11
-		IL_01fb: ldstr "call"
-		IL_0200: ldloc.s 11
+		IL_01b8: ldstr "console"
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c7: stloc.s 7
+		IL_01c9: ldloc.s 4
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01d5: dup
+		IL_01d6: ldstr "value"
+		IL_01db: ldc.r8 99
+		IL_01e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_01e9: stloc.s 9
+		IL_01eb: ldstr "call"
+		IL_01f0: ldloc.s 9
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f7: stloc.s 10
+		IL_01f9: ldloc.s 7
+		IL_01fb: ldstr "log"
+		IL_0200: ldloc.s 10
 		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0207: stloc.s 12
-		IL_0209: ldloc.s 7
-		IL_020b: ldstr "log"
-		IL_0210: ldloc.s 12
-		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0217: pop
-		IL_0218: ldstr "console"
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0227: stloc.s 12
-		IL_0229: ldloc.s 5
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0230: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0235: dup
-		IL_0236: ldstr "value"
-		IL_023b: ldc.r8 99
-		IL_0244: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0249: stloc.s 11
-		IL_024b: ldstr "call"
-		IL_0250: ldloc.s 11
+		IL_0207: pop
+		IL_0208: ldstr "console"
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0217: stloc.s 10
+		IL_0219: ldloc.s 5
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0220: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0225: dup
+		IL_0226: ldstr "value"
+		IL_022b: ldc.r8 99
+		IL_0234: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0239: stloc.s 9
+		IL_023b: ldstr "call"
+		IL_0240: ldloc.s 9
+		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0247: stloc.s 7
+		IL_0249: ldloc.s 10
+		IL_024b: ldstr "log"
+		IL_0250: ldloc.s 7
 		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0257: stloc.s 7
-		IL_0259: ldloc.s 12
-		IL_025b: ldstr "log"
-		IL_0260: ldloc.s 7
-		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0267: pop
-		IL_0268: ret
+		IL_0257: pop
+		IL_0258: ret
 	} // end of method ArrowFunction_LexicalSuper_MethodAndConstructor::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor
@@ -1242,7 +1232,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25b9
+		// Method begins at RVA 0x25a9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26a4
+					// Method begins at RVA 0x269c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x270a
+					// Method begins at RVA 0x2702
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -73,7 +73,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2727
+					// Method begins at RVA 0x271f
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -85,7 +85,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x272a
+					// Method begins at RVA 0x2722
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -100,7 +100,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x272d
+					// Method begins at RVA 0x2725
 					// Header size: 1
 					// Code size: 13 (0xd)
 					.maxstack 8
@@ -125,7 +125,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25b0
+				// Method begins at RVA 0x25a8
 				// Header size: 12
 				// Code size: 130 (0x82)
 				.maxstack 8
@@ -199,7 +199,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26ad
+					// Method begins at RVA 0x26a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -228,7 +228,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x273b
+					// Method begins at RVA 0x2733
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -250,7 +250,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2758
+					// Method begins at RVA 0x2750
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -262,7 +262,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x275b
+					// Method begins at RVA 0x2753
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -277,7 +277,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x275e
+					// Method begins at RVA 0x2756
 					// Header size: 1
 					// Code size: 13 (0xd)
 					.maxstack 8
@@ -302,7 +302,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2640
+				// Method begins at RVA 0x2638
 				// Header size: 12
 				// Code size: 70 (0x46)
 				.maxstack 8
@@ -342,7 +342,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x269b
+				// Method begins at RVA 0x2693
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -367,7 +367,7 @@
 					class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x26e3
+				// Method begins at RVA 0x26db
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -383,7 +383,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x26f2
+				// Method begins at RVA 0x26ea
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -395,7 +395,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x26f5
+				// Method begins at RVA 0x26ed
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -410,7 +410,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x26f8
+				// Method begins at RVA 0x26f0
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -437,7 +437,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x212c
+			// Method begins at RVA 0x2124
 			// Header size: 12
 			// Code size: 174 (0xae)
 			.maxstack 8
@@ -550,7 +550,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26b6
+				// Method begins at RVA 0x26ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -578,7 +578,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26d1
+						// Method begins at RVA 0x26c9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -596,7 +596,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26c8
+					// Method begins at RVA 0x26c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -614,7 +614,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26bf
+				// Method begins at RVA 0x26b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -641,7 +641,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x276c
+				// Method begins at RVA 0x2764
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -660,7 +660,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2782
+				// Method begins at RVA 0x277a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -672,7 +672,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2785
+				// Method begins at RVA 0x277d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -687,7 +687,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2788
+				// Method begins at RVA 0x2780
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -706,7 +706,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x279a
+				// Method begins at RVA 0x2792
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -731,7 +731,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21e8
+			// Method begins at RVA 0x21e0
 			// Header size: 12
 			// Code size: 919 (0x397)
 			.maxstack 8
@@ -1153,7 +1153,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26da
+				// Method begins at RVA 0x26d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1173,7 +1173,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27a8
+				// Method begins at RVA 0x27a0
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1186,7 +1186,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x27b0
+				// Method begins at RVA 0x27a8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1198,7 +1198,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x27b3
+				// Method begins at RVA 0x27ab
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1213,7 +1213,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x27b6
+				// Method begins at RVA 0x27ae
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1235,7 +1235,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x258b
+			// Method begins at RVA 0x2583
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -1269,7 +1269,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2692
+			// Method begins at RVA 0x268a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1295,7 +1295,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 208 (0xd0)
+		// Code size: 200 (0xc8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope,
@@ -1303,8 +1303,7 @@
 			[2] object[],
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[5] class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27,
-			[6] class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject
+			[5] class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope::.ctor()
@@ -1340,59 +1339,55 @@
 		IL_004c: ldloc.0
 		IL_004d: stelem.ref
 		IL_004e: stloc.2
-		IL_004f: ldloc.2
-		IL_0050: ldc.i4.0
-		IL_0051: ldelem.ref
-		IL_0052: castclass Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope
-		IL_0057: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27::.ctor(class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope)
-		IL_005c: ldc.i4.0
-		IL_005d: conv.r8
-		IL_005e: ldstr ""
-		IL_0063: ldc.i4.0
-		IL_0064: ldc.i4.1
-		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27>(!!0, float64, string, bool, bool)
-		IL_006a: stloc.s 5
-		IL_006c: ldloc.s 5
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27>(!!0)
-		IL_0073: stloc.s 5
-		IL_0075: ldloc.s 4
-		IL_0077: ldloc.3
-		IL_0078: ldloc.s 5
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_007f: pop
-		IL_0080: ldloc.0
-		IL_0081: ldloc.s 4
-		IL_0083: stfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope::iterable
-		IL_0088: nop
-		IL_0089: ldloc.1
-		IL_008a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_0094: stloc.3
-		IL_0095: ldloc.3
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009b: stloc.3
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
-		IL_00a6: stloc.2
-		IL_00a7: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject::.ctor()
+		IL_004f: ldloc.s 4
+		IL_0051: ldloc.3
+		IL_0052: ldloc.2
+		IL_0053: ldc.i4.0
+		IL_0054: ldelem.ref
+		IL_0055: castclass Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope
+		IL_005a: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27::.ctor(class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope)
+		IL_005f: ldc.i4.0
+		IL_0060: conv.r8
+		IL_0061: ldstr ""
+		IL_0066: ldc.i4.0
+		IL_0067: ldc.i4.1
+		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27>(!!0, float64, string, bool, bool)
+		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27>(!!0)
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0077: pop
+		IL_0078: ldloc.0
+		IL_0079: ldloc.s 4
+		IL_007b: stfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope::iterable
+		IL_0080: nop
+		IL_0081: ldloc.1
+		IL_0082: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_008c: stloc.3
+		IL_008d: ldloc.3
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0093: stloc.3
+		IL_0094: ldc.i4.1
+		IL_0095: newarr [System.Runtime]System.Object
+		IL_009a: dup
+		IL_009b: ldc.i4.0
+		IL_009c: ldloc.0
+		IL_009d: stelem.ref
+		IL_009e: stloc.2
+		IL_009f: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject::.ctor()
+		IL_00a4: ldc.i4.0
+		IL_00a5: conv.r8
+		IL_00a6: ldstr ""
+		IL_00ab: ldc.i4.0
 		IL_00ac: ldc.i4.0
-		IL_00ad: conv.r8
-		IL_00ae: ldstr ""
-		IL_00b3: ldc.i4.0
-		IL_00b4: ldc.i4.0
-		IL_00b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject>(!!0)
-		IL_00bf: stloc.s 6
-		IL_00c1: ldloc.3
-		IL_00c2: ldstr "then"
-		IL_00c7: ldloc.s 6
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ce: pop
-		IL_00cf: ret
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject>(!!0)
+		IL_00b7: stloc.s 5
+		IL_00b9: ldloc.3
+		IL_00ba: ldstr "then"
+		IL_00bf: ldloc.s 5
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c6: pop
+		IL_00c7: ret
 	} // end of method Async_ForAwaitOf_AsyncIterator_BreakCloses::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses
@@ -1404,7 +1399,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27be
+		// Method begins at RVA 0x27b6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x267d
+					// Method begins at RVA 0x2675
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x26e3
+					// Method begins at RVA 0x26db
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -73,7 +73,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2700
+					// Method begins at RVA 0x26f8
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -85,7 +85,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2703
+					// Method begins at RVA 0x26fb
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -100,7 +100,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2706
+					// Method begins at RVA 0x26fe
 					// Header size: 1
 					// Code size: 13 (0xd)
 					.maxstack 8
@@ -125,7 +125,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25b0
+				// Method begins at RVA 0x25a8
 				// Header size: 12
 				// Code size: 125 (0x7d)
 				.maxstack 8
@@ -198,7 +198,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2686
+					// Method begins at RVA 0x267e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -227,7 +227,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x2714
+					// Method begins at RVA 0x270c
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -249,7 +249,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2731
+					// Method begins at RVA 0x2729
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -261,7 +261,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2734
+					// Method begins at RVA 0x272c
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -276,7 +276,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2737
+					// Method begins at RVA 0x272f
 					// Header size: 1
 					// Code size: 13 (0xd)
 					.maxstack 8
@@ -301,7 +301,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2639
+				// Method begins at RVA 0x2631
 				// Header size: 1
 				// Code size: 49 (0x31)
 				.maxstack 8
@@ -336,7 +336,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2674
+				// Method begins at RVA 0x266c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -361,7 +361,7 @@
 					class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x26bc
+				// Method begins at RVA 0x26b4
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -377,7 +377,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x26cb
+				// Method begins at RVA 0x26c3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -389,7 +389,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x26ce
+				// Method begins at RVA 0x26c6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -404,7 +404,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x26d1
+				// Method begins at RVA 0x26c9
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -431,7 +431,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x212c
+			// Method begins at RVA 0x2124
 			// Header size: 12
 			// Code size: 174 (0xae)
 			.maxstack 8
@@ -544,7 +544,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x268f
+				// Method begins at RVA 0x2687
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -572,7 +572,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26aa
+						// Method begins at RVA 0x26a2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -590,7 +590,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26a1
+					// Method begins at RVA 0x2699
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -608,7 +608,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2698
+				// Method begins at RVA 0x2690
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -635,7 +635,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x2745
+				// Method begins at RVA 0x273d
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -654,7 +654,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x275b
+				// Method begins at RVA 0x2753
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -666,7 +666,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x275e
+				// Method begins at RVA 0x2756
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -681,7 +681,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2761
+				// Method begins at RVA 0x2759
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -700,7 +700,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2773
+				// Method begins at RVA 0x276b
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -725,7 +725,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21e8
+			// Method begins at RVA 0x21e0
 			// Header size: 12
 			// Code size: 919 (0x397)
 			.maxstack 8
@@ -1147,7 +1147,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26b3
+				// Method begins at RVA 0x26ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1167,7 +1167,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2781
+				// Method begins at RVA 0x2779
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1180,7 +1180,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2789
+				// Method begins at RVA 0x2781
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1192,7 +1192,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x278c
+				// Method begins at RVA 0x2784
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1207,7 +1207,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x278f
+				// Method begins at RVA 0x2787
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1229,7 +1229,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x258b
+			// Method begins at RVA 0x2583
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -1263,7 +1263,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x266b
+			// Method begins at RVA 0x2663
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1289,7 +1289,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 208 (0xd0)
+		// Code size: 200 (0xc8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope,
@@ -1297,8 +1297,7 @@
 			[2] object[],
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[5] class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22,
-			[6] class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject
+			[5] class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope::.ctor()
@@ -1334,59 +1333,55 @@
 		IL_004c: ldloc.0
 		IL_004d: stelem.ref
 		IL_004e: stloc.2
-		IL_004f: ldloc.2
-		IL_0050: ldc.i4.0
-		IL_0051: ldelem.ref
-		IL_0052: castclass Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope
-		IL_0057: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22::.ctor(class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope)
-		IL_005c: ldc.i4.0
-		IL_005d: conv.r8
-		IL_005e: ldstr ""
-		IL_0063: ldc.i4.0
-		IL_0064: ldc.i4.1
-		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22>(!!0, float64, string, bool, bool)
-		IL_006a: stloc.s 5
-		IL_006c: ldloc.s 5
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22>(!!0)
-		IL_0073: stloc.s 5
-		IL_0075: ldloc.s 4
-		IL_0077: ldloc.3
-		IL_0078: ldloc.s 5
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_007f: pop
-		IL_0080: ldloc.0
-		IL_0081: ldloc.s 4
-		IL_0083: stfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope::iterable
-		IL_0088: nop
-		IL_0089: ldloc.1
-		IL_008a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_0094: stloc.3
-		IL_0095: ldloc.3
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009b: stloc.3
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
-		IL_00a6: stloc.2
-		IL_00a7: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject::.ctor()
+		IL_004f: ldloc.s 4
+		IL_0051: ldloc.3
+		IL_0052: ldloc.2
+		IL_0053: ldc.i4.0
+		IL_0054: ldelem.ref
+		IL_0055: castclass Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope
+		IL_005a: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22::.ctor(class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope)
+		IL_005f: ldc.i4.0
+		IL_0060: conv.r8
+		IL_0061: ldstr ""
+		IL_0066: ldc.i4.0
+		IL_0067: ldc.i4.1
+		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22>(!!0, float64, string, bool, bool)
+		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22>(!!0)
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0077: pop
+		IL_0078: ldloc.0
+		IL_0079: ldloc.s 4
+		IL_007b: stfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope::iterable
+		IL_0080: nop
+		IL_0081: ldloc.1
+		IL_0082: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_008c: stloc.3
+		IL_008d: ldloc.3
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0093: stloc.3
+		IL_0094: ldc.i4.1
+		IL_0095: newarr [System.Runtime]System.Object
+		IL_009a: dup
+		IL_009b: ldc.i4.0
+		IL_009c: ldloc.0
+		IL_009d: stelem.ref
+		IL_009e: stloc.2
+		IL_009f: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject::.ctor()
+		IL_00a4: ldc.i4.0
+		IL_00a5: conv.r8
+		IL_00a6: ldstr ""
+		IL_00ab: ldc.i4.0
 		IL_00ac: ldc.i4.0
-		IL_00ad: conv.r8
-		IL_00ae: ldstr ""
-		IL_00b3: ldc.i4.0
-		IL_00b4: ldc.i4.0
-		IL_00b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject>(!!0)
-		IL_00bf: stloc.s 6
-		IL_00c1: ldloc.3
-		IL_00c2: ldstr "then"
-		IL_00c7: ldloc.s 6
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ce: pop
-		IL_00cf: ret
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject>(!!0)
+		IL_00b7: stloc.s 5
+		IL_00b9: ldloc.3
+		IL_00ba: ldstr "then"
+		IL_00bf: ldloc.s 5
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c6: pop
+		IL_00c7: ret
 	} // end of method Async_ForAwaitOf_SyncIteratorFallback_BreakCloses::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
@@ -1398,7 +1393,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2797
+		// Method begins at RVA 0x278f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_AccessorMethods_InstanceAndStatic.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_AccessorMethods_InstanceAndStatic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x249f
+				// Method begins at RVA 0x2477
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -48,7 +48,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b3
+				// Method begins at RVA 0x248b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24bc
+				// Method begins at RVA 0x2494
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24c5
+				// Method begins at RVA 0x249d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ce
+				// Method begins at RVA 0x24a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x24d7
+				// Method begins at RVA 0x24af
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -149,7 +149,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24e6
+				// Method begins at RVA 0x24be
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24e9
+				// Method begins at RVA 0x24c1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -176,7 +176,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x24ec
+				// Method begins at RVA 0x24c4
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -192,7 +192,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x24f8
+				// Method begins at RVA 0x24d0
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -211,7 +211,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2504
+				// Method begins at RVA 0x24dc
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -224,7 +224,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x250c
+				// Method begins at RVA 0x24e4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -236,7 +236,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x250f
+				// Method begins at RVA 0x24e7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -251,7 +251,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2512
+				// Method begins at RVA 0x24ea
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -278,7 +278,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2536
+				// Method begins at RVA 0x250e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -291,7 +291,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x253e
+				// Method begins at RVA 0x2516
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -303,7 +303,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2541
+				// Method begins at RVA 0x2519
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -318,7 +318,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2544
+				// Method begins at RVA 0x251c
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -348,7 +348,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x256f
+				// Method begins at RVA 0x2547
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -361,7 +361,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2577
+				// Method begins at RVA 0x254f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -373,7 +373,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x257a
+				// Method begins at RVA 0x2552
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -388,7 +388,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x257d
+				// Method begins at RVA 0x2555
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -420,7 +420,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x25a1
+				// Method begins at RVA 0x2579
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -436,7 +436,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x25b0
+				// Method begins at RVA 0x2588
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -448,7 +448,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x25b3
+				// Method begins at RVA 0x258b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -463,7 +463,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x25b6
+				// Method begins at RVA 0x258e
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -489,7 +489,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x25c4
+				// Method begins at RVA 0x259c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -505,7 +505,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x25d3
+				// Method begins at RVA 0x25ab
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -517,7 +517,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x25d6
+				// Method begins at RVA 0x25ae
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -532,7 +532,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x25d9
+				// Method begins at RVA 0x25b1
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -565,7 +565,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2398
+			// Method begins at RVA 0x2370
 			// Header size: 12
 			// Code size: 23 (0x17)
 			.maxstack 8
@@ -592,7 +592,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23bb
+			// Method begins at RVA 0x2393
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -610,7 +610,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23ec
+			// Method begins at RVA 0x23c4
 			// Header size: 12
 			// Code size: 25 (0x19)
 			.maxstack 8
@@ -635,7 +635,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23c4
+			// Method begins at RVA 0x239c
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -665,7 +665,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2414
+			// Method begins at RVA 0x23ec
 			// Header size: 12
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -689,7 +689,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x243c
+			// Method begins at RVA 0x2414
 			// Header size: 12
 			// Code size: 78 (0x4e)
 			.maxstack 8
@@ -731,7 +731,7 @@
 		.method private hidebysig specialname rtspecialname static 
 			void .cctor () cil managed 
 		{
-			// Method begins at RVA 0x2428
+			// Method begins at RVA 0x2400
 			// Header size: 12
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -753,7 +753,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2496
+			// Method begins at RVA 0x246e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -779,7 +779,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 827 (0x33b)
+		// Code size: 787 (0x313)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_AccessorMethods_InstanceAndStatic/Scope,
@@ -788,13 +788,8 @@
 			[3] object[],
 			[4] class [System.Runtime]System.Type,
 			[5] object,
-			[6] class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count,
-			[7] class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count,
-			[8] class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label,
-			[9] class [System.Runtime]System.Type,
-			[10] class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total,
-			[11] class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total,
-			[12] object
+			[6] class [System.Runtime]System.Type,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Scope::.ctor()
@@ -834,29 +829,28 @@
 		IL_0078: stloc.s 5
 		IL_007a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_007f: stloc.3
-		IL_0080: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count::.ctor()
-		IL_0085: ldc.i4.0
-		IL_0086: conv.r8
-		IL_0087: ldstr "get count"
-		IL_008c: ldc.i4.1
-		IL_008d: ldc.i4.1
-		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0, float64, string, bool, bool)
-		IL_0093: stloc.s 6
-		IL_0095: ldloc.s 6
-		IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0)
-		IL_009c: stloc.s 6
-		IL_009e: ldloc.s 5
-		IL_00a0: ldstr "count"
-		IL_00a5: ldloc.s 6
-		IL_00a7: ldnull
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_00ad: pop
-		IL_00ae: ldloc.s 4
-		IL_00b0: ldstr "prototype"
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ba: stloc.s 5
-		IL_00bc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00c1: stloc.3
+		IL_0080: ldloc.s 5
+		IL_0082: ldstr "count"
+		IL_0087: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count::.ctor()
+		IL_008c: ldc.i4.0
+		IL_008d: conv.r8
+		IL_008e: ldstr "get count"
+		IL_0093: ldc.i4.1
+		IL_0094: ldc.i4.1
+		IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0, float64, string, bool, bool)
+		IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0)
+		IL_009f: ldnull
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_00a5: pop
+		IL_00a6: ldloc.s 4
+		IL_00a8: ldstr "prototype"
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b2: stloc.s 5
+		IL_00b4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00b9: stloc.3
+		IL_00ba: ldloc.s 5
+		IL_00bc: ldstr "count"
+		IL_00c1: ldnull
 		IL_00c2: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::.ctor()
 		IL_00c7: ldc.i4.1
 		IL_00c8: conv.r8
@@ -864,204 +858,185 @@
 		IL_00ce: ldc.i4.1
 		IL_00cf: ldc.i4.1
 		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0, float64, string, bool, bool)
-		IL_00d5: stloc.s 7
-		IL_00d7: ldloc.s 7
-		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0)
-		IL_00de: stloc.s 7
-		IL_00e0: ldloc.s 5
-		IL_00e2: ldstr "count"
-		IL_00e7: ldnull
-		IL_00e8: ldloc.s 7
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_00ef: pop
-		IL_00f0: ldloc.s 4
-		IL_00f2: ldstr "prototype"
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fc: stloc.s 5
-		IL_00fe: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0103: stloc.3
-		IL_0104: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label::.ctor()
-		IL_0109: ldc.i4.0
-		IL_010a: conv.r8
-		IL_010b: ldstr "get label"
-		IL_0110: ldc.i4.1
-		IL_0111: ldc.i4.1
-		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0, float64, string, bool, bool)
-		IL_0117: stloc.s 8
-		IL_0119: ldloc.s 8
-		IL_011b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0)
-		IL_0120: stloc.s 8
-		IL_0122: ldloc.s 5
-		IL_0124: ldstr "label"
-		IL_0129: ldloc.s 8
-		IL_012b: ldnull
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_0131: pop
-		IL_0132: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0137: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_013c: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0141: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0146: stloc.s 9
-		IL_0148: ldc.i4.1
-		IL_0149: newarr [System.Runtime]System.Object
-		IL_014e: dup
+		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0)
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_00df: pop
+		IL_00e0: ldloc.s 4
+		IL_00e2: ldstr "prototype"
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ec: stloc.s 5
+		IL_00ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00f3: stloc.3
+		IL_00f4: ldloc.s 5
+		IL_00f6: ldstr "label"
+		IL_00fb: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label::.ctor()
+		IL_0100: ldc.i4.0
+		IL_0101: conv.r8
+		IL_0102: ldstr "get label"
+		IL_0107: ldc.i4.1
+		IL_0108: ldc.i4.1
+		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0, float64, string, bool, bool)
+		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0)
+		IL_0113: ldnull
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0119: pop
+		IL_011a: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_011f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0124: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_0129: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_012e: stloc.s 6
+		IL_0130: ldc.i4.1
+		IL_0131: newarr [System.Runtime]System.Object
+		IL_0136: dup
+		IL_0137: ldc.i4.0
+		IL_0138: ldloc.0
+		IL_0139: stelem.ref
+		IL_013a: stloc.3
+		IL_013b: ldloc.s 6
+		IL_013d: ldstr "total"
+		IL_0142: ldloc.3
+		IL_0143: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::.ctor(object[])
+		IL_0148: ldc.i4.0
+		IL_0149: conv.r8
+		IL_014a: ldstr "get total"
 		IL_014f: ldc.i4.0
-		IL_0150: ldloc.0
-		IL_0151: stelem.ref
-		IL_0152: stloc.3
-		IL_0153: ldloc.3
-		IL_0154: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::.ctor(object[])
-		IL_0159: ldc.i4.0
-		IL_015a: conv.r8
-		IL_015b: ldstr "get total"
-		IL_0160: ldc.i4.0
-		IL_0161: ldc.i4.1
-		IL_0162: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0, float64, string, bool, bool)
-		IL_0167: stloc.s 10
-		IL_0169: ldloc.s 10
-		IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0)
-		IL_0170: stloc.s 10
-		IL_0172: ldloc.s 9
-		IL_0174: ldstr "total"
-		IL_0179: ldloc.s 10
-		IL_017b: ldnull
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_0181: pop
-		IL_0182: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0187: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_018c: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0191: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0196: stloc.s 9
-		IL_0198: ldc.i4.1
-		IL_0199: newarr [System.Runtime]System.Object
-		IL_019e: dup
-		IL_019f: ldc.i4.0
-		IL_01a0: ldloc.0
-		IL_01a1: stelem.ref
-		IL_01a2: stloc.3
-		IL_01a3: ldloc.3
-		IL_01a4: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::.ctor(object[])
-		IL_01a9: ldc.i4.1
-		IL_01aa: conv.r8
-		IL_01ab: ldstr "set total"
-		IL_01b0: ldc.i4.0
-		IL_01b1: ldc.i4.1
-		IL_01b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0, float64, string, bool, bool)
-		IL_01b7: stloc.s 11
-		IL_01b9: ldloc.s 11
-		IL_01bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0)
-		IL_01c0: stloc.s 11
-		IL_01c2: ldloc.s 9
-		IL_01c4: ldstr "total"
-		IL_01c9: ldnull
-		IL_01ca: ldloc.s 11
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_01d1: pop
-		IL_01d2: ldc.i4.1
-		IL_01d3: newarr [System.Runtime]System.Object
-		IL_01d8: dup
-		IL_01d9: ldc.i4.0
-		IL_01da: ldloc.0
-		IL_01db: stelem.ref
-		IL_01dc: stloc.3
-		IL_01dd: ldloc.3
-		IL_01de: ldc.i4.1
-		IL_01df: newarr [System.Runtime]System.Object
-		IL_01e4: dup
-		IL_01e5: ldc.i4.0
-		IL_01e6: ldc.r8 4
-		IL_01ef: box [System.Runtime]System.Double
-		IL_01f4: stelem.ref
-		IL_01f5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_01fa: ldc.r8 4
-		IL_0203: box [System.Runtime]System.Double
-		IL_0208: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::.ctor(object[], object)
-		IL_020d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0212: stloc.2
-		IL_0213: ldloc.2
-		IL_0214: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0219: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_021e: ldstr "prototype"
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0228: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_022d: ldstr "console"
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023c: stloc.s 5
-		IL_023e: ldloc.2
-		IL_023f: ldstr "count"
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0249: stloc.s 12
-		IL_024b: ldloc.s 5
-		IL_024d: ldstr "log"
-		IL_0252: ldloc.s 12
-		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0259: pop
-		IL_025a: ldloc.2
-		IL_025b: ldstr "count"
-		IL_0260: ldc.r8 10
-		IL_0269: ldc.i4.1
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_026f: pop
-		IL_0270: ldstr "console"
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027f: stloc.s 12
-		IL_0281: ldloc.2
-		IL_0282: ldstr "count"
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_028c: stloc.s 5
-		IL_028e: ldloc.s 12
-		IL_0290: ldstr "log"
-		IL_0295: ldloc.s 5
-		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_029c: pop
-		IL_029d: ldstr "console"
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ac: stloc.s 5
-		IL_02ae: ldloc.2
-		IL_02af: ldstr "label"
-		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b9: stloc.s 12
-		IL_02bb: ldloc.s 5
-		IL_02bd: ldstr "log"
-		IL_02c2: ldloc.s 12
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c9: pop
-		IL_02ca: ldstr "console"
-		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d9: stloc.s 12
-		IL_02db: ldloc.1
-		IL_02dc: ldstr "total"
-		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e6: stloc.s 5
-		IL_02e8: ldloc.s 12
-		IL_02ea: ldstr "log"
-		IL_02ef: ldloc.s 5
-		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02f6: pop
-		IL_02f7: ldloc.1
-		IL_02f8: ldstr "total"
-		IL_02fd: ldc.r8 5
-		IL_0306: ldc.i4.1
-		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_030c: pop
-		IL_030d: ldstr "console"
-		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_031c: stloc.s 5
-		IL_031e: ldloc.1
-		IL_031f: ldstr "total"
-		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0329: stloc.s 12
-		IL_032b: ldloc.s 5
-		IL_032d: ldstr "log"
-		IL_0332: ldloc.s 12
-		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0339: pop
-		IL_033a: ret
+		IL_0150: ldc.i4.1
+		IL_0151: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0, float64, string, bool, bool)
+		IL_0156: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0)
+		IL_015b: ldnull
+		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0161: pop
+		IL_0162: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_0167: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_016c: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_0171: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0176: stloc.s 6
+		IL_0178: ldc.i4.1
+		IL_0179: newarr [System.Runtime]System.Object
+		IL_017e: dup
+		IL_017f: ldc.i4.0
+		IL_0180: ldloc.0
+		IL_0181: stelem.ref
+		IL_0182: stloc.3
+		IL_0183: ldloc.s 6
+		IL_0185: ldstr "total"
+		IL_018a: ldnull
+		IL_018b: ldloc.3
+		IL_018c: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::.ctor(object[])
+		IL_0191: ldc.i4.1
+		IL_0192: conv.r8
+		IL_0193: ldstr "set total"
+		IL_0198: ldc.i4.0
+		IL_0199: ldc.i4.1
+		IL_019a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0, float64, string, bool, bool)
+		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0)
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_01a9: pop
+		IL_01aa: ldc.i4.1
+		IL_01ab: newarr [System.Runtime]System.Object
+		IL_01b0: dup
+		IL_01b1: ldc.i4.0
+		IL_01b2: ldloc.0
+		IL_01b3: stelem.ref
+		IL_01b4: stloc.3
+		IL_01b5: ldloc.3
+		IL_01b6: ldc.i4.1
+		IL_01b7: newarr [System.Runtime]System.Object
+		IL_01bc: dup
+		IL_01bd: ldc.i4.0
+		IL_01be: ldc.r8 4
+		IL_01c7: box [System.Runtime]System.Double
+		IL_01cc: stelem.ref
+		IL_01cd: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_01d2: ldc.r8 4
+		IL_01db: box [System.Runtime]System.Double
+		IL_01e0: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::.ctor(object[], object)
+		IL_01e5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_01ea: stloc.2
+		IL_01eb: ldloc.2
+		IL_01ec: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_01f1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_01f6: ldstr "prototype"
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0200: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0205: ldstr "console"
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0214: stloc.s 5
+		IL_0216: ldloc.2
+		IL_0217: ldstr "count"
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0221: stloc.s 7
+		IL_0223: ldloc.s 5
+		IL_0225: ldstr "log"
+		IL_022a: ldloc.s 7
+		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0231: pop
+		IL_0232: ldloc.2
+		IL_0233: ldstr "count"
+		IL_0238: ldc.r8 10
+		IL_0241: ldc.i4.1
+		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0247: pop
+		IL_0248: ldstr "console"
+		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0257: stloc.s 7
+		IL_0259: ldloc.2
+		IL_025a: ldstr "count"
+		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0264: stloc.s 5
+		IL_0266: ldloc.s 7
+		IL_0268: ldstr "log"
+		IL_026d: ldloc.s 5
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0274: pop
+		IL_0275: ldstr "console"
+		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0284: stloc.s 5
+		IL_0286: ldloc.2
+		IL_0287: ldstr "label"
+		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0291: stloc.s 7
+		IL_0293: ldloc.s 5
+		IL_0295: ldstr "log"
+		IL_029a: ldloc.s 7
+		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a1: pop
+		IL_02a2: ldstr "console"
+		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b1: stloc.s 7
+		IL_02b3: ldloc.1
+		IL_02b4: ldstr "total"
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02be: stloc.s 5
+		IL_02c0: ldloc.s 7
+		IL_02c2: ldstr "log"
+		IL_02c7: ldloc.s 5
+		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ce: pop
+		IL_02cf: ldloc.1
+		IL_02d0: ldstr "total"
+		IL_02d5: ldc.r8 5
+		IL_02de: ldc.i4.1
+		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_02e4: pop
+		IL_02e5: ldstr "console"
+		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f4: stloc.s 5
+		IL_02f6: ldloc.1
+		IL_02f7: ldstr "total"
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0301: stloc.s 7
+		IL_0303: ldloc.s 5
+		IL_0305: ldstr "log"
+		IL_030a: ldloc.s 7
+		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0311: pop
+		IL_0312: ret
 	} // end of method Classes_AccessorMethods_InstanceAndStatic::__js_module_init__
 
 } // end of class Modules.Classes_AccessorMethods_InstanceAndStatic
@@ -1073,7 +1048,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25ee
+		// Method begins at RVA 0x25c6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DeclarationOrder.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DeclarationOrder.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21eb
+				// Method begins at RVA 0x21e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f4
+				// Method begins at RVA 0x21ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x21fd
+				// Method begins at RVA 0x21f5
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x220c
+				// Method begins at RVA 0x2204
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x220f
+				// Method begins at RVA 0x2207
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2212
+				// Method begins at RVA 0x220a
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x221e
+				// Method begins at RVA 0x2216
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222a
+				// Method begins at RVA 0x2222
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2232
+				// Method begins at RVA 0x222a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2235
+				// Method begins at RVA 0x222d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2238
+				// Method begins at RVA 0x2230
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -214,7 +214,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2180
+			// Method begins at RVA 0x2178
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -244,7 +244,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21b8
+			// Method begins at RVA 0x21b0
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -274,7 +274,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e2
+			// Method begins at RVA 0x21da
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -300,7 +300,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 289 (0x121)
+		// Code size: 281 (0x119)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Scope,
@@ -309,9 +309,8 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method,
-			[7] object,
-			[8] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
+			[6] object,
+			[7] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Scope::.ctor()
@@ -328,86 +327,82 @@
 		IL_0027: stloc.s 4
 		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002e: stloc.s 5
-		IL_0030: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method::.ctor()
-		IL_0035: ldc.i4.0
-		IL_0036: conv.r8
-		IL_0037: ldstr "method"
-		IL_003c: ldc.i4.1
-		IL_003d: ldc.i4.1
-		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0, float64, string, bool, bool)
-		IL_0043: stloc.s 6
-		IL_0045: ldloc.s 6
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0)
-		IL_004c: stloc.s 6
-		IL_004e: ldloc.s 4
-		IL_0050: ldstr "method"
-		IL_0055: ldloc.s 6
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005c: pop
-		IL_005d: ldc.i4.1
-		IL_005e: newarr [System.Runtime]System.Object
-		IL_0063: dup
-		IL_0064: ldc.i4.0
-		IL_0065: ldloc.0
-		IL_0066: stelem.ref
-		IL_0067: stloc.s 5
-		IL_0069: ldloc.3
-		IL_006a: ldloc.s 5
-		IL_006c: ldc.r8 0.0
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007f: stloc.s 4
-		IL_0081: ldloc.s 4
-		IL_0083: stloc.1
-		IL_0084: ldc.i4.1
-		IL_0085: newarr [System.Runtime]System.Object
-		IL_008a: dup
-		IL_008b: ldc.i4.0
-		IL_008c: ldloc.0
-		IL_008d: stelem.ref
-		IL_008e: stloc.s 5
-		IL_0090: ldloc.s 5
-		IL_0092: ldc.i4.0
-		IL_0093: newarr [System.Runtime]System.Object
-		IL_0098: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_009d: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::.ctor(object[])
-		IL_00a2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00a7: stloc.2
-		IL_00a8: ldloc.2
-		IL_00a9: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
-		IL_00ae: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00b3: ldstr "prototype"
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00bd: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00c2: ldstr "console"
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d1: stloc.s 4
-		IL_00d3: ldloc.2
-		IL_00d4: ldstr "field"
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00de: stloc.s 7
-		IL_00e0: ldloc.s 4
-		IL_00e2: ldstr "log"
-		IL_00e7: ldloc.s 7
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ee: pop
-		IL_00ef: ldstr "console"
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0030: ldloc.s 4
+		IL_0032: ldstr "method"
+		IL_0037: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method::.ctor()
+		IL_003c: ldc.i4.0
+		IL_003d: conv.r8
+		IL_003e: ldstr "method"
+		IL_0043: ldc.i4.1
+		IL_0044: ldc.i4.1
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0)
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0054: pop
+		IL_0055: ldc.i4.1
+		IL_0056: newarr [System.Runtime]System.Object
+		IL_005b: dup
+		IL_005c: ldc.i4.0
+		IL_005d: ldloc.0
+		IL_005e: stelem.ref
+		IL_005f: stloc.s 5
+		IL_0061: ldloc.3
+		IL_0062: ldloc.s 5
+		IL_0064: ldc.r8 0.0
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.s 4
+		IL_007b: stloc.1
+		IL_007c: ldc.i4.1
+		IL_007d: newarr [System.Runtime]System.Object
+		IL_0082: dup
+		IL_0083: ldc.i4.0
+		IL_0084: ldloc.0
+		IL_0085: stelem.ref
+		IL_0086: stloc.s 5
+		IL_0088: ldloc.s 5
+		IL_008a: ldc.i4.0
+		IL_008b: newarr [System.Runtime]System.Object
+		IL_0090: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0095: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::.ctor(object[])
+		IL_009a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_009f: stloc.2
+		IL_00a0: ldloc.2
+		IL_00a1: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
+		IL_00a6: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00ab: ldstr "prototype"
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00b5: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00ba: ldstr "console"
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c9: stloc.s 4
+		IL_00cb: ldloc.2
+		IL_00cc: ldstr "field"
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d6: stloc.s 6
+		IL_00d8: ldloc.s 4
+		IL_00da: ldstr "log"
+		IL_00df: ldloc.s 6
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e6: pop
+		IL_00e7: ldstr "console"
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f6: stloc.s 6
+		IL_00f8: ldloc.2
+		IL_00f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example>(!!0)
 		IL_00fe: stloc.s 7
-		IL_0100: ldloc.2
-		IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example>(!!0)
-		IL_0106: stloc.s 8
-		IL_0108: ldloc.s 8
-		IL_010a: callvirt instance object Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::'method'()
-		IL_010f: stloc.s 4
-		IL_0111: ldloc.s 7
-		IL_0113: ldstr "log"
-		IL_0118: ldloc.s 4
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011f: pop
-		IL_0120: ret
+		IL_0100: ldloc.s 7
+		IL_0102: callvirt instance object Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::'method'()
+		IL_0107: stloc.s 4
+		IL_0109: ldloc.s 6
+		IL_010b: ldstr "log"
+		IL_0110: ldloc.s 4
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0117: pop
+		IL_0118: ret
 	} // end of method Classes_ClassComputedFieldAndMethod_DeclarationOrder::__js_module_init__
 
 } // end of class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder
@@ -419,7 +414,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x225c
+		// Method begins at RVA 0x2254
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
@@ -23,7 +23,7 @@
 					class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22ce
+				// Method begins at RVA 0x22c6
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -39,7 +39,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22dd
+				// Method begins at RVA 0x22d5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22e0
+				// Method begins at RVA 0x22d8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -66,7 +66,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22e3
+				// Method begins at RVA 0x22db
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -93,7 +93,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x221c
+			// Method begins at RVA 0x2214
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -128,7 +128,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228f
+				// Method begins at RVA 0x2287
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -148,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2298
+				// Method begins at RVA 0x2290
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -173,7 +173,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22a1
+				// Method begins at RVA 0x2299
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -189,7 +189,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22b0
+				// Method begins at RVA 0x22a8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -201,7 +201,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22b3
+				// Method begins at RVA 0x22ab
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -216,7 +216,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22b6
+				// Method begins at RVA 0x22ae
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -232,7 +232,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22c2
+				// Method begins at RVA 0x22ba
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -257,7 +257,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2250
+			// Method begins at RVA 0x2248
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -290,7 +290,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2286
+			// Method begins at RVA 0x227e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -316,7 +316,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 448 (0x1c0)
+		// Code size: 440 (0x1b8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope,
@@ -325,11 +325,10 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14,
-			[7] object,
-			[8] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example,
-			[9] bool,
-			[10] object
+			[6] object,
+			[7] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example,
+			[8] bool,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::.ctor()
@@ -351,133 +350,129 @@
 		IL_0031: ldloc.0
 		IL_0032: stelem.ref
 		IL_0033: stloc.s 5
-		IL_0035: ldloc.s 5
-		IL_0037: ldc.i4.0
-		IL_0038: ldelem.ref
-		IL_0039: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
-		IL_003e: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14::.ctor(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope)
-		IL_0043: ldc.i4.0
-		IL_0044: conv.r8
-		IL_0045: ldstr ""
-		IL_004a: ldc.i4.1
-		IL_004b: ldc.i4.1
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14>(!!0, float64, string, bool, bool)
-		IL_0051: stloc.s 6
-		IL_0053: ldloc.s 6
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14>(!!0)
-		IL_005a: stloc.s 6
-		IL_005c: ldloc.s 4
-		IL_005e: ldstr "bump"
-		IL_0063: ldloc.s 6
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_006a: pop
-		IL_006b: ldc.i4.1
-		IL_006c: newarr [System.Runtime]System.Object
-		IL_0071: dup
-		IL_0072: ldc.i4.0
-		IL_0073: ldloc.0
-		IL_0074: stelem.ref
-		IL_0075: stloc.s 5
-		IL_0077: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_007c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0081: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_0086: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_008b: stloc.3
-		IL_008c: ldloc.3
-		IL_008d: ldloc.s 5
-		IL_008f: ldc.r8 0.0
-		IL_0098: box [System.Runtime]System.Double
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00a2: stloc.s 4
-		IL_00a4: ldloc.s 4
-		IL_00a6: stloc.1
-		IL_00a7: ldc.i4.1
-		IL_00a8: newarr [System.Runtime]System.Object
-		IL_00ad: dup
-		IL_00ae: ldc.i4.0
-		IL_00af: ldloc.0
-		IL_00b0: stelem.ref
-		IL_00b1: stloc.s 5
-		IL_00b3: ldloc.s 5
-		IL_00b5: ldc.i4.0
-		IL_00b6: newarr [System.Runtime]System.Object
-		IL_00bb: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00c0: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example::.ctor(object[])
-		IL_00c5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00ca: stloc.2
-		IL_00cb: ldloc.2
-		IL_00cc: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_00d1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00d6: ldstr "prototype"
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00e0: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00e5: ldstr "console"
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f4: stloc.s 4
-		IL_00f6: ldloc.2
-		IL_00f7: ldstr "value"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0101: stloc.s 7
-		IL_0103: ldloc.s 4
-		IL_0105: ldstr "log"
-		IL_010a: ldloc.s 7
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0111: pop
-		IL_0112: ldstr "console"
-		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0035: ldloc.s 4
+		IL_0037: ldstr "bump"
+		IL_003c: ldloc.s 5
+		IL_003e: ldc.i4.0
+		IL_003f: ldelem.ref
+		IL_0040: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
+		IL_0045: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14::.ctor(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope)
+		IL_004a: ldc.i4.0
+		IL_004b: conv.r8
+		IL_004c: ldstr ""
+		IL_0051: ldc.i4.1
+		IL_0052: ldc.i4.1
+		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14>(!!0, float64, string, bool, bool)
+		IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14>(!!0)
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0062: pop
+		IL_0063: ldc.i4.1
+		IL_0064: newarr [System.Runtime]System.Object
+		IL_0069: dup
+		IL_006a: ldc.i4.0
+		IL_006b: ldloc.0
+		IL_006c: stelem.ref
+		IL_006d: stloc.s 5
+		IL_006f: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_0074: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0079: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_007e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0083: stloc.3
+		IL_0084: ldloc.3
+		IL_0085: ldloc.s 5
+		IL_0087: ldc.r8 0.0
+		IL_0090: box [System.Runtime]System.Double
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_009a: stloc.s 4
+		IL_009c: ldloc.s 4
+		IL_009e: stloc.1
+		IL_009f: ldc.i4.1
+		IL_00a0: newarr [System.Runtime]System.Object
+		IL_00a5: dup
+		IL_00a6: ldc.i4.0
+		IL_00a7: ldloc.0
+		IL_00a8: stelem.ref
+		IL_00a9: stloc.s 5
+		IL_00ab: ldloc.s 5
+		IL_00ad: ldc.i4.0
+		IL_00ae: newarr [System.Runtime]System.Object
+		IL_00b3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00b8: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example::.ctor(object[])
+		IL_00bd: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00c2: stloc.2
+		IL_00c3: ldloc.2
+		IL_00c4: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_00c9: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00ce: ldstr "prototype"
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00d8: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00dd: ldstr "console"
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ec: stloc.s 4
+		IL_00ee: ldloc.2
+		IL_00ef: ldstr "value"
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f9: stloc.s 6
+		IL_00fb: ldloc.s 4
+		IL_00fd: ldstr "log"
+		IL_0102: ldloc.s 6
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0109: pop
+		IL_010a: ldstr "console"
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0119: stloc.s 6
+		IL_011b: ldloc.2
+		IL_011c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example>(!!0)
 		IL_0121: stloc.s 7
-		IL_0123: ldloc.2
-		IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example>(!!0)
-		IL_0129: stloc.s 8
-		IL_012b: ldc.i4.0
-		IL_012c: newarr [System.Runtime]System.Object
-		IL_0131: stloc.s 5
-		IL_0133: ldloc.s 8
-		IL_0135: ldstr "bump"
-		IL_013a: ldloc.s 5
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0141: stloc.s 4
-		IL_0143: ldloc.s 7
-		IL_0145: ldstr "log"
-		IL_014a: ldloc.s 4
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0151: pop
-		IL_0152: ldstr "console"
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0161: stloc.s 4
-		IL_0163: ldloc.2
-		IL_0164: ldstr "value"
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_016e: stloc.s 7
-		IL_0170: ldloc.s 4
-		IL_0172: ldstr "log"
-		IL_0177: ldloc.s 7
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017e: pop
-		IL_017f: ldstr "console"
-		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018e: stloc.s 7
-		IL_0190: ldloc.2
-		IL_0191: ldstr "fieldKey"
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_019b: stloc.s 4
-		IL_019d: ldloc.s 4
-		IL_019f: ldnull
-		IL_01a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01a5: stloc.s 9
-		IL_01a7: ldloc.s 9
-		IL_01a9: box [System.Runtime]System.Boolean
-		IL_01ae: stloc.s 10
-		IL_01b0: ldloc.s 7
-		IL_01b2: ldstr "log"
-		IL_01b7: ldloc.s 10
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01be: pop
-		IL_01bf: ret
+		IL_0123: ldc.i4.0
+		IL_0124: newarr [System.Runtime]System.Object
+		IL_0129: stloc.s 5
+		IL_012b: ldloc.s 7
+		IL_012d: ldstr "bump"
+		IL_0132: ldloc.s 5
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0139: stloc.s 4
+		IL_013b: ldloc.s 6
+		IL_013d: ldstr "log"
+		IL_0142: ldloc.s 4
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0149: pop
+		IL_014a: ldstr "console"
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0159: stloc.s 4
+		IL_015b: ldloc.2
+		IL_015c: ldstr "value"
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0166: stloc.s 6
+		IL_0168: ldloc.s 4
+		IL_016a: ldstr "log"
+		IL_016f: ldloc.s 6
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0176: pop
+		IL_0177: ldstr "console"
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0186: stloc.s 6
+		IL_0188: ldloc.2
+		IL_0189: ldstr "fieldKey"
+		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0193: stloc.s 4
+		IL_0195: ldloc.s 4
+		IL_0197: ldnull
+		IL_0198: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_019d: stloc.s 8
+		IL_019f: ldloc.s 8
+		IL_01a1: box [System.Runtime]System.Boolean
+		IL_01a6: stloc.s 9
+		IL_01a8: ldloc.s 6
+		IL_01aa: ldstr "log"
+		IL_01af: ldloc.s 9
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b6: pop
+		IL_01b7: ret
 	} // end of method Classes_ClassComputedFieldAndMethod_DynamicKey_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log
@@ -489,7 +484,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22f5
+		// Method begins at RVA 0x22ed
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassExpression_LazyPrototypeMetadata.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassExpression_LazyPrototypeMetadata.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22aa
+				// Method begins at RVA 0x22a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b3
+				// Method begins at RVA 0x22ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22bc
+				// Method begins at RVA 0x22b4
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22cb
+				// Method begins at RVA 0x22c3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22ce
+				// Method begins at RVA 0x22c6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22d1
+				// Method begins at RVA 0x22c9
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22dd
+				// Method begins at RVA 0x22d5
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e9
+				// Method begins at RVA 0x22e1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22f1
+				// Method begins at RVA 0x22e9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22f4
+				// Method begins at RVA 0x22ec
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22f7
+				// Method begins at RVA 0x22ef
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -209,7 +209,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2292
+			// Method begins at RVA 0x228a
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -225,7 +225,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x229a
+			// Method begins at RVA 0x2292
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -243,7 +243,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22a1
+			// Method begins at RVA 0x2299
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -269,7 +269,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 566 (0x236)
+		// Code size: 558 (0x22e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassExpression_LazyPrototypeMetadata/Scope,
@@ -279,12 +279,11 @@
 			[4] class [System.Runtime]System.Type,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet,
+			[7] object,
 			[8] object,
-			[9] object,
-			[10] bool,
-			[11] object,
-			[12] string
+			[9] bool,
+			[10] object,
+			[11] string
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -310,156 +309,152 @@
 		IL_0050: stloc.s 5
 		IL_0052: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0057: stloc.s 6
-		IL_0059: newobj instance void Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::.ctor()
-		IL_005e: ldc.i4.0
-		IL_005f: conv.r8
-		IL_0060: ldstr "greet"
+		IL_0059: ldloc.s 5
+		IL_005b: ldstr "greet"
+		IL_0060: newobj instance void Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::.ctor()
 		IL_0065: ldc.i4.0
-		IL_0066: ldc.i4.1
-		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0, float64, string, bool, bool)
-		IL_006c: stloc.s 7
-		IL_006e: ldloc.s 7
-		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0)
-		IL_0075: stloc.s 7
-		IL_0077: ldloc.s 5
-		IL_0079: ldstr "greet"
-		IL_007e: ldloc.s 7
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0085: pop
-		IL_0086: ldc.i4.1
-		IL_0087: newarr [System.Runtime]System.Object
-		IL_008c: dup
-		IL_008d: ldc.i4.0
-		IL_008e: ldloc.0
-		IL_008f: stelem.ref
-		IL_0090: stloc.s 6
-		IL_0092: ldloc.s 4
-		IL_0094: ldloc.s 6
-		IL_0096: ldc.r8 0.0
-		IL_009f: box [System.Runtime]System.Double
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
-		IL_00a9: stloc.s 5
-		IL_00ab: ldloc.s 5
-		IL_00ad: ldstr "Greeter"
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
-		IL_00b7: stloc.s 5
-		IL_00b9: ldloc.s 5
-		IL_00bb: ldstr "Greeter"
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
-		IL_00c5: stloc.2
-		IL_00c6: ldloc.2
-		IL_00c7: ldc.i4.0
-		IL_00c8: newarr [System.Runtime]System.Object
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_00d2: stloc.3
-		IL_00d3: ldstr "console"
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0066: conv.r8
+		IL_0067: ldstr "greet"
+		IL_006c: ldc.i4.0
+		IL_006d: ldc.i4.1
+		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0, float64, string, bool, bool)
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0)
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_007d: pop
+		IL_007e: ldc.i4.1
+		IL_007f: newarr [System.Runtime]System.Object
+		IL_0084: dup
+		IL_0085: ldc.i4.0
+		IL_0086: ldloc.0
+		IL_0087: stelem.ref
+		IL_0088: stloc.s 6
+		IL_008a: ldloc.s 4
+		IL_008c: ldloc.s 6
+		IL_008e: ldc.r8 0.0
+		IL_0097: box [System.Runtime]System.Double
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
+		IL_00a1: stloc.s 5
+		IL_00a3: ldloc.s 5
+		IL_00a5: ldstr "Greeter"
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
+		IL_00af: stloc.s 5
+		IL_00b1: ldloc.s 5
+		IL_00b3: ldstr "Greeter"
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
+		IL_00bd: stloc.2
+		IL_00be: ldloc.2
+		IL_00bf: ldc.i4.0
+		IL_00c0: newarr [System.Runtime]System.Object
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_00ca: stloc.3
+		IL_00cb: ldstr "console"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00da: stloc.s 5
+		IL_00dc: ldloc.3
 		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e2: stloc.s 5
-		IL_00e4: ldloc.3
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ea: stloc.s 8
-		IL_00ec: ldloc.s 8
-		IL_00ee: isinst Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
-		IL_00f3: dup
-		IL_00f4: brfalse IL_0105
+		IL_00e2: stloc.s 7
+		IL_00e4: ldloc.s 7
+		IL_00e6: isinst Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
+		IL_00eb: dup
+		IL_00ec: brfalse IL_00fd
 
-		IL_00f9: callvirt instance object Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17::greet()
-		IL_00fe: stloc.s 8
-		IL_0100: br IL_0114
+		IL_00f1: callvirt instance object Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17::greet()
+		IL_00f6: stloc.s 7
+		IL_00f8: br IL_010c
 
-		IL_0105: pop
-		IL_0106: ldloc.s 8
-		IL_0108: ldstr "greet"
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0112: stloc.s 8
+		IL_00fd: pop
+		IL_00fe: ldloc.s 7
+		IL_0100: ldstr "greet"
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_010a: stloc.s 7
 
-		IL_0114: ldloc.s 5
-		IL_0116: ldstr "log"
-		IL_011b: ldloc.s 8
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0122: pop
-		IL_0123: ldstr "console"
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0132: stloc.s 8
-		IL_0134: ldloc.3
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_013a: stloc.s 5
-		IL_013c: ldloc.2
-		IL_013d: ldstr "prototype"
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0147: stloc.s 9
-		IL_0149: ldloc.s 5
-		IL_014b: ldloc.s 9
-		IL_014d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0152: stloc.s 10
-		IL_0154: ldloc.s 10
-		IL_0156: box [System.Runtime]System.Boolean
-		IL_015b: stloc.s 11
-		IL_015d: ldloc.s 8
-		IL_015f: ldstr "log"
-		IL_0164: ldloc.s 11
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016b: pop
-		IL_016c: ldstr "console"
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017b: stloc.s 8
-		IL_017d: ldloc.2
-		IL_017e: ldstr "prototype"
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0188: stloc.s 9
-		IL_018a: ldloc.s 9
-		IL_018c: ldstr "greet"
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0196: stloc.s 9
-		IL_0198: ldloc.s 9
-		IL_019a: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_019f: stloc.s 12
-		IL_01a1: ldloc.s 8
-		IL_01a3: ldstr "log"
-		IL_01a8: ldloc.s 12
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01af: pop
-		IL_01b0: ldstr "console"
-		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bf: stloc.s 8
-		IL_01c1: ldloc.2
-		IL_01c2: ldstr "prototype"
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01cc: stloc.s 9
-		IL_01ce: ldloc.s 9
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_01d5: ldstr "length"
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01df: stloc.s 9
-		IL_01e1: ldloc.s 8
-		IL_01e3: ldstr "log"
-		IL_01e8: ldloc.s 9
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ef: pop
-		IL_01f0: ldstr "console"
-		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ff: stloc.s 9
-		IL_0201: ldloc.2
-		IL_0202: ldstr "prototype"
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_020c: stloc.s 8
-		IL_020e: ldloc.s 8
-		IL_0210: ldstr "greet"
-		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_021a: ldstr "enumerable"
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0224: stloc.s 8
-		IL_0226: ldloc.s 9
-		IL_0228: ldstr "log"
-		IL_022d: ldloc.s 8
-		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0234: pop
-		IL_0235: ret
+		IL_010c: ldloc.s 5
+		IL_010e: ldstr "log"
+		IL_0113: ldloc.s 7
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011a: pop
+		IL_011b: ldstr "console"
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012a: stloc.s 7
+		IL_012c: ldloc.3
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0132: stloc.s 5
+		IL_0134: ldloc.2
+		IL_0135: ldstr "prototype"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013f: stloc.s 8
+		IL_0141: ldloc.s 5
+		IL_0143: ldloc.s 8
+		IL_0145: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_014a: stloc.s 9
+		IL_014c: ldloc.s 9
+		IL_014e: box [System.Runtime]System.Boolean
+		IL_0153: stloc.s 10
+		IL_0155: ldloc.s 7
+		IL_0157: ldstr "log"
+		IL_015c: ldloc.s 10
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0163: pop
+		IL_0164: ldstr "console"
+		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0173: stloc.s 7
+		IL_0175: ldloc.2
+		IL_0176: ldstr "prototype"
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0180: stloc.s 8
+		IL_0182: ldloc.s 8
+		IL_0184: ldstr "greet"
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018e: stloc.s 8
+		IL_0190: ldloc.s 8
+		IL_0192: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0197: stloc.s 11
+		IL_0199: ldloc.s 7
+		IL_019b: ldstr "log"
+		IL_01a0: ldloc.s 11
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a7: pop
+		IL_01a8: ldstr "console"
+		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b7: stloc.s 7
+		IL_01b9: ldloc.2
+		IL_01ba: ldstr "prototype"
+		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c4: stloc.s 8
+		IL_01c6: ldloc.s 8
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_01cd: ldstr "length"
+		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d7: stloc.s 8
+		IL_01d9: ldloc.s 7
+		IL_01db: ldstr "log"
+		IL_01e0: ldloc.s 8
+		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e7: pop
+		IL_01e8: ldstr "console"
+		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f7: stloc.s 8
+		IL_01f9: ldloc.2
+		IL_01fa: ldstr "prototype"
+		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0204: stloc.s 7
+		IL_0206: ldloc.s 7
+		IL_0208: ldstr "greet"
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0212: ldstr "enumerable"
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_021c: stloc.s 7
+		IL_021e: ldloc.s 8
+		IL_0220: ldstr "log"
+		IL_0225: ldloc.s 7
+		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_022c: pop
+		IL_022d: ret
 	} // end of method Classes_ClassExpression_LazyPrototypeMetadata::__js_module_init__
 
 } // end of class Modules.Classes_ClassExpression_LazyPrototypeMetadata
@@ -471,7 +466,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x231b
+		// Method begins at RVA 0x2313
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassFieldTypeInference_Primitives.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassFieldTypeInference_Primitives.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2213
+				// Method begins at RVA 0x220b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x221c
+				// Method begins at RVA 0x2214
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2225
+				// Method begins at RVA 0x221d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x222e
+				// Method begins at RVA 0x2226
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x223d
+				// Method begins at RVA 0x2235
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2240
+				// Method begins at RVA 0x2238
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2243
+				// Method begins at RVA 0x223b
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -142,7 +142,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x224f
+				// Method begins at RVA 0x2247
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x225b
+				// Method begins at RVA 0x2253
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -174,7 +174,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2263
+				// Method begins at RVA 0x225b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -186,7 +186,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2266
+				// Method begins at RVA 0x225e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -201,7 +201,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2269
+				// Method begins at RVA 0x2261
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -234,7 +234,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21b8
+			// Method begins at RVA 0x21b0
 			// Header size: 1
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -259,7 +259,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21e4
+			// Method begins at RVA 0x21dc
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -288,7 +288,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x220a
+			// Method begins at RVA 0x2202
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,7 +314,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 348 (0x15c)
+		// Code size: 340 (0x154)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassFieldTypeInference_Primitives/Scope,
@@ -323,9 +323,8 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment,
-			[7] class Modules.Classes_ClassFieldTypeInference_Primitives/Counter,
-			[8] object
+			[6] class Modules.Classes_ClassFieldTypeInference_Primitives/Counter,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Scope::.ctor()
@@ -342,101 +341,97 @@
 		IL_0027: stloc.s 4
 		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002e: stloc.s 5
-		IL_0030: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment::.ctor()
-		IL_0035: ldc.i4.0
-		IL_0036: conv.r8
-		IL_0037: ldstr "increment"
-		IL_003c: ldc.i4.1
-		IL_003d: ldc.i4.1
-		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0, float64, string, bool, bool)
-		IL_0043: stloc.s 6
-		IL_0045: ldloc.s 6
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0)
-		IL_004c: stloc.s 6
-		IL_004e: ldloc.s 4
-		IL_0050: ldstr "increment"
-		IL_0055: ldloc.s 6
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005c: pop
-		IL_005d: ldc.i4.1
-		IL_005e: newarr [System.Runtime]System.Object
-		IL_0063: dup
-		IL_0064: ldc.i4.0
-		IL_0065: ldloc.0
-		IL_0066: stelem.ref
-		IL_0067: stloc.s 5
-		IL_0069: ldloc.3
-		IL_006a: ldloc.s 5
-		IL_006c: ldc.r8 0.0
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007f: stloc.s 4
-		IL_0081: ldloc.s 4
-		IL_0083: stloc.1
-		IL_0084: ldc.i4.0
-		IL_0085: newarr [System.Runtime]System.Object
-		IL_008a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_008f: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter::.ctor()
-		IL_0094: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0099: stloc.2
-		IL_009a: ldloc.2
-		IL_009b: ldtoken Modules.Classes_ClassFieldTypeInference_Primitives/Counter
-		IL_00a0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00a5: ldstr "prototype"
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00af: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00b4: ldloc.2
-		IL_00b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter>(!!0)
-		IL_00ba: stloc.s 7
-		IL_00bc: ldloc.s 7
-		IL_00be: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
-		IL_00c3: pop
-		IL_00c4: ldloc.2
-		IL_00c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter>(!!0)
-		IL_00ca: stloc.s 7
-		IL_00cc: ldloc.s 7
-		IL_00ce: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
-		IL_00d3: pop
-		IL_00d4: ldstr "console"
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e3: stloc.s 4
-		IL_00e5: ldloc.2
-		IL_00e6: ldstr "value"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f0: stloc.s 8
-		IL_00f2: ldloc.s 4
-		IL_00f4: ldstr "log"
-		IL_00f9: ldloc.s 8
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0100: pop
-		IL_0101: ldstr "console"
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0110: stloc.s 8
-		IL_0112: ldloc.2
-		IL_0113: ldstr "name"
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_011d: stloc.s 4
-		IL_011f: ldloc.s 8
-		IL_0121: ldstr "log"
-		IL_0126: ldloc.s 4
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012d: pop
-		IL_012e: ldstr "console"
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013d: stloc.s 4
-		IL_013f: ldloc.2
-		IL_0140: ldstr "active"
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_014a: stloc.s 8
-		IL_014c: ldloc.s 4
-		IL_014e: ldstr "log"
-		IL_0153: ldloc.s 8
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015a: pop
-		IL_015b: ret
+		IL_0030: ldloc.s 4
+		IL_0032: ldstr "increment"
+		IL_0037: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment::.ctor()
+		IL_003c: ldc.i4.0
+		IL_003d: conv.r8
+		IL_003e: ldstr "increment"
+		IL_0043: ldc.i4.1
+		IL_0044: ldc.i4.1
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0)
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0054: pop
+		IL_0055: ldc.i4.1
+		IL_0056: newarr [System.Runtime]System.Object
+		IL_005b: dup
+		IL_005c: ldc.i4.0
+		IL_005d: ldloc.0
+		IL_005e: stelem.ref
+		IL_005f: stloc.s 5
+		IL_0061: ldloc.3
+		IL_0062: ldloc.s 5
+		IL_0064: ldc.r8 0.0
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.s 4
+		IL_007b: stloc.1
+		IL_007c: ldc.i4.0
+		IL_007d: newarr [System.Runtime]System.Object
+		IL_0082: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0087: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter::.ctor()
+		IL_008c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0091: stloc.2
+		IL_0092: ldloc.2
+		IL_0093: ldtoken Modules.Classes_ClassFieldTypeInference_Primitives/Counter
+		IL_0098: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_009d: ldstr "prototype"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00a7: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00ac: ldloc.2
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter>(!!0)
+		IL_00b2: stloc.s 6
+		IL_00b4: ldloc.s 6
+		IL_00b6: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
+		IL_00bb: pop
+		IL_00bc: ldloc.2
+		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter>(!!0)
+		IL_00c2: stloc.s 6
+		IL_00c4: ldloc.s 6
+		IL_00c6: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
+		IL_00cb: pop
+		IL_00cc: ldstr "console"
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00db: stloc.s 4
+		IL_00dd: ldloc.2
+		IL_00de: ldstr "value"
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e8: stloc.s 7
+		IL_00ea: ldloc.s 4
+		IL_00ec: ldstr "log"
+		IL_00f1: ldloc.s 7
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f8: pop
+		IL_00f9: ldstr "console"
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0108: stloc.s 7
+		IL_010a: ldloc.2
+		IL_010b: ldstr "name"
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0115: stloc.s 4
+		IL_0117: ldloc.s 7
+		IL_0119: ldstr "log"
+		IL_011e: ldloc.s 4
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0125: pop
+		IL_0126: ldstr "console"
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0135: stloc.s 4
+		IL_0137: ldloc.2
+		IL_0138: ldstr "active"
+		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0142: stloc.s 7
+		IL_0144: ldloc.s 4
+		IL_0146: ldstr "log"
+		IL_014b: ldloc.s 7
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0152: pop
+		IL_0153: ret
 	} // end of method Classes_ClassFieldTypeInference_Primitives::__js_module_init__
 
 } // end of class Modules.Classes_ClassFieldTypeInference_Primitives
@@ -448,7 +443,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x228d
+		// Method begins at RVA 0x2285
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassLocal_ReassignedClass_FallsBack.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassLocal_ReassignedClass_FallsBack.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2207
+					// Method begins at RVA 0x21ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2210
+					// Method begins at RVA 0x2208
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fe
+				// Method begins at RVA 0x21f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 					class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x227d
+				// Method begins at RVA 0x2275
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -101,7 +101,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x228c
+				// Method begins at RVA 0x2284
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -113,7 +113,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x228f
+				// Method begins at RVA 0x2287
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -127,7 +127,7 @@
 					object thisArgument
 				) cil managed 
 			{
-				// Method begins at RVA 0x2292
+				// Method begins at RVA 0x228a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -143,7 +143,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x229a
+				// Method begins at RVA 0x2292
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -162,7 +162,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22ac
+				// Method begins at RVA 0x22a4
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -180,7 +180,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22ba
+				// Method begins at RVA 0x22b2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -208,7 +208,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2118
+			// Method begins at RVA 0x2110
 			// Header size: 12
 			// Code size: 154 (0x9a)
 			.maxstack 8
@@ -295,7 +295,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ec
+				// Method begins at RVA 0x21e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -315,7 +315,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f5
+				// Method begins at RVA 0x21ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -340,7 +340,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2219
+				// Method begins at RVA 0x2211
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -356,7 +356,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2228
+				// Method begins at RVA 0x2220
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -368,7 +368,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x222b
+				// Method begins at RVA 0x2223
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -383,7 +383,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x222e
+				// Method begins at RVA 0x2226
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -399,7 +399,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x223a
+				// Method begins at RVA 0x2232
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -418,7 +418,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2246
+				// Method begins at RVA 0x223e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -431,7 +431,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x224e
+				// Method begins at RVA 0x2246
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -443,7 +443,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2251
+				// Method begins at RVA 0x2249
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -458,7 +458,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2254
+				// Method begins at RVA 0x224c
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -487,7 +487,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21db
+			// Method begins at RVA 0x21d3
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -503,7 +503,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d0
+			// Method begins at RVA 0x21c8
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -529,7 +529,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e3
+			// Method begins at RVA 0x21db
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -555,15 +555,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 187 (0xbb)
+		// Code size: 179 (0xb3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope,
 			[1] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test,
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
-			[4] object,
-			[5] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope::.ctor()
@@ -598,45 +597,41 @@
 		IL_004d: stloc.s 4
 		IL_004f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0054: stloc.2
-		IL_0055: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read::.ctor()
-		IL_005a: ldc.i4.0
-		IL_005b: conv.r8
-		IL_005c: ldstr "read"
+		IL_0055: ldloc.s 4
+		IL_0057: ldstr "read"
+		IL_005c: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read::.ctor()
 		IL_0061: ldc.i4.0
-		IL_0062: ldc.i4.1
-		IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0, float64, string, bool, bool)
-		IL_0068: stloc.s 5
-		IL_006a: ldloc.s 5
-		IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0)
-		IL_0071: stloc.s 5
-		IL_0073: ldloc.s 4
-		IL_0075: ldstr "read"
-		IL_007a: ldloc.s 5
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0081: pop
-		IL_0082: ldc.i4.1
-		IL_0083: newarr [System.Runtime]System.Object
-		IL_0088: dup
-		IL_0089: ldc.i4.0
-		IL_008a: ldloc.0
-		IL_008b: stelem.ref
-		IL_008c: stloc.2
-		IL_008d: ldloc.3
-		IL_008e: ldloc.2
-		IL_008f: ldc.r8 0.0
-		IL_0098: box [System.Runtime]System.Double
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00a2: stloc.s 4
-		IL_00a4: ldloc.0
-		IL_00a5: ldloc.s 4
-		IL_00a7: stfld object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope::Box
-		IL_00ac: nop
-		IL_00ad: ldloc.0
-		IL_00ae: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope
-		IL_00b3: ldnull
-		IL_00b4: call object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test::__js_call__(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope, object)
-		IL_00b9: pop
-		IL_00ba: ret
+		IL_0062: conv.r8
+		IL_0063: ldstr "read"
+		IL_0068: ldc.i4.0
+		IL_0069: ldc.i4.1
+		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0, float64, string, bool, bool)
+		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0)
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0079: pop
+		IL_007a: ldc.i4.1
+		IL_007b: newarr [System.Runtime]System.Object
+		IL_0080: dup
+		IL_0081: ldc.i4.0
+		IL_0082: ldloc.0
+		IL_0083: stelem.ref
+		IL_0084: stloc.2
+		IL_0085: ldloc.3
+		IL_0086: ldloc.2
+		IL_0087: ldc.r8 0.0
+		IL_0090: box [System.Runtime]System.Double
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_009a: stloc.s 4
+		IL_009c: ldloc.0
+		IL_009d: ldloc.s 4
+		IL_009f: stfld object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope::Box
+		IL_00a4: nop
+		IL_00a5: ldloc.0
+		IL_00a6: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope
+		IL_00ab: ldnull
+		IL_00ac: call object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test::__js_call__(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope, object)
+		IL_00b1: pop
+		IL_00b2: ret
 	} // end of method Classes_ClassLocal_ReassignedClass_FallsBack::__js_module_init__
 
 } // end of class Modules.Classes_ClassLocal_ReassignedClass_FallsBack
@@ -648,7 +643,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22c9
+		// Method begins at RVA 0x22c1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2284
+				// Method begins at RVA 0x227c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228d
+				// Method begins at RVA 0x2285
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2296
+				// Method begins at RVA 0x228e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22ba
+				// Method begins at RVA 0x22b2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22c9
+				// Method begins at RVA 0x22c1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22cc
+				// Method begins at RVA 0x22c4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22cf
+				// Method begins at RVA 0x22c7
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -142,7 +142,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22db
+				// Method begins at RVA 0x22d3
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e7
+				// Method begins at RVA 0x22df
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -174,7 +174,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22ef
+				// Method begins at RVA 0x22e7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -186,7 +186,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22f2
+				// Method begins at RVA 0x22ea
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -201,7 +201,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22f5
+				// Method begins at RVA 0x22ed
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -233,7 +233,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a7
+			// Method begins at RVA 0x219f
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -252,7 +252,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2250
+			// Method begins at RVA 0x2248
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -286,7 +286,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x229f
+				// Method begins at RVA 0x2297
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -306,7 +306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a8
+				// Method begins at RVA 0x22a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -326,7 +326,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b1
+				// Method begins at RVA 0x22a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -353,7 +353,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x231e
+				// Method begins at RVA 0x2316
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -372,7 +372,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2334
+				// Method begins at RVA 0x232c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -384,7 +384,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2337
+				// Method begins at RVA 0x232f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -399,7 +399,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x233a
+				// Method begins at RVA 0x2332
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -415,7 +415,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2346
+				// Method begins at RVA 0x233e
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -434,7 +434,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2352
+				// Method begins at RVA 0x234a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -447,7 +447,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x235a
+				// Method begins at RVA 0x2352
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -459,7 +459,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x235d
+				// Method begins at RVA 0x2355
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -474,7 +474,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2360
+				// Method begins at RVA 0x2358
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -509,7 +509,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2180
+			// Method begins at RVA 0x2178
 			// Header size: 12
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -537,7 +537,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21c0
+			// Method begins at RVA 0x21b8
 			// Header size: 12
 			// Code size: 129 (0x81)
 			.maxstack 8
@@ -608,7 +608,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x227b
+			// Method begins at RVA 0x2273
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -634,7 +634,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 291 (0x123)
+		// Code size: 283 (0x11b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope,
@@ -643,9 +643,8 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext,
-			[7] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator,
-			[8] float64
+			[6] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator,
+			[7] float64
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope::.ctor()
@@ -662,89 +661,85 @@
 		IL_0027: stloc.s 4
 		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002e: stloc.s 5
-		IL_0030: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext::.ctor()
-		IL_0035: ldc.i4.0
-		IL_0036: conv.r8
-		IL_0037: ldstr "getNext"
-		IL_003c: ldc.i4.1
-		IL_003d: ldc.i4.1
-		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0, float64, string, bool, bool)
-		IL_0043: stloc.s 6
-		IL_0045: ldloc.s 6
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0)
-		IL_004c: stloc.s 6
-		IL_004e: ldloc.s 4
-		IL_0050: ldstr "getNext"
-		IL_0055: ldloc.s 6
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005c: pop
-		IL_005d: ldc.i4.1
-		IL_005e: newarr [System.Runtime]System.Object
-		IL_0063: dup
-		IL_0064: ldc.i4.0
-		IL_0065: ldloc.0
-		IL_0066: stelem.ref
-		IL_0067: stloc.s 5
-		IL_0069: ldloc.3
-		IL_006a: ldloc.s 5
-		IL_006c: ldc.r8 0.0
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007f: stloc.s 4
-		IL_0081: ldloc.0
-		IL_0082: ldloc.s 4
-		IL_0084: stfld object Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope::Counter
-		IL_0089: nop
-		IL_008a: ldc.i4.1
-		IL_008b: newarr [System.Runtime]System.Object
-		IL_0090: dup
-		IL_0091: ldc.i4.0
-		IL_0092: ldloc.0
-		IL_0093: stelem.ref
-		IL_0094: stloc.s 5
-		IL_0096: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
-		IL_009b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00a0: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
-		IL_00a5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00aa: stloc.3
-		IL_00ab: ldc.i4.1
-		IL_00ac: newarr [System.Runtime]System.Object
-		IL_00b1: dup
-		IL_00b2: ldc.i4.0
-		IL_00b3: ldloc.0
-		IL_00b4: stelem.ref
-		IL_00b5: stloc.s 5
-		IL_00b7: ldloc.s 5
-		IL_00b9: ldc.i4.0
-		IL_00ba: newarr [System.Runtime]System.Object
-		IL_00bf: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00c4: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::.ctor(object[])
-		IL_00c9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00ce: stloc.1
-		IL_00cf: ldloc.1
-		IL_00d0: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
-		IL_00d5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00da: ldstr "prototype"
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00e4: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00e9: ldloc.1
-		IL_00ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator>(!!0)
-		IL_00ef: stloc.s 7
-		IL_00f1: ldloc.s 7
-		IL_00f3: callvirt instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::compute()
-		IL_00f8: stloc.s 8
-		IL_00fa: ldloc.s 8
-		IL_00fc: box [System.Runtime]System.Double
-		IL_0101: stloc.2
-		IL_0102: ldstr "console"
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0111: ldstr "log"
-		IL_0116: ldstr "final output:"
-		IL_011b: ldloc.2
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0121: pop
-		IL_0122: ret
+		IL_0030: ldloc.s 4
+		IL_0032: ldstr "getNext"
+		IL_0037: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext::.ctor()
+		IL_003c: ldc.i4.0
+		IL_003d: conv.r8
+		IL_003e: ldstr "getNext"
+		IL_0043: ldc.i4.1
+		IL_0044: ldc.i4.1
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0)
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0054: pop
+		IL_0055: ldc.i4.1
+		IL_0056: newarr [System.Runtime]System.Object
+		IL_005b: dup
+		IL_005c: ldc.i4.0
+		IL_005d: ldloc.0
+		IL_005e: stelem.ref
+		IL_005f: stloc.s 5
+		IL_0061: ldloc.3
+		IL_0062: ldloc.s 5
+		IL_0064: ldc.r8 0.0
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.0
+		IL_007a: ldloc.s 4
+		IL_007c: stfld object Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope::Counter
+		IL_0081: nop
+		IL_0082: ldc.i4.1
+		IL_0083: newarr [System.Runtime]System.Object
+		IL_0088: dup
+		IL_0089: ldc.i4.0
+		IL_008a: ldloc.0
+		IL_008b: stelem.ref
+		IL_008c: stloc.s 5
+		IL_008e: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+		IL_0093: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0098: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+		IL_009d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00a2: stloc.3
+		IL_00a3: ldc.i4.1
+		IL_00a4: newarr [System.Runtime]System.Object
+		IL_00a9: dup
+		IL_00aa: ldc.i4.0
+		IL_00ab: ldloc.0
+		IL_00ac: stelem.ref
+		IL_00ad: stloc.s 5
+		IL_00af: ldloc.s 5
+		IL_00b1: ldc.i4.0
+		IL_00b2: newarr [System.Runtime]System.Object
+		IL_00b7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00bc: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::.ctor(object[])
+		IL_00c1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00c6: stloc.1
+		IL_00c7: ldloc.1
+		IL_00c8: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+		IL_00cd: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00d2: ldstr "prototype"
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00dc: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00e1: ldloc.1
+		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator>(!!0)
+		IL_00e7: stloc.s 6
+		IL_00e9: ldloc.s 6
+		IL_00eb: callvirt instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::compute()
+		IL_00f0: stloc.s 7
+		IL_00f2: ldloc.s 7
+		IL_00f4: box [System.Runtime]System.Double
+		IL_00f9: stloc.2
+		IL_00fa: ldstr "console"
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0109: ldstr "log"
+		IL_010e: ldstr "final output:"
+		IL_0113: ldloc.2
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0119: pop
+		IL_011a: ret
 	} // end of method Classes_ClassMethod_LocalVar_ReassignedFromMethodCall::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall
@@ -756,7 +751,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2389
+		// Method begins at RVA 0x2381
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MethodValueRequiresMetadata.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MethodValueRequiresMetadata.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b2
+				// Method begins at RVA 0x21a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21bb
+				// Method begins at RVA 0x21ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c4
+				// Method begins at RVA 0x21b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x21cd
+				// Method begins at RVA 0x21bd
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x21dc
+				// Method begins at RVA 0x21cc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x21df
+				// Method begins at RVA 0x21cf
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x21e2
+				// Method begins at RVA 0x21d2
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -142,7 +142,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x21ee
+				// Method begins at RVA 0x21de
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fa
+				// Method begins at RVA 0x21ea
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -174,7 +174,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2202
+				// Method begins at RVA 0x21f2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -186,7 +186,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2205
+				// Method begins at RVA 0x21f5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -201,7 +201,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2208
+				// Method begins at RVA 0x21f8
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -228,7 +228,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222c
+				// Method begins at RVA 0x221c
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -241,7 +241,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2234
+				// Method begins at RVA 0x2224
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -253,7 +253,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2237
+				// Method begins at RVA 0x2227
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -268,7 +268,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x223a
+				// Method begins at RVA 0x222a
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -296,7 +296,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x217e
+			// Method begins at RVA 0x216e
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -312,7 +312,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a2
+			// Method begins at RVA 0x2192
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -327,7 +327,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2188
+			// Method begins at RVA 0x2178
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -352,7 +352,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a9
+			// Method begins at RVA 0x2199
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -378,7 +378,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 290 (0x122)
+		// Code size: 274 (0x112)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Scope,
@@ -387,11 +387,9 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet,
-			[7] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet,
-			[8] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter,
-			[9] object,
-			[10] string
+			[6] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter,
+			[7] object,
+			[8] string
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Scope::.ctor()
@@ -407,86 +405,78 @@
 		IL_0026: stloc.s 4
 		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002d: stloc.s 5
-		IL_002f: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet::.ctor()
-		IL_0034: ldc.i4.0
-		IL_0035: conv.r8
-		IL_0036: ldstr "greet"
+		IL_002f: ldloc.s 4
+		IL_0031: ldstr "greet"
+		IL_0036: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet::.ctor()
 		IL_003b: ldc.i4.0
-		IL_003c: ldc.i4.1
-		IL_003d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0, float64, string, bool, bool)
-		IL_0042: stloc.s 6
-		IL_0044: ldloc.s 6
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0)
-		IL_004b: stloc.s 6
-		IL_004d: ldloc.s 4
-		IL_004f: ldstr "greet"
-		IL_0054: ldloc.s 6
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005b: pop
-		IL_005c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0061: stloc.s 5
-		IL_0063: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::.ctor()
-		IL_0068: ldc.i4.0
-		IL_0069: conv.r8
-		IL_006a: ldstr "getGreet"
+		IL_003c: conv.r8
+		IL_003d: ldstr "greet"
+		IL_0042: ldc.i4.0
+		IL_0043: ldc.i4.1
+		IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0)
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0053: pop
+		IL_0054: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0059: stloc.s 5
+		IL_005b: ldloc.s 4
+		IL_005d: ldstr "getGreet"
+		IL_0062: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::.ctor()
+		IL_0067: ldc.i4.0
+		IL_0068: conv.r8
+		IL_0069: ldstr "getGreet"
+		IL_006e: ldc.i4.1
 		IL_006f: ldc.i4.1
-		IL_0070: ldc.i4.1
-		IL_0071: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0, float64, string, bool, bool)
-		IL_0076: stloc.s 7
-		IL_0078: ldloc.s 7
-		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0)
-		IL_007f: stloc.s 7
-		IL_0081: ldloc.s 4
-		IL_0083: ldstr "getGreet"
-		IL_0088: ldloc.s 7
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_008f: pop
-		IL_0090: ldc.i4.1
-		IL_0091: newarr [System.Runtime]System.Object
-		IL_0096: dup
-		IL_0097: ldc.i4.0
-		IL_0098: ldloc.0
-		IL_0099: stelem.ref
-		IL_009a: stloc.s 5
-		IL_009c: ldloc.3
-		IL_009d: ldloc.s 5
-		IL_009f: ldc.r8 0.0
-		IL_00a8: box [System.Runtime]System.Double
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00b2: stloc.s 4
-		IL_00b4: ldloc.s 4
-		IL_00b6: stloc.1
-		IL_00b7: ldc.i4.0
-		IL_00b8: newarr [System.Runtime]System.Object
-		IL_00bd: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00c2: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::.ctor()
-		IL_00c7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00cc: stloc.2
-		IL_00cd: ldloc.2
-		IL_00ce: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
-		IL_00d3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00d8: ldstr "prototype"
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00e2: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00e7: ldstr "console"
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f6: stloc.s 4
-		IL_00f8: ldloc.2
-		IL_00f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter>(!!0)
-		IL_00fe: stloc.s 8
-		IL_0100: ldloc.s 8
-		IL_0102: callvirt instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::getGreet()
-		IL_0107: stloc.s 9
-		IL_0109: ldloc.s 9
-		IL_010b: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0110: stloc.s 10
-		IL_0112: ldloc.s 4
-		IL_0114: ldstr "log"
-		IL_0119: ldloc.s 10
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0120: pop
-		IL_0121: ret
+		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0, float64, string, bool, bool)
+		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0)
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_007f: pop
+		IL_0080: ldc.i4.1
+		IL_0081: newarr [System.Runtime]System.Object
+		IL_0086: dup
+		IL_0087: ldc.i4.0
+		IL_0088: ldloc.0
+		IL_0089: stelem.ref
+		IL_008a: stloc.s 5
+		IL_008c: ldloc.3
+		IL_008d: ldloc.s 5
+		IL_008f: ldc.r8 0.0
+		IL_0098: box [System.Runtime]System.Double
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00a2: stloc.s 4
+		IL_00a4: ldloc.s 4
+		IL_00a6: stloc.1
+		IL_00a7: ldc.i4.0
+		IL_00a8: newarr [System.Runtime]System.Object
+		IL_00ad: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00b2: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::.ctor()
+		IL_00b7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00bc: stloc.2
+		IL_00bd: ldloc.2
+		IL_00be: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
+		IL_00c3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00c8: ldstr "prototype"
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00d2: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00d7: ldstr "console"
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e6: stloc.s 4
+		IL_00e8: ldloc.2
+		IL_00e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter>(!!0)
+		IL_00ee: stloc.s 6
+		IL_00f0: ldloc.s 6
+		IL_00f2: callvirt instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::getGreet()
+		IL_00f7: stloc.s 7
+		IL_00f9: ldloc.s 7
+		IL_00fb: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0100: stloc.s 8
+		IL_0102: ldloc.s 4
+		IL_0104: ldstr "log"
+		IL_0109: ldloc.s 8
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0110: pop
+		IL_0111: ret
 	} // end of method Classes_ClassMethod_MethodValueRequiresMetadata::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_MethodValueRequiresMetadata
@@ -498,7 +488,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x225e
+		// Method begins at RVA 0x224e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_ClassExpression_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_ClassExpression_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ee
+				// Method begins at RVA 0x21de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f7
+				// Method begins at RVA 0x21e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2200
+				// Method begins at RVA 0x21f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 					class [System.Runtime]System.Object capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x2209
+				// Method begins at RVA 0x21f9
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -104,7 +104,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x221f
+				// Method begins at RVA 0x220f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -116,7 +116,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2222
+				// Method begins at RVA 0x2212
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -131,7 +131,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2225
+				// Method begins at RVA 0x2215
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -147,7 +147,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2231
+				// Method begins at RVA 0x2221
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x223d
+				// Method begins at RVA 0x222d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -179,7 +179,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2245
+				// Method begins at RVA 0x2235
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2248
+				// Method begins at RVA 0x2238
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -206,7 +206,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x224b
+				// Method begins at RVA 0x223b
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -239,7 +239,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2274
+				// Method begins at RVA 0x2264
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -255,7 +255,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2283
+				// Method begins at RVA 0x2273
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -267,7 +267,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2286
+				// Method begins at RVA 0x2276
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -282,7 +282,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2289
+				// Method begins at RVA 0x2279
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -311,7 +311,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x219a
+			// Method begins at RVA 0x218a
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -327,7 +327,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a2
+			// Method begins at RVA 0x2192
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -342,7 +342,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21b0
+			// Method begins at RVA 0x21a0
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -374,7 +374,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e5
+			// Method begins at RVA 0x21d5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -400,7 +400,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 318 (0x13e)
+		// Code size: 302 (0x12e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/Scope,
@@ -408,9 +408,7 @@
 			[2] object,
 			[3] class [System.Runtime]System.Type,
 			[4] object,
-			[5] object[],
-			[6] class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value,
-			[7] class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/Scope::.ctor()
@@ -436,91 +434,83 @@
 		IL_0048: stloc.s 4
 		IL_004a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_004f: stloc.s 5
-		IL_0051: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::.ctor()
-		IL_0056: ldc.i4.0
-		IL_0057: conv.r8
-		IL_0058: ldstr "get value"
+		IL_0051: ldloc.s 4
+		IL_0053: ldstr "value"
+		IL_0058: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::.ctor()
 		IL_005d: ldc.i4.0
-		IL_005e: ldc.i4.1
-		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0, float64, string, bool, bool)
-		IL_0064: stloc.s 6
-		IL_0066: ldloc.s 6
-		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0)
-		IL_006d: stloc.s 6
-		IL_006f: ldloc.s 4
-		IL_0071: ldstr "value"
-		IL_0076: ldloc.s 6
-		IL_0078: ldnull
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_007e: pop
-		IL_007f: ldloc.3
-		IL_0080: ldstr "prototype"
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_008a: stloc.s 4
-		IL_008c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0091: stloc.s 5
-		IL_0093: ldloc.3
-		IL_0094: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::.ctor(class [System.Runtime]System.Object)
-		IL_0099: ldc.i4.0
-		IL_009a: conv.r8
-		IL_009b: ldstr "log"
+		IL_005e: conv.r8
+		IL_005f: ldstr "get value"
+		IL_0064: ldc.i4.0
+		IL_0065: ldc.i4.1
+		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0, float64, string, bool, bool)
+		IL_006b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0)
+		IL_0070: ldnull
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0076: pop
+		IL_0077: ldloc.3
+		IL_0078: ldstr "prototype"
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0082: stloc.s 4
+		IL_0084: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0089: stloc.s 5
+		IL_008b: ldloc.s 4
+		IL_008d: ldstr "log"
+		IL_0092: ldloc.3
+		IL_0093: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::.ctor(class [System.Runtime]System.Object)
+		IL_0098: ldc.i4.0
+		IL_0099: conv.r8
+		IL_009a: ldstr "log"
+		IL_009f: ldc.i4.1
 		IL_00a0: ldc.i4.1
-		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0, float64, string, bool, bool)
-		IL_00a7: stloc.s 7
-		IL_00a9: ldloc.s 7
-		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0)
-		IL_00b0: stloc.s 7
-		IL_00b2: ldloc.s 4
-		IL_00b4: ldstr "log"
-		IL_00b9: ldloc.s 7
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00c0: pop
-		IL_00c1: ldc.i4.1
-		IL_00c2: newarr [System.Runtime]System.Object
-		IL_00c7: dup
-		IL_00c8: ldc.i4.0
-		IL_00c9: ldloc.0
-		IL_00ca: stelem.ref
-		IL_00cb: stloc.s 5
-		IL_00cd: ldloc.3
-		IL_00ce: ldloc.s 5
-		IL_00d0: ldc.r8 0.0
-		IL_00d9: box [System.Runtime]System.Double
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
-		IL_00e3: stloc.s 4
-		IL_00e5: ldloc.s 4
-		IL_00e7: ldstr "Counter"
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
-		IL_00f1: stloc.s 4
-		IL_00f3: ldloc.s 4
-		IL_00f5: ldstr "Counter"
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
-		IL_00ff: stloc.2
-		IL_0100: ldloc.2
-		IL_0101: ldc.i4.0
-		IL_0102: newarr [System.Runtime]System.Object
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_010c: stloc.s 4
-		IL_010e: ldloc.s 4
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0115: stloc.s 4
-		IL_0117: ldloc.s 4
-		IL_0119: isinst Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-		IL_011e: dup
-		IL_011f: brfalse IL_012f
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0, float64, string, bool, bool)
+		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0)
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00b0: pop
+		IL_00b1: ldc.i4.1
+		IL_00b2: newarr [System.Runtime]System.Object
+		IL_00b7: dup
+		IL_00b8: ldc.i4.0
+		IL_00b9: ldloc.0
+		IL_00ba: stelem.ref
+		IL_00bb: stloc.s 5
+		IL_00bd: ldloc.3
+		IL_00be: ldloc.s 5
+		IL_00c0: ldc.r8 0.0
+		IL_00c9: box [System.Runtime]System.Double
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
+		IL_00d3: stloc.s 4
+		IL_00d5: ldloc.s 4
+		IL_00d7: ldstr "Counter"
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
+		IL_00e1: stloc.s 4
+		IL_00e3: ldloc.s 4
+		IL_00e5: ldstr "Counter"
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
+		IL_00ef: stloc.2
+		IL_00f0: ldloc.2
+		IL_00f1: ldc.i4.0
+		IL_00f2: newarr [System.Runtime]System.Object
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_00fc: stloc.s 4
+		IL_00fe: ldloc.s 4
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0105: stloc.s 4
+		IL_0107: ldloc.s 4
+		IL_0109: isinst Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
+		IL_010e: dup
+		IL_010f: brfalse IL_011f
 
-		IL_0124: callvirt instance object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::log()
-		IL_0129: pop
-		IL_012a: br IL_013d
+		IL_0114: callvirt instance object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::log()
+		IL_0119: pop
+		IL_011a: br IL_012d
 
-		IL_012f: pop
-		IL_0130: ldloc.s 4
-		IL_0132: ldstr "log"
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_013c: pop
+		IL_011f: pop
+		IL_0120: ldloc.s 4
+		IL_0122: ldstr "log"
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_012c: pop
 
-		IL_013d: ret
+		IL_012d: ret
 	} // end of method Classes_ClassPrivateAccessor_ClassExpression_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log
@@ -532,7 +522,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22b2
+		// Method begins at RVA 0x22a2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x234b
+				// Method begins at RVA 0x2333
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2354
+				// Method begins at RVA 0x233c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x235d
+				// Method begins at RVA 0x2345
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x236f
+					// Method begins at RVA 0x2357
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2378
+					// Method begins at RVA 0x2360
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2366
+				// Method begins at RVA 0x234e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -147,7 +147,7 @@
 					class [System.Runtime]System.Object capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x2381
+				// Method begins at RVA 0x2369
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2397
+				// Method begins at RVA 0x237f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -178,7 +178,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x239a
+				// Method begins at RVA 0x2382
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -193,7 +193,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x239d
+				// Method begins at RVA 0x2385
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -209,7 +209,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x23a9
+				// Method begins at RVA 0x2391
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -228,7 +228,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b5
+				// Method begins at RVA 0x239d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -241,7 +241,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23bd
+				// Method begins at RVA 0x23a5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -253,7 +253,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23c0
+				// Method begins at RVA 0x23a8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -268,7 +268,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23c3
+				// Method begins at RVA 0x23ab
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -296,7 +296,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ec
+				// Method begins at RVA 0x23d4
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -309,7 +309,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23f4
+				// Method begins at RVA 0x23dc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -321,7 +321,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23f7
+				// Method begins at RVA 0x23df
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -336,7 +336,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23fa
+				// Method begins at RVA 0x23e2
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -371,7 +371,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2425
+				// Method begins at RVA 0x240d
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -387,7 +387,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2434
+				// Method begins at RVA 0x241c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -399,7 +399,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2437
+				// Method begins at RVA 0x241f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -414,7 +414,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x243a
+				// Method begins at RVA 0x2422
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -446,7 +446,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21bc
+			// Method begins at RVA 0x21a4
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -462,7 +462,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21ac
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -479,7 +479,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2338
+			// Method begins at RVA 0x2320
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -497,7 +497,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d0
+			// Method begins at RVA 0x21b8
 			// Header size: 12
 			// Code size: 330 (0x14a)
 			.maxstack 8
@@ -638,7 +638,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2342
+			// Method begins at RVA 0x232a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -664,7 +664,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 352 (0x160)
+		// Code size: 328 (0x148)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/Scope,
@@ -672,10 +672,7 @@
 			[2] class [System.Runtime]System.Type,
 			[3] object,
 			[4] object[],
-			[5] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly,
-			[6] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly,
-			[7] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log,
-			[8] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+			[5] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/Scope::.ctor()
@@ -692,115 +689,103 @@
 		IL_0027: stloc.3
 		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002d: stloc.s 4
-		IL_002f: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::.ctor()
-		IL_0034: ldc.i4.0
-		IL_0035: conv.r8
-		IL_0036: ldstr "get readOnly"
-		IL_003b: ldc.i4.0
-		IL_003c: ldc.i4.1
-		IL_003d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0, float64, string, bool, bool)
-		IL_0042: stloc.s 5
-		IL_0044: ldloc.s 5
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0)
-		IL_004b: stloc.s 5
-		IL_004d: ldloc.3
-		IL_004e: ldstr "readOnly"
-		IL_0053: ldloc.s 5
-		IL_0055: ldnull
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_005b: pop
-		IL_005c: ldloc.2
-		IL_005d: ldstr "prototype"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0067: stloc.3
-		IL_0068: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006d: stloc.s 4
-		IL_006f: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::.ctor()
-		IL_0074: ldc.i4.1
-		IL_0075: conv.r8
-		IL_0076: ldstr "set writeOnly"
+		IL_002f: ldloc.3
+		IL_0030: ldstr "readOnly"
+		IL_0035: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::.ctor()
+		IL_003a: ldc.i4.0
+		IL_003b: conv.r8
+		IL_003c: ldstr "get readOnly"
+		IL_0041: ldc.i4.0
+		IL_0042: ldc.i4.1
+		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0, float64, string, bool, bool)
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0)
+		IL_004d: ldnull
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0053: pop
+		IL_0054: ldloc.2
+		IL_0055: ldstr "prototype"
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_005f: stloc.3
+		IL_0060: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0065: stloc.s 4
+		IL_0067: ldloc.3
+		IL_0068: ldstr "writeOnly"
+		IL_006d: ldnull
+		IL_006e: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::.ctor()
+		IL_0073: ldc.i4.1
+		IL_0074: conv.r8
+		IL_0075: ldstr "set writeOnly"
+		IL_007a: ldc.i4.1
 		IL_007b: ldc.i4.1
-		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0, float64, string, bool, bool)
-		IL_0082: stloc.s 6
-		IL_0084: ldloc.s 6
-		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0)
-		IL_008b: stloc.s 6
-		IL_008d: ldloc.3
-		IL_008e: ldstr "writeOnly"
-		IL_0093: ldnull
-		IL_0094: ldloc.s 6
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_009b: pop
-		IL_009c: ldloc.2
-		IL_009d: ldstr "prototype"
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a7: stloc.3
-		IL_00a8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ad: stloc.s 4
-		IL_00af: ldloc.2
-		IL_00b0: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log::.ctor(class [System.Runtime]System.Object)
-		IL_00b5: ldc.i4.0
-		IL_00b6: conv.r8
-		IL_00b7: ldstr "log"
-		IL_00bc: ldc.i4.1
-		IL_00bd: ldc.i4.1
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0, float64, string, bool, bool)
-		IL_00c3: stloc.s 7
-		IL_00c5: ldloc.s 7
-		IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0)
-		IL_00cc: stloc.s 7
-		IL_00ce: ldloc.3
-		IL_00cf: ldstr "log"
-		IL_00d4: ldloc.s 7
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00db: pop
-		IL_00dc: ldc.i4.1
-		IL_00dd: newarr [System.Runtime]System.Object
-		IL_00e2: dup
-		IL_00e3: ldc.i4.0
-		IL_00e4: ldloc.0
-		IL_00e5: stelem.ref
-		IL_00e6: stloc.s 4
-		IL_00e8: ldloc.2
-		IL_00e9: ldloc.s 4
-		IL_00eb: ldc.r8 0.0
-		IL_00f4: box [System.Runtime]System.Double
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00fe: stloc.3
-		IL_00ff: ldloc.3
-		IL_0100: stloc.1
-		IL_0101: ldc.i4.0
-		IL_0102: newarr [System.Runtime]System.Object
-		IL_0107: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_010c: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::.ctor()
-		IL_0111: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0116: stloc.s 8
-		IL_0118: ldloc.s 8
-		IL_011a: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_011f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0124: ldstr "prototype"
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_012e: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0133: ldloc.s 8
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013a: stloc.3
+		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0, float64, string, bool, bool)
+		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0)
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_008b: pop
+		IL_008c: ldloc.2
+		IL_008d: ldstr "prototype"
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0097: stloc.3
+		IL_0098: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_009d: stloc.s 4
+		IL_009f: ldloc.3
+		IL_00a0: ldstr "log"
+		IL_00a5: ldloc.2
+		IL_00a6: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log::.ctor(class [System.Runtime]System.Object)
+		IL_00ab: ldc.i4.0
+		IL_00ac: conv.r8
+		IL_00ad: ldstr "log"
+		IL_00b2: ldc.i4.1
+		IL_00b3: ldc.i4.1
+		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0, float64, string, bool, bool)
+		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0)
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00c3: pop
+		IL_00c4: ldc.i4.1
+		IL_00c5: newarr [System.Runtime]System.Object
+		IL_00ca: dup
+		IL_00cb: ldc.i4.0
+		IL_00cc: ldloc.0
+		IL_00cd: stelem.ref
+		IL_00ce: stloc.s 4
+		IL_00d0: ldloc.2
+		IL_00d1: ldloc.s 4
+		IL_00d3: ldc.r8 0.0
+		IL_00dc: box [System.Runtime]System.Double
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00e6: stloc.3
+		IL_00e7: ldloc.3
+		IL_00e8: stloc.1
+		IL_00e9: ldc.i4.0
+		IL_00ea: newarr [System.Runtime]System.Object
+		IL_00ef: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00f4: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::.ctor()
+		IL_00f9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00fe: stloc.s 5
+		IL_0100: ldloc.s 5
+		IL_0102: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+		IL_0107: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_010c: ldstr "prototype"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0116: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_011b: ldloc.s 5
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0122: stloc.3
+		IL_0123: ldloc.3
+		IL_0124: isinst Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+		IL_0129: dup
+		IL_012a: brfalse IL_013a
+
+		IL_012f: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::log()
+		IL_0134: pop
+		IL_0135: br IL_0147
+
+		IL_013a: pop
 		IL_013b: ldloc.3
-		IL_013c: isinst Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_0141: dup
-		IL_0142: brfalse IL_0152
+		IL_013c: ldstr "log"
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0146: pop
 
-		IL_0147: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::log()
-		IL_014c: pop
-		IL_014d: br IL_015f
-
-		IL_0152: pop
-		IL_0153: ldloc.3
-		IL_0154: ldstr "log"
-		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_015e: pop
-
-		IL_015f: ret
+		IL_0147: ret
 	} // end of method Classes_ClassPrivateAccessor_EdgeCases_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log
@@ -812,7 +797,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2463
+		// Method begins at RVA 0x244b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2183
+				// Method begins at RVA 0x217b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x218c
+				// Method begins at RVA 0x2184
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 					class [System.Runtime]System.Object capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x2195
+				// Method begins at RVA 0x218d
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -84,7 +84,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x21ab
+				// Method begins at RVA 0x21a3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -96,7 +96,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x21ae
+				// Method begins at RVA 0x21a6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -111,7 +111,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x21b1
+				// Method begins at RVA 0x21a9
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -127,7 +127,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x21bd
+				// Method begins at RVA 0x21b5
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -151,7 +151,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x21c9
+				// Method begins at RVA 0x21c1
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -167,7 +167,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x21d8
+				// Method begins at RVA 0x21d0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -179,7 +179,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x21db
+				// Method begins at RVA 0x21d3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -194,7 +194,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x21de
+				// Method begins at RVA 0x21d6
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -229,7 +229,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2130
+			// Method begins at RVA 0x2128
 			// Header size: 12
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -256,7 +256,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2157
+			// Method begins at RVA 0x214f
 			// Header size: 1
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -282,7 +282,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217a
+			// Method begins at RVA 0x2172
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -308,7 +308,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 212 (0xd4)
+		// Code size: 204 (0xcc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Scope,
@@ -317,8 +317,7 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret,
-			[7] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
+			[6] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Scope::.ctor()
@@ -335,65 +334,61 @@
 		IL_0027: stloc.s 4
 		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002e: stloc.s 5
-		IL_0030: ldloc.3
-		IL_0031: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret::.ctor(class [System.Runtime]System.Object)
-		IL_0036: ldc.i4.0
-		IL_0037: conv.r8
-		IL_0038: ldstr "logSecret"
-		IL_003d: ldc.i4.1
-		IL_003e: ldc.i4.1
-		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0, float64, string, bool, bool)
-		IL_0044: stloc.s 6
-		IL_0046: ldloc.s 6
-		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0)
-		IL_004d: stloc.s 6
-		IL_004f: ldloc.s 4
-		IL_0051: ldstr "logSecret"
-		IL_0056: ldloc.s 6
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005d: pop
-		IL_005e: ldc.i4.1
-		IL_005f: newarr [System.Runtime]System.Object
-		IL_0064: dup
-		IL_0065: ldc.i4.0
-		IL_0066: ldloc.0
-		IL_0067: stelem.ref
-		IL_0068: stloc.s 5
-		IL_006a: ldloc.3
-		IL_006b: ldloc.s 5
-		IL_006d: ldc.r8 0.0
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0080: stloc.s 4
-		IL_0082: ldloc.s 4
-		IL_0084: stloc.1
-		IL_0085: ldc.i4.1
-		IL_0086: newarr [System.Runtime]System.Object
-		IL_008b: dup
-		IL_008c: ldc.i4.0
-		IL_008d: ldloc.0
-		IL_008e: stelem.ref
-		IL_008f: stloc.s 5
-		IL_0091: ldloc.s 5
-		IL_0093: ldc.i4.0
-		IL_0094: newarr [System.Runtime]System.Object
-		IL_0099: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_009e: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::.ctor(object[])
-		IL_00a3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00a8: stloc.2
-		IL_00a9: ldloc.2
-		IL_00aa: ldtoken Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
-		IL_00af: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00b4: ldstr "prototype"
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00be: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00c3: ldloc.2
-		IL_00c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter>(!!0)
-		IL_00c9: stloc.s 7
-		IL_00cb: ldloc.s 7
-		IL_00cd: callvirt instance object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::logSecret()
-		IL_00d2: pop
-		IL_00d3: ret
+		IL_0030: ldloc.s 4
+		IL_0032: ldstr "logSecret"
+		IL_0037: ldloc.3
+		IL_0038: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret::.ctor(class [System.Runtime]System.Object)
+		IL_003d: ldc.i4.0
+		IL_003e: conv.r8
+		IL_003f: ldstr "logSecret"
+		IL_0044: ldc.i4.1
+		IL_0045: ldc.i4.1
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0, float64, string, bool, bool)
+		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0)
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0055: pop
+		IL_0056: ldc.i4.1
+		IL_0057: newarr [System.Runtime]System.Object
+		IL_005c: dup
+		IL_005d: ldc.i4.0
+		IL_005e: ldloc.0
+		IL_005f: stelem.ref
+		IL_0060: stloc.s 5
+		IL_0062: ldloc.3
+		IL_0063: ldloc.s 5
+		IL_0065: ldc.r8 0.0
+		IL_006e: box [System.Runtime]System.Double
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0078: stloc.s 4
+		IL_007a: ldloc.s 4
+		IL_007c: stloc.1
+		IL_007d: ldc.i4.1
+		IL_007e: newarr [System.Runtime]System.Object
+		IL_0083: dup
+		IL_0084: ldc.i4.0
+		IL_0085: ldloc.0
+		IL_0086: stelem.ref
+		IL_0087: stloc.s 5
+		IL_0089: ldloc.s 5
+		IL_008b: ldc.i4.0
+		IL_008c: newarr [System.Runtime]System.Object
+		IL_0091: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0096: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::.ctor(object[])
+		IL_009b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00a0: stloc.2
+		IL_00a1: ldloc.2
+		IL_00a2: ldtoken Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
+		IL_00a7: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00ac: ldstr "prototype"
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00b6: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00bb: ldloc.2
+		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter>(!!0)
+		IL_00c1: stloc.s 6
+		IL_00c3: ldloc.s 6
+		IL_00c5: callvirt instance object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::logSecret()
+		IL_00ca: pop
+		IL_00cb: ret
 	} // end of method Classes_ClassPrivateField_HelperMethod_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateField_HelperMethod_Log
@@ -405,7 +400,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2207
+		// Method begins at RVA 0x21ff
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2381
+				// Method begins at RVA 0x2361
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x238a
+				// Method begins at RVA 0x236a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2393
+				// Method begins at RVA 0x2373
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x239c
+				// Method begins at RVA 0x237c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a5
+				// Method begins at RVA 0x2385
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -125,7 +125,7 @@
 					class [System.Runtime]System.Object capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x23ae
+				// Method begins at RVA 0x238e
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -144,7 +144,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23c4
+				// Method begins at RVA 0x23a4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -156,7 +156,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23c7
+				// Method begins at RVA 0x23a7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -171,7 +171,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23ca
+				// Method begins at RVA 0x23aa
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -187,7 +187,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x23d6
+				// Method begins at RVA 0x23b6
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -211,7 +211,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x23e2
+				// Method begins at RVA 0x23c2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -227,7 +227,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23f1
+				// Method begins at RVA 0x23d1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23f4
+				// Method begins at RVA 0x23d4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -254,7 +254,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23f7
+				// Method begins at RVA 0x23d7
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -287,7 +287,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2420
+				// Method begins at RVA 0x2400
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -303,7 +303,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x242f
+				// Method begins at RVA 0x240f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -315,7 +315,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2432
+				// Method begins at RVA 0x2412
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -330,7 +330,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2435
+				// Method begins at RVA 0x2415
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -363,7 +363,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x245e
+				// Method begins at RVA 0x243e
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -379,7 +379,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x246d
+				// Method begins at RVA 0x244d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -391,7 +391,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2470
+				// Method begins at RVA 0x2450
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -406,7 +406,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2473
+				// Method begins at RVA 0x2453
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -442,7 +442,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x24a3
+				// Method begins at RVA 0x2483
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -458,7 +458,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24b2
+				// Method begins at RVA 0x2492
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -470,7 +470,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24b5
+				// Method begins at RVA 0x2495
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -485,7 +485,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x24b8
+				// Method begins at RVA 0x2498
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -520,7 +520,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2270
+			// Method begins at RVA 0x2250
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -548,7 +548,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22d6
+			// Method begins at RVA 0x22b6
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -568,7 +568,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a0
+			// Method begins at RVA 0x2280
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -601,7 +601,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x236e
+			// Method begins at RVA 0x234e
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -619,7 +619,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22f4
+			// Method begins at RVA 0x22d4
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -673,7 +673,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2378
+			// Method begins at RVA 0x2358
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -699,7 +699,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 532 (0x214)
+		// Code size: 500 (0x1f4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Scope,
@@ -708,12 +708,8 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double,
-			[7] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret,
-			[8] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret,
-			[9] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log,
-			[10] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter,
-			[11] object
+			[6] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Scope::.ctor()
@@ -730,168 +726,152 @@
 		IL_0027: stloc.s 4
 		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002e: stloc.s 5
-		IL_0030: ldloc.3
-		IL_0031: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::.ctor(class [System.Runtime]System.Object)
-		IL_0036: ldc.i4.0
-		IL_0037: conv.r8
-		IL_0038: ldstr "#double"
-		IL_003d: ldc.i4.1
-		IL_003e: ldc.i4.1
-		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0, float64, string, bool, bool)
-		IL_0044: stloc.s 6
-		IL_0046: ldloc.s 6
-		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0)
-		IL_004d: stloc.s 6
-		IL_004f: ldloc.s 4
-		IL_0051: ldstr "__jroc_priv_method_double"
-		IL_0056: ldloc.s 6
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005d: pop
-		IL_005e: ldloc.3
-		IL_005f: ldstr "prototype"
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0069: stloc.s 4
-		IL_006b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0070: stloc.s 5
-		IL_0072: ldloc.3
-		IL_0073: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::.ctor(class [System.Runtime]System.Object)
-		IL_0078: ldc.i4.0
-		IL_0079: conv.r8
-		IL_007a: ldstr "get secret"
+		IL_0030: ldloc.s 4
+		IL_0032: ldstr "__jroc_priv_method_double"
+		IL_0037: ldloc.3
+		IL_0038: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::.ctor(class [System.Runtime]System.Object)
+		IL_003d: ldc.i4.0
+		IL_003e: conv.r8
+		IL_003f: ldstr "#double"
+		IL_0044: ldc.i4.1
+		IL_0045: ldc.i4.1
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0, float64, string, bool, bool)
+		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0)
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0055: pop
+		IL_0056: ldloc.3
+		IL_0057: ldstr "prototype"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0061: stloc.s 4
+		IL_0063: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0068: stloc.s 5
+		IL_006a: ldloc.s 4
+		IL_006c: ldstr "secret"
+		IL_0071: ldloc.3
+		IL_0072: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::.ctor(class [System.Runtime]System.Object)
+		IL_0077: ldc.i4.0
+		IL_0078: conv.r8
+		IL_0079: ldstr "get secret"
+		IL_007e: ldc.i4.1
 		IL_007f: ldc.i4.1
-		IL_0080: ldc.i4.1
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0, float64, string, bool, bool)
-		IL_0086: stloc.s 7
-		IL_0088: ldloc.s 7
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0)
-		IL_008f: stloc.s 7
-		IL_0091: ldloc.s 4
-		IL_0093: ldstr "secret"
-		IL_0098: ldloc.s 7
-		IL_009a: ldnull
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_00a0: pop
-		IL_00a1: ldloc.3
-		IL_00a2: ldstr "prototype"
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ac: stloc.s 4
-		IL_00ae: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00b3: stloc.s 5
-		IL_00b5: ldloc.3
-		IL_00b6: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::.ctor(class [System.Runtime]System.Object)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0, float64, string, bool, bool)
+		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0)
+		IL_008a: ldnull
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0090: pop
+		IL_0091: ldloc.3
+		IL_0092: ldstr "prototype"
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009c: stloc.s 4
+		IL_009e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a3: stloc.s 5
+		IL_00a5: ldloc.s 4
+		IL_00a7: ldstr "secret"
+		IL_00ac: ldnull
+		IL_00ad: ldloc.3
+		IL_00ae: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::.ctor(class [System.Runtime]System.Object)
+		IL_00b3: ldc.i4.1
+		IL_00b4: conv.r8
+		IL_00b5: ldstr "set secret"
+		IL_00ba: ldc.i4.1
 		IL_00bb: ldc.i4.1
-		IL_00bc: conv.r8
-		IL_00bd: ldstr "set secret"
-		IL_00c2: ldc.i4.1
-		IL_00c3: ldc.i4.1
-		IL_00c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0, float64, string, bool, bool)
-		IL_00c9: stloc.s 8
-		IL_00cb: ldloc.s 8
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0)
-		IL_00d2: stloc.s 8
-		IL_00d4: ldloc.s 4
-		IL_00d6: ldstr "secret"
-		IL_00db: ldnull
-		IL_00dc: ldloc.s 8
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_00e3: pop
-		IL_00e4: ldloc.3
-		IL_00e5: ldstr "prototype"
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ef: stloc.s 4
-		IL_00f1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00f6: stloc.s 5
-		IL_00f8: ldloc.3
-		IL_00f9: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log::.ctor(class [System.Runtime]System.Object)
-		IL_00fe: ldc.i4.0
-		IL_00ff: conv.r8
-		IL_0100: ldstr "log"
-		IL_0105: ldc.i4.1
+		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0, float64, string, bool, bool)
+		IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0)
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_00cb: pop
+		IL_00cc: ldloc.3
+		IL_00cd: ldstr "prototype"
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d7: stloc.s 4
+		IL_00d9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00de: stloc.s 5
+		IL_00e0: ldloc.s 4
+		IL_00e2: ldstr "log"
+		IL_00e7: ldloc.3
+		IL_00e8: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log::.ctor(class [System.Runtime]System.Object)
+		IL_00ed: ldc.i4.0
+		IL_00ee: conv.r8
+		IL_00ef: ldstr "log"
+		IL_00f4: ldc.i4.1
+		IL_00f5: ldc.i4.1
+		IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0, float64, string, bool, bool)
+		IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0)
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0105: pop
 		IL_0106: ldc.i4.1
-		IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0, float64, string, bool, bool)
-		IL_010c: stloc.s 9
-		IL_010e: ldloc.s 9
-		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0)
-		IL_0115: stloc.s 9
-		IL_0117: ldloc.s 4
-		IL_0119: ldstr "log"
-		IL_011e: ldloc.s 9
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0125: pop
-		IL_0126: ldc.i4.1
-		IL_0127: newarr [System.Runtime]System.Object
-		IL_012c: dup
-		IL_012d: ldc.i4.0
-		IL_012e: ldloc.0
-		IL_012f: stelem.ref
-		IL_0130: stloc.s 5
-		IL_0132: ldloc.3
-		IL_0133: ldloc.s 5
-		IL_0135: ldc.r8 0.0
-		IL_013e: box [System.Runtime]System.Double
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0148: stloc.s 4
-		IL_014a: ldloc.s 4
-		IL_014c: stloc.1
-		IL_014d: ldc.i4.1
-		IL_014e: newarr [System.Runtime]System.Object
-		IL_0153: dup
-		IL_0154: ldc.i4.0
-		IL_0155: ldloc.0
-		IL_0156: stelem.ref
-		IL_0157: stloc.s 5
-		IL_0159: ldloc.s 5
-		IL_015b: ldc.i4.0
-		IL_015c: newarr [System.Runtime]System.Object
-		IL_0161: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0166: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::.ctor(object[])
-		IL_016b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0170: stloc.2
-		IL_0171: ldloc.2
-		IL_0172: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_0177: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_017c: ldstr "prototype"
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0186: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_018b: ldloc.2
-		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter>(!!0)
-		IL_0191: stloc.s 10
-		IL_0193: ldloc.s 10
-		IL_0195: callvirt instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::log()
-		IL_019a: pop
-		IL_019b: ldstr "console"
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01aa: stloc.s 4
-		IL_01ac: ldloc.2
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b7: ldstr "includes"
-		IL_01bc: ldstr "#double"
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c6: stloc.s 11
-		IL_01c8: ldloc.s 4
-		IL_01ca: ldstr "log"
-		IL_01cf: ldloc.s 11
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d6: pop
-		IL_01d7: ldstr "console"
-		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e6: stloc.s 11
-		IL_01e8: ldloc.2
-		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f3: ldstr "includes"
-		IL_01f8: ldstr "#secret"
-		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0202: stloc.s 4
-		IL_0204: ldloc.s 11
-		IL_0206: ldstr "log"
-		IL_020b: ldloc.s 4
-		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0212: pop
-		IL_0213: ret
+		IL_0107: newarr [System.Runtime]System.Object
+		IL_010c: dup
+		IL_010d: ldc.i4.0
+		IL_010e: ldloc.0
+		IL_010f: stelem.ref
+		IL_0110: stloc.s 5
+		IL_0112: ldloc.3
+		IL_0113: ldloc.s 5
+		IL_0115: ldc.r8 0.0
+		IL_011e: box [System.Runtime]System.Double
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0128: stloc.s 4
+		IL_012a: ldloc.s 4
+		IL_012c: stloc.1
+		IL_012d: ldc.i4.1
+		IL_012e: newarr [System.Runtime]System.Object
+		IL_0133: dup
+		IL_0134: ldc.i4.0
+		IL_0135: ldloc.0
+		IL_0136: stelem.ref
+		IL_0137: stloc.s 5
+		IL_0139: ldloc.s 5
+		IL_013b: ldc.i4.0
+		IL_013c: newarr [System.Runtime]System.Object
+		IL_0141: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0146: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::.ctor(object[])
+		IL_014b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0150: stloc.2
+		IL_0151: ldloc.2
+		IL_0152: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+		IL_0157: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_015c: ldstr "prototype"
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0166: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_016b: ldloc.2
+		IL_016c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter>(!!0)
+		IL_0171: stloc.s 6
+		IL_0173: ldloc.s 6
+		IL_0175: callvirt instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::log()
+		IL_017a: pop
+		IL_017b: ldstr "console"
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018a: stloc.s 4
+		IL_018c: ldloc.2
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0197: ldstr "includes"
+		IL_019c: ldstr "#double"
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a6: stloc.s 7
+		IL_01a8: ldloc.s 4
+		IL_01aa: ldstr "log"
+		IL_01af: ldloc.s 7
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b6: pop
+		IL_01b7: ldstr "console"
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c6: stloc.s 7
+		IL_01c8: ldloc.2
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d3: ldstr "includes"
+		IL_01d8: ldstr "#secret"
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e2: stloc.s 4
+		IL_01e4: ldloc.s 7
+		IL_01e6: ldstr "log"
+		IL_01eb: ldloc.s 4
+		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f2: pop
+		IL_01f3: ret
 	} // end of method Classes_ClassPrivateMethodAndAccessor_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateMethodAndAccessor_Log
@@ -903,7 +883,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24e1
+		// Method begins at RVA 0x24c1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticMethod_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticMethod_HelloWorld.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x211d
+				// Method begins at RVA 0x2115
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2126
+				// Method begins at RVA 0x211e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x212f
+				// Method begins at RVA 0x2127
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x213e
+				// Method begins at RVA 0x2136
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2141
+				// Method begins at RVA 0x2139
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2144
+				// Method begins at RVA 0x213c
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2150
+				// Method begins at RVA 0x2148
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x215c
+				// Method begins at RVA 0x2154
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2164
+				// Method begins at RVA 0x215c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2167
+				// Method begins at RVA 0x215f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x216a
+				// Method begins at RVA 0x2162
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -200,7 +200,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20ea
+			// Method begins at RVA 0x20e2
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -216,7 +216,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20f2
+			// Method begins at RVA 0x20ea
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -241,7 +241,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2114
+			// Method begins at RVA 0x210c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -267,15 +267,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 142 (0x8e)
+		// Code size: 134 (0x86)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassWithStaticMethod_HelloWorld/Scope,
 			[1] object,
 			[2] class [System.Runtime]System.Type,
 			[3] object[],
-			[4] class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld,
-			[5] object
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassWithStaticMethod_HelloWorld/Scope::.ctor()
@@ -292,43 +291,39 @@
 		IL_0027: pop
 		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002d: stloc.3
-		IL_002e: newobj instance void Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::.ctor()
-		IL_0033: ldc.i4.0
-		IL_0034: conv.r8
-		IL_0035: ldstr "helloWorld"
-		IL_003a: ldc.i4.0
-		IL_003b: ldc.i4.1
-		IL_003c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0, float64, string, bool, bool)
-		IL_0041: stloc.s 4
-		IL_0043: ldloc.s 4
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0)
-		IL_004a: stloc.s 4
-		IL_004c: ldloc.2
-		IL_004d: ldstr "helloWorld"
-		IL_0052: ldloc.s 4
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0059: pop
-		IL_005a: ldc.i4.1
-		IL_005b: newarr [System.Runtime]System.Object
-		IL_0060: dup
-		IL_0061: ldc.i4.0
-		IL_0062: ldloc.0
-		IL_0063: stelem.ref
-		IL_0064: stloc.3
-		IL_0065: ldloc.2
-		IL_0066: ldloc.3
-		IL_0067: ldc.r8 0.0
-		IL_0070: box [System.Runtime]System.Double
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007a: stloc.s 5
-		IL_007c: ldloc.s 5
-		IL_007e: stloc.1
-		IL_007f: ldloc.1
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_0085: stloc.s 5
-		IL_0087: call object Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter::helloWorld()
-		IL_008c: pop
-		IL_008d: ret
+		IL_002e: ldloc.2
+		IL_002f: ldstr "helloWorld"
+		IL_0034: newobj instance void Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::.ctor()
+		IL_0039: ldc.i4.0
+		IL_003a: conv.r8
+		IL_003b: ldstr "helloWorld"
+		IL_0040: ldc.i4.0
+		IL_0041: ldc.i4.1
+		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0, float64, string, bool, bool)
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0)
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0051: pop
+		IL_0052: ldc.i4.1
+		IL_0053: newarr [System.Runtime]System.Object
+		IL_0058: dup
+		IL_0059: ldc.i4.0
+		IL_005a: ldloc.0
+		IL_005b: stelem.ref
+		IL_005c: stloc.3
+		IL_005d: ldloc.2
+		IL_005e: ldloc.3
+		IL_005f: ldc.r8 0.0
+		IL_0068: box [System.Runtime]System.Double
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0072: stloc.s 4
+		IL_0074: ldloc.s 4
+		IL_0076: stloc.1
+		IL_0077: ldloc.1
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_007d: stloc.s 4
+		IL_007f: call object Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter::helloWorld()
+		IL_0084: pop
+		IL_0085: ret
 	} // end of method Classes_ClassWithStaticMethod_HelloWorld::__js_module_init__
 
 } // end of class Modules.Classes_ClassWithStaticMethod_HelloWorld
@@ -340,7 +335,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2171
+		// Method begins at RVA 0x2169
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3097
+					// Method begins at RVA 0x3047
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30a0
+					// Method begins at RVA 0x3050
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 						object[] capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x332e
+					// Method begins at RVA 0x32de
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -83,7 +83,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x333d
+					// Method begins at RVA 0x32ed
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -95,7 +95,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x3340
+					// Method begins at RVA 0x32f0
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -110,7 +110,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x3343
+					// Method begins at RVA 0x32f3
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -126,7 +126,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x334f
+					// Method begins at RVA 0x32ff
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -145,7 +145,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x335b
+					// Method begins at RVA 0x330b
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -158,7 +158,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x3363
+					// Method begins at RVA 0x3313
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -170,7 +170,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x3366
+					// Method begins at RVA 0x3316
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -185,7 +185,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x3369
+					// Method begins at RVA 0x3319
 					// Header size: 1
 					// Code size: 40 (0x28)
 					.maxstack 8
@@ -214,7 +214,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f73
+				// Method begins at RVA 0x2f23
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -230,7 +230,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f7b
+				// Method begins at RVA 0x2f2b
 				// Header size: 1
 				// Code size: 10 (0xa)
 				.maxstack 8
@@ -248,7 +248,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x308e
+				// Method begins at RVA 0x303e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -268,7 +268,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32fd
+				// Method begins at RVA 0x32ad
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -281,7 +281,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3305
+				// Method begins at RVA 0x32b5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -293,7 +293,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3308
+				// Method begins at RVA 0x32b8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -308,7 +308,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x330b
+				// Method begins at RVA 0x32bb
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -325,7 +325,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3317
+				// Method begins at RVA 0x32c7
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -341,7 +341,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x331f
+				// Method begins at RVA 0x32cf
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -366,16 +366,15 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d10
+			// Method begins at RVA 0x2ce0
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 111 (0x6f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/Scope,
 				[1] class [System.Runtime]System.Type,
 				[2] object,
-				[3] object[],
-				[4] class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method
+				[3] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/Scope::.ctor()
@@ -391,32 +390,28 @@
 			IL_0026: stloc.2
 			IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_002c: stloc.3
-			IL_002d: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method::.ctor()
-			IL_0032: ldc.i4.0
-			IL_0033: conv.r8
-			IL_0034: ldstr "method"
-			IL_0039: ldc.i4.0
-			IL_003a: ldc.i4.1
-			IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0, float64, string, bool, bool)
-			IL_0040: stloc.s 4
-			IL_0042: ldloc.s 4
-			IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0)
-			IL_0049: stloc.s 4
-			IL_004b: ldloc.2
-			IL_004c: ldstr "method"
-			IL_0051: ldloc.s 4
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_0058: pop
-			IL_0059: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_005e: stloc.3
-			IL_005f: ldloc.1
-			IL_0060: ldloc.3
-			IL_0061: ldc.r8 0.0
-			IL_006a: box [System.Runtime]System.Double
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
-			IL_0074: stloc.2
-			IL_0075: ldloc.2
-			IL_0076: ret
+			IL_002d: ldloc.2
+			IL_002e: ldstr "method"
+			IL_0033: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method::.ctor()
+			IL_0038: ldc.i4.0
+			IL_0039: conv.r8
+			IL_003a: ldstr "method"
+			IL_003f: ldc.i4.0
+			IL_0040: ldc.i4.1
+			IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0, float64, string, bool, bool)
+			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0)
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_0050: pop
+			IL_0051: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0056: stloc.3
+			IL_0057: ldloc.1
+			IL_0058: ldloc.3
+			IL_0059: ldc.r8 0.0
+			IL_0062: box [System.Runtime]System.Double
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
+			IL_006c: stloc.2
+			IL_006d: ldloc.2
+			IL_006e: ret
 		} // end of method makeClass::__js_call__
 
 	} // end of class makeClass
@@ -436,7 +431,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30b2
+					// Method begins at RVA 0x3062
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -456,7 +451,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30bb
+					// Method begins at RVA 0x306b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -476,7 +471,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30c4
+					// Method begins at RVA 0x3074
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -496,7 +491,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30cd
+					// Method begins at RVA 0x307d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -516,7 +511,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30d6
+					// Method begins at RVA 0x3086
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -543,7 +538,7 @@
 						class [System.Runtime]System.Object capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x33c3
+					// Method begins at RVA 0x3373
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -562,7 +557,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x33d9
+					// Method begins at RVA 0x3389
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -574,7 +569,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x33dc
+					// Method begins at RVA 0x338c
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -589,7 +584,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x33df
+					// Method begins at RVA 0x338f
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -605,7 +600,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x33eb
+					// Method begins at RVA 0x339b
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -629,7 +624,7 @@
 						class [System.Runtime]System.Object capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x33f7
+					// Method begins at RVA 0x33a7
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -645,7 +640,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x3406
+					// Method begins at RVA 0x33b6
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -657,7 +652,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x3409
+					// Method begins at RVA 0x33b9
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -672,7 +667,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x340c
+					// Method begins at RVA 0x33bc
 					// Header size: 1
 					// Code size: 40 (0x28)
 					.maxstack 8
@@ -700,7 +695,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3435
+					// Method begins at RVA 0x33e5
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -713,7 +708,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x343d
+					// Method begins at RVA 0x33ed
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -725,7 +720,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x3440
+					// Method begins at RVA 0x33f0
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -740,7 +735,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x3443
+					// Method begins at RVA 0x33f3
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -764,7 +759,7 @@
 						class [System.Runtime]System.Object capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x344f
+					// Method begins at RVA 0x33ff
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -780,7 +775,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x345e
+					// Method begins at RVA 0x340e
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -792,7 +787,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x3461
+					// Method begins at RVA 0x3411
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -807,7 +802,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x3464
+					// Method begins at RVA 0x3414
 					// Header size: 1
 					// Code size: 30 (0x1e)
 					.maxstack 8
@@ -841,7 +836,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f88
+				// Method begins at RVA 0x2f38
 				// Header size: 12
 				// Code size: 30 (0x1e)
 				.maxstack 8
@@ -871,7 +866,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2fb2
+				// Method begins at RVA 0x2f62
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -887,7 +882,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2fba
+				// Method begins at RVA 0x2f6a
 				// Header size: 1
 				// Code size: 10 (0xa)
 				.maxstack 8
@@ -902,7 +897,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2fc8
+				// Method begins at RVA 0x2f78
 				// Header size: 12
 				// Code size: 51 (0x33)
 				.maxstack 8
@@ -937,7 +932,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30a9
+				// Method begins at RVA 0x3059
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -957,7 +952,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3392
+				// Method begins at RVA 0x3342
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -970,7 +965,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x339a
+				// Method begins at RVA 0x334a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -982,7 +977,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x339d
+				// Method begins at RVA 0x334d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -997,7 +992,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x33a0
+				// Method begins at RVA 0x3350
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1014,7 +1009,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x33ac
+				// Method begins at RVA 0x335c
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1030,7 +1025,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x33b4
+				// Method begins at RVA 0x3364
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1055,19 +1050,16 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d94
+			// Method begins at RVA 0x2d5c
 			// Header size: 12
-			// Code size: 224 (0xe0)
+			// Code size: 200 (0xc8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/Scope,
 				[1] class [System.Runtime]System.Type,
 				[2] object,
 				[3] object[],
-				[4] object[],
-				[5] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read,
-				[6] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden,
-				[7] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic
+				[4] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/Scope::.ctor()
@@ -1085,68 +1077,56 @@
 			IL_002c: stloc.3
 			IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_0032: stloc.s 4
-			IL_0034: ldloc.1
-			IL_0035: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read::.ctor(class [System.Runtime]System.Object)
-			IL_003a: ldc.i4.0
-			IL_003b: conv.r8
-			IL_003c: ldstr "read"
-			IL_0041: ldc.i4.1
-			IL_0042: ldc.i4.1
-			IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0, float64, string, bool, bool)
-			IL_0048: stloc.s 5
-			IL_004a: ldloc.s 5
-			IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0)
-			IL_0051: stloc.s 5
-			IL_0053: ldloc.2
-			IL_0054: ldstr "read"
-			IL_0059: ldloc.s 5
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_0060: pop
-			IL_0061: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0066: stloc.s 4
-			IL_0068: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden::.ctor()
-			IL_006d: ldc.i4.0
-			IL_006e: conv.r8
-			IL_006f: ldstr "#hidden"
-			IL_0074: ldc.i4.0
-			IL_0075: ldc.i4.1
-			IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0, float64, string, bool, bool)
-			IL_007b: stloc.s 6
-			IL_007d: ldloc.s 6
-			IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0)
-			IL_0084: stloc.s 6
-			IL_0086: ldloc.1
-			IL_0087: ldstr "__jroc_priv_method_hidden"
-			IL_008c: ldloc.s 6
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_0093: pop
-			IL_0094: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0099: stloc.s 4
-			IL_009b: ldloc.1
-			IL_009c: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::.ctor(class [System.Runtime]System.Object)
-			IL_00a1: ldc.i4.0
-			IL_00a2: conv.r8
-			IL_00a3: ldstr "readStatic"
-			IL_00a8: ldc.i4.1
-			IL_00a9: ldc.i4.1
-			IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0, float64, string, bool, bool)
-			IL_00af: stloc.s 7
-			IL_00b1: ldloc.s 7
-			IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0)
-			IL_00b8: stloc.s 7
-			IL_00ba: ldloc.1
-			IL_00bb: ldstr "readStatic"
-			IL_00c0: ldloc.s 7
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_00c7: pop
-			IL_00c8: ldloc.1
-			IL_00c9: ldloc.3
-			IL_00ca: ldc.r8 1
-			IL_00d3: box [System.Runtime]System.Double
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
-			IL_00dd: stloc.2
-			IL_00de: ldloc.2
-			IL_00df: ret
+			IL_0034: ldloc.2
+			IL_0035: ldstr "read"
+			IL_003a: ldloc.1
+			IL_003b: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read::.ctor(class [System.Runtime]System.Object)
+			IL_0040: ldc.i4.0
+			IL_0041: conv.r8
+			IL_0042: ldstr "read"
+			IL_0047: ldc.i4.1
+			IL_0048: ldc.i4.1
+			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0, float64, string, bool, bool)
+			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0)
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_0058: pop
+			IL_0059: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_005e: stloc.s 4
+			IL_0060: ldloc.1
+			IL_0061: ldstr "__jroc_priv_method_hidden"
+			IL_0066: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden::.ctor()
+			IL_006b: ldc.i4.0
+			IL_006c: conv.r8
+			IL_006d: ldstr "#hidden"
+			IL_0072: ldc.i4.0
+			IL_0073: ldc.i4.1
+			IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0, float64, string, bool, bool)
+			IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0)
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_0083: pop
+			IL_0084: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0089: stloc.s 4
+			IL_008b: ldloc.1
+			IL_008c: ldstr "readStatic"
+			IL_0091: ldloc.1
+			IL_0092: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::.ctor(class [System.Runtime]System.Object)
+			IL_0097: ldc.i4.0
+			IL_0098: conv.r8
+			IL_0099: ldstr "readStatic"
+			IL_009e: ldc.i4.1
+			IL_009f: ldc.i4.1
+			IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0, float64, string, bool, bool)
+			IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0)
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_00af: pop
+			IL_00b0: ldloc.1
+			IL_00b1: ldloc.3
+			IL_00b2: ldc.r8 1
+			IL_00bb: box [System.Runtime]System.Double
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
+			IL_00c5: stloc.2
+			IL_00c6: ldloc.2
+			IL_00c7: ret
 		} // end of method makeSecretClass::__js_call__
 
 	} // end of class makeSecretClass
@@ -1162,7 +1142,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3010
+				// Method begins at RVA 0x2fc0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1182,7 +1162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3019
+				// Method begins at RVA 0x2fc9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1207,7 +1187,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3103
+				// Method begins at RVA 0x30b3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1223,7 +1203,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3112
+				// Method begins at RVA 0x30c2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1235,7 +1215,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3115
+				// Method begins at RVA 0x30c5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1250,7 +1230,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3118
+				// Method begins at RVA 0x30c8
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1266,7 +1246,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3124
+				// Method begins at RVA 0x30d4
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1285,7 +1265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3130
+				// Method begins at RVA 0x30e0
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1298,7 +1278,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3138
+				// Method begins at RVA 0x30e8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1310,7 +1290,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x313b
+				// Method begins at RVA 0x30eb
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1325,7 +1305,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x313e
+				// Method begins at RVA 0x30ee
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -1353,7 +1333,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e80
+			// Method begins at RVA 0x2e30
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1369,7 +1349,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f2e
+			// Method begins at RVA 0x2ede
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -1391,7 +1371,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3022
+				// Method begins at RVA 0x2fd2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1411,7 +1391,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x302b
+				// Method begins at RVA 0x2fdb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1431,7 +1411,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3034
+				// Method begins at RVA 0x2fe4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1451,7 +1431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x303d
+				// Method begins at RVA 0x2fed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1471,7 +1451,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3046
+				// Method begins at RVA 0x2ff6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1500,7 +1480,7 @@
 					object[] capture2
 				) cil managed 
 			{
-				// Method begins at RVA 0x3162
+				// Method begins at RVA 0x3112
 				// Header size: 1
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -1522,7 +1502,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x317f
+				// Method begins at RVA 0x312f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1534,7 +1514,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3182
+				// Method begins at RVA 0x3132
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1546,7 +1526,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x3185
+				// Method begins at RVA 0x3135
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1559,7 +1539,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x318d
+				// Method begins at RVA 0x313d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1575,7 +1555,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3195
+				// Method begins at RVA 0x3145
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1591,7 +1571,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x31a1
+				// Method begins at RVA 0x3151
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1617,7 +1597,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x31ad
+				// Method begins at RVA 0x315d
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -1636,7 +1616,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x31c3
+				// Method begins at RVA 0x3173
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1648,7 +1628,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x31c6
+				// Method begins at RVA 0x3176
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1660,7 +1640,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x31c9
+				// Method begins at RVA 0x3179
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1673,7 +1653,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x31d1
+				// Method begins at RVA 0x3181
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1689,7 +1669,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x31d9
+				// Method begins at RVA 0x3189
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -1719,7 +1699,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3204
+				// Method begins at RVA 0x31b4
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1732,7 +1712,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x320c
+				// Method begins at RVA 0x31bc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1744,7 +1724,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x320f
+				// Method begins at RVA 0x31bf
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1759,7 +1739,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3212
+				// Method begins at RVA 0x31c2
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -1786,7 +1766,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3236
+				// Method begins at RVA 0x31e6
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1799,7 +1779,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x323e
+				// Method begins at RVA 0x31ee
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1811,7 +1791,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3241
+				// Method begins at RVA 0x31f1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1826,7 +1806,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3244
+				// Method begins at RVA 0x31f4
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -1856,7 +1836,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x326f
+				// Method begins at RVA 0x321f
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1869,7 +1849,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3277
+				// Method begins at RVA 0x3227
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1881,7 +1861,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x327a
+				// Method begins at RVA 0x322a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1896,7 +1876,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x327d
+				// Method begins at RVA 0x322d
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1923,7 +1903,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e88
+			// Method begins at RVA 0x2e38
 			// Header size: 1
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -1959,7 +1939,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ef8
+			// Method begins at RVA 0x2ea8
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1995,7 +1975,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2eee
+			// Method begins at RVA 0x2e9e
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -2013,7 +1993,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f3d
+			// Method begins at RVA 0x2eed
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -2033,7 +2013,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f48
+			// Method begins at RVA 0x2ef8
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -2068,7 +2048,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3061
+				// Method begins at RVA 0x3011
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2088,7 +2068,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x306a
+				// Method begins at RVA 0x301a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2108,7 +2088,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3073
+				// Method begins at RVA 0x3023
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2135,7 +2115,7 @@
 					class [System.Runtime]System.Object capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x328b
+				// Method begins at RVA 0x323b
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -2154,7 +2134,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x32a1
+				// Method begins at RVA 0x3251
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2166,7 +2146,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x32a4
+				// Method begins at RVA 0x3254
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2181,7 +2161,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x32a7
+				// Method begins at RVA 0x3257
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -2197,7 +2177,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x32b3
+				// Method begins at RVA 0x3263
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -2221,7 +2201,7 @@
 					class [System.Runtime]System.Object capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x32bf
+				// Method begins at RVA 0x326f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2237,7 +2217,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x32ce
+				// Method begins at RVA 0x327e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2249,7 +2229,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x32d1
+				// Method begins at RVA 0x3281
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2264,7 +2244,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x32d4
+				// Method begins at RVA 0x3284
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -2300,7 +2280,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ec4
+			// Method begins at RVA 0x2e74
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -2330,7 +2310,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f35
+			// Method begins at RVA 0x2ee5
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -2360,7 +2340,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x304f
+				// Method begins at RVA 0x2fff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2380,7 +2360,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3058
+				// Method begins at RVA 0x3008
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2400,7 +2380,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x307c
+				// Method begins at RVA 0x302c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2420,7 +2400,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3085
+				// Method begins at RVA 0x3035
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2440,7 +2420,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30df
+				// Method begins at RVA 0x308f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2460,7 +2440,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30e8
+				// Method begins at RVA 0x3098
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2480,7 +2460,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30f1
+				// Method begins at RVA 0x30a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2500,7 +2480,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30fa
+				// Method begins at RVA 0x30aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2522,7 +2502,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3007
+			// Method begins at RVA 0x2fb7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2548,7 +2528,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 3200 (0xc80)
+		// Code size: 3152 (0xc50)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Classes_GeneratedMethodFunctionObjects/Scope,
@@ -2589,23 +2569,17 @@
 			[35] object[],
 			[36] class [System.Runtime]System.Type,
 			[37] object,
-			[38] class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label,
-			[39] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add,
-			[40] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current,
-			[41] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current,
-			[42] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify,
-			[43] object,
+			[38] object,
+			[39] object,
+			[40] object,
+			[41] object,
+			[42] object,
+			[43] bool,
 			[44] object,
 			[45] object,
 			[46] object,
-			[47] object,
-			[48] bool,
-			[49] object,
-			[50] object,
-			[51] object,
-			[52] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[53] class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read,
-			[54] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[47] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[48] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
 		IL_0000: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Scope::.ctor()
@@ -2652,876 +2626,867 @@
 		IL_0069: stloc.s 37
 		IL_006b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0070: stloc.s 35
-		IL_0072: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label::.ctor()
-		IL_0077: ldc.i4.0
-		IL_0078: conv.r8
-		IL_0079: ldstr "label"
+		IL_0072: ldloc.s 37
+		IL_0074: ldstr "label"
+		IL_0079: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label::.ctor()
 		IL_007e: ldc.i4.0
-		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0, float64, string, bool, bool)
-		IL_0085: stloc.s 38
-		IL_0087: ldloc.s 38
-		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0)
-		IL_008e: stloc.s 38
-		IL_0090: ldloc.s 37
-		IL_0092: ldstr "label"
-		IL_0097: ldloc.s 38
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_009e: pop
-		IL_009f: ldc.i4.1
-		IL_00a0: newarr [System.Runtime]System.Object
-		IL_00a5: dup
-		IL_00a6: ldc.i4.0
-		IL_00a7: ldloc.0
-		IL_00a8: stelem.ref
-		IL_00a9: stloc.s 35
-		IL_00ab: ldloc.s 36
-		IL_00ad: ldloc.s 35
-		IL_00af: ldc.r8 0.0
-		IL_00b8: box [System.Runtime]System.Double
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00c2: stloc.s 37
-		IL_00c4: ldloc.s 37
-		IL_00c6: stloc.3
-		IL_00c7: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_00cc: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00d1: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_00d6: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00db: stloc.s 36
-		IL_00dd: ldloc.s 36
-		IL_00df: ldstr "prototype"
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e9: stloc.s 37
-		IL_00eb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00f0: stloc.s 35
-		IL_00f2: ldloc.s 37
-		IL_00f4: ldloc.s 35
-		IL_00f6: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add::.ctor(class [System.Runtime]System.Object, object[])
-		IL_00fb: ldc.i4.1
-		IL_00fc: conv.r8
-		IL_00fd: ldstr "add"
+		IL_007f: conv.r8
+		IL_0080: ldstr "label"
+		IL_0085: ldc.i4.0
+		IL_0086: ldc.i4.1
+		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0, float64, string, bool, bool)
+		IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0)
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0096: pop
+		IL_0097: ldc.i4.1
+		IL_0098: newarr [System.Runtime]System.Object
+		IL_009d: dup
+		IL_009e: ldc.i4.0
+		IL_009f: ldloc.0
+		IL_00a0: stelem.ref
+		IL_00a1: stloc.s 35
+		IL_00a3: ldloc.s 36
+		IL_00a5: ldloc.s 35
+		IL_00a7: ldc.r8 0.0
+		IL_00b0: box [System.Runtime]System.Double
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00ba: stloc.s 37
+		IL_00bc: ldloc.s 37
+		IL_00be: stloc.3
+		IL_00bf: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
+		IL_00c4: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00c9: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
+		IL_00ce: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00d3: stloc.s 36
+		IL_00d5: ldloc.s 36
+		IL_00d7: ldstr "prototype"
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e1: stloc.s 37
+		IL_00e3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e8: stloc.s 35
+		IL_00ea: ldloc.s 37
+		IL_00ec: ldstr "add"
+		IL_00f1: ldloc.s 37
+		IL_00f3: ldloc.s 35
+		IL_00f5: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add::.ctor(class [System.Runtime]System.Object, object[])
+		IL_00fa: ldc.i4.1
+		IL_00fb: conv.r8
+		IL_00fc: ldstr "add"
+		IL_0101: ldc.i4.1
 		IL_0102: ldc.i4.1
-		IL_0103: ldc.i4.1
-		IL_0104: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0, float64, string, bool, bool)
-		IL_0109: stloc.s 39
-		IL_010b: ldloc.s 39
-		IL_010d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0)
-		IL_0112: stloc.s 39
-		IL_0114: ldloc.s 37
-		IL_0116: ldstr "add"
-		IL_011b: ldloc.s 39
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0122: pop
-		IL_0123: ldloc.s 36
-		IL_0125: ldstr "prototype"
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012f: stloc.s 37
-		IL_0131: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0136: stloc.s 35
-		IL_0138: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current::.ctor()
-		IL_013d: ldc.i4.0
-		IL_013e: conv.r8
-		IL_013f: ldstr "get current"
-		IL_0144: ldc.i4.1
-		IL_0145: ldc.i4.1
-		IL_0146: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0, float64, string, bool, bool)
-		IL_014b: stloc.s 40
-		IL_014d: ldloc.s 40
-		IL_014f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0)
-		IL_0154: stloc.s 40
-		IL_0156: ldloc.s 37
-		IL_0158: ldstr "current"
-		IL_015d: ldloc.s 40
-		IL_015f: ldnull
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_0165: pop
-		IL_0166: ldloc.s 36
-		IL_0168: ldstr "prototype"
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0172: stloc.s 37
-		IL_0174: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0179: stloc.s 35
-		IL_017b: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current::.ctor()
-		IL_0180: ldc.i4.1
-		IL_0181: conv.r8
-		IL_0182: ldstr "set current"
-		IL_0187: ldc.i4.1
-		IL_0188: ldc.i4.1
-		IL_0189: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0, float64, string, bool, bool)
-		IL_018e: stloc.s 41
-		IL_0190: ldloc.s 41
-		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0)
-		IL_0197: stloc.s 41
-		IL_0199: ldloc.s 37
-		IL_019b: ldstr "current"
-		IL_01a0: ldnull
-		IL_01a1: ldloc.s 41
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_01a8: pop
-		IL_01a9: ldloc.s 36
-		IL_01ab: ldstr "prototype"
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b5: pop
-		IL_01b6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01bb: stloc.s 35
-		IL_01bd: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify::.ctor()
+		IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0, float64, string, bool, bool)
+		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0)
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0112: pop
+		IL_0113: ldloc.s 36
+		IL_0115: ldstr "prototype"
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011f: stloc.s 37
+		IL_0121: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0126: stloc.s 35
+		IL_0128: ldloc.s 37
+		IL_012a: ldstr "current"
+		IL_012f: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current::.ctor()
+		IL_0134: ldc.i4.0
+		IL_0135: conv.r8
+		IL_0136: ldstr "get current"
+		IL_013b: ldc.i4.1
+		IL_013c: ldc.i4.1
+		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0, float64, string, bool, bool)
+		IL_0142: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0)
+		IL_0147: ldnull
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_014d: pop
+		IL_014e: ldloc.s 36
+		IL_0150: ldstr "prototype"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015a: stloc.s 37
+		IL_015c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0161: stloc.s 35
+		IL_0163: ldloc.s 37
+		IL_0165: ldstr "current"
+		IL_016a: ldnull
+		IL_016b: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current::.ctor()
+		IL_0170: ldc.i4.1
+		IL_0171: conv.r8
+		IL_0172: ldstr "set current"
+		IL_0177: ldc.i4.1
+		IL_0178: ldc.i4.1
+		IL_0179: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0, float64, string, bool, bool)
+		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0)
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0188: pop
+		IL_0189: ldloc.s 36
+		IL_018b: ldstr "prototype"
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0195: pop
+		IL_0196: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_019b: stloc.s 35
+		IL_019d: ldloc.s 36
+		IL_019f: ldstr "identify"
+		IL_01a4: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify::.ctor()
+		IL_01a9: ldc.i4.1
+		IL_01aa: conv.r8
+		IL_01ab: ldstr "identify"
+		IL_01b0: ldc.i4.1
+		IL_01b1: ldc.i4.1
+		IL_01b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0, float64, string, bool, bool)
+		IL_01b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0)
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01c1: pop
 		IL_01c2: ldc.i4.1
-		IL_01c3: conv.r8
-		IL_01c4: ldstr "identify"
-		IL_01c9: ldc.i4.1
-		IL_01ca: ldc.i4.1
-		IL_01cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0, float64, string, bool, bool)
-		IL_01d0: stloc.s 42
-		IL_01d2: ldloc.s 42
-		IL_01d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0)
-		IL_01d9: stloc.s 42
-		IL_01db: ldloc.s 36
-		IL_01dd: ldstr "identify"
-		IL_01e2: ldloc.s 42
-		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01e9: pop
-		IL_01ea: ldc.i4.1
-		IL_01eb: newarr [System.Runtime]System.Object
-		IL_01f0: dup
-		IL_01f1: ldc.i4.0
-		IL_01f2: ldloc.0
-		IL_01f3: stelem.ref
-		IL_01f4: stloc.s 35
-		IL_01f6: ldloc.s 36
-		IL_01f8: ldloc.s 35
-		IL_01fa: ldc.r8 1
-		IL_0203: box [System.Runtime]System.Double
-		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_020d: stloc.s 37
-		IL_020f: ldloc.s 37
-		IL_0211: ldloc.3
-		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0217: stloc.s 37
-		IL_0219: ldloc.s 37
-		IL_021b: stloc.s 4
-		IL_021d: ldloc.s 4
-		IL_021f: ldstr "prefix"
-		IL_0224: ldstr "static:"
-		IL_0229: ldc.i4.1
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_022f: pop
-		IL_0230: ldc.i4.1
-		IL_0231: newarr [System.Runtime]System.Object
-		IL_0236: dup
-		IL_0237: ldc.i4.0
-		IL_0238: ldc.r8 3
-		IL_0241: box [System.Runtime]System.Double
-		IL_0246: stelem.ref
-		IL_0247: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_024c: ldloc.s 4
-		IL_024e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_0253: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0258: ldc.r8 3
-		IL_0261: box [System.Runtime]System.Double
-		IL_0266: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example::.ctor(object)
-		IL_026b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_0270: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0275: dup
-		IL_0276: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_027b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0280: ldstr "prototype"
-		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_028a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_028f: stloc.s 5
-		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_029b: stloc.s 5
-		IL_029d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_02a2: ldloc.s 4
-		IL_02a4: ldstr "prototype"
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ae: stloc.s 37
-		IL_02b0: ldloc.s 37
-		IL_02b2: ldstr "add"
-		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_02bc: stloc.s 6
-		IL_02be: ldloc.s 4
-		IL_02c0: ldstr "prototype"
-		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ca: stloc.s 37
-		IL_02cc: ldloc.s 37
-		IL_02ce: ldstr "current"
-		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_02d8: stloc.s 7
-		IL_02da: ldloc.s 4
-		IL_02dc: ldstr "identify"
-		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_02e6: stloc.s 8
-		IL_02e8: ldstr "console"
-		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f7: stloc.s 37
-		IL_02f9: ldloc.s 5
-		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0300: stloc.s 43
-		IL_0302: ldloc.s 43
-		IL_0304: isinst Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_0309: dup
-		IL_030a: brfalse IL_0329
+		IL_01c3: newarr [System.Runtime]System.Object
+		IL_01c8: dup
+		IL_01c9: ldc.i4.0
+		IL_01ca: ldloc.0
+		IL_01cb: stelem.ref
+		IL_01cc: stloc.s 35
+		IL_01ce: ldloc.s 36
+		IL_01d0: ldloc.s 35
+		IL_01d2: ldc.r8 1
+		IL_01db: box [System.Runtime]System.Double
+		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_01e5: stloc.s 37
+		IL_01e7: ldloc.s 37
+		IL_01e9: ldloc.3
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_01ef: stloc.s 37
+		IL_01f1: ldloc.s 37
+		IL_01f3: stloc.s 4
+		IL_01f5: ldloc.s 4
+		IL_01f7: ldstr "prefix"
+		IL_01fc: ldstr "static:"
+		IL_0201: ldc.i4.1
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0207: pop
+		IL_0208: ldc.i4.1
+		IL_0209: newarr [System.Runtime]System.Object
+		IL_020e: dup
+		IL_020f: ldc.i4.0
+		IL_0210: ldc.r8 3
+		IL_0219: box [System.Runtime]System.Double
+		IL_021e: stelem.ref
+		IL_021f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0224: ldloc.s 4
+		IL_0226: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_022b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0230: ldc.r8 3
+		IL_0239: box [System.Runtime]System.Double
+		IL_023e: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example::.ctor(object)
+		IL_0243: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_0248: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_024d: dup
+		IL_024e: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
+		IL_0253: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0258: ldstr "prototype"
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0262: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0267: stloc.s 5
+		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0273: stloc.s 5
+		IL_0275: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_027a: ldloc.s 4
+		IL_027c: ldstr "prototype"
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0286: stloc.s 37
+		IL_0288: ldloc.s 37
+		IL_028a: ldstr "add"
+		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0294: stloc.s 6
+		IL_0296: ldloc.s 4
+		IL_0298: ldstr "prototype"
+		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a2: stloc.s 37
+		IL_02a4: ldloc.s 37
+		IL_02a6: ldstr "current"
+		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_02b0: stloc.s 7
+		IL_02b2: ldloc.s 4
+		IL_02b4: ldstr "identify"
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_02be: stloc.s 8
+		IL_02c0: ldstr "console"
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02cf: stloc.s 37
+		IL_02d1: ldloc.s 5
+		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d8: stloc.s 38
+		IL_02da: ldloc.s 38
+		IL_02dc: isinst Modules.Classes_GeneratedMethodFunctionObjects/Example
+		IL_02e1: dup
+		IL_02e2: brfalse IL_0301
 
-		IL_030f: ldc.r8 4
-		IL_0318: box [System.Runtime]System.Double
-		IL_031d: callvirt instance object Modules.Classes_GeneratedMethodFunctionObjects/Example::'add'(object)
-		IL_0322: stloc.s 43
-		IL_0324: br IL_0346
+		IL_02e7: ldc.r8 4
+		IL_02f0: box [System.Runtime]System.Double
+		IL_02f5: callvirt instance object Modules.Classes_GeneratedMethodFunctionObjects/Example::'add'(object)
+		IL_02fa: stloc.s 38
+		IL_02fc: br IL_031e
 
-		IL_0329: pop
-		IL_032a: ldloc.s 43
-		IL_032c: ldstr "add"
-		IL_0331: ldc.r8 4
-		IL_033a: box [System.Runtime]System.Double
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0344: stloc.s 43
+		IL_0301: pop
+		IL_0302: ldloc.s 38
+		IL_0304: ldstr "add"
+		IL_0309: ldc.r8 4
+		IL_0312: box [System.Runtime]System.Double
+		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_031c: stloc.s 38
 
-		IL_0346: ldloc.s 6
-		IL_0348: ldstr "value"
-		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0352: stloc.s 44
-		IL_0354: ldloc.s 44
-		IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_035b: ldstr "call"
-		IL_0360: ldloc.s 5
-		IL_0362: ldc.r8 5
-		IL_036b: box [System.Runtime]System.Double
-		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0375: stloc.s 44
-		IL_0377: ldloc.s 37
-		IL_0379: ldstr "log"
-		IL_037e: ldstr "calls"
-		IL_0383: ldloc.s 43
-		IL_0385: ldloc.s 44
-		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_038c: pop
+		IL_031e: ldloc.s 6
+		IL_0320: ldstr "value"
+		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_032a: stloc.s 39
+		IL_032c: ldloc.s 39
+		IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0333: ldstr "call"
+		IL_0338: ldloc.s 5
+		IL_033a: ldc.r8 5
+		IL_0343: box [System.Runtime]System.Double
+		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_034d: stloc.s 39
+		IL_034f: ldloc.s 37
+		IL_0351: ldstr "log"
+		IL_0356: ldstr "calls"
+		IL_035b: ldloc.s 38
+		IL_035d: ldloc.s 39
+		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0364: pop
+		IL_0365: ldloc.s 5
+		IL_0367: ldstr "current"
+		IL_036c: ldc.r8 9
+		IL_0375: ldc.i4.1
+		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_037b: pop
+		IL_037c: ldstr "console"
+		IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_038b: stloc.s 39
 		IL_038d: ldloc.s 5
 		IL_038f: ldstr "current"
-		IL_0394: ldc.r8 9
-		IL_039d: ldc.i4.1
-		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_03a3: pop
-		IL_03a4: ldstr "console"
-		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b3: stloc.s 44
+		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0399: stloc.s 38
+		IL_039b: ldloc.s 7
+		IL_039d: ldstr "get"
+		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03a7: stloc.s 37
+		IL_03a9: ldloc.s 37
+		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03b0: ldstr "call"
 		IL_03b5: ldloc.s 5
-		IL_03b7: ldstr "current"
-		IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03c1: stloc.s 43
-		IL_03c3: ldloc.s 7
-		IL_03c5: ldstr "get"
-		IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03cf: stloc.s 37
-		IL_03d1: ldloc.s 37
-		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d8: ldstr "call"
-		IL_03dd: ldloc.s 5
-		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03e4: stloc.s 37
-		IL_03e6: ldloc.s 44
-		IL_03e8: ldstr "log"
-		IL_03ed: ldstr "accessors"
-		IL_03f2: ldloc.s 43
-		IL_03f4: ldloc.s 37
-		IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_03fb: pop
-		IL_03fc: ldloc.s 7
-		IL_03fe: ldstr "set"
-		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0408: stloc.s 37
-		IL_040a: ldloc.s 37
-		IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0411: ldstr "call"
-		IL_0416: ldloc.s 5
-		IL_0418: ldc.r8 11
-		IL_0421: box [System.Runtime]System.Double
-		IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_042b: pop
-		IL_042c: ldstr "console"
-		IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_043b: stloc.s 37
-		IL_043d: ldloc.s 5
-		IL_043f: ldstr "current"
-		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0449: stloc.s 43
-		IL_044b: ldloc.s 37
-		IL_044d: ldstr "log"
-		IL_0452: ldstr "setter"
-		IL_0457: ldloc.s 43
-		IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_045e: pop
-		IL_045f: ldstr "console"
-		IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_046e: stloc.s 43
-		IL_0470: ldloc.s 4
-		IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_0477: stloc.s 37
-		IL_0479: ldstr "ok"
-		IL_047e: call object Modules.Classes_GeneratedMethodFunctionObjects/Example::identify(object)
-		IL_0483: stloc.s 44
-		IL_0485: ldloc.s 8
-		IL_0487: ldstr "value"
-		IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0491: stloc.s 37
+		IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03bc: stloc.s 37
+		IL_03be: ldloc.s 39
+		IL_03c0: ldstr "log"
+		IL_03c5: ldstr "accessors"
+		IL_03ca: ldloc.s 38
+		IL_03cc: ldloc.s 37
+		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_03d3: pop
+		IL_03d4: ldloc.s 7
+		IL_03d6: ldstr "set"
+		IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03e0: stloc.s 37
+		IL_03e2: ldloc.s 37
+		IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03e9: ldstr "call"
+		IL_03ee: ldloc.s 5
+		IL_03f0: ldc.r8 11
+		IL_03f9: box [System.Runtime]System.Double
+		IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0403: pop
+		IL_0404: ldstr "console"
+		IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0413: stloc.s 37
+		IL_0415: ldloc.s 5
+		IL_0417: ldstr "current"
+		IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0421: stloc.s 38
+		IL_0423: ldloc.s 37
+		IL_0425: ldstr "log"
+		IL_042a: ldstr "setter"
+		IL_042f: ldloc.s 38
+		IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0436: pop
+		IL_0437: ldstr "console"
+		IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0446: stloc.s 38
+		IL_0448: ldloc.s 4
+		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_044f: stloc.s 37
+		IL_0451: ldstr "ok"
+		IL_0456: call object Modules.Classes_GeneratedMethodFunctionObjects/Example::identify(object)
+		IL_045b: stloc.s 39
+		IL_045d: ldloc.s 8
+		IL_045f: ldstr "value"
+		IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0469: stloc.s 37
+		IL_046b: ldloc.s 37
+		IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0472: ldstr "call"
+		IL_0477: ldloc.s 4
+		IL_0479: ldstr "call"
+		IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0483: stloc.s 37
+		IL_0485: ldloc.s 38
+		IL_0487: ldstr "log"
+		IL_048c: ldstr "static"
+		IL_0491: ldloc.s 39
 		IL_0493: ldloc.s 37
-		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_049a: ldstr "call"
-		IL_049f: ldloc.s 4
-		IL_04a1: ldstr "call"
-		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04ab: stloc.s 37
-		IL_04ad: ldloc.s 43
-		IL_04af: ldstr "log"
-		IL_04b4: ldstr "static"
-		IL_04b9: ldloc.s 44
-		IL_04bb: ldloc.s 37
-		IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_04c2: pop
-		IL_04c3: ldstr "console"
-		IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04d2: stloc.s 37
-		IL_04d4: ldloc.s 6
-		IL_04d6: ldstr "value"
-		IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04e0: stloc.s 44
-		IL_04e2: ldloc.s 44
-		IL_04e4: ldstr "name"
-		IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04ee: stloc.s 44
-		IL_04f0: ldloc.s 6
-		IL_04f2: ldstr "value"
-		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04fc: stloc.s 43
-		IL_04fe: ldloc.s 43
-		IL_0500: ldstr "length"
-		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_050a: stloc.s 43
-		IL_050c: ldloc.s 7
-		IL_050e: ldstr "get"
-		IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0518: stloc.s 45
-		IL_051a: ldloc.s 45
-		IL_051c: ldstr "name"
-		IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0526: stloc.s 45
-		IL_0528: ldloc.s 7
-		IL_052a: ldstr "set"
-		IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0534: stloc.s 46
-		IL_0536: ldloc.s 46
-		IL_0538: ldstr "name"
-		IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0542: stloc.s 46
-		IL_0544: ldloc.s 8
-		IL_0546: ldstr "value"
-		IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0550: stloc.s 47
-		IL_0552: ldloc.s 47
-		IL_0554: ldstr "name"
-		IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_055e: stloc.s 47
-		IL_0560: ldloc.s 37
-		IL_0562: ldstr "log"
-		IL_0567: ldc.i4.6
-		IL_0568: newarr [System.Runtime]System.Object
-		IL_056d: dup
-		IL_056e: ldc.i4.0
-		IL_056f: ldstr "metadata"
-		IL_0574: stelem.ref
-		IL_0575: dup
-		IL_0576: ldc.i4.1
-		IL_0577: ldloc.s 44
-		IL_0579: stelem.ref
-		IL_057a: dup
-		IL_057b: ldc.i4.2
-		IL_057c: ldloc.s 43
-		IL_057e: stelem.ref
-		IL_057f: dup
-		IL_0580: ldc.i4.3
-		IL_0581: ldloc.s 45
-		IL_0583: stelem.ref
-		IL_0584: dup
-		IL_0585: ldc.i4.4
-		IL_0586: ldloc.s 46
-		IL_0588: stelem.ref
-		IL_0589: dup
-		IL_058a: ldc.i4.5
-		IL_058b: ldloc.s 47
-		IL_058d: stelem.ref
-		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0593: pop
-		IL_0594: ldstr "console"
-		IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05a3: stloc.s 37
-		IL_05a5: ldloc.s 6
-		IL_05a7: ldstr "value"
-		IL_05ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05b1: stloc.s 47
-		IL_05b3: ldloc.s 4
-		IL_05b5: ldstr "prototype"
-		IL_05ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05bf: stloc.s 46
-		IL_05c1: ldloc.s 46
-		IL_05c3: ldstr "add"
-		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05cd: stloc.s 46
-		IL_05cf: ldloc.s 47
-		IL_05d1: ldloc.s 46
-		IL_05d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_05d8: stloc.s 48
-		IL_05da: ldloc.s 48
-		IL_05dc: box [System.Runtime]System.Boolean
-		IL_05e1: stloc.s 49
-		IL_05e3: ldloc.s 7
-		IL_05e5: ldstr "get"
-		IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05ef: stloc.s 46
-		IL_05f1: ldloc.s 4
-		IL_05f3: ldstr "prototype"
-		IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05fd: stloc.s 47
-		IL_05ff: ldloc.s 47
-		IL_0601: ldstr "current"
-		IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_060b: ldstr "get"
-		IL_0610: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0615: stloc.s 47
-		IL_0617: ldloc.s 46
-		IL_0619: ldloc.s 47
-		IL_061b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0620: stloc.s 48
-		IL_0622: ldloc.s 48
-		IL_0624: box [System.Runtime]System.Boolean
-		IL_0629: stloc.s 50
-		IL_062b: ldloc.s 6
-		IL_062d: ldstr "value"
-		IL_0632: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0637: stloc.s 47
-		IL_0639: ldloc.s 47
-		IL_063b: ldstr "prototype"
-		IL_0640: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0645: box [System.Runtime]System.Boolean
-		IL_064a: stloc.s 51
-		IL_064c: ldloc.s 37
-		IL_064e: ldstr "log"
-		IL_0653: ldc.i4.4
-		IL_0654: newarr [System.Runtime]System.Object
-		IL_0659: dup
-		IL_065a: ldc.i4.0
-		IL_065b: ldstr "descriptors"
-		IL_0660: stelem.ref
-		IL_0661: dup
-		IL_0662: ldc.i4.1
-		IL_0663: ldloc.s 49
-		IL_0665: stelem.ref
-		IL_0666: dup
-		IL_0667: ldc.i4.2
-		IL_0668: ldloc.s 50
-		IL_066a: stelem.ref
-		IL_066b: dup
-		IL_066c: ldc.i4.3
-		IL_066d: ldloc.s 51
-		IL_066f: stelem.ref
-		IL_0670: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0675: pop
-		IL_0676: ldc.i4.0
-		IL_0677: box [System.Runtime]System.Boolean
-		IL_067c: stloc.s 9
+		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_049a: pop
+		IL_049b: ldstr "console"
+		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04aa: stloc.s 37
+		IL_04ac: ldloc.s 6
+		IL_04ae: ldstr "value"
+		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04b8: stloc.s 39
+		IL_04ba: ldloc.s 39
+		IL_04bc: ldstr "name"
+		IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04c6: stloc.s 39
+		IL_04c8: ldloc.s 6
+		IL_04ca: ldstr "value"
+		IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04d4: stloc.s 38
+		IL_04d6: ldloc.s 38
+		IL_04d8: ldstr "length"
+		IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04e2: stloc.s 38
+		IL_04e4: ldloc.s 7
+		IL_04e6: ldstr "get"
+		IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04f0: stloc.s 40
+		IL_04f2: ldloc.s 40
+		IL_04f4: ldstr "name"
+		IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04fe: stloc.s 40
+		IL_0500: ldloc.s 7
+		IL_0502: ldstr "set"
+		IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_050c: stloc.s 41
+		IL_050e: ldloc.s 41
+		IL_0510: ldstr "name"
+		IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_051a: stloc.s 41
+		IL_051c: ldloc.s 8
+		IL_051e: ldstr "value"
+		IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0528: stloc.s 42
+		IL_052a: ldloc.s 42
+		IL_052c: ldstr "name"
+		IL_0531: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0536: stloc.s 42
+		IL_0538: ldloc.s 37
+		IL_053a: ldstr "log"
+		IL_053f: ldc.i4.6
+		IL_0540: newarr [System.Runtime]System.Object
+		IL_0545: dup
+		IL_0546: ldc.i4.0
+		IL_0547: ldstr "metadata"
+		IL_054c: stelem.ref
+		IL_054d: dup
+		IL_054e: ldc.i4.1
+		IL_054f: ldloc.s 39
+		IL_0551: stelem.ref
+		IL_0552: dup
+		IL_0553: ldc.i4.2
+		IL_0554: ldloc.s 38
+		IL_0556: stelem.ref
+		IL_0557: dup
+		IL_0558: ldc.i4.3
+		IL_0559: ldloc.s 40
+		IL_055b: stelem.ref
+		IL_055c: dup
+		IL_055d: ldc.i4.4
+		IL_055e: ldloc.s 41
+		IL_0560: stelem.ref
+		IL_0561: dup
+		IL_0562: ldc.i4.5
+		IL_0563: ldloc.s 42
+		IL_0565: stelem.ref
+		IL_0566: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_056b: pop
+		IL_056c: ldstr "console"
+		IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_057b: stloc.s 37
+		IL_057d: ldloc.s 6
+		IL_057f: ldstr "value"
+		IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0589: stloc.s 42
+		IL_058b: ldloc.s 4
+		IL_058d: ldstr "prototype"
+		IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0597: stloc.s 41
+		IL_0599: ldloc.s 41
+		IL_059b: ldstr "add"
+		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05a5: stloc.s 41
+		IL_05a7: ldloc.s 42
+		IL_05a9: ldloc.s 41
+		IL_05ab: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05b0: stloc.s 43
+		IL_05b2: ldloc.s 43
+		IL_05b4: box [System.Runtime]System.Boolean
+		IL_05b9: stloc.s 44
+		IL_05bb: ldloc.s 7
+		IL_05bd: ldstr "get"
+		IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05c7: stloc.s 41
+		IL_05c9: ldloc.s 4
+		IL_05cb: ldstr "prototype"
+		IL_05d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05d5: stloc.s 42
+		IL_05d7: ldloc.s 42
+		IL_05d9: ldstr "current"
+		IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_05e3: ldstr "get"
+		IL_05e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ed: stloc.s 42
+		IL_05ef: ldloc.s 41
+		IL_05f1: ldloc.s 42
+		IL_05f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05f8: stloc.s 43
+		IL_05fa: ldloc.s 43
+		IL_05fc: box [System.Runtime]System.Boolean
+		IL_0601: stloc.s 45
+		IL_0603: ldloc.s 6
+		IL_0605: ldstr "value"
+		IL_060a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_060f: stloc.s 42
+		IL_0611: ldloc.s 42
+		IL_0613: ldstr "prototype"
+		IL_0618: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_061d: box [System.Runtime]System.Boolean
+		IL_0622: stloc.s 46
+		IL_0624: ldloc.s 37
+		IL_0626: ldstr "log"
+		IL_062b: ldc.i4.4
+		IL_062c: newarr [System.Runtime]System.Object
+		IL_0631: dup
+		IL_0632: ldc.i4.0
+		IL_0633: ldstr "descriptors"
+		IL_0638: stelem.ref
+		IL_0639: dup
+		IL_063a: ldc.i4.1
+		IL_063b: ldloc.s 44
+		IL_063d: stelem.ref
+		IL_063e: dup
+		IL_063f: ldc.i4.2
+		IL_0640: ldloc.s 45
+		IL_0642: stelem.ref
+		IL_0643: dup
+		IL_0644: ldc.i4.3
+		IL_0645: ldloc.s 46
+		IL_0647: stelem.ref
+		IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_064d: pop
+		IL_064e: ldc.i4.0
+		IL_064f: box [System.Runtime]System.Boolean
+		IL_0654: stloc.s 9
 		.try
 		{
-			IL_067e: nop
-			IL_067f: ldstr "Reflect"
-			IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_068e: stloc.s 37
-			IL_0690: ldloc.s 6
-			IL_0692: ldstr "value"
-			IL_0697: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_069c: stloc.s 47
-			IL_069e: ldc.i4.0
-			IL_069f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_06a4: stloc.s 52
-			IL_06a6: ldloc.s 37
-			IL_06a8: ldstr "construct"
-			IL_06ad: ldloc.s 47
-			IL_06af: ldloc.s 52
-			IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_06b6: pop
-			IL_06b7: leave IL_071b
+			IL_0656: nop
+			IL_0657: ldstr "Reflect"
+			IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0666: stloc.s 37
+			IL_0668: ldloc.s 6
+			IL_066a: ldstr "value"
+			IL_066f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0674: stloc.s 42
+			IL_0676: ldc.i4.0
+			IL_0677: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_067c: stloc.s 47
+			IL_067e: ldloc.s 37
+			IL_0680: ldstr "construct"
+			IL_0685: ldloc.s 42
+			IL_0687: ldloc.s 47
+			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_068e: pop
+			IL_068f: leave IL_06f3
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_06bc: stloc.s 10
-			IL_06be: ldloc.s 10
-			IL_06c0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_06c5: dup
-			IL_06c6: brtrue IL_06dc
+			IL_0694: stloc.s 10
+			IL_0696: ldloc.s 10
+			IL_0698: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_069d: dup
+			IL_069e: brtrue IL_06b4
 
-			IL_06cb: pop
-			IL_06cc: ldloc.s 10
-			IL_06ce: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_06d3: dup
-			IL_06d4: brtrue IL_06e8
+			IL_06a3: pop
+			IL_06a4: ldloc.s 10
+			IL_06a6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_06ab: dup
+			IL_06ac: brtrue IL_06c0
 
-			IL_06d9: pop
-			IL_06da: rethrow
+			IL_06b1: pop
+			IL_06b2: rethrow
 
-			IL_06dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_06e1: stloc.s 11
-			IL_06e3: br IL_06ea
+			IL_06b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_06b9: stloc.s 11
+			IL_06bb: br IL_06c2
 
-			IL_06e8: stloc.s 11
+			IL_06c0: stloc.s 11
 
-			IL_06ea: ldloc.s 11
-			IL_06ec: stloc.s 12
-			IL_06ee: ldloc.s 12
-			IL_06f0: stloc.s 47
-			IL_06f2: ldstr "TypeError"
-			IL_06f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06fc: stloc.s 37
-			IL_06fe: ldloc.s 47
-			IL_0700: ldloc.s 37
-			IL_0702: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0707: stloc.s 48
-			IL_0709: ldloc.s 48
-			IL_070b: box [System.Runtime]System.Boolean
-			IL_0710: stloc.s 51
-			IL_0712: ldloc.s 51
-			IL_0714: stloc.s 9
-			IL_0716: leave IL_071b
+			IL_06c2: ldloc.s 11
+			IL_06c4: stloc.s 12
+			IL_06c6: ldloc.s 12
+			IL_06c8: stloc.s 42
+			IL_06ca: ldstr "TypeError"
+			IL_06cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06d4: stloc.s 37
+			IL_06d6: ldloc.s 42
+			IL_06d8: ldloc.s 37
+			IL_06da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_06df: stloc.s 43
+			IL_06e1: ldloc.s 43
+			IL_06e3: box [System.Runtime]System.Boolean
+			IL_06e8: stloc.s 46
+			IL_06ea: ldloc.s 46
+			IL_06ec: stloc.s 9
+			IL_06ee: leave IL_06f3
 		} // end handler
 
-		IL_071b: ldstr "console"
-		IL_0720: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0725: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_072a: ldstr "log"
-		IL_072f: ldstr "nonconstructor"
-		IL_0734: ldloc.s 9
-		IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_073b: pop
-		IL_073c: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_0741: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0746: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_074b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0750: stloc.s 36
-		IL_0752: ldloc.s 36
-		IL_0754: ldstr "prototype"
-		IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_075e: stloc.s 37
-		IL_0760: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0765: stloc.s 35
-		IL_0767: ldloc.s 36
-		IL_0769: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read::.ctor(class [System.Runtime]System.Object)
-		IL_076e: ldc.i4.0
-		IL_076f: conv.r8
-		IL_0770: ldstr "read"
-		IL_0775: ldc.i4.1
-		IL_0776: ldc.i4.1
-		IL_0777: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0, float64, string, bool, bool)
-		IL_077c: stloc.s 53
-		IL_077e: ldloc.s 53
-		IL_0780: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0)
-		IL_0785: stloc.s 53
-		IL_0787: ldloc.s 37
-		IL_0789: ldstr "read"
-		IL_078e: ldloc.s 53
-		IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0795: pop
-		IL_0796: ldc.i4.1
-		IL_0797: newarr [System.Runtime]System.Object
-		IL_079c: dup
-		IL_079d: ldc.i4.0
-		IL_079e: ldloc.0
-		IL_079f: stelem.ref
-		IL_07a0: stloc.s 35
-		IL_07a2: ldloc.s 36
-		IL_07a4: ldloc.s 35
-		IL_07a6: ldc.r8 1
-		IL_07af: box [System.Runtime]System.Double
-		IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_07b9: stloc.s 37
-		IL_07bb: ldloc.s 37
-		IL_07bd: stloc.s 13
-		IL_07bf: ldc.i4.1
-		IL_07c0: newarr [System.Runtime]System.Object
-		IL_07c5: dup
-		IL_07c6: ldc.i4.0
-		IL_07c7: ldloc.0
-		IL_07c8: stelem.ref
-		IL_07c9: stloc.s 35
-		IL_07cb: ldloc.s 35
-		IL_07cd: ldc.i4.1
-		IL_07ce: newarr [System.Runtime]System.Object
-		IL_07d3: dup
-		IL_07d4: ldc.i4.0
-		IL_07d5: ldc.r8 17
-		IL_07de: box [System.Runtime]System.Double
-		IL_07e3: stelem.ref
-		IL_07e4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_07e9: ldc.r8 17
-		IL_07f2: box [System.Runtime]System.Double
-		IL_07f7: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret::.ctor(object[], object)
-		IL_07fc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0801: stloc.s 14
-		IL_0803: ldloc.s 14
-		IL_0805: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_080a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_080f: ldstr "prototype"
-		IL_0814: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0819: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_081e: ldloc.s 13
-		IL_0820: ldstr "prototype"
-		IL_0825: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_082a: stloc.s 37
-		IL_082c: ldloc.s 37
-		IL_082e: ldstr "read"
-		IL_0833: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0838: stloc.s 15
-		IL_083a: ldc.i4.0
-		IL_083b: box [System.Runtime]System.Boolean
-		IL_0840: stloc.s 16
+		IL_06f3: ldstr "console"
+		IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0702: ldstr "log"
+		IL_0707: ldstr "nonconstructor"
+		IL_070c: ldloc.s 9
+		IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0713: pop
+		IL_0714: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+		IL_0719: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_071e: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+		IL_0723: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0728: stloc.s 36
+		IL_072a: ldloc.s 36
+		IL_072c: ldstr "prototype"
+		IL_0731: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0736: stloc.s 37
+		IL_0738: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_073d: stloc.s 35
+		IL_073f: ldloc.s 37
+		IL_0741: ldstr "read"
+		IL_0746: ldloc.s 36
+		IL_0748: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read::.ctor(class [System.Runtime]System.Object)
+		IL_074d: ldc.i4.0
+		IL_074e: conv.r8
+		IL_074f: ldstr "read"
+		IL_0754: ldc.i4.1
+		IL_0755: ldc.i4.1
+		IL_0756: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0, float64, string, bool, bool)
+		IL_075b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0)
+		IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0765: pop
+		IL_0766: ldc.i4.1
+		IL_0767: newarr [System.Runtime]System.Object
+		IL_076c: dup
+		IL_076d: ldc.i4.0
+		IL_076e: ldloc.0
+		IL_076f: stelem.ref
+		IL_0770: stloc.s 35
+		IL_0772: ldloc.s 36
+		IL_0774: ldloc.s 35
+		IL_0776: ldc.r8 1
+		IL_077f: box [System.Runtime]System.Double
+		IL_0784: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0789: stloc.s 37
+		IL_078b: ldloc.s 37
+		IL_078d: stloc.s 13
+		IL_078f: ldc.i4.1
+		IL_0790: newarr [System.Runtime]System.Object
+		IL_0795: dup
+		IL_0796: ldc.i4.0
+		IL_0797: ldloc.0
+		IL_0798: stelem.ref
+		IL_0799: stloc.s 35
+		IL_079b: ldloc.s 35
+		IL_079d: ldc.i4.1
+		IL_079e: newarr [System.Runtime]System.Object
+		IL_07a3: dup
+		IL_07a4: ldc.i4.0
+		IL_07a5: ldc.r8 17
+		IL_07ae: box [System.Runtime]System.Double
+		IL_07b3: stelem.ref
+		IL_07b4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_07b9: ldc.r8 17
+		IL_07c2: box [System.Runtime]System.Double
+		IL_07c7: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret::.ctor(object[], object)
+		IL_07cc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_07d1: stloc.s 14
+		IL_07d3: ldloc.s 14
+		IL_07d5: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+		IL_07da: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_07df: ldstr "prototype"
+		IL_07e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_07e9: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_07ee: ldloc.s 13
+		IL_07f0: ldstr "prototype"
+		IL_07f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07fa: stloc.s 37
+		IL_07fc: ldloc.s 37
+		IL_07fe: ldstr "read"
+		IL_0803: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0808: stloc.s 15
+		IL_080a: ldc.i4.0
+		IL_080b: box [System.Runtime]System.Boolean
+		IL_0810: stloc.s 16
 		.try
 		{
-			IL_0842: nop
-			IL_0843: ldloc.s 15
-			IL_0845: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_084a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_084f: stloc.s 54
-			IL_0851: ldstr "call"
-			IL_0856: ldloc.s 54
-			IL_0858: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_085d: pop
-			IL_085e: leave IL_08c2
+			IL_0812: nop
+			IL_0813: ldloc.s 15
+			IL_0815: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_081a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_081f: stloc.s 48
+			IL_0821: ldstr "call"
+			IL_0826: ldloc.s 48
+			IL_0828: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_082d: pop
+			IL_082e: leave IL_0892
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0863: stloc.s 17
-			IL_0865: ldloc.s 17
-			IL_0867: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_086c: dup
-			IL_086d: brtrue IL_0883
+			IL_0833: stloc.s 17
+			IL_0835: ldloc.s 17
+			IL_0837: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_083c: dup
+			IL_083d: brtrue IL_0853
 
-			IL_0872: pop
-			IL_0873: ldloc.s 17
-			IL_0875: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_087a: dup
-			IL_087b: brtrue IL_088f
+			IL_0842: pop
+			IL_0843: ldloc.s 17
+			IL_0845: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_084a: dup
+			IL_084b: brtrue IL_085f
 
-			IL_0880: pop
-			IL_0881: rethrow
+			IL_0850: pop
+			IL_0851: rethrow
 
-			IL_0883: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0888: stloc.s 18
-			IL_088a: br IL_0891
+			IL_0853: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0858: stloc.s 18
+			IL_085a: br IL_0861
 
-			IL_088f: stloc.s 18
+			IL_085f: stloc.s 18
 
-			IL_0891: ldloc.s 18
-			IL_0893: stloc.s 19
-			IL_0895: ldloc.s 19
-			IL_0897: stloc.s 37
-			IL_0899: ldstr "TypeError"
-			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_08a3: stloc.s 47
-			IL_08a5: ldloc.s 37
-			IL_08a7: ldloc.s 47
-			IL_08a9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_08ae: stloc.s 48
-			IL_08b0: ldloc.s 48
-			IL_08b2: box [System.Runtime]System.Boolean
-			IL_08b7: stloc.s 51
-			IL_08b9: ldloc.s 51
-			IL_08bb: stloc.s 16
-			IL_08bd: leave IL_08c2
+			IL_0861: ldloc.s 18
+			IL_0863: stloc.s 19
+			IL_0865: ldloc.s 19
+			IL_0867: stloc.s 37
+			IL_0869: ldstr "TypeError"
+			IL_086e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0873: stloc.s 42
+			IL_0875: ldloc.s 37
+			IL_0877: ldloc.s 42
+			IL_0879: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_087e: stloc.s 43
+			IL_0880: ldloc.s 43
+			IL_0882: box [System.Runtime]System.Boolean
+			IL_0887: stloc.s 46
+			IL_0889: ldloc.s 46
+			IL_088b: stloc.s 16
+			IL_088d: leave IL_0892
 		} // end handler
 
-		IL_08c2: ldstr "console"
-		IL_08c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08d1: stloc.s 47
-		IL_08d3: ldloc.s 15
-		IL_08d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08da: ldstr "call"
-		IL_08df: ldloc.s 14
-		IL_08e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_08e6: stloc.s 37
-		IL_08e8: ldloc.s 47
-		IL_08ea: ldstr "log"
-		IL_08ef: ldstr "private"
-		IL_08f4: ldloc.s 37
-		IL_08f6: ldloc.s 16
-		IL_08f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_08fd: pop
-		IL_08fe: nop
-		IL_08ff: ldloc.1
-		IL_0900: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0905: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_090a: stloc.s 20
-		IL_090c: ldloc.1
-		IL_090d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0912: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0917: stloc.s 21
-		IL_0919: ldstr "console"
-		IL_091e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0923: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0928: stloc.s 37
-		IL_092a: ldloc.s 20
-		IL_092c: ldstr "prototype"
-		IL_0931: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0936: stloc.s 47
-		IL_0938: ldloc.s 47
-		IL_093a: ldstr "method"
-		IL_093f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0944: stloc.s 47
-		IL_0946: ldloc.s 21
-		IL_0948: ldstr "prototype"
-		IL_094d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0952: stloc.s 46
-		IL_0954: ldloc.s 46
-		IL_0956: ldstr "method"
-		IL_095b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0960: stloc.s 46
-		IL_0962: ldloc.s 47
-		IL_0964: ldloc.s 46
-		IL_0966: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_096b: stloc.s 48
-		IL_096d: ldloc.s 48
-		IL_096f: box [System.Runtime]System.Boolean
-		IL_0974: stloc.s 51
-		IL_0976: ldloc.s 37
-		IL_0978: ldstr "log"
-		IL_097d: ldstr "identity"
-		IL_0982: ldloc.s 51
-		IL_0984: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0989: pop
-		IL_098a: nop
-		IL_098b: ldloc.2
-		IL_098c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0991: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0996: stloc.s 22
-		IL_0998: ldloc.2
-		IL_0999: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_099e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_09a3: stloc.s 23
-		IL_09a5: ldloc.s 22
-		IL_09a7: ldc.i4.1
-		IL_09a8: newarr [System.Runtime]System.Object
-		IL_09ad: dup
-		IL_09ae: ldc.i4.0
-		IL_09af: ldc.r8 1
-		IL_09b8: box [System.Runtime]System.Double
-		IL_09bd: stelem.ref
-		IL_09be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_09c3: stloc.s 24
-		IL_09c5: ldloc.s 23
-		IL_09c7: ldc.i4.1
-		IL_09c8: newarr [System.Runtime]System.Object
-		IL_09cd: dup
-		IL_09ce: ldc.i4.0
-		IL_09cf: ldc.r8 2
-		IL_09d8: box [System.Runtime]System.Double
-		IL_09dd: stelem.ref
-		IL_09de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_09e3: stloc.s 25
-		IL_09e5: ldc.i4.0
-		IL_09e6: box [System.Runtime]System.Boolean
-		IL_09eb: stloc.s 26
+		IL_0892: ldstr "console"
+		IL_0897: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_089c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08a1: stloc.s 42
+		IL_08a3: ldloc.s 15
+		IL_08a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08aa: ldstr "call"
+		IL_08af: ldloc.s 14
+		IL_08b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_08b6: stloc.s 37
+		IL_08b8: ldloc.s 42
+		IL_08ba: ldstr "log"
+		IL_08bf: ldstr "private"
+		IL_08c4: ldloc.s 37
+		IL_08c6: ldloc.s 16
+		IL_08c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_08cd: pop
+		IL_08ce: nop
+		IL_08cf: ldloc.1
+		IL_08d0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_08d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_08da: stloc.s 20
+		IL_08dc: ldloc.1
+		IL_08dd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_08e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_08e7: stloc.s 21
+		IL_08e9: ldstr "console"
+		IL_08ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08f8: stloc.s 37
+		IL_08fa: ldloc.s 20
+		IL_08fc: ldstr "prototype"
+		IL_0901: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0906: stloc.s 42
+		IL_0908: ldloc.s 42
+		IL_090a: ldstr "method"
+		IL_090f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0914: stloc.s 42
+		IL_0916: ldloc.s 21
+		IL_0918: ldstr "prototype"
+		IL_091d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0922: stloc.s 41
+		IL_0924: ldloc.s 41
+		IL_0926: ldstr "method"
+		IL_092b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0930: stloc.s 41
+		IL_0932: ldloc.s 42
+		IL_0934: ldloc.s 41
+		IL_0936: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_093b: stloc.s 43
+		IL_093d: ldloc.s 43
+		IL_093f: box [System.Runtime]System.Boolean
+		IL_0944: stloc.s 46
+		IL_0946: ldloc.s 37
+		IL_0948: ldstr "log"
+		IL_094d: ldstr "identity"
+		IL_0952: ldloc.s 46
+		IL_0954: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0959: pop
+		IL_095a: nop
+		IL_095b: ldloc.2
+		IL_095c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0961: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0966: stloc.s 22
+		IL_0968: ldloc.2
+		IL_0969: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_096e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0973: stloc.s 23
+		IL_0975: ldloc.s 22
+		IL_0977: ldc.i4.1
+		IL_0978: newarr [System.Runtime]System.Object
+		IL_097d: dup
+		IL_097e: ldc.i4.0
+		IL_097f: ldc.r8 1
+		IL_0988: box [System.Runtime]System.Double
+		IL_098d: stelem.ref
+		IL_098e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_0993: stloc.s 24
+		IL_0995: ldloc.s 23
+		IL_0997: ldc.i4.1
+		IL_0998: newarr [System.Runtime]System.Object
+		IL_099d: dup
+		IL_099e: ldc.i4.0
+		IL_099f: ldc.r8 2
+		IL_09a8: box [System.Runtime]System.Double
+		IL_09ad: stelem.ref
+		IL_09ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_09b3: stloc.s 25
+		IL_09b5: ldc.i4.0
+		IL_09b6: box [System.Runtime]System.Boolean
+		IL_09bb: stloc.s 26
 		.try
 		{
-			IL_09ed: nop
-			IL_09ee: ldloc.s 22
-			IL_09f0: ldstr "prototype"
-			IL_09f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09fa: stloc.s 37
-			IL_09fc: ldloc.s 37
-			IL_09fe: ldstr "read"
-			IL_0a03: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a08: stloc.s 37
-			IL_0a0a: ldloc.s 37
-			IL_0a0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a11: ldstr "call"
-			IL_0a16: ldloc.s 25
-			IL_0a18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0a1d: pop
-			IL_0a1e: leave IL_0a82
+			IL_09bd: nop
+			IL_09be: ldloc.s 22
+			IL_09c0: ldstr "prototype"
+			IL_09c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09ca: stloc.s 37
+			IL_09cc: ldloc.s 37
+			IL_09ce: ldstr "read"
+			IL_09d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09d8: stloc.s 37
+			IL_09da: ldloc.s 37
+			IL_09dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09e1: ldstr "call"
+			IL_09e6: ldloc.s 25
+			IL_09e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_09ed: pop
+			IL_09ee: leave IL_0a52
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0a23: stloc.s 27
-			IL_0a25: ldloc.s 27
-			IL_0a27: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0a2c: dup
-			IL_0a2d: brtrue IL_0a43
+			IL_09f3: stloc.s 27
+			IL_09f5: ldloc.s 27
+			IL_09f7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_09fc: dup
+			IL_09fd: brtrue IL_0a13
 
-			IL_0a32: pop
-			IL_0a33: ldloc.s 27
-			IL_0a35: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0a3a: dup
-			IL_0a3b: brtrue IL_0a4f
+			IL_0a02: pop
+			IL_0a03: ldloc.s 27
+			IL_0a05: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0a0a: dup
+			IL_0a0b: brtrue IL_0a1f
 
-			IL_0a40: pop
-			IL_0a41: rethrow
+			IL_0a10: pop
+			IL_0a11: rethrow
 
-			IL_0a43: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0a48: stloc.s 28
-			IL_0a4a: br IL_0a51
+			IL_0a13: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0a18: stloc.s 28
+			IL_0a1a: br IL_0a21
 
-			IL_0a4f: stloc.s 28
+			IL_0a1f: stloc.s 28
 
-			IL_0a51: ldloc.s 28
-			IL_0a53: stloc.s 29
-			IL_0a55: ldloc.s 29
-			IL_0a57: stloc.s 37
-			IL_0a59: ldstr "TypeError"
-			IL_0a5e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a63: stloc.s 46
-			IL_0a65: ldloc.s 37
-			IL_0a67: ldloc.s 46
-			IL_0a69: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0a6e: stloc.s 48
-			IL_0a70: ldloc.s 48
-			IL_0a72: box [System.Runtime]System.Boolean
-			IL_0a77: stloc.s 51
-			IL_0a79: ldloc.s 51
-			IL_0a7b: stloc.s 26
-			IL_0a7d: leave IL_0a82
+			IL_0a21: ldloc.s 28
+			IL_0a23: stloc.s 29
+			IL_0a25: ldloc.s 29
+			IL_0a27: stloc.s 37
+			IL_0a29: ldstr "TypeError"
+			IL_0a2e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a33: stloc.s 41
+			IL_0a35: ldloc.s 37
+			IL_0a37: ldloc.s 41
+			IL_0a39: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0a3e: stloc.s 43
+			IL_0a40: ldloc.s 43
+			IL_0a42: box [System.Runtime]System.Boolean
+			IL_0a47: stloc.s 46
+			IL_0a49: ldloc.s 46
+			IL_0a4b: stloc.s 26
+			IL_0a4d: leave IL_0a52
 		} // end handler
 
-		IL_0a82: ldstr "console"
-		IL_0a87: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0a8c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0a52: ldstr "console"
+		IL_0a57: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0a5c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0a61: stloc.s 41
+		IL_0a63: ldloc.s 22
+		IL_0a65: ldstr "prototype"
+		IL_0a6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a6f: stloc.s 37
+		IL_0a71: ldloc.s 23
+		IL_0a73: ldstr "prototype"
+		IL_0a78: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a7d: stloc.s 42
+		IL_0a7f: ldloc.s 37
+		IL_0a81: ldloc.s 42
+		IL_0a83: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0a88: stloc.s 43
+		IL_0a8a: ldloc.s 43
+		IL_0a8c: box [System.Runtime]System.Boolean
 		IL_0a91: stloc.s 46
 		IL_0a93: ldloc.s 22
 		IL_0a95: ldstr "prototype"
 		IL_0a9a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a9f: stloc.s 37
-		IL_0aa1: ldloc.s 23
-		IL_0aa3: ldstr "prototype"
+		IL_0a9f: stloc.s 42
+		IL_0aa1: ldloc.s 42
+		IL_0aa3: ldstr "read"
 		IL_0aa8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0aad: stloc.s 47
-		IL_0aaf: ldloc.s 37
-		IL_0ab1: ldloc.s 47
-		IL_0ab3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0ab8: stloc.s 48
-		IL_0aba: ldloc.s 48
-		IL_0abc: box [System.Runtime]System.Boolean
-		IL_0ac1: stloc.s 51
-		IL_0ac3: ldloc.s 22
-		IL_0ac5: ldstr "prototype"
-		IL_0aca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0acf: stloc.s 47
-		IL_0ad1: ldloc.s 47
-		IL_0ad3: ldstr "read"
-		IL_0ad8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0add: stloc.s 47
-		IL_0adf: ldloc.s 23
+		IL_0aad: stloc.s 42
+		IL_0aaf: ldloc.s 23
+		IL_0ab1: ldstr "prototype"
+		IL_0ab6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0abb: stloc.s 37
+		IL_0abd: ldloc.s 37
+		IL_0abf: ldstr "read"
+		IL_0ac4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0ac9: stloc.s 37
+		IL_0acb: ldloc.s 42
+		IL_0acd: ldloc.s 37
+		IL_0acf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0ad4: stloc.s 43
+		IL_0ad6: ldloc.s 43
+		IL_0ad8: box [System.Runtime]System.Boolean
+		IL_0add: stloc.s 45
+		IL_0adf: ldloc.s 22
 		IL_0ae1: ldstr "prototype"
 		IL_0ae6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0aeb: stloc.s 37
@@ -3529,162 +3494,147 @@
 		IL_0aef: ldstr "read"
 		IL_0af4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0af9: stloc.s 37
-		IL_0afb: ldloc.s 47
-		IL_0afd: ldloc.s 37
-		IL_0aff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0b04: stloc.s 48
-		IL_0b06: ldloc.s 48
-		IL_0b08: box [System.Runtime]System.Boolean
-		IL_0b0d: stloc.s 50
-		IL_0b0f: ldloc.s 22
-		IL_0b11: ldstr "prototype"
-		IL_0b16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b1b: stloc.s 37
-		IL_0b1d: ldloc.s 37
-		IL_0b1f: ldstr "read"
-		IL_0b24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b29: stloc.s 37
-		IL_0b2b: ldloc.s 37
-		IL_0b2d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0b32: ldstr "call"
-		IL_0b37: ldloc.s 24
-		IL_0b39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0b3e: stloc.s 37
-		IL_0b40: ldloc.s 46
-		IL_0b42: ldstr "log"
-		IL_0b47: ldc.i4.5
-		IL_0b48: newarr [System.Runtime]System.Object
-		IL_0b4d: dup
-		IL_0b4e: ldc.i4.0
-		IL_0b4f: ldstr "privateIdentity"
-		IL_0b54: stelem.ref
-		IL_0b55: dup
-		IL_0b56: ldc.i4.1
-		IL_0b57: ldloc.s 51
-		IL_0b59: stelem.ref
-		IL_0b5a: dup
-		IL_0b5b: ldc.i4.2
-		IL_0b5c: ldloc.s 50
-		IL_0b5e: stelem.ref
-		IL_0b5f: dup
-		IL_0b60: ldc.i4.3
-		IL_0b61: ldloc.s 37
-		IL_0b63: stelem.ref
-		IL_0b64: dup
-		IL_0b65: ldc.i4.4
-		IL_0b66: ldloc.s 26
-		IL_0b68: stelem.ref
-		IL_0b69: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0b6e: pop
-		IL_0b6f: ldc.i4.0
-		IL_0b70: box [System.Runtime]System.Boolean
-		IL_0b75: stloc.s 30
+		IL_0afb: ldloc.s 37
+		IL_0afd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0b02: ldstr "call"
+		IL_0b07: ldloc.s 24
+		IL_0b09: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0b0e: stloc.s 37
+		IL_0b10: ldloc.s 41
+		IL_0b12: ldstr "log"
+		IL_0b17: ldc.i4.5
+		IL_0b18: newarr [System.Runtime]System.Object
+		IL_0b1d: dup
+		IL_0b1e: ldc.i4.0
+		IL_0b1f: ldstr "privateIdentity"
+		IL_0b24: stelem.ref
+		IL_0b25: dup
+		IL_0b26: ldc.i4.1
+		IL_0b27: ldloc.s 46
+		IL_0b29: stelem.ref
+		IL_0b2a: dup
+		IL_0b2b: ldc.i4.2
+		IL_0b2c: ldloc.s 45
+		IL_0b2e: stelem.ref
+		IL_0b2f: dup
+		IL_0b30: ldc.i4.3
+		IL_0b31: ldloc.s 37
+		IL_0b33: stelem.ref
+		IL_0b34: dup
+		IL_0b35: ldc.i4.4
+		IL_0b36: ldloc.s 26
+		IL_0b38: stelem.ref
+		IL_0b39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0b3e: pop
+		IL_0b3f: ldc.i4.0
+		IL_0b40: box [System.Runtime]System.Boolean
+		IL_0b45: stloc.s 30
 		.try
 		{
-			IL_0b77: nop
-			IL_0b78: ldloc.s 22
-			IL_0b7a: ldstr "readStatic"
-			IL_0b7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b84: stloc.s 46
-			IL_0b86: ldloc.s 46
-			IL_0b88: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b8d: ldstr "call"
-			IL_0b92: ldloc.s 23
-			IL_0b94: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0b99: pop
-			IL_0b9a: leave IL_0bfe
+			IL_0b47: nop
+			IL_0b48: ldloc.s 22
+			IL_0b4a: ldstr "readStatic"
+			IL_0b4f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b54: stloc.s 41
+			IL_0b56: ldloc.s 41
+			IL_0b58: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b5d: ldstr "call"
+			IL_0b62: ldloc.s 23
+			IL_0b64: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0b69: pop
+			IL_0b6a: leave IL_0bce
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0b9f: stloc.s 31
-			IL_0ba1: ldloc.s 31
-			IL_0ba3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0ba8: dup
-			IL_0ba9: brtrue IL_0bbf
+			IL_0b6f: stloc.s 31
+			IL_0b71: ldloc.s 31
+			IL_0b73: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0b78: dup
+			IL_0b79: brtrue IL_0b8f
 
-			IL_0bae: pop
-			IL_0baf: ldloc.s 31
-			IL_0bb1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0bb6: dup
-			IL_0bb7: brtrue IL_0bcb
+			IL_0b7e: pop
+			IL_0b7f: ldloc.s 31
+			IL_0b81: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0b86: dup
+			IL_0b87: brtrue IL_0b9b
 
-			IL_0bbc: pop
-			IL_0bbd: rethrow
+			IL_0b8c: pop
+			IL_0b8d: rethrow
 
-			IL_0bbf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0bc4: stloc.s 32
-			IL_0bc6: br IL_0bcd
+			IL_0b8f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0b94: stloc.s 32
+			IL_0b96: br IL_0b9d
 
-			IL_0bcb: stloc.s 32
+			IL_0b9b: stloc.s 32
 
-			IL_0bcd: ldloc.s 32
-			IL_0bcf: stloc.s 33
-			IL_0bd1: ldloc.s 33
-			IL_0bd3: stloc.s 46
-			IL_0bd5: ldstr "TypeError"
-			IL_0bda: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0bdf: stloc.s 37
-			IL_0be1: ldloc.s 46
-			IL_0be3: ldloc.s 37
-			IL_0be5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0bea: stloc.s 48
-			IL_0bec: ldloc.s 48
-			IL_0bee: box [System.Runtime]System.Boolean
-			IL_0bf3: stloc.s 50
-			IL_0bf5: ldloc.s 50
-			IL_0bf7: stloc.s 30
-			IL_0bf9: leave IL_0bfe
+			IL_0b9d: ldloc.s 32
+			IL_0b9f: stloc.s 33
+			IL_0ba1: ldloc.s 33
+			IL_0ba3: stloc.s 41
+			IL_0ba5: ldstr "TypeError"
+			IL_0baa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0baf: stloc.s 37
+			IL_0bb1: ldloc.s 41
+			IL_0bb3: ldloc.s 37
+			IL_0bb5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0bba: stloc.s 43
+			IL_0bbc: ldloc.s 43
+			IL_0bbe: box [System.Runtime]System.Boolean
+			IL_0bc3: stloc.s 45
+			IL_0bc5: ldloc.s 45
+			IL_0bc7: stloc.s 30
+			IL_0bc9: leave IL_0bce
 		} // end handler
 
-		IL_0bfe: ldstr "console"
-		IL_0c03: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0c08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0c0d: stloc.s 37
+		IL_0bce: ldstr "console"
+		IL_0bd3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0bd8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0bdd: stloc.s 37
+		IL_0bdf: ldloc.s 22
+		IL_0be1: ldstr "readStatic"
+		IL_0be6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0beb: stloc.s 41
+		IL_0bed: ldloc.s 23
+		IL_0bef: ldstr "readStatic"
+		IL_0bf4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0bf9: stloc.s 42
+		IL_0bfb: ldloc.s 41
+		IL_0bfd: ldloc.s 42
+		IL_0bff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0c04: stloc.s 43
+		IL_0c06: ldloc.s 43
+		IL_0c08: box [System.Runtime]System.Boolean
+		IL_0c0d: stloc.s 45
 		IL_0c0f: ldloc.s 22
-		IL_0c11: ldstr "readStatic"
-		IL_0c16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c1b: stloc.s 46
-		IL_0c1d: ldloc.s 23
-		IL_0c1f: ldstr "readStatic"
-		IL_0c24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c29: stloc.s 47
-		IL_0c2b: ldloc.s 46
-		IL_0c2d: ldloc.s 47
-		IL_0c2f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0c34: stloc.s 48
-		IL_0c36: ldloc.s 48
-		IL_0c38: box [System.Runtime]System.Boolean
-		IL_0c3d: stloc.s 50
-		IL_0c3f: ldloc.s 22
-		IL_0c41: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0c46: ldstr "readStatic"
-		IL_0c4b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0c50: stloc.s 47
-		IL_0c52: ldloc.s 37
-		IL_0c54: ldstr "log"
-		IL_0c59: ldc.i4.4
-		IL_0c5a: newarr [System.Runtime]System.Object
-		IL_0c5f: dup
-		IL_0c60: ldc.i4.0
-		IL_0c61: ldstr "staticPrivateIdentity"
-		IL_0c66: stelem.ref
-		IL_0c67: dup
-		IL_0c68: ldc.i4.1
-		IL_0c69: ldloc.s 50
-		IL_0c6b: stelem.ref
-		IL_0c6c: dup
-		IL_0c6d: ldc.i4.2
-		IL_0c6e: ldloc.s 47
-		IL_0c70: stelem.ref
-		IL_0c71: dup
-		IL_0c72: ldc.i4.3
-		IL_0c73: ldloc.s 30
-		IL_0c75: stelem.ref
-		IL_0c76: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0c7b: pop
-		IL_0c7c: ldnull
-		IL_0c7d: stloc.s 34
-		IL_0c7f: ret
+		IL_0c11: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0c16: ldstr "readStatic"
+		IL_0c1b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0c20: stloc.s 42
+		IL_0c22: ldloc.s 37
+		IL_0c24: ldstr "log"
+		IL_0c29: ldc.i4.4
+		IL_0c2a: newarr [System.Runtime]System.Object
+		IL_0c2f: dup
+		IL_0c30: ldc.i4.0
+		IL_0c31: ldstr "staticPrivateIdentity"
+		IL_0c36: stelem.ref
+		IL_0c37: dup
+		IL_0c38: ldc.i4.1
+		IL_0c39: ldloc.s 45
+		IL_0c3b: stelem.ref
+		IL_0c3c: dup
+		IL_0c3d: ldc.i4.2
+		IL_0c3e: ldloc.s 42
+		IL_0c40: stelem.ref
+		IL_0c41: dup
+		IL_0c42: ldc.i4.3
+		IL_0c43: ldloc.s 30
+		IL_0c45: stelem.ref
+		IL_0c46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0c4b: pop
+		IL_0c4c: ldnull
+		IL_0c4d: stloc.s 34
+		IL_0c4f: ret
 	} // end of method Classes_GeneratedMethodFunctionObjects::__js_module_init__
 
 } // end of class Modules.Classes_GeneratedMethodFunctionObjects
@@ -3696,7 +3646,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3483
+		// Method begins at RVA 0x3433
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22df
+					// Method begins at RVA 0x22cf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22e8
+					// Method begins at RVA 0x22d8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 						object[] capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x2386
+					// Method begins at RVA 0x2376
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -83,7 +83,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2395
+					// Method begins at RVA 0x2385
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -95,7 +95,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2398
+					// Method begins at RVA 0x2388
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -110,7 +110,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x239b
+					// Method begins at RVA 0x238b
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -126,7 +126,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x23a7
+					// Method begins at RVA 0x2397
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -152,7 +152,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x23b3
+					// Method begins at RVA 0x23a3
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -171,7 +171,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x23c9
+					// Method begins at RVA 0x23b9
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -183,7 +183,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x23cc
+					// Method begins at RVA 0x23bc
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -195,7 +195,7 @@
 				.method family hidebysig virtual 
 					instance object GetLexicalSuperReceiverCore () cil managed 
 				{
-					// Method begins at RVA 0x23cf
+					// Method begins at RVA 0x23bf
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -208,7 +208,7 @@
 				.method family hidebysig virtual 
 					instance object[] GetLexicalSuperScopesCore () cil managed 
 				{
-					// Method begins at RVA 0x23d7
+					// Method begins at RVA 0x23c7
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -224,7 +224,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x23df
+					// Method begins at RVA 0x23cf
 					// Header size: 1
 					// Code size: 35 (0x23)
 					.maxstack 8
@@ -252,7 +252,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x227c
+				// Method begins at RVA 0x226c
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -270,7 +270,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x228c
+				// Method begins at RVA 0x227c
 				// Header size: 12
 				// Code size: 24 (0x18)
 				.maxstack 8
@@ -297,7 +297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d6
+				// Method begins at RVA 0x22c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -317,7 +317,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2355
+				// Method begins at RVA 0x2345
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -330,7 +330,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x235d
+				// Method begins at RVA 0x234d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -342,7 +342,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2360
+				// Method begins at RVA 0x2350
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -357,7 +357,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2363
+				// Method begins at RVA 0x2353
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -374,7 +374,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x236f
+				// Method begins at RVA 0x235f
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -390,7 +390,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2377
+				// Method begins at RVA 0x2367
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -415,9 +415,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2110
+			// Method begins at RVA 0x2108
 			// Header size: 12
-			// Code size: 344 (0x158)
+			// Code size: 336 (0x150)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/Scope,
@@ -425,8 +425,7 @@
 				[2] class [System.Runtime]System.Type,
 				[3] object,
 				[4] object[],
-				[5] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n,
-				[6] object
+				[5] object
 			)
 
 			IL_0000: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/Scope::.ctor()
@@ -443,99 +442,95 @@
 			IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_002c: stloc.s 4
 			IL_002e: ldloc.3
-			IL_002f: ldloc.s 4
-			IL_0031: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::.ctor(class [System.Runtime]System.Object, object[])
-			IL_0036: ldc.i4.0
-			IL_0037: conv.r8
-			IL_0038: ldstr "n"
-			IL_003d: ldc.i4.1
-			IL_003e: ldc.i4.1
-			IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0, float64, string, bool, bool)
-			IL_0044: stloc.s 5
-			IL_0046: ldloc.s 5
-			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0)
-			IL_004d: stloc.s 5
-			IL_004f: ldloc.3
-			IL_0050: ldstr "n"
-			IL_0055: ldloc.s 5
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_005c: pop
-			IL_005d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0062: stloc.s 4
-			IL_0064: ldloc.2
-			IL_0065: ldloc.s 4
-			IL_0067: ldc.r8 0.0
-			IL_0070: box [System.Runtime]System.Double
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_007a: stloc.3
-			IL_007b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0080: stloc.s 4
-			IL_0082: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
-			IL_0087: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_008c: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
-			IL_0091: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0096: stloc.2
-			IL_0097: ldloc.2
-			IL_0098: ldloc.s 4
-			IL_009a: ldc.r8 0.0
-			IL_00a3: box [System.Runtime]System.Double
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_00ad: stloc.s 6
-			IL_00af: ldloc.3
-			IL_00b0: ldloc.s 6
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-			IL_00b7: stloc.s 6
-			IL_00b9: ldloc.s 6
-			IL_00bb: stloc.1
-			IL_00bc: ldstr "console"
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00cb: stloc.s 6
-			IL_00cd: ldc.i4.0
-			IL_00ce: newarr [System.Runtime]System.Object
-			IL_00d3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_00d8: ldloc.1
-			IL_00d9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-			IL_00de: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-			IL_00e3: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::.ctor()
-			IL_00e8: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-			IL_00ed: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_00f2: dup
-			IL_00f3: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
-			IL_00f8: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00fd: ldstr "prototype"
-			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_0107: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_010c: stloc.3
-			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_0117: stloc.3
-			IL_0118: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-			IL_011d: ldloc.3
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0123: stloc.3
-			IL_0124: ldloc.3
-			IL_0125: isinst Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
-			IL_012a: dup
-			IL_012b: brfalse IL_013b
+			IL_002f: ldstr "n"
+			IL_0034: ldloc.3
+			IL_0035: ldloc.s 4
+			IL_0037: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::.ctor(class [System.Runtime]System.Object, object[])
+			IL_003c: ldc.i4.0
+			IL_003d: conv.r8
+			IL_003e: ldstr "n"
+			IL_0043: ldc.i4.1
+			IL_0044: ldc.i4.1
+			IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0, float64, string, bool, bool)
+			IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0)
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_0054: pop
+			IL_0055: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_005a: stloc.s 4
+			IL_005c: ldloc.2
+			IL_005d: ldloc.s 4
+			IL_005f: ldc.r8 0.0
+			IL_0068: box [System.Runtime]System.Double
+			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_0072: stloc.3
+			IL_0073: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0078: stloc.s 4
+			IL_007a: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
+			IL_007f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0084: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
+			IL_0089: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_008e: stloc.2
+			IL_008f: ldloc.2
+			IL_0090: ldloc.s 4
+			IL_0092: ldc.r8 0.0
+			IL_009b: box [System.Runtime]System.Double
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_00a5: stloc.s 5
+			IL_00a7: ldloc.3
+			IL_00a8: ldloc.s 5
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+			IL_00af: stloc.s 5
+			IL_00b1: ldloc.s 5
+			IL_00b3: stloc.1
+			IL_00b4: ldstr "console"
+			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c3: stloc.s 5
+			IL_00c5: ldc.i4.0
+			IL_00c6: newarr [System.Runtime]System.Object
+			IL_00cb: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_00d0: ldloc.1
+			IL_00d1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+			IL_00d6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+			IL_00db: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::.ctor()
+			IL_00e0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+			IL_00e5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_00ea: dup
+			IL_00eb: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
+			IL_00f0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_00f5: ldstr "prototype"
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_00ff: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0104: stloc.3
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_010f: stloc.3
+			IL_0110: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+			IL_0115: ldloc.3
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_011b: stloc.3
+			IL_011c: ldloc.3
+			IL_011d: isinst Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
+			IL_0122: dup
+			IL_0123: brfalse IL_0133
 
-			IL_0130: callvirt instance object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::n()
-			IL_0135: stloc.3
-			IL_0136: br IL_0148
+			IL_0128: callvirt instance object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::n()
+			IL_012d: stloc.3
+			IL_012e: br IL_0140
 
-			IL_013b: pop
-			IL_013c: ldloc.3
-			IL_013d: ldstr "n"
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0147: stloc.3
+			IL_0133: pop
+			IL_0134: ldloc.3
+			IL_0135: ldstr "n"
+			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_013f: stloc.3
 
-			IL_0148: ldloc.s 6
-			IL_014a: ldstr "log"
-			IL_014f: ldloc.3
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0155: pop
-			IL_0156: ldnull
-			IL_0157: ret
+			IL_0140: ldloc.s 5
+			IL_0142: ldstr "log"
+			IL_0147: ldloc.3
+			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_014d: pop
+			IL_014e: ldnull
+			IL_014f: ret
 		} // end of method makeAndRun::__js_call__
 
 	} // end of class makeAndRun
@@ -551,7 +546,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c4
+				// Method begins at RVA 0x22b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -571,7 +566,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22cd
+				// Method begins at RVA 0x22bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -596,7 +591,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22f1
+				// Method begins at RVA 0x22e1
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -612,7 +607,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2300
+				// Method begins at RVA 0x22f0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -624,7 +619,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2303
+				// Method begins at RVA 0x22f3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -639,7 +634,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2306
+				// Method begins at RVA 0x22f6
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -655,7 +650,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2312
+				// Method begins at RVA 0x2302
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -674,7 +669,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x231e
+				// Method begins at RVA 0x230e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -687,7 +682,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2326
+				// Method begins at RVA 0x2316
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -699,7 +694,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2329
+				// Method begins at RVA 0x2319
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -714,7 +709,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x232c
+				// Method begins at RVA 0x231c
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -743,7 +738,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2274
+			// Method begins at RVA 0x2264
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -759,7 +754,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22b0
+			// Method begins at RVA 0x22a0
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -785,7 +780,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22bb
+			// Method begins at RVA 0x22ab
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -811,7 +806,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 177 (0xb1)
+		// Code size: 169 (0xa9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope,
@@ -819,8 +814,7 @@
 			[2] object,
 			[3] object[],
 			[4] class [System.Runtime]System.Type,
-			[5] object,
-			[6] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope::.ctor()
@@ -852,43 +846,39 @@
 		IL_0048: stloc.s 5
 		IL_004a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_004f: stloc.3
-		IL_0050: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::.ctor()
-		IL_0055: ldc.i4.0
-		IL_0056: conv.r8
-		IL_0057: ldstr "m"
+		IL_0050: ldloc.s 5
+		IL_0052: ldstr "m"
+		IL_0057: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::.ctor()
 		IL_005c: ldc.i4.0
-		IL_005d: ldc.i4.1
-		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0, float64, string, bool, bool)
-		IL_0063: stloc.s 6
-		IL_0065: ldloc.s 6
-		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0)
-		IL_006c: stloc.s 6
-		IL_006e: ldloc.s 5
-		IL_0070: ldstr "m"
-		IL_0075: ldloc.s 6
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_007c: pop
-		IL_007d: ldc.i4.1
-		IL_007e: newarr [System.Runtime]System.Object
-		IL_0083: dup
-		IL_0084: ldc.i4.0
-		IL_0085: ldloc.0
-		IL_0086: stelem.ref
-		IL_0087: stloc.3
-		IL_0088: ldloc.s 4
-		IL_008a: ldloc.3
-		IL_008b: ldc.r8 0.0
-		IL_0094: box [System.Runtime]System.Double
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_009e: stloc.s 5
-		IL_00a0: ldloc.s 5
-		IL_00a2: stloc.2
-		IL_00a3: nop
-		IL_00a4: ldloc.1
-		IL_00a5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00af: pop
-		IL_00b0: ret
+		IL_005d: conv.r8
+		IL_005e: ldstr "m"
+		IL_0063: ldc.i4.0
+		IL_0064: ldc.i4.1
+		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0, float64, string, bool, bool)
+		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0)
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0074: pop
+		IL_0075: ldc.i4.1
+		IL_0076: newarr [System.Runtime]System.Object
+		IL_007b: dup
+		IL_007c: ldc.i4.0
+		IL_007d: ldloc.0
+		IL_007e: stelem.ref
+		IL_007f: stloc.3
+		IL_0080: ldloc.s 4
+		IL_0082: ldloc.3
+		IL_0083: ldc.r8 0.0
+		IL_008c: box [System.Runtime]System.Double
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0096: stloc.s 5
+		IL_0098: ldloc.s 5
+		IL_009a: stloc.2
+		IL_009b: nop
+		IL_009c: ldloc.1
+		IL_009d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00a7: pop
+		IL_00a8: ret
 	} // end of method Classes_Inheritance_NestedClassExtendsGlobal::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_NestedClassExtendsGlobal
@@ -900,7 +890,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2403
+		// Method begins at RVA 0x23f3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22f3
+					// Method begins at RVA 0x22e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22fc
+					// Method begins at RVA 0x22ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 						object[] capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x235b
+					// Method begins at RVA 0x234b
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -83,7 +83,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x236a
+					// Method begins at RVA 0x235a
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -95,7 +95,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x236d
+					// Method begins at RVA 0x235d
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -110,7 +110,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2370
+					// Method begins at RVA 0x2360
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -126,7 +126,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x237c
+					// Method begins at RVA 0x236c
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -150,7 +150,7 @@
 						object[] capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x2388
+					// Method begins at RVA 0x2378
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -166,7 +166,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2397
+					// Method begins at RVA 0x2387
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -178,7 +178,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x239a
+					// Method begins at RVA 0x238a
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -193,7 +193,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x239d
+					// Method begins at RVA 0x238d
 					// Header size: 1
 					// Code size: 40 (0x28)
 					.maxstack 8
@@ -227,7 +227,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x227c
+				// Method begins at RVA 0x226c
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -251,7 +251,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22d6
+				// Method begins at RVA 0x22c6
 				// Header size: 1
 				// Code size: 10 (0xa)
 				.maxstack 8
@@ -273,7 +273,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2305
+					// Method begins at RVA 0x22f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -293,7 +293,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x230e
+					// Method begins at RVA 0x22fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -318,7 +318,7 @@
 						object[] capture0
 					) cil managed 
 				{
-					// Method begins at RVA 0x23c6
+					// Method begins at RVA 0x23b6
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -334,7 +334,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x23d5
+					// Method begins at RVA 0x23c5
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -346,7 +346,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x23d8
+					// Method begins at RVA 0x23c8
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -361,7 +361,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x23db
+					// Method begins at RVA 0x23cb
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -377,7 +377,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x23e7
+					// Method begins at RVA 0x23d7
 					// Header size: 1
 					// Code size: 11 (0xb)
 					.maxstack 8
@@ -403,7 +403,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x23f3
+					// Method begins at RVA 0x23e3
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -422,7 +422,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2409
+					// Method begins at RVA 0x23f9
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -434,7 +434,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x240c
+					// Method begins at RVA 0x23fc
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -446,7 +446,7 @@
 				.method family hidebysig virtual 
 					instance object GetLexicalSuperReceiverCore () cil managed 
 				{
-					// Method begins at RVA 0x240f
+					// Method begins at RVA 0x23ff
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -459,7 +459,7 @@
 				.method family hidebysig virtual 
 					instance object[] GetLexicalSuperScopesCore () cil managed 
 				{
-					// Method begins at RVA 0x2417
+					// Method begins at RVA 0x2407
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -475,7 +475,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x241f
+					// Method begins at RVA 0x240f
 					// Header size: 1
 					// Code size: 35 (0x23)
 					.maxstack 8
@@ -508,7 +508,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2298
+				// Method begins at RVA 0x2288
 				// Header size: 12
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -535,7 +535,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22bc
+				// Method begins at RVA 0x22ac
 				// Header size: 12
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -560,7 +560,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ea
+				// Method begins at RVA 0x22da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -585,7 +585,7 @@
 					class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2317
+				// Method begins at RVA 0x2307
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -601,7 +601,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2326
+				// Method begins at RVA 0x2316
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -613,7 +613,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2329
+				// Method begins at RVA 0x2319
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -628,7 +628,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x232c
+				// Method begins at RVA 0x231c
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -647,7 +647,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x233e
+				// Method begins at RVA 0x232e
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -665,7 +665,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x234c
+				// Method begins at RVA 0x233c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -695,7 +695,7 @@
 			)
 			// Method begins at RVA 0x2098
 			// Header size: 12
-			// Code size: 472 (0x1d8)
+			// Code size: 456 (0x1c8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope,
@@ -704,9 +704,7 @@
 				[3] class [System.Runtime]System.Type,
 				[4] object,
 				[5] object[],
-				[6] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m,
-				[7] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n,
-				[8] object
+				[6] object
 			)
 
 			IL_0000: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::.ctor()
@@ -731,155 +729,147 @@
 			IL_0034: ldloc.0
 			IL_0035: stelem.ref
 			IL_0036: stloc.s 5
-			IL_0038: ldloc.s 5
-			IL_003a: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m::.ctor(object[])
-			IL_003f: ldc.i4.0
-			IL_0040: conv.r8
-			IL_0041: ldstr "m"
+			IL_0038: ldloc.s 4
+			IL_003a: ldstr "m"
+			IL_003f: ldloc.s 5
+			IL_0041: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m::.ctor(object[])
 			IL_0046: ldc.i4.0
-			IL_0047: ldc.i4.1
-			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0, float64, string, bool, bool)
-			IL_004d: stloc.s 6
-			IL_004f: ldloc.s 6
-			IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0)
-			IL_0056: stloc.s 6
-			IL_0058: ldloc.s 4
-			IL_005a: ldstr "m"
-			IL_005f: ldloc.s 6
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_0066: pop
-			IL_0067: ldc.i4.2
-			IL_0068: newarr [System.Runtime]System.Object
-			IL_006d: dup
-			IL_006e: ldc.i4.0
-			IL_006f: ldarg.0
-			IL_0070: stelem.ref
-			IL_0071: dup
-			IL_0072: ldc.i4.1
-			IL_0073: ldloc.0
-			IL_0074: stelem.ref
-			IL_0075: stloc.s 5
-			IL_0077: ldloc.3
-			IL_0078: ldloc.s 5
-			IL_007a: ldc.r8 0.0
-			IL_0083: box [System.Runtime]System.Double
-			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_008d: stloc.s 4
-			IL_008f: ldloc.s 4
-			IL_0091: stloc.1
-			IL_0092: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_0097: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_009c: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_00a1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00a6: stloc.3
-			IL_00a7: ldloc.3
-			IL_00a8: ldstr "prototype"
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b2: stloc.s 4
-			IL_00b4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_00b9: stloc.s 5
-			IL_00bb: ldloc.s 4
-			IL_00bd: ldloc.s 5
-			IL_00bf: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n::.ctor(class [System.Runtime]System.Object, object[])
-			IL_00c4: ldc.i4.0
-			IL_00c5: conv.r8
-			IL_00c6: ldstr "n"
+			IL_0047: conv.r8
+			IL_0048: ldstr "m"
+			IL_004d: ldc.i4.0
+			IL_004e: ldc.i4.1
+			IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0, float64, string, bool, bool)
+			IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0)
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_005e: pop
+			IL_005f: ldc.i4.2
+			IL_0060: newarr [System.Runtime]System.Object
+			IL_0065: dup
+			IL_0066: ldc.i4.0
+			IL_0067: ldarg.0
+			IL_0068: stelem.ref
+			IL_0069: dup
+			IL_006a: ldc.i4.1
+			IL_006b: ldloc.0
+			IL_006c: stelem.ref
+			IL_006d: stloc.s 5
+			IL_006f: ldloc.3
+			IL_0070: ldloc.s 5
+			IL_0072: ldc.r8 0.0
+			IL_007b: box [System.Runtime]System.Double
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_0085: stloc.s 4
+			IL_0087: ldloc.s 4
+			IL_0089: stloc.1
+			IL_008a: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_008f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0094: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_0099: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_009e: stloc.3
+			IL_009f: ldloc.3
+			IL_00a0: ldstr "prototype"
+			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00aa: stloc.s 4
+			IL_00ac: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_00b1: stloc.s 5
+			IL_00b3: ldloc.s 4
+			IL_00b5: ldstr "n"
+			IL_00ba: ldloc.s 4
+			IL_00bc: ldloc.s 5
+			IL_00be: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n::.ctor(class [System.Runtime]System.Object, object[])
+			IL_00c3: ldc.i4.0
+			IL_00c4: conv.r8
+			IL_00c5: ldstr "n"
+			IL_00ca: ldc.i4.1
 			IL_00cb: ldc.i4.1
-			IL_00cc: ldc.i4.1
-			IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0, float64, string, bool, bool)
-			IL_00d2: stloc.s 7
-			IL_00d4: ldloc.s 7
-			IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0)
-			IL_00db: stloc.s 7
-			IL_00dd: ldloc.s 4
-			IL_00df: ldstr "n"
-			IL_00e4: ldloc.s 7
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_00eb: pop
-			IL_00ec: ldc.i4.2
-			IL_00ed: newarr [System.Runtime]System.Object
-			IL_00f2: dup
-			IL_00f3: ldc.i4.0
-			IL_00f4: ldarg.0
-			IL_00f5: stelem.ref
-			IL_00f6: dup
-			IL_00f7: ldc.i4.1
-			IL_00f8: ldloc.0
-			IL_00f9: stelem.ref
-			IL_00fa: stloc.s 5
-			IL_00fc: ldloc.3
-			IL_00fd: ldloc.s 5
-			IL_00ff: ldc.r8 0.0
-			IL_0108: box [System.Runtime]System.Double
-			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_0112: stloc.s 4
-			IL_0114: ldloc.s 4
-			IL_0116: ldloc.1
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-			IL_011c: stloc.s 4
-			IL_011e: ldloc.s 4
-			IL_0120: stloc.2
-			IL_0121: ldstr "console"
-			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0130: stloc.s 4
-			IL_0132: ldc.i4.2
-			IL_0133: newarr [System.Runtime]System.Object
-			IL_0138: dup
-			IL_0139: ldc.i4.0
-			IL_013a: ldarg.0
-			IL_013b: stelem.ref
-			IL_013c: dup
-			IL_013d: ldc.i4.1
-			IL_013e: ldloc.0
-			IL_013f: stelem.ref
-			IL_0140: stloc.s 5
-			IL_0142: ldloc.s 5
-			IL_0144: ldc.i4.0
-			IL_0145: newarr [System.Runtime]System.Object
-			IL_014a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_014f: ldloc.2
-			IL_0150: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-			IL_0155: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-			IL_015a: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
-			IL_015f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-			IL_0164: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_0169: dup
-			IL_016a: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_016f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0174: ldstr "prototype"
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_017e: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0183: stloc.s 8
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_018f: stloc.s 8
-			IL_0191: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-			IL_0196: ldloc.s 8
-			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_019d: stloc.s 8
-			IL_019f: ldloc.s 8
-			IL_01a1: isinst Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_01a6: dup
-			IL_01a7: brfalse IL_01b8
+			IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0, float64, string, bool, bool)
+			IL_00d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0)
+			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_00db: pop
+			IL_00dc: ldc.i4.2
+			IL_00dd: newarr [System.Runtime]System.Object
+			IL_00e2: dup
+			IL_00e3: ldc.i4.0
+			IL_00e4: ldarg.0
+			IL_00e5: stelem.ref
+			IL_00e6: dup
+			IL_00e7: ldc.i4.1
+			IL_00e8: ldloc.0
+			IL_00e9: stelem.ref
+			IL_00ea: stloc.s 5
+			IL_00ec: ldloc.3
+			IL_00ed: ldloc.s 5
+			IL_00ef: ldc.r8 0.0
+			IL_00f8: box [System.Runtime]System.Double
+			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_0102: stloc.s 4
+			IL_0104: ldloc.s 4
+			IL_0106: ldloc.1
+			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+			IL_010c: stloc.s 4
+			IL_010e: ldloc.s 4
+			IL_0110: stloc.2
+			IL_0111: ldstr "console"
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0120: stloc.s 4
+			IL_0122: ldc.i4.2
+			IL_0123: newarr [System.Runtime]System.Object
+			IL_0128: dup
+			IL_0129: ldc.i4.0
+			IL_012a: ldarg.0
+			IL_012b: stelem.ref
+			IL_012c: dup
+			IL_012d: ldc.i4.1
+			IL_012e: ldloc.0
+			IL_012f: stelem.ref
+			IL_0130: stloc.s 5
+			IL_0132: ldloc.s 5
+			IL_0134: ldc.i4.0
+			IL_0135: newarr [System.Runtime]System.Object
+			IL_013a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_013f: ldloc.2
+			IL_0140: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+			IL_0145: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+			IL_014a: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
+			IL_014f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+			IL_0154: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_0159: dup
+			IL_015a: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_015f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0164: ldstr "prototype"
+			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_016e: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0173: stloc.s 6
+			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_017f: stloc.s 6
+			IL_0181: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+			IL_0186: ldloc.s 6
+			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_018d: stloc.s 6
+			IL_018f: ldloc.s 6
+			IL_0191: isinst Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_0196: dup
+			IL_0197: brfalse IL_01a8
 
-			IL_01ac: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
-			IL_01b1: stloc.s 8
-			IL_01b3: br IL_01c7
+			IL_019c: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
+			IL_01a1: stloc.s 6
+			IL_01a3: br IL_01b7
 
-			IL_01b8: pop
-			IL_01b9: ldloc.s 8
-			IL_01bb: ldstr "n"
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_01c5: stloc.s 8
+			IL_01a8: pop
+			IL_01a9: ldloc.s 6
+			IL_01ab: ldstr "n"
+			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_01b5: stloc.s 6
 
-			IL_01c7: ldloc.s 4
-			IL_01c9: ldstr "log"
-			IL_01ce: ldloc.s 8
-			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01d5: pop
-			IL_01d6: ldnull
-			IL_01d7: ret
+			IL_01b7: ldloc.s 4
+			IL_01b9: ldstr "log"
+			IL_01be: ldloc.s 6
+			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01c5: pop
+			IL_01c6: ldnull
+			IL_01c7: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -898,7 +888,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e1
+			// Method begins at RVA 0x22d1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -971,7 +961,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2443
+		// Method begins at RVA 0x2433
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperMethodCall.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperMethodCall.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2240
+				// Method begins at RVA 0x2230
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2249
+				// Method begins at RVA 0x2239
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2264
+				// Method begins at RVA 0x2254
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2273
+				// Method begins at RVA 0x2263
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2276
+				// Method begins at RVA 0x2266
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2279
+				// Method begins at RVA 0x2269
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2285
+				// Method begins at RVA 0x2275
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2291
+				// Method begins at RVA 0x2281
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2299
+				// Method begins at RVA 0x2289
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x229c
+				// Method begins at RVA 0x228c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x229f
+				// Method begins at RVA 0x228f
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f1
+			// Method begins at RVA 0x21e1
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -226,7 +226,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x222c
+			// Method begins at RVA 0x221c
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -248,7 +248,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2252
+				// Method begins at RVA 0x2242
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -268,7 +268,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x225b
+				// Method begins at RVA 0x224b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -293,7 +293,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22c8
+				// Method begins at RVA 0x22b8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -309,7 +309,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22d7
+				// Method begins at RVA 0x22c7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -321,7 +321,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22da
+				// Method begins at RVA 0x22ca
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -336,7 +336,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22dd
+				// Method begins at RVA 0x22cd
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -352,7 +352,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22e9
+				// Method begins at RVA 0x22d9
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -378,7 +378,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x22f5
+				// Method begins at RVA 0x22e5
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -397,7 +397,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x230b
+				// Method begins at RVA 0x22fb
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -409,7 +409,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x230e
+				// Method begins at RVA 0x22fe
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -421,7 +421,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x2311
+				// Method begins at RVA 0x2301
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -434,7 +434,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x2319
+				// Method begins at RVA 0x2309
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -450,7 +450,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2321
+				// Method begins at RVA 0x2311
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -478,7 +478,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f9
+			// Method begins at RVA 0x21e9
 			// Header size: 1
 			// Code size: 13 (0xd)
 			.maxstack 8
@@ -496,7 +496,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2208
+			// Method begins at RVA 0x21f8
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -523,7 +523,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2237
+			// Method begins at RVA 0x2227
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -549,7 +549,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 405 (0x195)
+		// Code size: 389 (0x185)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_SuperMethodCall/Scope,
@@ -558,9 +558,7 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m,
-			[7] class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m,
-			[8] object
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/Scope::.ctor()
@@ -577,120 +575,112 @@
 		IL_0027: stloc.s 4
 		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002e: stloc.s 5
-		IL_0030: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m::.ctor()
-		IL_0035: ldc.i4.0
-		IL_0036: conv.r8
-		IL_0037: ldstr "m"
+		IL_0030: ldloc.s 4
+		IL_0032: ldstr "m"
+		IL_0037: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m::.ctor()
 		IL_003c: ldc.i4.0
-		IL_003d: ldc.i4.1
-		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0, float64, string, bool, bool)
-		IL_0043: stloc.s 6
-		IL_0045: ldloc.s 6
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0)
-		IL_004c: stloc.s 6
-		IL_004e: ldloc.s 4
-		IL_0050: ldstr "m"
-		IL_0055: ldloc.s 6
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005c: pop
-		IL_005d: ldc.i4.1
-		IL_005e: newarr [System.Runtime]System.Object
-		IL_0063: dup
-		IL_0064: ldc.i4.0
-		IL_0065: ldloc.0
-		IL_0066: stelem.ref
-		IL_0067: stloc.s 5
-		IL_0069: ldloc.3
-		IL_006a: ldloc.s 5
-		IL_006c: ldc.r8 0.0
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007f: stloc.s 4
-		IL_0081: ldloc.s 4
-		IL_0083: stloc.1
-		IL_0084: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
-		IL_0089: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_008e: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
-		IL_0093: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0098: stloc.3
-		IL_0099: ldloc.3
-		IL_009a: ldstr "prototype"
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a4: stloc.s 4
-		IL_00a6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ab: stloc.s 5
-		IL_00ad: ldloc.s 4
-		IL_00af: ldloc.s 5
-		IL_00b1: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m::.ctor(class [System.Runtime]System.Object, object[])
-		IL_00b6: ldc.i4.0
-		IL_00b7: conv.r8
-		IL_00b8: ldstr "m"
+		IL_003d: conv.r8
+		IL_003e: ldstr "m"
+		IL_0043: ldc.i4.0
+		IL_0044: ldc.i4.1
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0)
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0054: pop
+		IL_0055: ldc.i4.1
+		IL_0056: newarr [System.Runtime]System.Object
+		IL_005b: dup
+		IL_005c: ldc.i4.0
+		IL_005d: ldloc.0
+		IL_005e: stelem.ref
+		IL_005f: stloc.s 5
+		IL_0061: ldloc.3
+		IL_0062: ldloc.s 5
+		IL_0064: ldc.r8 0.0
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.s 4
+		IL_007b: stloc.1
+		IL_007c: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
+		IL_0081: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0086: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
+		IL_008b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0090: stloc.3
+		IL_0091: ldloc.3
+		IL_0092: ldstr "prototype"
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009c: stloc.s 4
+		IL_009e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a3: stloc.s 5
+		IL_00a5: ldloc.s 4
+		IL_00a7: ldstr "m"
+		IL_00ac: ldloc.s 4
+		IL_00ae: ldloc.s 5
+		IL_00b0: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m::.ctor(class [System.Runtime]System.Object, object[])
+		IL_00b5: ldc.i4.0
+		IL_00b6: conv.r8
+		IL_00b7: ldstr "m"
+		IL_00bc: ldc.i4.1
 		IL_00bd: ldc.i4.1
-		IL_00be: ldc.i4.1
-		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0, float64, string, bool, bool)
-		IL_00c4: stloc.s 7
-		IL_00c6: ldloc.s 7
-		IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0)
-		IL_00cd: stloc.s 7
-		IL_00cf: ldloc.s 4
-		IL_00d1: ldstr "m"
-		IL_00d6: ldloc.s 7
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00dd: pop
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: stloc.s 5
-		IL_00ea: ldloc.3
-		IL_00eb: ldloc.s 5
-		IL_00ed: ldc.r8 0.0
-		IL_00f6: box [System.Runtime]System.Double
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0100: stloc.s 4
-		IL_0102: ldloc.s 4
-		IL_0104: ldloc.1
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_010a: stloc.s 4
-		IL_010c: ldloc.s 4
-		IL_010e: stloc.2
-		IL_010f: ldstr "console"
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011e: stloc.s 4
-		IL_0120: ldc.i4.0
-		IL_0121: newarr [System.Runtime]System.Object
-		IL_0126: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_012b: ldloc.2
-		IL_012c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_0131: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0136: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D::.ctor()
-		IL_013b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_0140: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0145: dup
-		IL_0146: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
-		IL_014b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0150: ldstr "prototype"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_015a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_015f: stloc.s 8
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_016b: stloc.s 8
-		IL_016d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_0172: ldloc.s 8
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0179: ldstr "m"
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0183: stloc.s 8
-		IL_0185: ldloc.s 4
-		IL_0187: ldstr "log"
-		IL_018c: ldloc.s 8
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0193: pop
-		IL_0194: ret
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0, float64, string, bool, bool)
+		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0)
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00cd: pop
+		IL_00ce: ldc.i4.1
+		IL_00cf: newarr [System.Runtime]System.Object
+		IL_00d4: dup
+		IL_00d5: ldc.i4.0
+		IL_00d6: ldloc.0
+		IL_00d7: stelem.ref
+		IL_00d8: stloc.s 5
+		IL_00da: ldloc.3
+		IL_00db: ldloc.s 5
+		IL_00dd: ldc.r8 0.0
+		IL_00e6: box [System.Runtime]System.Double
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00f0: stloc.s 4
+		IL_00f2: ldloc.s 4
+		IL_00f4: ldloc.1
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_00fa: stloc.s 4
+		IL_00fc: ldloc.s 4
+		IL_00fe: stloc.2
+		IL_00ff: ldstr "console"
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010e: stloc.s 4
+		IL_0110: ldc.i4.0
+		IL_0111: newarr [System.Runtime]System.Object
+		IL_0116: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_011b: ldloc.2
+		IL_011c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0121: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0126: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D::.ctor()
+		IL_012b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_0130: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0135: dup
+		IL_0136: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
+		IL_013b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0140: ldstr "prototype"
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_014a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_014f: stloc.s 6
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_015b: stloc.s 6
+		IL_015d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_0162: ldloc.s 6
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0169: ldstr "m"
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0173: stloc.s 6
+		IL_0175: ldloc.s 4
+		IL_0177: ldstr "log"
+		IL_017c: ldloc.s 6
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0183: pop
+		IL_0184: ret
 	} // end of method Classes_Inheritance_SuperMethodCall::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_SuperMethodCall
@@ -702,7 +692,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2345
+		// Method begins at RVA 0x2335
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2346
+				// Method begins at RVA 0x2326
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x234f
+				// Method begins at RVA 0x232f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2358
+				// Method begins at RVA 0x2338
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2361
+				// Method begins at RVA 0x2341
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x236a
+				// Method begins at RVA 0x234a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2373
+				// Method begins at RVA 0x2353
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -143,7 +143,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x237c
+				// Method begins at RVA 0x235c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -159,7 +159,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x238b
+				// Method begins at RVA 0x236b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -171,7 +171,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x238e
+				// Method begins at RVA 0x236e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -186,7 +186,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2391
+				// Method begins at RVA 0x2371
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -202,7 +202,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x239d
+				// Method begins at RVA 0x237d
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -221,7 +221,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a9
+				// Method begins at RVA 0x2389
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -234,7 +234,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23b1
+				// Method begins at RVA 0x2391
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -246,7 +246,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23b4
+				// Method begins at RVA 0x2394
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -261,7 +261,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23b7
+				// Method begins at RVA 0x2397
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -288,7 +288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23db
+				// Method begins at RVA 0x23bb
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -301,7 +301,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x23e3
+				// Method begins at RVA 0x23c3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -313,7 +313,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x23e6
+				// Method begins at RVA 0x23c6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -328,7 +328,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x23e9
+				// Method begins at RVA 0x23c9
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -355,7 +355,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x240d
+				// Method begins at RVA 0x23ed
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -368,7 +368,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2415
+				// Method begins at RVA 0x23f5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -380,7 +380,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2418
+				// Method begins at RVA 0x23f8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -395,7 +395,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x241b
+				// Method begins at RVA 0x23fb
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -423,7 +423,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2444
+				// Method begins at RVA 0x2424
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -436,7 +436,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x244c
+				// Method begins at RVA 0x242c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -448,7 +448,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x244f
+				// Method begins at RVA 0x242f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -463,7 +463,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2452
+				// Method begins at RVA 0x2432
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -496,7 +496,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2301
+			// Method begins at RVA 0x22e1
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -515,7 +515,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2310
+			// Method begins at RVA 0x22f0
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -538,7 +538,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2332
+			// Method begins at RVA 0x2312
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -553,7 +553,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2335
+			// Method begins at RVA 0x2315
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -569,7 +569,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x232f
+			// Method begins at RVA 0x230f
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -587,7 +587,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x233d
+			// Method begins at RVA 0x231d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -613,7 +613,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 677 (0x2a5)
+		// Code size: 645 (0x285)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Method_DefaultReturnUndefined/Scope,
@@ -629,13 +629,9 @@
 			[10] class [System.Runtime]System.Type,
 			[11] object,
 			[12] object[],
-			[13] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing,
-			[14] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined,
-			[15] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue,
-			[16] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis,
-			[17] class Modules.Classes_Method_DefaultReturnUndefined/Calculator,
-			[18] bool,
-			[19] float64
+			[13] class Modules.Classes_Method_DefaultReturnUndefined/Calculator,
+			[14] bool,
+			[15] float64
 		)
 
 		IL_0000: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Scope::.ctor()
@@ -652,215 +648,199 @@
 		IL_0029: stloc.s 11
 		IL_002b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0030: stloc.s 12
-		IL_0032: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::.ctor()
-		IL_0037: ldc.i4.0
-		IL_0038: conv.r8
-		IL_0039: ldstr "doNothing"
-		IL_003e: ldc.i4.1
-		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0, float64, string, bool, bool)
-		IL_0045: stloc.s 13
-		IL_0047: ldloc.s 13
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0)
-		IL_004e: stloc.s 13
-		IL_0050: ldloc.s 11
-		IL_0052: ldstr "doNothing"
-		IL_0057: ldloc.s 13
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005e: pop
-		IL_005f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0064: stloc.s 12
-		IL_0066: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::.ctor()
-		IL_006b: ldc.i4.0
-		IL_006c: conv.r8
-		IL_006d: ldstr "returnsUndefined"
-		IL_0072: ldc.i4.0
-		IL_0073: ldc.i4.1
-		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0, float64, string, bool, bool)
-		IL_0079: stloc.s 14
-		IL_007b: ldloc.s 14
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0)
-		IL_0082: stloc.s 14
-		IL_0084: ldloc.s 11
-		IL_0086: ldstr "returnsUndefined"
-		IL_008b: ldloc.s 14
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0092: pop
-		IL_0093: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0098: stloc.s 12
-		IL_009a: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::.ctor()
-		IL_009f: ldc.i4.0
-		IL_00a0: conv.r8
-		IL_00a1: ldstr "returnsValue"
-		IL_00a6: ldc.i4.1
-		IL_00a7: ldc.i4.1
-		IL_00a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0, float64, string, bool, bool)
-		IL_00ad: stloc.s 15
-		IL_00af: ldloc.s 15
-		IL_00b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0)
-		IL_00b6: stloc.s 15
-		IL_00b8: ldloc.s 11
-		IL_00ba: ldstr "returnsValue"
-		IL_00bf: ldloc.s 15
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00c6: pop
-		IL_00c7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00cc: stloc.s 12
-		IL_00ce: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::.ctor()
-		IL_00d3: ldc.i4.0
-		IL_00d4: conv.r8
-		IL_00d5: ldstr "returnsThis"
-		IL_00da: ldc.i4.1
+		IL_0032: ldloc.s 11
+		IL_0034: ldstr "doNothing"
+		IL_0039: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::.ctor()
+		IL_003e: ldc.i4.0
+		IL_003f: conv.r8
+		IL_0040: ldstr "doNothing"
+		IL_0045: ldc.i4.1
+		IL_0046: ldc.i4.1
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0)
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0056: pop
+		IL_0057: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_005c: stloc.s 12
+		IL_005e: ldloc.s 11
+		IL_0060: ldstr "returnsUndefined"
+		IL_0065: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::.ctor()
+		IL_006a: ldc.i4.0
+		IL_006b: conv.r8
+		IL_006c: ldstr "returnsUndefined"
+		IL_0071: ldc.i4.0
+		IL_0072: ldc.i4.1
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0, float64, string, bool, bool)
+		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0)
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0082: pop
+		IL_0083: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0088: stloc.s 12
+		IL_008a: ldloc.s 11
+		IL_008c: ldstr "returnsValue"
+		IL_0091: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::.ctor()
+		IL_0096: ldc.i4.0
+		IL_0097: conv.r8
+		IL_0098: ldstr "returnsValue"
+		IL_009d: ldc.i4.1
+		IL_009e: ldc.i4.1
+		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0)
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00ae: pop
+		IL_00af: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00b4: stloc.s 12
+		IL_00b6: ldloc.s 11
+		IL_00b8: ldstr "returnsThis"
+		IL_00bd: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::.ctor()
+		IL_00c2: ldc.i4.0
+		IL_00c3: conv.r8
+		IL_00c4: ldstr "returnsThis"
+		IL_00c9: ldc.i4.1
+		IL_00ca: ldc.i4.1
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0, float64, string, bool, bool)
+		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0)
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00da: pop
 		IL_00db: ldc.i4.1
-		IL_00dc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0, float64, string, bool, bool)
-		IL_00e1: stloc.s 16
-		IL_00e3: ldloc.s 16
-		IL_00e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0)
-		IL_00ea: stloc.s 16
-		IL_00ec: ldloc.s 11
-		IL_00ee: ldstr "returnsThis"
-		IL_00f3: ldloc.s 16
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00fa: pop
-		IL_00fb: ldc.i4.1
-		IL_00fc: newarr [System.Runtime]System.Object
-		IL_0101: dup
-		IL_0102: ldc.i4.0
-		IL_0103: ldloc.0
-		IL_0104: stelem.ref
-		IL_0105: stloc.s 12
-		IL_0107: ldloc.s 10
-		IL_0109: ldloc.s 12
-		IL_010b: ldc.r8 1
+		IL_00dc: newarr [System.Runtime]System.Object
+		IL_00e1: dup
+		IL_00e2: ldc.i4.0
+		IL_00e3: ldloc.0
+		IL_00e4: stelem.ref
+		IL_00e5: stloc.s 12
+		IL_00e7: ldloc.s 10
+		IL_00e9: ldloc.s 12
+		IL_00eb: ldc.r8 1
+		IL_00f4: box [System.Runtime]System.Double
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00fe: stloc.s 11
+		IL_0100: ldloc.s 11
+		IL_0102: stloc.1
+		IL_0103: ldc.i4.1
+		IL_0104: newarr [System.Runtime]System.Object
+		IL_0109: dup
+		IL_010a: ldc.i4.0
+		IL_010b: ldc.r8 10
 		IL_0114: box [System.Runtime]System.Double
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_011e: stloc.s 11
-		IL_0120: ldloc.s 11
-		IL_0122: stloc.1
-		IL_0123: ldc.i4.1
-		IL_0124: newarr [System.Runtime]System.Object
-		IL_0129: dup
-		IL_012a: ldc.i4.0
-		IL_012b: ldc.r8 10
-		IL_0134: box [System.Runtime]System.Double
-		IL_0139: stelem.ref
-		IL_013a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_013f: ldc.r8 10
-		IL_0148: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator::.ctor(float64)
-		IL_014d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0152: stloc.2
-		IL_0153: ldloc.2
-		IL_0154: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
-		IL_0159: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_015e: ldstr "prototype"
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0168: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_016d: ldloc.2
-		IL_016e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
-		IL_0173: stloc.s 17
-		IL_0175: ldloc.s 17
-		IL_0177: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::doNothing()
-		IL_017c: stloc.3
-		IL_017d: ldstr "console"
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018c: stloc.s 11
-		IL_018e: ldloc.3
-		IL_018f: ldnull
-		IL_0190: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0195: stloc.s 18
-		IL_0197: ldloc.s 18
-		IL_0199: brfalse IL_01aa
+		IL_0119: stelem.ref
+		IL_011a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_011f: ldc.r8 10
+		IL_0128: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator::.ctor(float64)
+		IL_012d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0132: stloc.2
+		IL_0133: ldloc.2
+		IL_0134: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
+		IL_0139: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_013e: ldstr "prototype"
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0148: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_014d: ldloc.2
+		IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
+		IL_0153: stloc.s 13
+		IL_0155: ldloc.s 13
+		IL_0157: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::doNothing()
+		IL_015c: stloc.3
+		IL_015d: ldstr "console"
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016c: stloc.s 11
+		IL_016e: ldloc.3
+		IL_016f: ldnull
+		IL_0170: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0175: stloc.s 14
+		IL_0177: ldloc.s 14
+		IL_0179: brfalse IL_018a
 
-		IL_019e: ldstr "undefined"
-		IL_01a3: stloc.s 4
-		IL_01a5: br IL_01b1
+		IL_017e: ldstr "undefined"
+		IL_0183: stloc.s 4
+		IL_0185: br IL_0191
 
-		IL_01aa: ldstr "not undefined"
-		IL_01af: stloc.s 4
+		IL_018a: ldstr "not undefined"
+		IL_018f: stloc.s 4
 
-		IL_01b1: ldloc.s 11
-		IL_01b3: ldstr "log"
-		IL_01b8: ldloc.s 4
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bf: pop
-		IL_01c0: ldloc.2
-		IL_01c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
-		IL_01c6: stloc.s 17
-		IL_01c8: ldloc.s 17
-		IL_01ca: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsUndefined()
-		IL_01cf: stloc.s 5
-		IL_01d1: ldstr "console"
-		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e0: stloc.s 11
-		IL_01e2: ldloc.s 5
-		IL_01e4: ldnull
-		IL_01e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01ea: stloc.s 18
-		IL_01ec: ldloc.s 18
-		IL_01ee: brfalse IL_01ff
+		IL_0191: ldloc.s 11
+		IL_0193: ldstr "log"
+		IL_0198: ldloc.s 4
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019f: pop
+		IL_01a0: ldloc.2
+		IL_01a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
+		IL_01a6: stloc.s 13
+		IL_01a8: ldloc.s 13
+		IL_01aa: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsUndefined()
+		IL_01af: stloc.s 5
+		IL_01b1: ldstr "console"
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c0: stloc.s 11
+		IL_01c2: ldloc.s 5
+		IL_01c4: ldnull
+		IL_01c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01ca: stloc.s 14
+		IL_01cc: ldloc.s 14
+		IL_01ce: brfalse IL_01df
 
-		IL_01f3: ldstr "undefined"
-		IL_01f8: stloc.s 6
-		IL_01fa: br IL_0206
+		IL_01d3: ldstr "undefined"
+		IL_01d8: stloc.s 6
+		IL_01da: br IL_01e6
 
-		IL_01ff: ldstr "not undefined"
-		IL_0204: stloc.s 6
+		IL_01df: ldstr "not undefined"
+		IL_01e4: stloc.s 6
 
-		IL_0206: ldloc.s 11
-		IL_0208: ldstr "log"
-		IL_020d: ldloc.s 6
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0214: pop
-		IL_0215: ldloc.2
-		IL_0216: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
-		IL_021b: stloc.s 17
-		IL_021d: ldloc.s 17
-		IL_021f: callvirt instance float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
-		IL_0224: stloc.s 19
-		IL_0226: ldloc.s 19
-		IL_0228: box [System.Runtime]System.Double
-		IL_022d: stloc.s 7
-		IL_022f: ldstr "console"
-		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023e: ldstr "log"
-		IL_0243: ldloc.s 7
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024a: pop
-		IL_024b: ldloc.2
-		IL_024c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
-		IL_0251: stloc.s 17
-		IL_0253: ldloc.s 17
-		IL_0255: callvirt instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
-		IL_025a: stloc.s 17
-		IL_025c: ldloc.s 17
-		IL_025e: stloc.s 8
-		IL_0260: ldstr "console"
-		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026f: stloc.s 11
-		IL_0271: ldloc.s 8
-		IL_0273: ldloc.2
-		IL_0274: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0279: stloc.s 18
-		IL_027b: ldloc.s 18
-		IL_027d: brfalse IL_028e
+		IL_01e6: ldloc.s 11
+		IL_01e8: ldstr "log"
+		IL_01ed: ldloc.s 6
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f4: pop
+		IL_01f5: ldloc.2
+		IL_01f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
+		IL_01fb: stloc.s 13
+		IL_01fd: ldloc.s 13
+		IL_01ff: callvirt instance float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
+		IL_0204: stloc.s 15
+		IL_0206: ldloc.s 15
+		IL_0208: box [System.Runtime]System.Double
+		IL_020d: stloc.s 7
+		IL_020f: ldstr "console"
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021e: ldstr "log"
+		IL_0223: ldloc.s 7
+		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_022a: pop
+		IL_022b: ldloc.2
+		IL_022c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
+		IL_0231: stloc.s 13
+		IL_0233: ldloc.s 13
+		IL_0235: callvirt instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
+		IL_023a: stloc.s 13
+		IL_023c: ldloc.s 13
+		IL_023e: stloc.s 8
+		IL_0240: ldstr "console"
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024f: stloc.s 11
+		IL_0251: ldloc.s 8
+		IL_0253: ldloc.2
+		IL_0254: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0259: stloc.s 14
+		IL_025b: ldloc.s 14
+		IL_025d: brfalse IL_026e
 
-		IL_0282: ldstr "same instance"
-		IL_0287: stloc.s 9
-		IL_0289: br IL_0295
+		IL_0262: ldstr "same instance"
+		IL_0267: stloc.s 9
+		IL_0269: br IL_0275
 
-		IL_028e: ldstr "different"
-		IL_0293: stloc.s 9
+		IL_026e: ldstr "different"
+		IL_0273: stloc.s 9
 
-		IL_0295: ldloc.s 11
-		IL_0297: ldstr "log"
-		IL_029c: ldloc.s 9
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a3: pop
-		IL_02a4: ret
+		IL_0275: ldloc.s 11
+		IL_0277: ldstr "log"
+		IL_027c: ldloc.s 9
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0283: pop
+		IL_0284: ret
 	} // end of method Classes_Method_DefaultReturnUndefined::__js_module_init__
 
 } // end of class Modules.Classes_Method_DefaultReturnUndefined
@@ -872,7 +852,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2476
+		// Method begins at RVA 0x2456
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2292
+			// Method begins at RVA 0x2282
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a4
+				// Method begins at RVA 0x2294
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -174,7 +174,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ad
+				// Method begins at RVA 0x229d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -194,7 +194,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b6
+				// Method begins at RVA 0x22a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -219,7 +219,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22bf
+				// Method begins at RVA 0x22af
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -235,7 +235,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22ce
+				// Method begins at RVA 0x22be
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -247,7 +247,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22d1
+				// Method begins at RVA 0x22c1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -262,7 +262,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22d4
+				// Method begins at RVA 0x22c4
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -278,7 +278,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x22e0
+				// Method begins at RVA 0x22d0
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -297,7 +297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ec
+				// Method begins at RVA 0x22dc
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -310,7 +310,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22f4
+				// Method begins at RVA 0x22e4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -322,7 +322,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22f7
+				// Method begins at RVA 0x22e7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -337,7 +337,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22fa
+				// Method begins at RVA 0x22ea
 				// Header size: 1
 				// Code size: 49 (0x31)
 				.maxstack 8
@@ -370,7 +370,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x232c
+				// Method begins at RVA 0x231c
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -383,7 +383,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2334
+				// Method begins at RVA 0x2324
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -395,7 +395,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2337
+				// Method begins at RVA 0x2327
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -410,7 +410,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x233a
+				// Method begins at RVA 0x232a
 				// Header size: 1
 				// Code size: 49 (0x31)
 				.maxstack 8
@@ -444,7 +444,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x225e
+			// Method begins at RVA 0x224e
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -463,7 +463,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2268
+			// Method begins at RVA 0x2258
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -488,7 +488,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x227e
+			// Method begins at RVA 0x226e
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -511,7 +511,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x229b
+			// Method begins at RVA 0x228b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -537,16 +537,14 @@
 	{
 		// Method begins at RVA 0x2190
 		// Header size: 12
-		// Code size: 194 (0xc2)
+		// Code size: 178 (0xb2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_Class_Lib/Scope,
 			[1] object,
 			[2] class [System.Runtime]System.Type,
 			[3] object,
-			[4] object[],
-			[5] class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add,
-			[6] class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply
+			[4] object[]
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Export_Class_Lib/Scope::.ctor()
@@ -563,62 +561,54 @@
 		IL_0027: stloc.3
 		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002d: stloc.s 4
-		IL_002f: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add::.ctor()
-		IL_0034: ldc.i4.2
-		IL_0035: conv.r8
-		IL_0036: ldstr "add"
-		IL_003b: ldc.i4.0
-		IL_003c: ldc.i4.1
-		IL_003d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0, float64, string, bool, bool)
-		IL_0042: stloc.s 5
-		IL_0044: ldloc.s 5
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0)
-		IL_004b: stloc.s 5
-		IL_004d: ldloc.3
-		IL_004e: ldstr "add"
-		IL_0053: ldloc.s 5
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005a: pop
-		IL_005b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0060: stloc.s 4
-		IL_0062: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::.ctor()
-		IL_0067: ldc.i4.2
-		IL_0068: conv.r8
-		IL_0069: ldstr "multiply"
-		IL_006e: ldc.i4.0
-		IL_006f: ldc.i4.1
-		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0, float64, string, bool, bool)
-		IL_0075: stloc.s 6
-		IL_0077: ldloc.s 6
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0)
-		IL_007e: stloc.s 6
-		IL_0080: ldloc.3
-		IL_0081: ldstr "multiply"
-		IL_0086: ldloc.s 6
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_008d: pop
-		IL_008e: ldc.i4.1
-		IL_008f: newarr [System.Runtime]System.Object
-		IL_0094: dup
-		IL_0095: ldc.i4.0
-		IL_0096: ldloc.0
-		IL_0097: stelem.ref
-		IL_0098: stloc.s 4
-		IL_009a: ldloc.2
-		IL_009b: ldloc.s 4
-		IL_009d: ldc.r8 0.0
-		IL_00a6: box [System.Runtime]System.Double
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00b0: stloc.3
-		IL_00b1: ldloc.3
-		IL_00b2: stloc.1
-		IL_00b3: ldarg.2
-		IL_00b4: ldstr "exports"
-		IL_00b9: ldloc.1
-		IL_00ba: ldc.i4.1
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00c0: pop
-		IL_00c1: ret
+		IL_002f: ldloc.3
+		IL_0030: ldstr "add"
+		IL_0035: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add::.ctor()
+		IL_003a: ldc.i4.2
+		IL_003b: conv.r8
+		IL_003c: ldstr "add"
+		IL_0041: ldc.i4.0
+		IL_0042: ldc.i4.1
+		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0, float64, string, bool, bool)
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0)
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0052: pop
+		IL_0053: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0058: stloc.s 4
+		IL_005a: ldloc.3
+		IL_005b: ldstr "multiply"
+		IL_0060: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::.ctor()
+		IL_0065: ldc.i4.2
+		IL_0066: conv.r8
+		IL_0067: ldstr "multiply"
+		IL_006c: ldc.i4.0
+		IL_006d: ldc.i4.1
+		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0, float64, string, bool, bool)
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0)
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_007d: pop
+		IL_007e: ldc.i4.1
+		IL_007f: newarr [System.Runtime]System.Object
+		IL_0084: dup
+		IL_0085: ldc.i4.0
+		IL_0086: ldloc.0
+		IL_0087: stelem.ref
+		IL_0088: stloc.s 4
+		IL_008a: ldloc.2
+		IL_008b: ldloc.s 4
+		IL_008d: ldc.r8 0.0
+		IL_0096: box [System.Runtime]System.Double
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00a0: stloc.3
+		IL_00a1: ldloc.3
+		IL_00a2: stloc.1
+		IL_00a3: ldarg.2
+		IL_00a4: ldstr "exports"
+		IL_00a9: ldloc.1
+		IL_00aa: ldc.i4.1
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_00b0: pop
+		IL_00b1: ret
 	} // end of method CommonJS_Export_Class_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_Class_Lib
@@ -630,7 +620,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x236c
+		// Method begins at RVA 0x235c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22c4
+			// Method begins at RVA 0x22bc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -190,7 +190,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d6
+				// Method begins at RVA 0x22ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22df
+				// Method begins at RVA 0x22d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -230,7 +230,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e8
+				// Method begins at RVA 0x22e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -255,7 +255,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x22f1
+				// Method begins at RVA 0x22e9
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -271,7 +271,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2300
+				// Method begins at RVA 0x22f8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -283,7 +283,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2303
+				// Method begins at RVA 0x22fb
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -298,7 +298,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2306
+				// Method begins at RVA 0x22fe
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -314,7 +314,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2312
+				// Method begins at RVA 0x230a
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -333,7 +333,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x231e
+				// Method begins at RVA 0x2316
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -346,7 +346,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2326
+				// Method begins at RVA 0x231e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -358,7 +358,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2329
+				// Method begins at RVA 0x2321
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -373,7 +373,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x232c
+				// Method begins at RVA 0x2324
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -408,7 +408,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2267
+			// Method begins at RVA 0x225f
 			// Header size: 1
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -430,7 +430,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2280
+			// Method begins at RVA 0x2278
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -469,7 +469,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22cd
+			// Method begins at RVA 0x22c5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -495,15 +495,14 @@
 	{
 		// Method begins at RVA 0x21cc
 		// Header size: 12
-		// Code size: 143 (0x8f)
+		// Code size: 135 (0x87)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ClassWithConstructor_Lib/Scope,
 			[1] object,
 			[2] class [System.Runtime]System.Type,
 			[3] object,
-			[4] object[],
-			[5] class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet
+			[4] object[]
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Export_ClassWithConstructor_Lib/Scope::.ctor()
@@ -520,44 +519,40 @@
 		IL_0027: stloc.3
 		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002d: stloc.s 4
-		IL_002f: newobj instance void Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet::.ctor()
-		IL_0034: ldc.i4.0
-		IL_0035: conv.r8
-		IL_0036: ldstr "greet"
-		IL_003b: ldc.i4.1
-		IL_003c: ldc.i4.1
-		IL_003d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0, float64, string, bool, bool)
-		IL_0042: stloc.s 5
-		IL_0044: ldloc.s 5
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0)
-		IL_004b: stloc.s 5
-		IL_004d: ldloc.3
-		IL_004e: ldstr "greet"
-		IL_0053: ldloc.s 5
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005a: pop
-		IL_005b: ldc.i4.1
-		IL_005c: newarr [System.Runtime]System.Object
-		IL_0061: dup
-		IL_0062: ldc.i4.0
-		IL_0063: ldloc.0
-		IL_0064: stelem.ref
-		IL_0065: stloc.s 4
-		IL_0067: ldloc.2
-		IL_0068: ldloc.s 4
-		IL_006a: ldc.r8 2
-		IL_0073: box [System.Runtime]System.Double
-		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007d: stloc.3
-		IL_007e: ldloc.3
-		IL_007f: stloc.1
-		IL_0080: ldarg.2
-		IL_0081: ldstr "exports"
-		IL_0086: ldloc.1
-		IL_0087: ldc.i4.1
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_008d: pop
-		IL_008e: ret
+		IL_002f: ldloc.3
+		IL_0030: ldstr "greet"
+		IL_0035: newobj instance void Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet::.ctor()
+		IL_003a: ldc.i4.0
+		IL_003b: conv.r8
+		IL_003c: ldstr "greet"
+		IL_0041: ldc.i4.1
+		IL_0042: ldc.i4.1
+		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0, float64, string, bool, bool)
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0)
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0052: pop
+		IL_0053: ldc.i4.1
+		IL_0054: newarr [System.Runtime]System.Object
+		IL_0059: dup
+		IL_005a: ldc.i4.0
+		IL_005b: ldloc.0
+		IL_005c: stelem.ref
+		IL_005d: stloc.s 4
+		IL_005f: ldloc.2
+		IL_0060: ldloc.s 4
+		IL_0062: ldc.r8 2
+		IL_006b: box [System.Runtime]System.Double
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0075: stloc.3
+		IL_0076: ldloc.3
+		IL_0077: stloc.1
+		IL_0078: ldarg.2
+		IL_0079: ldstr "exports"
+		IL_007e: ldloc.1
+		IL_007f: ldc.i4.1
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0085: pop
+		IL_0086: ret
 	} // end of method CommonJS_Export_ClassWithConstructor_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_ClassWithConstructor_Lib
@@ -569,7 +564,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2350
+		// Method begins at RVA 0x2348
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ClassExpression_ExtendsArray.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ClassExpression_ExtendsArray.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222b
+				// Method begins at RVA 0x2223
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2246
+						// Method begins at RVA 0x223e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x223d
+					// Method begins at RVA 0x2235
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2234
+				// Method begins at RVA 0x222c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x224f
+				// Method begins at RVA 0x2247
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,7 +131,7 @@
 					object[] capture2
 				) cil managed 
 			{
-				// Method begins at RVA 0x2258
+				// Method begins at RVA 0x2250
 				// Header size: 1
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -153,7 +153,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2275
+				// Method begins at RVA 0x226d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2278
+				// Method begins at RVA 0x2270
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -177,7 +177,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x227b
+				// Method begins at RVA 0x2273
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -190,7 +190,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x2283
+				// Method begins at RVA 0x227b
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -206,7 +206,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x228b
+				// Method begins at RVA 0x2283
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -222,7 +222,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2297
+				// Method begins at RVA 0x228f
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -241,7 +241,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a3
+				// Method begins at RVA 0x229b
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -254,7 +254,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x22ab
+				// Method begins at RVA 0x22a3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -266,7 +266,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x22ae
+				// Method begins at RVA 0x22a6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -281,7 +281,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x22b1
+				// Method begins at RVA 0x22a9
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -314,7 +314,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2134
+			// Method begins at RVA 0x212c
 			// Header size: 12
 			// Code size: 182 (0xb6)
 			.maxstack 10
@@ -417,7 +417,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f8
+			// Method begins at RVA 0x21f0
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -453,7 +453,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2222
+			// Method begins at RVA 0x221a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -479,15 +479,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 213 (0xd5)
+		// Code size: 205 (0xcd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/Scope,
 			[1] object[],
 			[2] class [System.Runtime]System.Type,
 			[3] object,
-			[4] object,
-			[5] class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/Scope::.ctor()
@@ -529,36 +528,32 @@
 		IL_0073: stloc.3
 		IL_0074: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0079: stloc.1
-		IL_007a: newobj instance void Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item::.ctor()
-		IL_007f: ldc.i4.1
-		IL_0080: conv.r8
-		IL_0081: ldstr "item"
-		IL_0086: ldc.i4.1
-		IL_0087: ldc.i4.1
-		IL_0088: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0, float64, string, bool, bool)
-		IL_008d: stloc.s 5
-		IL_008f: ldloc.s 5
-		IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0)
-		IL_0096: stloc.s 5
-		IL_0098: ldloc.3
-		IL_0099: ldstr "item"
-		IL_009e: ldloc.s 5
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00a5: pop
-		IL_00a6: ldarg.2
-		IL_00a7: ldstr "exports"
-		IL_00ac: ldloc.s 4
-		IL_00ae: ldc.i4.1
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00b4: pop
-		IL_00b5: ldstr "console"
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c4: ldstr "log"
-		IL_00c9: ldstr "ok"
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ret
+		IL_007a: ldloc.3
+		IL_007b: ldstr "item"
+		IL_0080: newobj instance void Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item::.ctor()
+		IL_0085: ldc.i4.1
+		IL_0086: conv.r8
+		IL_0087: ldstr "item"
+		IL_008c: ldc.i4.1
+		IL_008d: ldc.i4.1
+		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0, float64, string, bool, bool)
+		IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0)
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_009d: pop
+		IL_009e: ldarg.2
+		IL_009f: ldstr "exports"
+		IL_00a4: ldloc.s 4
+		IL_00a6: ldc.i4.1
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_00ac: pop
+		IL_00ad: ldstr "console"
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00bc: ldstr "log"
+		IL_00c1: ldstr "ok"
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cb: pop
+		IL_00cc: ret
 	} // end of method CommonJS_Module_Exports_ClassExpression_ExtendsArray::__js_module_init__
 
 } // end of class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray
@@ -570,7 +565,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22dc
+		// Method begins at RVA 0x22d4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a8c
+				// Method begins at RVA 0x2a84
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aef
+				// Method begins at RVA 0x2ae7
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2af7
+				// Method begins at RVA 0x2aef
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2afa
+				// Method begins at RVA 0x2af2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -78,7 +78,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2afd
+				// Method begins at RVA 0x2af5
 				// Header size: 1
 				// Code size: 25 (0x19)
 				.maxstack 8
@@ -101,7 +101,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b17
+				// Method begins at RVA 0x2b0f
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -123,7 +123,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b2d
+				// Method begins at RVA 0x2b25
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -150,7 +150,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28e9
+			// Method begins at RVA 0x28e1
 			// Header size: 1
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -186,7 +186,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a95
+				// Method begins at RVA 0x2a8d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -206,7 +206,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b3c
+				// Method begins at RVA 0x2b34
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -219,7 +219,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2b44
+				// Method begins at RVA 0x2b3c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -231,7 +231,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2b47
+				// Method begins at RVA 0x2b3f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -246,7 +246,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b4a
+				// Method begins at RVA 0x2b42
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -263,7 +263,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b56
+				// Method begins at RVA 0x2b4e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -279,7 +279,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b5e
+				// Method begins at RVA 0x2b56
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -304,7 +304,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x291c
+			// Method begins at RVA 0x2914
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -345,7 +345,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a9e
+				// Method begins at RVA 0x2a96
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -370,7 +370,7 @@
 					class Modules.Function_ConstructedInstance_ObjectSemantics/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b6d
+				// Method begins at RVA 0x2b65
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -386,7 +386,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2b7c
+				// Method begins at RVA 0x2b74
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -398,7 +398,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2b7f
+				// Method begins at RVA 0x2b77
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -413,7 +413,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b82
+				// Method begins at RVA 0x2b7a
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -432,7 +432,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b94
+				// Method begins at RVA 0x2b8c
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -450,7 +450,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ba2
+				// Method begins at RVA 0x2b9a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -478,7 +478,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x295c
+			// Method begins at RVA 0x2954
 			// Header size: 1
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -512,7 +512,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa7
+				// Method begins at RVA 0x2a9f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -532,7 +532,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bb1
+				// Method begins at RVA 0x2ba9
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -545,7 +545,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2bb9
+				// Method begins at RVA 0x2bb1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -557,7 +557,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2bbc
+				// Method begins at RVA 0x2bb4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -572,7 +572,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bbf
+				// Method begins at RVA 0x2bb7
 				// Header size: 1
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -590,7 +590,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bd0
+				// Method begins at RVA 0x2bc8
 				// Header size: 1
 				// Code size: 12 (0xc)
 				.maxstack 8
@@ -607,7 +607,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bdd
+				// Method begins at RVA 0x2bd5
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -632,7 +632,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x298f
+			// Method begins at RVA 0x2987
 			// Header size: 1
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -665,7 +665,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ab9
+					// Method begins at RVA 0x2ab1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -692,7 +692,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x2c3e
+					// Method begins at RVA 0x2c36
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -711,7 +711,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2c54
+					// Method begins at RVA 0x2c4c
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -723,7 +723,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2c57
+					// Method begins at RVA 0x2c4f
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -738,7 +738,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2c5a
+					// Method begins at RVA 0x2c52
 					// Header size: 1
 					// Code size: 24 (0x18)
 					.maxstack 8
@@ -760,7 +760,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x2c73
+					// Method begins at RVA 0x2c6b
 					// Header size: 1
 					// Code size: 20 (0x14)
 					.maxstack 8
@@ -781,7 +781,7 @@
 						object newTarget
 					) cil managed 
 				{
-					// Method begins at RVA 0x2c88
+					// Method begins at RVA 0x2c80
 					// Header size: 1
 					// Code size: 14 (0xe)
 					.maxstack 8
@@ -808,7 +808,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a20
+				// Method begins at RVA 0x2a18
 				// Header size: 12
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -854,7 +854,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab0
+				// Method begins at RVA 0x2aa8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -879,7 +879,7 @@
 					class Modules.Function_ConstructedInstance_ObjectSemantics/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bec
+				// Method begins at RVA 0x2be4
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -895,7 +895,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2bfb
+				// Method begins at RVA 0x2bf3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -907,7 +907,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2bfe
+				// Method begins at RVA 0x2bf6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -922,7 +922,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c01
+				// Method begins at RVA 0x2bf9
 				// Header size: 1
 				// Code size: 24 (0x18)
 				.maxstack 8
@@ -944,7 +944,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c1a
+				// Method begins at RVA 0x2c12
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -965,7 +965,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c2f
+				// Method begins at RVA 0x2c27
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -994,7 +994,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x29b8
+			// Method begins at RVA 0x29b0
 			// Header size: 12
 			// Code size: 59 (0x3b)
 			.maxstack 8
@@ -1050,7 +1050,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac2
+				// Method begins at RVA 0x2aba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1070,7 +1070,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c97
+				// Method begins at RVA 0x2c8f
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1083,7 +1083,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2c9f
+				// Method begins at RVA 0x2c97
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1095,7 +1095,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2ca2
+				// Method begins at RVA 0x2c9a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1109,7 +1109,7 @@
 					object thisArgument
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ca5
+				// Method begins at RVA 0x2c9d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1125,7 +1125,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2cad
+				// Method begins at RVA 0x2ca5
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -1145,7 +1145,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2cc0
+				// Method begins at RVA 0x2cb8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1164,7 +1164,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ccf
+				// Method begins at RVA 0x2cc7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1190,7 +1190,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29ff
+			// Method begins at RVA 0x29f7
 			// Header size: 1
 			// Code size: 25 (0x19)
 			.maxstack 8
@@ -1219,7 +1219,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2acb
+				// Method begins at RVA 0x2ac3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1239,7 +1239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2cde
+				// Method begins at RVA 0x2cd6
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1252,7 +1252,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2ce6
+				// Method begins at RVA 0x2cde
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1264,7 +1264,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2ce9
+				// Method begins at RVA 0x2ce1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1279,7 +1279,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2cec
+				// Method begins at RVA 0x2ce4
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1296,7 +1296,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2cf8
+				// Method begins at RVA 0x2cf0
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1312,7 +1312,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d00
+				// Method begins at RVA 0x2cf8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1337,7 +1337,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a19
+			// Method begins at RVA 0x2a11
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -1359,7 +1359,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad4
+				// Method begins at RVA 0x2acc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1379,7 +1379,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d0f
+				// Method begins at RVA 0x2d07
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1392,7 +1392,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2d17
+				// Method begins at RVA 0x2d0f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1404,7 +1404,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2d1a
+				// Method begins at RVA 0x2d12
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1419,7 +1419,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d1d
+				// Method begins at RVA 0x2d15
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1436,7 +1436,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d29
+				// Method begins at RVA 0x2d21
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1452,7 +1452,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d31
+				// Method begins at RVA 0x2d29
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1477,7 +1477,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a1c
+			// Method begins at RVA 0x2a14
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -1499,7 +1499,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2add
+				// Method begins at RVA 0x2ad5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1519,7 +1519,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae6
+				// Method begins at RVA 0x2ade
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1544,7 +1544,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d40
+				// Method begins at RVA 0x2d38
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1560,7 +1560,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2d4f
+				// Method begins at RVA 0x2d47
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1572,7 +1572,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2d52
+				// Method begins at RVA 0x2d4a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1587,7 +1587,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d55
+				// Method begins at RVA 0x2d4d
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1603,7 +1603,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d61
+				// Method begins at RVA 0x2d59
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1622,7 +1622,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d6d
+				// Method begins at RVA 0x2d65
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1635,7 +1635,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2d75
+				// Method begins at RVA 0x2d6d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1647,7 +1647,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2d78
+				// Method begins at RVA 0x2d70
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1662,7 +1662,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d7b
+				// Method begins at RVA 0x2d73
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1684,7 +1684,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a5b
+			// Method begins at RVA 0x2a53
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1702,7 +1702,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a64
+			// Method begins at RVA 0x2a5c
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1751,7 +1751,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a83
+			// Method begins at RVA 0x2a7b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1777,7 +1777,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2189 (0x88d)
+		// Code size: 2181 (0x885)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ConstructedInstance_ObjectSemantics/Scope,
@@ -1805,8 +1805,7 @@
 			[22] object,
 			[23] object,
 			[24] object,
-			[25] class [System.Runtime]System.Type,
-			[26] class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read
+			[25] class [System.Runtime]System.Type
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -2455,68 +2454,64 @@
 		IL_07cc: pop
 		IL_07cd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_07d2: stloc.s 16
-		IL_07d4: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::.ctor()
-		IL_07d9: ldc.i4.1
-		IL_07da: conv.r8
-		IL_07db: ldstr "read"
-		IL_07e0: ldc.i4.0
-		IL_07e1: ldc.i4.1
-		IL_07e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0, float64, string, bool, bool)
-		IL_07e7: stloc.s 26
-		IL_07e9: ldloc.s 26
-		IL_07eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0)
-		IL_07f0: stloc.s 26
-		IL_07f2: ldloc.s 25
-		IL_07f4: ldstr "read"
-		IL_07f9: ldloc.s 26
-		IL_07fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0800: pop
-		IL_0801: ldc.i4.1
-		IL_0802: newarr [System.Runtime]System.Object
-		IL_0807: dup
-		IL_0808: ldc.i4.0
-		IL_0809: ldloc.0
-		IL_080a: stelem.ref
-		IL_080b: stloc.s 16
-		IL_080d: ldloc.s 25
-		IL_080f: ldloc.s 16
-		IL_0811: ldc.r8 0.0
-		IL_081a: box [System.Runtime]System.Double
-		IL_081f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0824: stloc.s 24
-		IL_0826: ldloc.s 24
-		IL_0828: stloc.s 15
-		IL_082a: ldstr "console"
-		IL_082f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0834: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0839: stloc.s 24
-		IL_083b: ldloc.1
-		IL_083c: ldc.i4.2
-		IL_083d: newarr [System.Runtime]System.Object
-		IL_0842: dup
-		IL_0843: ldc.i4.0
-		IL_0844: ldc.r8 6
-		IL_084d: box [System.Runtime]System.Double
-		IL_0852: stelem.ref
-		IL_0853: dup
-		IL_0854: ldc.i4.1
-		IL_0855: ldc.r8 1
-		IL_085e: box [System.Runtime]System.Double
-		IL_0863: stelem.ref
-		IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_0869: stloc.s 23
-		IL_086b: ldloc.s 15
-		IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_0872: stloc.s 19
-		IL_0874: ldloc.s 23
-		IL_0876: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
-		IL_087b: stloc.s 23
-		IL_087d: ldloc.s 24
-		IL_087f: ldstr "log"
-		IL_0884: ldloc.s 23
-		IL_0886: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_088b: pop
-		IL_088c: ret
+		IL_07d4: ldloc.s 25
+		IL_07d6: ldstr "read"
+		IL_07db: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::.ctor()
+		IL_07e0: ldc.i4.1
+		IL_07e1: conv.r8
+		IL_07e2: ldstr "read"
+		IL_07e7: ldc.i4.0
+		IL_07e8: ldc.i4.1
+		IL_07e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0, float64, string, bool, bool)
+		IL_07ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0)
+		IL_07f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_07f8: pop
+		IL_07f9: ldc.i4.1
+		IL_07fa: newarr [System.Runtime]System.Object
+		IL_07ff: dup
+		IL_0800: ldc.i4.0
+		IL_0801: ldloc.0
+		IL_0802: stelem.ref
+		IL_0803: stloc.s 16
+		IL_0805: ldloc.s 25
+		IL_0807: ldloc.s 16
+		IL_0809: ldc.r8 0.0
+		IL_0812: box [System.Runtime]System.Double
+		IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_081c: stloc.s 24
+		IL_081e: ldloc.s 24
+		IL_0820: stloc.s 15
+		IL_0822: ldstr "console"
+		IL_0827: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_082c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0831: stloc.s 24
+		IL_0833: ldloc.1
+		IL_0834: ldc.i4.2
+		IL_0835: newarr [System.Runtime]System.Object
+		IL_083a: dup
+		IL_083b: ldc.i4.0
+		IL_083c: ldc.r8 6
+		IL_0845: box [System.Runtime]System.Double
+		IL_084a: stelem.ref
+		IL_084b: dup
+		IL_084c: ldc.i4.1
+		IL_084d: ldc.r8 1
+		IL_0856: box [System.Runtime]System.Double
+		IL_085b: stelem.ref
+		IL_085c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_0861: stloc.s 23
+		IL_0863: ldloc.s 15
+		IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_086a: stloc.s 19
+		IL_086c: ldloc.s 23
+		IL_086e: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
+		IL_0873: stloc.s 23
+		IL_0875: ldloc.s 24
+		IL_0877: ldstr "log"
+		IL_087c: ldloc.s 23
+		IL_087e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0883: pop
+		IL_0884: ret
 	} // end of method Function_ConstructedInstance_ObjectSemantics::__js_module_init__
 
 } // end of class Modules.Function_ConstructedInstance_ObjectSemantics
@@ -2528,7 +2523,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2d89
+		// Method begins at RVA 0x2d81
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3080
+				// Method begins at RVA 0x3038
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3185
+				// Method begins at RVA 0x313d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x318d
+				// Method begins at RVA 0x3145
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3190
+				// Method begins at RVA 0x3148
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -78,7 +78,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3193
+				// Method begins at RVA 0x314b
 				// Header size: 1
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -99,7 +99,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x31ab
+				// Method begins at RVA 0x3163
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -119,7 +119,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x31bf
+				// Method begins at RVA 0x3177
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -145,7 +145,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27da
+			// Method begins at RVA 0x2792
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -173,7 +173,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3089
+				// Method begins at RVA 0x3041
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -193,7 +193,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31ce
+				// Method begins at RVA 0x3186
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -206,7 +206,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x31d6
+				// Method begins at RVA 0x318e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -218,7 +218,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x31d9
+				// Method begins at RVA 0x3191
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -233,7 +233,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x31dc
+				// Method begins at RVA 0x3194
 				// Header size: 1
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -254,7 +254,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x31f4
+				// Method begins at RVA 0x31ac
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -274,7 +274,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3208
+				// Method begins at RVA 0x31c0
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -300,7 +300,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27f3
+			// Method begins at RVA 0x27ab
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -326,7 +326,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3092
+				// Method begins at RVA 0x304a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -346,7 +346,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3217
+				// Method begins at RVA 0x31cf
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -359,7 +359,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x321f
+				// Method begins at RVA 0x31d7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -371,7 +371,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3222
+				// Method begins at RVA 0x31da
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -386,7 +386,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3225
+				// Method begins at RVA 0x31dd
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -411,7 +411,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3249
+				// Method begins at RVA 0x3201
 				// Header size: 1
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -435,7 +435,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3269
+				// Method begins at RVA 0x3221
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -462,7 +462,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x280a
+			// Method begins at RVA 0x27c2
 			// Header size: 1
 			// Code size: 25 (0x19)
 			.maxstack 8
@@ -490,7 +490,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x309b
+				// Method begins at RVA 0x3053
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -510,7 +510,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3278
+				// Method begins at RVA 0x3230
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -523,7 +523,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3280
+				// Method begins at RVA 0x3238
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -535,7 +535,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3283
+				// Method begins at RVA 0x323b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -550,7 +550,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3286
+				// Method begins at RVA 0x323e
 				// Header size: 1
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -571,7 +571,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x329e
+				// Method begins at RVA 0x3256
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -591,7 +591,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x32b2
+				// Method begins at RVA 0x326a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -617,7 +617,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2824
+			// Method begins at RVA 0x27dc
 			// Header size: 1
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -655,7 +655,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30a4
+				// Method begins at RVA 0x305c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -675,7 +675,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32c1
+				// Method begins at RVA 0x3279
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -688,7 +688,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x32c9
+				// Method begins at RVA 0x3281
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -700,7 +700,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x32cc
+				// Method begins at RVA 0x3284
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -715,7 +715,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x32cf
+				// Method begins at RVA 0x3287
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -744,7 +744,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x32ff
+				// Method begins at RVA 0x32b7
 				// Header size: 1
 				// Code size: 43 (0x2b)
 				.maxstack 8
@@ -772,7 +772,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x332b
+				// Method begins at RVA 0x32e3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -800,7 +800,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2858
+			// Method begins at RVA 0x2810
 			// Header size: 12
 			// Code size: 61 (0x3d)
 			.maxstack 9
@@ -841,7 +841,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30ad
+				// Method begins at RVA 0x3065
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -866,7 +866,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x333a
+				// Method begins at RVA 0x32f2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -882,7 +882,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3349
+				// Method begins at RVA 0x3301
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -894,7 +894,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x334c
+				// Method begins at RVA 0x3304
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -909,7 +909,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x334f
+				// Method begins at RVA 0x3307
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -928,7 +928,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3361
+				// Method begins at RVA 0x3319
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -946,7 +946,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x336f
+				// Method begins at RVA 0x3327
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -974,7 +974,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x28a4
+			// Method begins at RVA 0x285c
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -1011,7 +1011,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30b6
+				// Method begins at RVA 0x306e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1036,7 +1036,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x337e
+				// Method begins at RVA 0x3336
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1052,7 +1052,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x338d
+				// Method begins at RVA 0x3345
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1064,7 +1064,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3390
+				// Method begins at RVA 0x3348
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1079,7 +1079,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3393
+				// Method begins at RVA 0x334b
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1098,7 +1098,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x33a5
+				// Method begins at RVA 0x335d
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1116,7 +1116,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x33b3
+				// Method begins at RVA 0x336b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1144,7 +1144,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x28dc
+			// Method begins at RVA 0x2894
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -1181,7 +1181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30bf
+				// Method begins at RVA 0x3077
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1206,7 +1206,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x33c2
+				// Method begins at RVA 0x337a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1222,7 +1222,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x33d1
+				// Method begins at RVA 0x3389
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1234,7 +1234,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x33d4
+				// Method begins at RVA 0x338c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1249,7 +1249,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x33d7
+				// Method begins at RVA 0x338f
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1268,7 +1268,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x33e9
+				// Method begins at RVA 0x33a1
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1286,7 +1286,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x33f7
+				// Method begins at RVA 0x33af
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1314,7 +1314,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2914
+			// Method begins at RVA 0x28cc
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -1384,7 +1384,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30da
+					// Method begins at RVA 0x3092
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1411,7 +1411,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x344a
+					// Method begins at RVA 0x3402
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -1430,7 +1430,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x3460
+					// Method begins at RVA 0x3418
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1442,7 +1442,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x3463
+					// Method begins at RVA 0x341b
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1457,7 +1457,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x3466
+					// Method begins at RVA 0x341e
 					// Header size: 1
 					// Code size: 13 (0xd)
 					.maxstack 8
@@ -1482,7 +1482,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d98
+				// Method begins at RVA 0x2d50
 				// Header size: 12
 				// Code size: 74 (0x4a)
 				.maxstack 8
@@ -1540,7 +1540,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30d1
+					// Method begins at RVA 0x3089
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1560,7 +1560,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30e3
+					// Method begins at RVA 0x309b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1578,7 +1578,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30c8
+				// Method begins at RVA 0x3080
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1603,7 +1603,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3406
+				// Method begins at RVA 0x33be
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1619,7 +1619,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3415
+				// Method begins at RVA 0x33cd
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1631,7 +1631,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3418
+				// Method begins at RVA 0x33d0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1646,7 +1646,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x341b
+				// Method begins at RVA 0x33d3
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1665,7 +1665,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x342d
+				// Method begins at RVA 0x33e5
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1683,7 +1683,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x343b
+				// Method begins at RVA 0x33f3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1711,7 +1711,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x297c
+			// Method begins at RVA 0x2934
 			// Header size: 12
 			// Code size: 212 (0xd4)
 			.maxstack 8
@@ -1846,7 +1846,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30ec
+				// Method begins at RVA 0x30a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1871,7 +1871,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3474
+				// Method begins at RVA 0x342c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1887,7 +1887,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3483
+				// Method begins at RVA 0x343b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1899,7 +1899,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3486
+				// Method begins at RVA 0x343e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1914,7 +1914,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3489
+				// Method begins at RVA 0x3441
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1933,7 +1933,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x349b
+				// Method begins at RVA 0x3453
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1951,7 +1951,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x34a9
+				// Method begins at RVA 0x3461
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1979,7 +1979,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2a6c
+			// Method begins at RVA 0x2a24
 			// Header size: 12
 			// Code size: 73 (0x49)
 			.maxstack 8
@@ -2038,7 +2038,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3158
+				// Method begins at RVA 0x3110
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2063,7 +2063,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x373a
+				// Method begins at RVA 0x36f2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2079,7 +2079,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3749
+				// Method begins at RVA 0x3701
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2091,7 +2091,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x374c
+				// Method begins at RVA 0x3704
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2106,7 +2106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x374f
+				// Method begins at RVA 0x3707
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -2125,7 +2125,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3761
+				// Method begins at RVA 0x3719
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -2143,7 +2143,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x376f
+				// Method begins at RVA 0x3727
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2171,7 +2171,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2ac4
+			// Method begins at RVA 0x2a7c
 			// Header size: 12
 			// Code size: 119 (0x77)
 			.maxstack 8
@@ -2233,7 +2233,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3161
+				// Method begins at RVA 0x3119
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2258,7 +2258,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x377e
+				// Method begins at RVA 0x3736
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2274,7 +2274,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x378d
+				// Method begins at RVA 0x3745
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2286,7 +2286,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3790
+				// Method begins at RVA 0x3748
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2301,7 +2301,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3793
+				// Method begins at RVA 0x374b
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -2320,7 +2320,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x37a5
+				// Method begins at RVA 0x375d
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -2338,7 +2338,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x37b3
+				// Method begins at RVA 0x376b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2366,7 +2366,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2b48
+			// Method begins at RVA 0x2b00
 			// Header size: 12
 			// Code size: 162 (0xa2)
 			.maxstack 8
@@ -2446,7 +2446,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x316a
+				// Method begins at RVA 0x3122
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2471,7 +2471,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x37c2
+				// Method begins at RVA 0x377a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2487,7 +2487,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x37d1
+				// Method begins at RVA 0x3789
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2499,7 +2499,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x37d4
+				// Method begins at RVA 0x378c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2514,7 +2514,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x37d7
+				// Method begins at RVA 0x378f
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -2533,7 +2533,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x37e9
+				// Method begins at RVA 0x37a1
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -2551,7 +2551,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x37f7
+				// Method begins at RVA 0x37af
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2579,7 +2579,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2bf8
+			// Method begins at RVA 0x2bb0
 			// Header size: 12
 			// Code size: 129 (0x81)
 			.maxstack 8
@@ -2645,7 +2645,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3173
+				// Method begins at RVA 0x312b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2670,7 +2670,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3806
+				// Method begins at RVA 0x37be
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2686,7 +2686,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3815
+				// Method begins at RVA 0x37cd
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2698,7 +2698,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3818
+				// Method begins at RVA 0x37d0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2713,7 +2713,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x381b
+				// Method begins at RVA 0x37d3
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -2732,7 +2732,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x382d
+				// Method begins at RVA 0x37e5
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -2750,7 +2750,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x383b
+				// Method begins at RVA 0x37f3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2778,7 +2778,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2c88
+			// Method begins at RVA 0x2c40
 			// Header size: 12
 			// Code size: 124 (0x7c)
 			.maxstack 8
@@ -2841,7 +2841,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x317c
+				// Method begins at RVA 0x3134
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2866,7 +2866,7 @@
 					class Modules.Function_SchedulerCallResults/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x384a
+				// Method begins at RVA 0x3802
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2882,7 +2882,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3859
+				// Method begins at RVA 0x3811
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2894,7 +2894,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x385c
+				// Method begins at RVA 0x3814
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2909,7 +2909,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x385f
+				// Method begins at RVA 0x3817
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -2928,7 +2928,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3871
+				// Method begins at RVA 0x3829
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -2946,7 +2946,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x387f
+				// Method begins at RVA 0x3837
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2974,7 +2974,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
-			// Method begins at RVA 0x2d10
+			// Method begins at RVA 0x2cc8
 			// Header size: 12
 			// Code size: 124 (0x7c)
 			.maxstack 8
@@ -3037,7 +3037,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30f5
+				// Method begins at RVA 0x30ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3057,7 +3057,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30fe
+				// Method begins at RVA 0x30b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3077,7 +3077,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3107
+				// Method begins at RVA 0x30bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3097,7 +3097,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3110
+				// Method begins at RVA 0x30c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3117,7 +3117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3119
+				// Method begins at RVA 0x30d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3137,7 +3137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3122
+				// Method begins at RVA 0x30da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3157,7 +3157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x312b
+				// Method begins at RVA 0x30e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3177,7 +3177,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3134
+				// Method begins at RVA 0x30ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3197,7 +3197,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x313d
+				// Method begins at RVA 0x30f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3217,7 +3217,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3146
+				// Method begins at RVA 0x30fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3237,7 +3237,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x314f
+				// Method begins at RVA 0x3107
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3262,7 +3262,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x34b8
+				// Method begins at RVA 0x3470
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3278,7 +3278,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x34c7
+				// Method begins at RVA 0x347f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3290,7 +3290,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x34ca
+				// Method begins at RVA 0x3482
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3305,7 +3305,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x34cd
+				// Method begins at RVA 0x3485
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -3321,7 +3321,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x34d9
+				// Method begins at RVA 0x3491
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -3340,7 +3340,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34e5
+				// Method begins at RVA 0x349d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3353,7 +3353,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x34ed
+				// Method begins at RVA 0x34a5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3365,7 +3365,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x34f0
+				// Method begins at RVA 0x34a8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3380,7 +3380,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x34f3
+				// Method begins at RVA 0x34ab
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -3410,7 +3410,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x351e
+				// Method begins at RVA 0x34d6
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3423,7 +3423,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3526
+				// Method begins at RVA 0x34de
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3435,7 +3435,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3529
+				// Method begins at RVA 0x34e1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3450,7 +3450,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x352c
+				// Method begins at RVA 0x34e4
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -3477,7 +3477,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3550
+				// Method begins at RVA 0x3508
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3490,7 +3490,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3558
+				// Method begins at RVA 0x3510
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3502,7 +3502,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x355b
+				// Method begins at RVA 0x3513
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3517,7 +3517,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x355e
+				// Method begins at RVA 0x3516
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -3544,7 +3544,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3582
+				// Method begins at RVA 0x353a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3557,7 +3557,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x358a
+				// Method begins at RVA 0x3542
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3569,7 +3569,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x358d
+				// Method begins at RVA 0x3545
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3584,7 +3584,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3590
+				// Method begins at RVA 0x3548
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -3611,7 +3611,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35b4
+				// Method begins at RVA 0x356c
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3624,7 +3624,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x35bc
+				// Method begins at RVA 0x3574
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3636,7 +3636,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x35bf
+				// Method begins at RVA 0x3577
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3651,7 +3651,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x35c2
+				// Method begins at RVA 0x357a
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -3678,7 +3678,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35e6
+				// Method begins at RVA 0x359e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3691,7 +3691,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x35ee
+				// Method begins at RVA 0x35a6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3703,7 +3703,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x35f1
+				// Method begins at RVA 0x35a9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3718,7 +3718,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x35f4
+				// Method begins at RVA 0x35ac
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -3746,7 +3746,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x361d
+				// Method begins at RVA 0x35d5
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3759,7 +3759,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3625
+				// Method begins at RVA 0x35dd
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3771,7 +3771,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3628
+				// Method begins at RVA 0x35e0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3786,7 +3786,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x362c
+				// Method begins at RVA 0x35e4
 				// Header size: 12
 				// Code size: 148 (0x94)
 				.maxstack 12
@@ -3850,7 +3850,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36cc
+				// Method begins at RVA 0x3684
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3863,7 +3863,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x36d4
+				// Method begins at RVA 0x368c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3875,7 +3875,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x36d7
+				// Method begins at RVA 0x368f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3890,7 +3890,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x36da
+				// Method begins at RVA 0x3692
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -3918,7 +3918,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3703
+				// Method begins at RVA 0x36bb
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3931,7 +3931,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x370b
+				// Method begins at RVA 0x36c3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3943,7 +3943,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x370e
+				// Method begins at RVA 0x36c6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3958,7 +3958,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3711
+				// Method begins at RVA 0x36c9
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -3992,7 +3992,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3063
+			// Method begins at RVA 0x301b
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -4014,7 +4014,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e98
+			// Method begins at RVA 0x2e50
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -4044,7 +4044,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ec1
+			// Method begins at RVA 0x2e79
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -4060,7 +4060,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e04
+			// Method begins at RVA 0x2dbc
 			// Header size: 12
 			// Code size: 135 (0x87)
 			.maxstack 8
@@ -4121,7 +4121,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2dee
+			// Method begins at RVA 0x2da6
 			// Header size: 1
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -4139,7 +4139,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3014
+			// Method begins at RVA 0x2fcc
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -4170,7 +4170,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ec9
+			// Method begins at RVA 0x2e81
 			// Header size: 1
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -4207,7 +4207,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x304a
+			// Method begins at RVA 0x3002
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -4238,7 +4238,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ef0
+			// Method begins at RVA 0x2ea8
 			// Header size: 12
 			// Code size: 124 (0x7c)
 			.maxstack 13
@@ -4275,7 +4275,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f78
+			// Method begins at RVA 0x2f30
 			// Header size: 12
 			// Code size: 144 (0x90)
 			.maxstack 16
@@ -4352,7 +4352,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3077
+			// Method begins at RVA 0x302f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4378,7 +4378,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1918 (0x77e)
+		// Code size: 1846 (0x736)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerCallResults/Scope,
@@ -4400,18 +4400,9 @@
 			[16] class Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h,
 			[17] class [System.Runtime]System.Type,
 			[18] object,
-			[19] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add,
-			[20] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue,
-			[21] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain,
-			[22] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce,
-			[23] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next,
-			[24] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext,
-			[25] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum,
-			[26] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum,
-			[27] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor,
-			[28] object,
-			[29] float64,
-			[30] object
+			[19] object,
+			[20] float64,
+			[21] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_SchedulerCallResults/Scope::.ctor()
@@ -4712,388 +4703,352 @@
 		IL_0294: stloc.s 18
 		IL_0296: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_029b: stloc.s 14
-		IL_029d: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add::.ctor()
-		IL_02a2: ldc.i4.1
-		IL_02a3: conv.r8
-		IL_02a4: ldstr "add"
+		IL_029d: ldloc.s 18
+		IL_029f: ldstr "add"
+		IL_02a4: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add::.ctor()
 		IL_02a9: ldc.i4.1
-		IL_02aa: ldc.i4.1
-		IL_02ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0, float64, string, bool, bool)
-		IL_02b0: stloc.s 19
-		IL_02b2: ldloc.s 19
-		IL_02b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0)
-		IL_02b9: stloc.s 19
-		IL_02bb: ldloc.s 18
-		IL_02bd: ldstr "add"
-		IL_02c2: ldloc.s 19
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02c9: pop
-		IL_02ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02cf: stloc.s 14
-		IL_02d1: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue::.ctor()
-		IL_02d6: ldc.i4.0
-		IL_02d7: conv.r8
-		IL_02d8: ldstr "getValue"
+		IL_02aa: conv.r8
+		IL_02ab: ldstr "add"
+		IL_02b0: ldc.i4.1
+		IL_02b1: ldc.i4.1
+		IL_02b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0, float64, string, bool, bool)
+		IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0)
+		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02c1: pop
+		IL_02c2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02c7: stloc.s 14
+		IL_02c9: ldloc.s 18
+		IL_02cb: ldstr "getValue"
+		IL_02d0: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue::.ctor()
+		IL_02d5: ldc.i4.0
+		IL_02d6: conv.r8
+		IL_02d7: ldstr "getValue"
+		IL_02dc: ldc.i4.1
 		IL_02dd: ldc.i4.1
-		IL_02de: ldc.i4.1
-		IL_02df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0, float64, string, bool, bool)
-		IL_02e4: stloc.s 20
-		IL_02e6: ldloc.s 20
-		IL_02e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0)
-		IL_02ed: stloc.s 20
-		IL_02ef: ldloc.s 18
-		IL_02f1: ldstr "getValue"
-		IL_02f6: ldloc.s 20
-		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02fd: pop
-		IL_02fe: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0303: stloc.s 14
-		IL_0305: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain::.ctor()
-		IL_030a: ldc.i4.0
-		IL_030b: conv.r8
-		IL_030c: ldstr "chain"
-		IL_0311: ldc.i4.1
-		IL_0312: ldc.i4.1
-		IL_0313: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0, float64, string, bool, bool)
-		IL_0318: stloc.s 21
-		IL_031a: ldloc.s 21
-		IL_031c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0)
-		IL_0321: stloc.s 21
-		IL_0323: ldloc.s 18
-		IL_0325: ldstr "chain"
-		IL_032a: ldloc.s 21
-		IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0331: pop
-		IL_0332: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0337: stloc.s 14
-		IL_0339: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::.ctor()
-		IL_033e: ldc.i4.0
-		IL_033f: conv.r8
-		IL_0340: ldstr "addOnce"
-		IL_0345: ldc.i4.1
-		IL_0346: ldc.i4.1
-		IL_0347: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0, float64, string, bool, bool)
-		IL_034c: stloc.s 22
-		IL_034e: ldloc.s 22
-		IL_0350: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0)
-		IL_0355: stloc.s 22
-		IL_0357: ldloc.s 18
-		IL_0359: ldstr "addOnce"
-		IL_035e: ldloc.s 22
-		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0365: pop
-		IL_0366: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_036b: stloc.s 14
-		IL_036d: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next::.ctor()
-		IL_0372: ldc.i4.0
-		IL_0373: conv.r8
-		IL_0374: ldstr "next"
-		IL_0379: ldc.i4.1
-		IL_037a: ldc.i4.1
-		IL_037b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0, float64, string, bool, bool)
-		IL_0380: stloc.s 23
-		IL_0382: ldloc.s 23
-		IL_0384: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0)
-		IL_0389: stloc.s 23
-		IL_038b: ldloc.s 18
-		IL_038d: ldstr "next"
-		IL_0392: ldloc.s 23
-		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0399: pop
-		IL_039a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_039f: stloc.s 14
-		IL_03a1: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext::.ctor()
-		IL_03a6: ldc.i4.0
-		IL_03a7: conv.r8
-		IL_03a8: ldstr "maxNext"
-		IL_03ad: ldc.i4.1
-		IL_03ae: ldc.i4.1
-		IL_03af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0, float64, string, bool, bool)
-		IL_03b4: stloc.s 24
-		IL_03b6: ldloc.s 24
-		IL_03b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0)
-		IL_03bd: stloc.s 24
-		IL_03bf: ldloc.s 18
-		IL_03c1: ldstr "maxNext"
-		IL_03c6: ldloc.s 24
-		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_03cd: pop
-		IL_03ce: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03d3: stloc.s 14
-		IL_03d5: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum::.ctor()
-		IL_03da: ldc.i4.s 9
-		IL_03dc: conv.r8
-		IL_03dd: ldstr "sum"
-		IL_03e2: ldc.i4.0
-		IL_03e3: ldc.i4.1
-		IL_03e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0, float64, string, bool, bool)
-		IL_03e9: stloc.s 25
-		IL_03eb: ldloc.s 25
-		IL_03ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0)
-		IL_03f2: stloc.s 25
-		IL_03f4: ldloc.s 18
-		IL_03f6: ldstr "sum"
-		IL_03fb: ldloc.s 25
-		IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0402: pop
-		IL_0403: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0408: stloc.s 14
-		IL_040a: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::.ctor()
-		IL_040f: ldc.i4.0
-		IL_0410: conv.r8
-		IL_0411: ldstr "maxSum"
-		IL_0416: ldc.i4.1
-		IL_0417: ldc.i4.1
-		IL_0418: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0, float64, string, bool, bool)
-		IL_041d: stloc.s 26
-		IL_041f: ldloc.s 26
-		IL_0421: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0)
-		IL_0426: stloc.s 26
-		IL_0428: ldloc.s 18
-		IL_042a: ldstr "maxSum"
-		IL_042f: ldloc.s 26
-		IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0436: pop
-		IL_0437: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_043c: stloc.s 14
-		IL_043e: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::.ctor()
-		IL_0443: ldc.i4.0
-		IL_0444: conv.r8
-		IL_0445: ldstr "maxSumWithFloor"
-		IL_044a: ldc.i4.1
-		IL_044b: ldc.i4.1
-		IL_044c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0, float64, string, bool, bool)
-		IL_0451: stloc.s 27
-		IL_0453: ldloc.s 27
-		IL_0455: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0)
-		IL_045a: stloc.s 27
-		IL_045c: ldloc.s 18
-		IL_045e: ldstr "maxSumWithFloor"
-		IL_0463: ldloc.s 27
-		IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_046a: pop
-		IL_046b: ldc.i4.1
-		IL_046c: newarr [System.Runtime]System.Object
-		IL_0471: dup
-		IL_0472: ldc.i4.0
-		IL_0473: ldloc.0
-		IL_0474: stelem.ref
-		IL_0475: stloc.s 14
-		IL_0477: ldloc.s 17
-		IL_0479: ldloc.s 14
-		IL_047b: ldc.r8 1
-		IL_0484: box [System.Runtime]System.Double
-		IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_048e: stloc.s 18
-		IL_0490: ldloc.0
-		IL_0491: ldloc.s 18
-		IL_0493: stfld object Modules.Function_SchedulerCallResults/Scope::Counter
-		IL_0498: nop
-		IL_0499: nop
-		IL_049a: nop
-		IL_049b: nop
-		IL_049c: nop
-		IL_049d: ldstr "console"
-		IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04ac: stloc.s 18
-		IL_04ae: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04b3: stloc.s 14
-		IL_04b5: ldloc.1
-		IL_04b6: ldloc.s 14
-		IL_04b8: ldc.r8 9
-		IL_04c1: box [System.Runtime]System.Double
+		IL_02de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0, float64, string, bool, bool)
+		IL_02e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0)
+		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02ed: pop
+		IL_02ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02f3: stloc.s 14
+		IL_02f5: ldloc.s 18
+		IL_02f7: ldstr "chain"
+		IL_02fc: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain::.ctor()
+		IL_0301: ldc.i4.0
+		IL_0302: conv.r8
+		IL_0303: ldstr "chain"
+		IL_0308: ldc.i4.1
+		IL_0309: ldc.i4.1
+		IL_030a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0, float64, string, bool, bool)
+		IL_030f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0)
+		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0319: pop
+		IL_031a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_031f: stloc.s 14
+		IL_0321: ldloc.s 18
+		IL_0323: ldstr "addOnce"
+		IL_0328: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::.ctor()
+		IL_032d: ldc.i4.0
+		IL_032e: conv.r8
+		IL_032f: ldstr "addOnce"
+		IL_0334: ldc.i4.1
+		IL_0335: ldc.i4.1
+		IL_0336: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0, float64, string, bool, bool)
+		IL_033b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0)
+		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0345: pop
+		IL_0346: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_034b: stloc.s 14
+		IL_034d: ldloc.s 18
+		IL_034f: ldstr "next"
+		IL_0354: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next::.ctor()
+		IL_0359: ldc.i4.0
+		IL_035a: conv.r8
+		IL_035b: ldstr "next"
+		IL_0360: ldc.i4.1
+		IL_0361: ldc.i4.1
+		IL_0362: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0, float64, string, bool, bool)
+		IL_0367: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0)
+		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0371: pop
+		IL_0372: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0377: stloc.s 14
+		IL_0379: ldloc.s 18
+		IL_037b: ldstr "maxNext"
+		IL_0380: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext::.ctor()
+		IL_0385: ldc.i4.0
+		IL_0386: conv.r8
+		IL_0387: ldstr "maxNext"
+		IL_038c: ldc.i4.1
+		IL_038d: ldc.i4.1
+		IL_038e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0, float64, string, bool, bool)
+		IL_0393: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0)
+		IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_039d: pop
+		IL_039e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03a3: stloc.s 14
+		IL_03a5: ldloc.s 18
+		IL_03a7: ldstr "sum"
+		IL_03ac: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum::.ctor()
+		IL_03b1: ldc.i4.s 9
+		IL_03b3: conv.r8
+		IL_03b4: ldstr "sum"
+		IL_03b9: ldc.i4.0
+		IL_03ba: ldc.i4.1
+		IL_03bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0, float64, string, bool, bool)
+		IL_03c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0)
+		IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_03ca: pop
+		IL_03cb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03d0: stloc.s 14
+		IL_03d2: ldloc.s 18
+		IL_03d4: ldstr "maxSum"
+		IL_03d9: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::.ctor()
+		IL_03de: ldc.i4.0
+		IL_03df: conv.r8
+		IL_03e0: ldstr "maxSum"
+		IL_03e5: ldc.i4.1
+		IL_03e6: ldc.i4.1
+		IL_03e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0, float64, string, bool, bool)
+		IL_03ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0)
+		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_03f6: pop
+		IL_03f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03fc: stloc.s 14
+		IL_03fe: ldloc.s 18
+		IL_0400: ldstr "maxSumWithFloor"
+		IL_0405: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::.ctor()
+		IL_040a: ldc.i4.0
+		IL_040b: conv.r8
+		IL_040c: ldstr "maxSumWithFloor"
+		IL_0411: ldc.i4.1
+		IL_0412: ldc.i4.1
+		IL_0413: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0, float64, string, bool, bool)
+		IL_0418: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0)
+		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0422: pop
+		IL_0423: ldc.i4.1
+		IL_0424: newarr [System.Runtime]System.Object
+		IL_0429: dup
+		IL_042a: ldc.i4.0
+		IL_042b: ldloc.0
+		IL_042c: stelem.ref
+		IL_042d: stloc.s 14
+		IL_042f: ldloc.s 17
+		IL_0431: ldloc.s 14
+		IL_0433: ldc.r8 1
+		IL_043c: box [System.Runtime]System.Double
+		IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0446: stloc.s 18
+		IL_0448: ldloc.0
+		IL_0449: ldloc.s 18
+		IL_044b: stfld object Modules.Function_SchedulerCallResults/Scope::Counter
+		IL_0450: nop
+		IL_0451: nop
+		IL_0452: nop
+		IL_0453: nop
+		IL_0454: nop
+		IL_0455: ldstr "console"
+		IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0464: stloc.s 18
+		IL_0466: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_046b: stloc.s 14
+		IL_046d: ldloc.1
+		IL_046e: ldloc.s 14
+		IL_0470: ldc.r8 9
+		IL_0479: box [System.Runtime]System.Double
+		IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0483: stloc.s 19
+		IL_0485: ldloc.s 18
+		IL_0487: ldstr "log"
+		IL_048c: ldloc.s 19
+		IL_048e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0493: pop
+		IL_0494: ldstr "console"
+		IL_0499: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04a3: stloc.s 19
+		IL_04a5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04aa: stloc.s 14
+		IL_04ac: ldc.r8 2.7
+		IL_04b5: neg
+		IL_04b6: stloc.s 20
+		IL_04b8: ldloc.s 20
+		IL_04ba: box [System.Runtime]System.Double
+		IL_04bf: stloc.s 21
+		IL_04c1: ldloc.2
+		IL_04c2: ldloc.s 14
+		IL_04c4: ldloc.s 21
 		IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_04cb: stloc.s 28
-		IL_04cd: ldloc.s 18
+		IL_04cb: stloc.s 18
+		IL_04cd: ldloc.s 19
 		IL_04cf: ldstr "log"
-		IL_04d4: ldloc.s 28
+		IL_04d4: ldloc.s 18
 		IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_04db: pop
 		IL_04dc: ldstr "console"
 		IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04eb: stloc.s 28
+		IL_04eb: stloc.s 18
 		IL_04ed: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_04f2: stloc.s 14
-		IL_04f4: ldc.r8 2.7
-		IL_04fd: neg
-		IL_04fe: stloc.s 29
-		IL_0500: ldloc.s 29
-		IL_0502: box [System.Runtime]System.Double
-		IL_0507: stloc.s 30
-		IL_0509: ldloc.2
-		IL_050a: ldloc.s 14
-		IL_050c: ldloc.s 30
-		IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0513: stloc.s 18
-		IL_0515: ldloc.s 28
-		IL_0517: ldstr "log"
-		IL_051c: ldloc.s 18
-		IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0523: pop
-		IL_0524: ldstr "console"
-		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0533: stloc.s 18
-		IL_0535: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_053a: stloc.s 14
-		IL_053c: ldloc.3
-		IL_053d: ldloc.s 14
-		IL_053f: ldc.r8 1.2
-		IL_0548: box [System.Runtime]System.Double
-		IL_054d: ldc.r8 1.1
-		IL_0556: box [System.Runtime]System.Double
-		IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0560: stloc.s 28
-		IL_0562: ldloc.s 18
-		IL_0564: ldstr "log"
-		IL_0569: ldloc.s 28
-		IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0570: pop
-		IL_0571: ldstr "console"
-		IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0580: stloc.s 28
-		IL_0582: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0587: stloc.s 14
-		IL_0589: ldloc.s 4
-		IL_058b: ldloc.s 14
-		IL_058d: ldc.r8 9
-		IL_0596: box [System.Runtime]System.Double
-		IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_05a0: stloc.s 18
-		IL_05a2: ldloc.s 28
-		IL_05a4: ldstr "log"
-		IL_05a9: ldloc.s 18
-		IL_05ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05b0: pop
-		IL_05b1: ldstr "console"
-		IL_05b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05c0: stloc.s 18
-		IL_05c2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05c7: stloc.s 14
-		IL_05c9: ldloc.s 5
-		IL_05cb: ldloc.s 14
-		IL_05cd: ldc.r8 2
-		IL_05d6: box [System.Runtime]System.Double
-		IL_05db: ldc.r8 3
-		IL_05e4: box [System.Runtime]System.Double
-		IL_05e9: ldc.r8 2
-		IL_05f2: box [System.Runtime]System.Double
-		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_05fc: stloc.s 28
-		IL_05fe: ldloc.s 18
-		IL_0600: ldstr "log"
-		IL_0605: ldloc.s 28
-		IL_0607: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_060c: pop
-		IL_060d: ldstr "console"
-		IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_061c: stloc.s 28
-		IL_061e: ldloc.s 6
-		IL_0620: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0625: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_062a: stloc.s 18
-		IL_062c: ldloc.s 28
-		IL_062e: ldstr "log"
-		IL_0633: ldloc.s 18
-		IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_063a: pop
-		IL_063b: ldstr "console"
-		IL_0640: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_064a: stloc.s 18
-		IL_064c: ldloc.s 7
-		IL_064e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0658: stloc.s 28
-		IL_065a: ldloc.s 18
-		IL_065c: ldstr "log"
-		IL_0661: ldloc.s 28
-		IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0668: pop
-		IL_0669: ldstr "console"
-		IL_066e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0673: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0678: stloc.s 28
-		IL_067a: ldloc.s 8
-		IL_067c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0686: stloc.s 18
-		IL_0688: ldloc.s 28
-		IL_068a: ldstr "log"
-		IL_068f: ldloc.s 18
-		IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0696: pop
-		IL_0697: ldstr "console"
-		IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06a6: stloc.s 18
-		IL_06a8: ldloc.s 9
-		IL_06aa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_06af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_06b4: stloc.s 28
-		IL_06b6: ldloc.s 18
-		IL_06b8: ldstr "log"
-		IL_06bd: ldloc.s 28
-		IL_06bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06c4: pop
-		IL_06c5: ldstr "console"
-		IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06d4: stloc.s 28
-		IL_06d6: ldloc.s 10
-		IL_06d8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_06dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_06e2: stloc.s 18
-		IL_06e4: ldloc.s 28
-		IL_06e6: ldstr "log"
-		IL_06eb: ldloc.s 18
-		IL_06ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06f2: pop
-		IL_06f3: ldstr "console"
-		IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0702: stloc.s 18
-		IL_0704: ldloc.s 11
-		IL_0706: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0710: stloc.s 28
-		IL_0712: ldloc.s 18
-		IL_0714: ldstr "log"
-		IL_0719: ldloc.s 28
-		IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0720: pop
-		IL_0721: ldstr "console"
-		IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0730: stloc.s 28
-		IL_0732: ldloc.s 12
-		IL_0734: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_073e: stloc.s 18
-		IL_0740: ldloc.s 28
-		IL_0742: ldstr "log"
-		IL_0747: ldloc.s 18
-		IL_0749: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_074e: pop
-		IL_074f: ldstr "console"
-		IL_0754: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_075e: stloc.s 18
-		IL_0760: ldloc.s 13
-		IL_0762: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0767: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_076c: stloc.s 28
-		IL_076e: ldloc.s 18
-		IL_0770: ldstr "log"
-		IL_0775: ldloc.s 28
-		IL_0777: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_077c: pop
-		IL_077d: ret
+		IL_04f4: ldloc.3
+		IL_04f5: ldloc.s 14
+		IL_04f7: ldc.r8 1.2
+		IL_0500: box [System.Runtime]System.Double
+		IL_0505: ldc.r8 1.1
+		IL_050e: box [System.Runtime]System.Double
+		IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0518: stloc.s 19
+		IL_051a: ldloc.s 18
+		IL_051c: ldstr "log"
+		IL_0521: ldloc.s 19
+		IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0528: pop
+		IL_0529: ldstr "console"
+		IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0538: stloc.s 19
+		IL_053a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_053f: stloc.s 14
+		IL_0541: ldloc.s 4
+		IL_0543: ldloc.s 14
+		IL_0545: ldc.r8 9
+		IL_054e: box [System.Runtime]System.Double
+		IL_0553: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0558: stloc.s 18
+		IL_055a: ldloc.s 19
+		IL_055c: ldstr "log"
+		IL_0561: ldloc.s 18
+		IL_0563: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0568: pop
+		IL_0569: ldstr "console"
+		IL_056e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0573: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0578: stloc.s 18
+		IL_057a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_057f: stloc.s 14
+		IL_0581: ldloc.s 5
+		IL_0583: ldloc.s 14
+		IL_0585: ldc.r8 2
+		IL_058e: box [System.Runtime]System.Double
+		IL_0593: ldc.r8 3
+		IL_059c: box [System.Runtime]System.Double
+		IL_05a1: ldc.r8 2
+		IL_05aa: box [System.Runtime]System.Double
+		IL_05af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_05b4: stloc.s 19
+		IL_05b6: ldloc.s 18
+		IL_05b8: ldstr "log"
+		IL_05bd: ldloc.s 19
+		IL_05bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05c4: pop
+		IL_05c5: ldstr "console"
+		IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05d4: stloc.s 19
+		IL_05d6: ldloc.s 6
+		IL_05d8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_05e2: stloc.s 18
+		IL_05e4: ldloc.s 19
+		IL_05e6: ldstr "log"
+		IL_05eb: ldloc.s 18
+		IL_05ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05f2: pop
+		IL_05f3: ldstr "console"
+		IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0602: stloc.s 18
+		IL_0604: ldloc.s 7
+		IL_0606: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_060b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0610: stloc.s 19
+		IL_0612: ldloc.s 18
+		IL_0614: ldstr "log"
+		IL_0619: ldloc.s 19
+		IL_061b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0620: pop
+		IL_0621: ldstr "console"
+		IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_062b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0630: stloc.s 19
+		IL_0632: ldloc.s 8
+		IL_0634: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0639: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_063e: stloc.s 18
+		IL_0640: ldloc.s 19
+		IL_0642: ldstr "log"
+		IL_0647: ldloc.s 18
+		IL_0649: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_064e: pop
+		IL_064f: ldstr "console"
+		IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_065e: stloc.s 18
+		IL_0660: ldloc.s 9
+		IL_0662: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0667: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_066c: stloc.s 19
+		IL_066e: ldloc.s 18
+		IL_0670: ldstr "log"
+		IL_0675: ldloc.s 19
+		IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_067c: pop
+		IL_067d: ldstr "console"
+		IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_068c: stloc.s 19
+		IL_068e: ldloc.s 10
+		IL_0690: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_069a: stloc.s 18
+		IL_069c: ldloc.s 19
+		IL_069e: ldstr "log"
+		IL_06a3: ldloc.s 18
+		IL_06a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06aa: pop
+		IL_06ab: ldstr "console"
+		IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06ba: stloc.s 18
+		IL_06bc: ldloc.s 11
+		IL_06be: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_06c8: stloc.s 19
+		IL_06ca: ldloc.s 18
+		IL_06cc: ldstr "log"
+		IL_06d1: ldloc.s 19
+		IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06d8: pop
+		IL_06d9: ldstr "console"
+		IL_06de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06e8: stloc.s 19
+		IL_06ea: ldloc.s 12
+		IL_06ec: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_06f6: stloc.s 18
+		IL_06f8: ldloc.s 19
+		IL_06fa: ldstr "log"
+		IL_06ff: ldloc.s 18
+		IL_0701: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0706: pop
+		IL_0707: ldstr "console"
+		IL_070c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0711: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0716: stloc.s 18
+		IL_0718: ldloc.s 13
+		IL_071a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_071f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0724: stloc.s 19
+		IL_0726: ldloc.s 18
+		IL_0728: ldstr "log"
+		IL_072d: ldloc.s 19
+		IL_072f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0734: pop
+		IL_0735: ret
 	} // end of method Function_SchedulerCallResults::__js_module_init__
 
 } // end of class Modules.Function_SchedulerCallResults
@@ -5105,7 +5060,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x388e
+		// Method begins at RVA 0x3846
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerGeneralRegions.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerGeneralRegions.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2842
+				// Method begins at RVA 0x2832
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28a5
+				// Method begins at RVA 0x2895
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x28ad
+				// Method begins at RVA 0x289d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x28b0
+				// Method begins at RVA 0x28a0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -78,7 +78,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x28b3
+				// Method begins at RVA 0x28a3
 				// Header size: 1
 				// Code size: 59 (0x3b)
 				.maxstack 8
@@ -111,7 +111,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x28ef
+				// Method begins at RVA 0x28df
 				// Header size: 1
 				// Code size: 55 (0x37)
 				.maxstack 8
@@ -143,7 +143,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2927
+				// Method begins at RVA 0x2917
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -219,7 +219,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x284b
+				// Method begins at RVA 0x283b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -244,7 +244,7 @@
 					class Modules.Function_SchedulerGeneralRegions/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2936
+				// Method begins at RVA 0x2926
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -260,7 +260,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2945
+				// Method begins at RVA 0x2935
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -272,7 +272,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2948
+				// Method begins at RVA 0x2938
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -287,7 +287,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x294b
+				// Method begins at RVA 0x293b
 				// Header size: 1
 				// Code size: 41 (0x29)
 				.maxstack 8
@@ -314,7 +314,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2975
+				// Method begins at RVA 0x2965
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -340,7 +340,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x299b
+				// Method begins at RVA 0x298b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -416,7 +416,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2854
+				// Method begins at RVA 0x2844
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -441,7 +441,7 @@
 					class Modules.Function_SchedulerGeneralRegions/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x29aa
+				// Method begins at RVA 0x299a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -457,7 +457,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x29b9
+				// Method begins at RVA 0x29a9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -469,7 +469,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x29bc
+				// Method begins at RVA 0x29ac
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -484,7 +484,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x29bf
+				// Method begins at RVA 0x29af
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -503,7 +503,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x29d1
+				// Method begins at RVA 0x29c1
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -521,7 +521,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x29df
+				// Method begins at RVA 0x29cf
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -586,7 +586,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x285d
+				// Method begins at RVA 0x284d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -611,7 +611,7 @@
 					class Modules.Function_SchedulerGeneralRegions/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x29ee
+				// Method begins at RVA 0x29de
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -627,7 +627,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x29fd
+				// Method begins at RVA 0x29ed
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -639,7 +639,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2a00
+				// Method begins at RVA 0x29f0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -654,7 +654,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a03
+				// Method begins at RVA 0x29f3
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -673,7 +673,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a15
+				// Method begins at RVA 0x2a05
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -691,7 +691,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a23
+				// Method begins at RVA 0x2a13
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -770,7 +770,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2866
+				// Method begins at RVA 0x2856
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -795,7 +795,7 @@
 					class Modules.Function_SchedulerGeneralRegions/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a32
+				// Method begins at RVA 0x2a22
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -811,7 +811,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2a41
+				// Method begins at RVA 0x2a31
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -823,7 +823,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2a44
+				// Method begins at RVA 0x2a34
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -838,7 +838,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a47
+				// Method begins at RVA 0x2a37
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -857,7 +857,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a59
+				// Method begins at RVA 0x2a49
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -875,7 +875,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a67
+				// Method begins at RVA 0x2a57
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -991,7 +991,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2878
+					// Method begins at RVA 0x2868
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1018,7 +1018,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x2ad2
+					// Method begins at RVA 0x2ac2
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -1037,7 +1037,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2ae8
+					// Method begins at RVA 0x2ad8
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1049,7 +1049,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2aeb
+					// Method begins at RVA 0x2adb
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1064,7 +1064,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2aee
+					// Method begins at RVA 0x2ade
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -1089,7 +1089,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x27a0
+				// Method begins at RVA 0x2790
 				// Header size: 12
 				// Code size: 63 (0x3f)
 				.maxstack 8
@@ -1136,7 +1136,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2881
+					// Method begins at RVA 0x2871
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1163,7 +1163,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x2b00
+					// Method begins at RVA 0x2af0
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -1182,7 +1182,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2b16
+					// Method begins at RVA 0x2b06
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1194,7 +1194,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2b19
+					// Method begins at RVA 0x2b09
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1209,7 +1209,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2b1c
+					// Method begins at RVA 0x2b0c
 					// Header size: 1
 					// Code size: 24 (0x18)
 					.maxstack 8
@@ -1238,7 +1238,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x27ec
+				// Method begins at RVA 0x27dc
 				// Header size: 12
 				// Code size: 65 (0x41)
 				.maxstack 8
@@ -1283,7 +1283,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x286f
+				// Method begins at RVA 0x285f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1308,7 +1308,7 @@
 					class Modules.Function_SchedulerGeneralRegions/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a76
+				// Method begins at RVA 0x2a66
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1324,7 +1324,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2a85
+				// Method begins at RVA 0x2a75
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1336,7 +1336,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2a88
+				// Method begins at RVA 0x2a78
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1351,7 +1351,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a8b
+				// Method begins at RVA 0x2a7b
 				// Header size: 1
 				// Code size: 29 (0x1d)
 				.maxstack 8
@@ -1374,7 +1374,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2aa9
+				// Method begins at RVA 0x2a99
 				// Header size: 1
 				// Code size: 25 (0x19)
 				.maxstack 8
@@ -1396,7 +1396,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ac3
+				// Method begins at RVA 0x2ab3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1427,7 +1427,7 @@
 			)
 			// Method begins at RVA 0x2544
 			// Header size: 12
-			// Code size: 343 (0x157)
+			// Code size: 327 (0x147)
 			.maxstack 13
 			.locals init (
 				[0] class Modules.Function_SchedulerGeneralRegions/getter/Scope,
@@ -1437,9 +1437,8 @@
 				[4] object[],
 				[5] class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14,
 				[6] object,
-				[7] class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14,
-				[8] object,
-				[9] object
+				[7] object,
+				[8] object
 			)
 
 			IL_0000: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/Scope::.ctor()
@@ -1506,73 +1505,65 @@
 			IL_0094: ldloc.0
 			IL_0095: stelem.ref
 			IL_0096: stloc.s 4
-			IL_0098: ldloc.s 4
-			IL_009a: ldc.i4.0
-			IL_009b: ldelem.ref
-			IL_009c: castclass Modules.Function_SchedulerGeneralRegions/Scope
-			IL_00a1: ldloc.s 4
-			IL_00a3: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope, object[])
-			IL_00a8: ldc.i4.1
-			IL_00a9: conv.r8
-			IL_00aa: ldstr ""
+			IL_0098: ldloc.3
+			IL_0099: ldstr "x"
+			IL_009e: ldnull
+			IL_009f: ldloc.s 4
+			IL_00a1: ldc.i4.0
+			IL_00a2: ldelem.ref
+			IL_00a3: castclass Modules.Function_SchedulerGeneralRegions/Scope
+			IL_00a8: ldloc.s 4
+			IL_00aa: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope, object[])
 			IL_00af: ldc.i4.1
-			IL_00b0: ldc.i4.1
-			IL_00b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0, float64, string, bool, bool)
-			IL_00b6: stloc.s 7
-			IL_00b8: ldloc.s 7
-			IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0)
-			IL_00bf: stloc.s 7
-			IL_00c1: ldloc.s 7
-			IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0)
-			IL_00c8: stloc.s 7
-			IL_00ca: ldloc.s 7
-			IL_00cc: ldstr "x"
-			IL_00d1: ldstr "set"
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-			IL_00db: stloc.s 6
-			IL_00dd: ldloc.3
-			IL_00de: ldstr "x"
-			IL_00e3: ldnull
-			IL_00e4: ldloc.s 6
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-			IL_00eb: pop
-			IL_00ec: ldloc.3
-			IL_00ed: stloc.1
-			IL_00ee: ldloc.1
-			IL_00ef: ldstr "x"
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f9: stloc.s 6
-			IL_00fb: ldloc.1
-			IL_00fc: ldstr "x"
-			IL_0101: ldc.r8 2
-			IL_010a: ldc.i4.1
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0110: stloc.s 8
-			IL_0112: ldloc.s 6
-			IL_0114: ldloc.s 8
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_011b: stloc.s 9
-			IL_011d: ldloc.1
-			IL_011e: ldstr "x"
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0128: stloc.s 8
-			IL_012a: ldloc.s 9
-			IL_012c: ldloc.s 8
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0133: stloc.2
-			IL_0134: ldloc.2
-			IL_0135: ldstr ","
-			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_013f: stloc.s 9
-			IL_0141: ldarg.0
-			IL_0142: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::order
-			IL_0147: stloc.s 8
-			IL_0149: ldloc.s 9
-			IL_014b: ldloc.s 8
-			IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0152: stloc.s 9
-			IL_0154: ldloc.s 9
-			IL_0156: ret
+			IL_00b0: conv.r8
+			IL_00b1: ldstr ""
+			IL_00b6: ldc.i4.1
+			IL_00b7: ldc.i4.1
+			IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0, float64, string, bool, bool)
+			IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0)
+			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0)
+			IL_00c7: ldstr "x"
+			IL_00cc: ldstr "set"
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+			IL_00db: pop
+			IL_00dc: ldloc.3
+			IL_00dd: stloc.1
+			IL_00de: ldloc.1
+			IL_00df: ldstr "x"
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e9: stloc.s 6
+			IL_00eb: ldloc.1
+			IL_00ec: ldstr "x"
+			IL_00f1: ldc.r8 2
+			IL_00fa: ldc.i4.1
+			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0100: stloc.s 7
+			IL_0102: ldloc.s 6
+			IL_0104: ldloc.s 7
+			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_010b: stloc.s 8
+			IL_010d: ldloc.1
+			IL_010e: ldstr "x"
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0118: stloc.s 7
+			IL_011a: ldloc.s 8
+			IL_011c: ldloc.s 7
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0123: stloc.2
+			IL_0124: ldloc.2
+			IL_0125: ldstr ","
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_012f: stloc.s 8
+			IL_0131: ldarg.0
+			IL_0132: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::order
+			IL_0137: stloc.s 7
+			IL_0139: ldloc.s 8
+			IL_013b: ldloc.s 7
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0142: stloc.s 8
+			IL_0144: ldloc.s 8
+			IL_0146: ret
 		} // end of method getter::__js_call__
 
 	} // end of class getter
@@ -1592,7 +1583,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2893
+					// Method begins at RVA 0x2883
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1612,7 +1603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x289c
+					// Method begins at RVA 0x288c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1630,7 +1621,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x288a
+				// Method begins at RVA 0x287a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1655,7 +1646,7 @@
 					class Modules.Function_SchedulerGeneralRegions/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b35
+				// Method begins at RVA 0x2b25
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1671,7 +1662,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2b44
+				// Method begins at RVA 0x2b34
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1683,7 +1674,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2b47
+				// Method begins at RVA 0x2b37
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1698,7 +1689,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b4a
+				// Method begins at RVA 0x2b3a
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1717,7 +1708,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b5c
+				// Method begins at RVA 0x2b4c
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1735,7 +1726,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b6a
+				// Method begins at RVA 0x2b5a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1763,7 +1754,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x26a8
+			// Method begins at RVA 0x2698
 			// Header size: 12
 			// Code size: 217 (0xd9)
 			.maxstack 8
@@ -1904,7 +1895,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2839
+			// Method begins at RVA 0x2829
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2233,7 +2224,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b79
+		// Method begins at RVA 0x2b69
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b41
+				// Method begins at RVA 0x2b39
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bbf
+				// Method begins at RVA 0x2bb7
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2bc7
+				// Method begins at RVA 0x2bbf
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2bca
+				// Method begins at RVA 0x2bc2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -78,7 +78,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bcd
+				// Method begins at RVA 0x2bc5
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -103,7 +103,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bf1
+				// Method begins at RVA 0x2be9
 				// Header size: 1
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -127,7 +127,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c11
+				// Method begins at RVA 0x2c09
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2610
+			// Method begins at RVA 0x2608
 			// Header size: 1
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -193,7 +193,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b4a
+				// Method begins at RVA 0x2b42
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -213,7 +213,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c20
+				// Method begins at RVA 0x2c18
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -226,7 +226,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2c28
+				// Method begins at RVA 0x2c20
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -238,7 +238,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2c2b
+				// Method begins at RVA 0x2c23
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -253,7 +253,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c2e
+				// Method begins at RVA 0x2c26
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -278,7 +278,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c52
+				// Method begins at RVA 0x2c4a
 				// Header size: 1
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -302,7 +302,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c72
+				// Method begins at RVA 0x2c6a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -329,7 +329,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2648
+			// Method begins at RVA 0x2640
 			// Header size: 1
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -362,7 +362,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b53
+				// Method begins at RVA 0x2b4b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -387,7 +387,7 @@
 					class Modules.Function_SchedulerLiteralArguments/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c81
+				// Method begins at RVA 0x2c79
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -403,7 +403,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2c90
+				// Method begins at RVA 0x2c88
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -415,7 +415,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2c93
+				// Method begins at RVA 0x2c8b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -430,7 +430,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c96
+				// Method begins at RVA 0x2c8e
 				// Header size: 1
 				// Code size: 41 (0x29)
 				.maxstack 8
@@ -457,7 +457,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2cc0
+				// Method begins at RVA 0x2cb8
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -483,7 +483,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ce6
+				// Method begins at RVA 0x2cde
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -513,7 +513,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2672
+			// Method begins at RVA 0x266a
 			// Header size: 1
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -547,7 +547,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b5c
+				// Method begins at RVA 0x2b54
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -572,7 +572,7 @@
 					class Modules.Function_SchedulerLiteralArguments/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2cf5
+				// Method begins at RVA 0x2ced
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -588,7 +588,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2d04
+				// Method begins at RVA 0x2cfc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -600,7 +600,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2d07
+				// Method begins at RVA 0x2cff
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -615,7 +615,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d0a
+				// Method begins at RVA 0x2d02
 				// Header size: 1
 				// Code size: 41 (0x29)
 				.maxstack 8
@@ -642,7 +642,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d34
+				// Method begins at RVA 0x2d2c
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -668,7 +668,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d5a
+				// Method begins at RVA 0x2d52
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -698,7 +698,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x26a8
+			// Method begins at RVA 0x26a0
 			// Header size: 12
 			// Code size: 69 (0x45)
 			.maxstack 8
@@ -739,7 +739,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b65
+				// Method begins at RVA 0x2b5d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -759,7 +759,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d69
+				// Method begins at RVA 0x2d61
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -772,7 +772,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2d71
+				// Method begins at RVA 0x2d69
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -784,7 +784,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2d74
+				// Method begins at RVA 0x2d6c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -799,7 +799,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2d78
+				// Method begins at RVA 0x2d70
 				// Header size: 12
 				// Code size: 119 (0x77)
 				.maxstack 12
@@ -852,7 +852,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2dfc
+				// Method begins at RVA 0x2df4
 				// Header size: 12
 				// Code size: 115 (0x73)
 				.maxstack 12
@@ -904,7 +904,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2e7b
+				// Method begins at RVA 0x2e73
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -938,7 +938,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26fc
+			// Method begins at RVA 0x26f4
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 11
@@ -980,7 +980,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b6e
+				// Method begins at RVA 0x2b66
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1005,7 +1005,7 @@
 					class Modules.Function_SchedulerLiteralArguments/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2e8a
+				// Method begins at RVA 0x2e82
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1021,7 +1021,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2e99
+				// Method begins at RVA 0x2e91
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1033,7 +1033,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2e9c
+				// Method begins at RVA 0x2e94
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1048,7 +1048,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2e9f
+				// Method begins at RVA 0x2e97
 				// Header size: 1
 				// Code size: 29 (0x1d)
 				.maxstack 8
@@ -1071,7 +1071,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ebd
+				// Method begins at RVA 0x2eb5
 				// Header size: 1
 				// Code size: 25 (0x19)
 				.maxstack 8
@@ -1093,7 +1093,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ed7
+				// Method begins at RVA 0x2ecf
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1122,7 +1122,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x272c
+			// Method begins at RVA 0x2724
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -1158,7 +1158,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b77
+				// Method begins at RVA 0x2b6f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1183,7 +1183,7 @@
 					class Modules.Function_SchedulerLiteralArguments/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ee6
+				// Method begins at RVA 0x2ede
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1199,7 +1199,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2ef5
+				// Method begins at RVA 0x2eed
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1211,7 +1211,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2ef8
+				// Method begins at RVA 0x2ef0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1226,7 +1226,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2efb
+				// Method begins at RVA 0x2ef3
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1245,7 +1245,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2f0d
+				// Method begins at RVA 0x2f05
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1263,7 +1263,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2f1b
+				// Method begins at RVA 0x2f13
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1291,7 +1291,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2750
+			// Method begins at RVA 0x2748
 			// Header size: 12
 			// Code size: 251 (0xfb)
 			.maxstack 8
@@ -1408,7 +1408,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b80
+				// Method begins at RVA 0x2b78
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1433,7 +1433,7 @@
 					class Modules.Function_SchedulerLiteralArguments/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2f2a
+				// Method begins at RVA 0x2f22
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1449,7 +1449,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2f39
+				// Method begins at RVA 0x2f31
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1461,7 +1461,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2f3c
+				// Method begins at RVA 0x2f34
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1476,7 +1476,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2f3f
+				// Method begins at RVA 0x2f37
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1495,7 +1495,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2f51
+				// Method begins at RVA 0x2f49
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1513,7 +1513,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2f5f
+				// Method begins at RVA 0x2f57
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1541,7 +1541,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2858
+			// Method begins at RVA 0x2850
 			// Header size: 12
 			// Code size: 191 (0xbf)
 			.maxstack 8
@@ -1644,7 +1644,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b89
+				// Method begins at RVA 0x2b81
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1669,7 +1669,7 @@
 					class Modules.Function_SchedulerLiteralArguments/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2f6e
+				// Method begins at RVA 0x2f66
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1685,7 +1685,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2f7d
+				// Method begins at RVA 0x2f75
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1697,7 +1697,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2f80
+				// Method begins at RVA 0x2f78
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1712,7 +1712,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2f83
+				// Method begins at RVA 0x2f7b
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1739,7 +1739,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2924
+			// Method begins at RVA 0x291c
 			// Header size: 12
 			// Code size: 69 (0x45)
 			.maxstack 8
@@ -1784,7 +1784,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b92
+				// Method begins at RVA 0x2b8a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1809,7 +1809,7 @@
 					class Modules.Function_SchedulerLiteralArguments/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2f95
+				// Method begins at RVA 0x2f8d
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1825,7 +1825,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2fa4
+				// Method begins at RVA 0x2f9c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1837,7 +1837,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2fa7
+				// Method begins at RVA 0x2f9f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1852,7 +1852,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2faa
+				// Method begins at RVA 0x2fa2
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1871,7 +1871,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2fbc
+				// Method begins at RVA 0x2fb4
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -1889,7 +1889,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2fca
+				// Method begins at RVA 0x2fc2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1917,7 +1917,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2978
+			// Method begins at RVA 0x2970
 			// Header size: 12
 			// Code size: 162 (0xa2)
 			.maxstack 8
@@ -2017,7 +2017,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ba4
+					// Method begins at RVA 0x2b9c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2037,7 +2037,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bad
+					// Method begins at RVA 0x2ba5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2055,7 +2055,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b9b
+				// Method begins at RVA 0x2b93
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2080,7 +2080,7 @@
 					class Modules.Function_SchedulerLiteralArguments/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2fd9
+				// Method begins at RVA 0x2fd1
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2096,7 +2096,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2fe8
+				// Method begins at RVA 0x2fe0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2108,7 +2108,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2feb
+				// Method begins at RVA 0x2fe3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2123,7 +2123,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2fee
+				// Method begins at RVA 0x2fe6
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -2142,7 +2142,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3000
+				// Method begins at RVA 0x2ff8
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -2160,7 +2160,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x300e
+				// Method begins at RVA 0x3006
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2188,7 +2188,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2a28
+			// Method begins at RVA 0x2a20
 			// Header size: 12
 			// Code size: 177 (0xb1)
 			.maxstack 8
@@ -2302,7 +2302,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bb6
+				// Method begins at RVA 0x2bae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2327,7 +2327,7 @@
 					class Modules.Function_SchedulerLiteralArguments/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x301d
+				// Method begins at RVA 0x3015
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2343,7 +2343,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x302c
+				// Method begins at RVA 0x3024
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2355,7 +2355,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x302f
+				// Method begins at RVA 0x3027
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2370,7 +2370,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3032
+				// Method begins at RVA 0x302a
 				// Header size: 1
 				// Code size: 29 (0x1d)
 				.maxstack 8
@@ -2393,7 +2393,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3050
+				// Method begins at RVA 0x3048
 				// Header size: 1
 				// Code size: 25 (0x19)
 				.maxstack 8
@@ -2415,7 +2415,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x306a
+				// Method begins at RVA 0x3062
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2444,7 +2444,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2af8
+			// Method begins at RVA 0x2af0
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -2520,7 +2520,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b38
+			// Method begins at RVA 0x2b30
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2546,7 +2546,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1460 (0x5b4)
+		// Code size: 1452 (0x5ac)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerLiteralArguments/Scope,
@@ -2566,9 +2566,8 @@
 			[14] class Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue,
 			[15] object,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[17] class Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22,
-			[18] object,
-			[19] object
+			[17] object,
+			[18] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_SchedulerLiteralArguments/Scope::.ctor()
@@ -2800,273 +2799,269 @@
 		IL_01f6: ldloc.0
 		IL_01f7: stelem.ref
 		IL_01f8: stloc.s 12
-		IL_01fa: ldloc.s 12
-		IL_01fc: ldc.i4.0
-		IL_01fd: ldelem.ref
-		IL_01fe: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_0203: newobj instance void Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
-		IL_0208: ldc.i4.0
-		IL_0209: conv.r8
-		IL_020a: ldstr ""
-		IL_020f: ldc.i4.0
-		IL_0210: ldc.i4.1
-		IL_0211: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22>(!!0, float64, string, bool, bool)
-		IL_0216: stloc.s 17
-		IL_0218: ldloc.s 17
+		IL_01fa: ldloc.s 16
+		IL_01fc: ldloc.s 15
+		IL_01fe: ldloc.s 12
+		IL_0200: ldc.i4.0
+		IL_0201: ldelem.ref
+		IL_0202: castclass Modules.Function_SchedulerLiteralArguments/Scope
+		IL_0207: newobj instance void Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_020c: ldc.i4.0
+		IL_020d: conv.r8
+		IL_020e: ldstr ""
+		IL_0213: ldc.i4.0
+		IL_0214: ldc.i4.1
+		IL_0215: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22>(!!0, float64, string, bool, bool)
 		IL_021a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22>(!!0)
-		IL_021f: stloc.s 17
-		IL_0221: ldloc.s 16
-		IL_0223: ldloc.s 15
-		IL_0225: ldloc.s 17
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_022c: pop
-		IL_022d: ldloc.0
-		IL_022e: ldloc.s 16
-		IL_0230: stfld object Modules.Function_SchedulerLiteralArguments/Scope::spread
-		IL_0235: nop
-		IL_0236: nop
-		IL_0237: nop
-		IL_0238: ldstr "console"
-		IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0247: stloc.s 15
-		IL_0249: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_024e: stloc.s 12
-		IL_0250: ldloc.1
-		IL_0251: ldloc.s 12
-		IL_0253: ldc.r8 2
-		IL_025c: box [System.Runtime]System.Double
-		IL_0261: ldc.r8 4
-		IL_026a: box [System.Runtime]System.Double
-		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0274: stloc.s 18
-		IL_0276: ldloc.s 15
-		IL_0278: ldstr "log"
-		IL_027d: ldloc.s 18
-		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0284: pop
-		IL_0285: ldstr "console"
-		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0294: stloc.s 18
-		IL_0296: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_029b: stloc.s 12
-		IL_029d: ldloc.2
-		IL_029e: ldloc.s 12
-		IL_02a0: ldc.r8 2
-		IL_02a9: box [System.Runtime]System.Double
-		IL_02ae: ldc.r8 4
-		IL_02b7: box [System.Runtime]System.Double
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02c1: stloc.s 15
-		IL_02c3: ldloc.s 15
-		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ca: ldstr "join"
-		IL_02cf: ldstr ","
-		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d9: stloc.s 15
-		IL_02db: ldloc.s 18
-		IL_02dd: ldstr "log"
-		IL_02e2: ldloc.s 15
-		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e9: pop
-		IL_02ea: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02ef: stloc.s 12
-		IL_02f1: ldloc.3
-		IL_02f2: ldloc.s 12
-		IL_02f4: ldc.r8 2
-		IL_02fd: box [System.Runtime]System.Double
-		IL_0302: ldc.r8 4
-		IL_030b: box [System.Runtime]System.Double
-		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0315: stloc.s 10
-		IL_0317: ldstr "console"
-		IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0326: stloc.s 15
-		IL_0328: ldloc.s 10
-		IL_032a: ldstr "x"
-		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0334: stloc.s 18
-		IL_0336: ldloc.s 18
-		IL_0338: ldstr ","
-		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0342: stloc.s 19
-		IL_0344: ldloc.s 10
-		IL_0346: ldstr "y"
-		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0350: stloc.s 18
-		IL_0352: ldloc.s 19
-		IL_0354: ldloc.s 18
-		IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_035b: stloc.s 19
-		IL_035d: ldloc.s 15
-		IL_035f: ldstr "log"
-		IL_0364: ldloc.s 19
-		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_036b: pop
-		IL_036c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0371: stloc.s 12
-		IL_0373: ldloc.s 4
-		IL_0375: ldloc.s 12
-		IL_0377: ldc.r8 2
-		IL_0380: box [System.Runtime]System.Double
-		IL_0385: ldc.r8 4
-		IL_038e: box [System.Runtime]System.Double
-		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0398: stloc.s 11
-		IL_039a: ldstr "console"
-		IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03a9: stloc.s 15
-		IL_03ab: ldloc.s 11
-		IL_03ad: ldc.r8 0.0
-		IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03bb: stloc.s 18
-		IL_03bd: ldloc.s 18
-		IL_03bf: ldc.r8 0.0
-		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03cd: stloc.s 18
-		IL_03cf: ldloc.s 18
-		IL_03d1: ldstr ","
-		IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_03db: stloc.s 19
-		IL_03dd: ldloc.s 11
-		IL_03df: ldc.r8 1
-		IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03ed: stloc.s 18
-		IL_03ef: ldloc.s 18
-		IL_03f1: ldstr "y"
-		IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03fb: stloc.s 18
-		IL_03fd: ldloc.s 19
-		IL_03ff: ldloc.s 18
-		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0406: stloc.s 19
-		IL_0408: ldloc.s 15
-		IL_040a: ldstr "log"
-		IL_040f: ldloc.s 19
-		IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0416: pop
-		IL_0417: ldstr "console"
-		IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0426: stloc.s 15
-		IL_0428: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_042d: stloc.s 12
-		IL_042f: ldloc.s 5
-		IL_0431: ldloc.s 12
-		IL_0433: ldc.i4.s 9
-		IL_0435: newarr [System.Runtime]System.Object
-		IL_043a: dup
-		IL_043b: ldc.i4.0
-		IL_043c: ldc.r8 1
-		IL_0445: box [System.Runtime]System.Double
-		IL_044a: stelem.ref
-		IL_044b: dup
-		IL_044c: ldc.i4.1
-		IL_044d: ldc.r8 2
-		IL_0456: box [System.Runtime]System.Double
-		IL_045b: stelem.ref
-		IL_045c: dup
-		IL_045d: ldc.i4.2
-		IL_045e: ldc.r8 3
-		IL_0467: box [System.Runtime]System.Double
-		IL_046c: stelem.ref
-		IL_046d: dup
-		IL_046e: ldc.i4.3
-		IL_046f: ldc.r8 4
-		IL_0478: box [System.Runtime]System.Double
-		IL_047d: stelem.ref
-		IL_047e: dup
-		IL_047f: ldc.i4.4
-		IL_0480: ldc.r8 5
-		IL_0489: box [System.Runtime]System.Double
-		IL_048e: stelem.ref
-		IL_048f: dup
-		IL_0490: ldc.i4.5
-		IL_0491: ldc.r8 6
-		IL_049a: box [System.Runtime]System.Double
-		IL_049f: stelem.ref
-		IL_04a0: dup
-		IL_04a1: ldc.i4.6
-		IL_04a2: ldc.r8 7
-		IL_04ab: box [System.Runtime]System.Double
-		IL_04b0: stelem.ref
-		IL_04b1: dup
-		IL_04b2: ldc.i4.7
-		IL_04b3: ldc.r8 8
-		IL_04bc: box [System.Runtime]System.Double
-		IL_04c1: stelem.ref
-		IL_04c2: dup
-		IL_04c3: ldc.i4.8
-		IL_04c4: ldc.r8 9
-		IL_04cd: box [System.Runtime]System.Double
-		IL_04d2: stelem.ref
-		IL_04d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_04d8: stloc.s 18
-		IL_04da: ldloc.s 18
-		IL_04dc: ldc.r8 0.0
-		IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_04ea: stloc.s 18
-		IL_04ec: ldloc.s 15
-		IL_04ee: ldstr "log"
-		IL_04f3: ldloc.s 18
-		IL_04f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04fa: pop
-		IL_04fb: ldstr "console"
-		IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_050a: stloc.s 18
-		IL_050c: ldloc.s 6
-		IL_050e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0518: stloc.s 15
-		IL_051a: ldloc.s 18
-		IL_051c: ldstr "log"
-		IL_0521: ldloc.s 15
-		IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0528: pop
-		IL_0529: ldstr "console"
-		IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0538: stloc.s 15
-		IL_053a: ldloc.s 7
-		IL_053c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0546: stloc.s 18
-		IL_0548: ldloc.s 15
-		IL_054a: ldstr "log"
-		IL_054f: ldloc.s 18
-		IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0556: pop
-		IL_0557: ldstr "console"
-		IL_055c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0566: stloc.s 18
-		IL_0568: ldloc.s 8
-		IL_056a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0574: stloc.s 15
-		IL_0576: ldloc.s 18
-		IL_0578: ldstr "log"
-		IL_057d: ldloc.s 15
-		IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0584: pop
-		IL_0585: ldstr "console"
-		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0594: stloc.s 15
-		IL_0596: ldloc.s 9
-		IL_0598: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_05a2: stloc.s 18
-		IL_05a4: ldloc.s 15
-		IL_05a6: ldstr "log"
-		IL_05ab: ldloc.s 18
-		IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05b2: pop
-		IL_05b3: ret
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0224: pop
+		IL_0225: ldloc.0
+		IL_0226: ldloc.s 16
+		IL_0228: stfld object Modules.Function_SchedulerLiteralArguments/Scope::spread
+		IL_022d: nop
+		IL_022e: nop
+		IL_022f: nop
+		IL_0230: ldstr "console"
+		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_023f: stloc.s 15
+		IL_0241: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0246: stloc.s 12
+		IL_0248: ldloc.1
+		IL_0249: ldloc.s 12
+		IL_024b: ldc.r8 2
+		IL_0254: box [System.Runtime]System.Double
+		IL_0259: ldc.r8 4
+		IL_0262: box [System.Runtime]System.Double
+		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_026c: stloc.s 17
+		IL_026e: ldloc.s 15
+		IL_0270: ldstr "log"
+		IL_0275: ldloc.s 17
+		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027c: pop
+		IL_027d: ldstr "console"
+		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028c: stloc.s 17
+		IL_028e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0293: stloc.s 12
+		IL_0295: ldloc.2
+		IL_0296: ldloc.s 12
+		IL_0298: ldc.r8 2
+		IL_02a1: box [System.Runtime]System.Double
+		IL_02a6: ldc.r8 4
+		IL_02af: box [System.Runtime]System.Double
+		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02b9: stloc.s 15
+		IL_02bb: ldloc.s 15
+		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c2: ldstr "join"
+		IL_02c7: ldstr ","
+		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d1: stloc.s 15
+		IL_02d3: ldloc.s 17
+		IL_02d5: ldstr "log"
+		IL_02da: ldloc.s 15
+		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02e1: pop
+		IL_02e2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02e7: stloc.s 12
+		IL_02e9: ldloc.3
+		IL_02ea: ldloc.s 12
+		IL_02ec: ldc.r8 2
+		IL_02f5: box [System.Runtime]System.Double
+		IL_02fa: ldc.r8 4
+		IL_0303: box [System.Runtime]System.Double
+		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_030d: stloc.s 10
+		IL_030f: ldstr "console"
+		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_031e: stloc.s 15
+		IL_0320: ldloc.s 10
+		IL_0322: ldstr "x"
+		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_032c: stloc.s 17
+		IL_032e: ldloc.s 17
+		IL_0330: ldstr ","
+		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_033a: stloc.s 18
+		IL_033c: ldloc.s 10
+		IL_033e: ldstr "y"
+		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0348: stloc.s 17
+		IL_034a: ldloc.s 18
+		IL_034c: ldloc.s 17
+		IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0353: stloc.s 18
+		IL_0355: ldloc.s 15
+		IL_0357: ldstr "log"
+		IL_035c: ldloc.s 18
+		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0363: pop
+		IL_0364: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0369: stloc.s 12
+		IL_036b: ldloc.s 4
+		IL_036d: ldloc.s 12
+		IL_036f: ldc.r8 2
+		IL_0378: box [System.Runtime]System.Double
+		IL_037d: ldc.r8 4
+		IL_0386: box [System.Runtime]System.Double
+		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0390: stloc.s 11
+		IL_0392: ldstr "console"
+		IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03a1: stloc.s 15
+		IL_03a3: ldloc.s 11
+		IL_03a5: ldc.r8 0.0
+		IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_03b3: stloc.s 17
+		IL_03b5: ldloc.s 17
+		IL_03b7: ldc.r8 0.0
+		IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_03c5: stloc.s 17
+		IL_03c7: ldloc.s 17
+		IL_03c9: ldstr ","
+		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03d3: stloc.s 18
+		IL_03d5: ldloc.s 11
+		IL_03d7: ldc.r8 1
+		IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_03e5: stloc.s 17
+		IL_03e7: ldloc.s 17
+		IL_03e9: ldstr "y"
+		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03f3: stloc.s 17
+		IL_03f5: ldloc.s 18
+		IL_03f7: ldloc.s 17
+		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03fe: stloc.s 18
+		IL_0400: ldloc.s 15
+		IL_0402: ldstr "log"
+		IL_0407: ldloc.s 18
+		IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_040e: pop
+		IL_040f: ldstr "console"
+		IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0419: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_041e: stloc.s 15
+		IL_0420: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0425: stloc.s 12
+		IL_0427: ldloc.s 5
+		IL_0429: ldloc.s 12
+		IL_042b: ldc.i4.s 9
+		IL_042d: newarr [System.Runtime]System.Object
+		IL_0432: dup
+		IL_0433: ldc.i4.0
+		IL_0434: ldc.r8 1
+		IL_043d: box [System.Runtime]System.Double
+		IL_0442: stelem.ref
+		IL_0443: dup
+		IL_0444: ldc.i4.1
+		IL_0445: ldc.r8 2
+		IL_044e: box [System.Runtime]System.Double
+		IL_0453: stelem.ref
+		IL_0454: dup
+		IL_0455: ldc.i4.2
+		IL_0456: ldc.r8 3
+		IL_045f: box [System.Runtime]System.Double
+		IL_0464: stelem.ref
+		IL_0465: dup
+		IL_0466: ldc.i4.3
+		IL_0467: ldc.r8 4
+		IL_0470: box [System.Runtime]System.Double
+		IL_0475: stelem.ref
+		IL_0476: dup
+		IL_0477: ldc.i4.4
+		IL_0478: ldc.r8 5
+		IL_0481: box [System.Runtime]System.Double
+		IL_0486: stelem.ref
+		IL_0487: dup
+		IL_0488: ldc.i4.5
+		IL_0489: ldc.r8 6
+		IL_0492: box [System.Runtime]System.Double
+		IL_0497: stelem.ref
+		IL_0498: dup
+		IL_0499: ldc.i4.6
+		IL_049a: ldc.r8 7
+		IL_04a3: box [System.Runtime]System.Double
+		IL_04a8: stelem.ref
+		IL_04a9: dup
+		IL_04aa: ldc.i4.7
+		IL_04ab: ldc.r8 8
+		IL_04b4: box [System.Runtime]System.Double
+		IL_04b9: stelem.ref
+		IL_04ba: dup
+		IL_04bb: ldc.i4.8
+		IL_04bc: ldc.r8 9
+		IL_04c5: box [System.Runtime]System.Double
+		IL_04ca: stelem.ref
+		IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_04d0: stloc.s 17
+		IL_04d2: ldloc.s 17
+		IL_04d4: ldc.r8 0.0
+		IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_04e2: stloc.s 17
+		IL_04e4: ldloc.s 15
+		IL_04e6: ldstr "log"
+		IL_04eb: ldloc.s 17
+		IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04f2: pop
+		IL_04f3: ldstr "console"
+		IL_04f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0502: stloc.s 17
+		IL_0504: ldloc.s 6
+		IL_0506: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0510: stloc.s 15
+		IL_0512: ldloc.s 17
+		IL_0514: ldstr "log"
+		IL_0519: ldloc.s 15
+		IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0520: pop
+		IL_0521: ldstr "console"
+		IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0530: stloc.s 15
+		IL_0532: ldloc.s 7
+		IL_0534: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0539: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_053e: stloc.s 17
+		IL_0540: ldloc.s 15
+		IL_0542: ldstr "log"
+		IL_0547: ldloc.s 17
+		IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_054e: pop
+		IL_054f: ldstr "console"
+		IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_055e: stloc.s 17
+		IL_0560: ldloc.s 8
+		IL_0562: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_056c: stloc.s 15
+		IL_056e: ldloc.s 17
+		IL_0570: ldstr "log"
+		IL_0575: ldloc.s 15
+		IL_0577: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_057c: pop
+		IL_057d: ldstr "console"
+		IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0587: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_058c: stloc.s 15
+		IL_058e: ldloc.s 9
+		IL_0590: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0595: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_059a: stloc.s 17
+		IL_059c: ldloc.s 15
+		IL_059e: ldstr "log"
+		IL_05a3: ldloc.s 17
+		IL_05a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05aa: pop
+		IL_05ab: ret
 	} // end of method Function_SchedulerLiteralArguments::__js_module_init__
 
 } // end of class Modules.Function_SchedulerLiteralArguments
@@ -3078,7 +3073,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3079
+		// Method begins at RVA 0x3071
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Inheritance_SuperIteratorMethod.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Inheritance_SuperIteratorMethod.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2425
+				// Method begins at RVA 0x241d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x242e
+				// Method begins at RVA 0x2426
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2449
+				// Method begins at RVA 0x2441
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2458
+				// Method begins at RVA 0x2450
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x245b
+				// Method begins at RVA 0x2453
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -106,7 +106,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x245e
+				// Method begins at RVA 0x2456
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -122,7 +122,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x246a
+				// Method begins at RVA 0x2462
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2476
+				// Method begins at RVA 0x246e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x247e
+				// Method begins at RVA 0x2476
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -166,7 +166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2481
+				// Method begins at RVA 0x2479
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -181,7 +181,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2484
+				// Method begins at RVA 0x247c
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -209,7 +209,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2228
+			// Method begins at RVA 0x2220
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -228,7 +228,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22d0
+			// Method begins at RVA 0x22c8
 			// Header size: 12
 			// Code size: 320 (0x140)
 			.maxstack 8
@@ -379,7 +379,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2437
+				// Method begins at RVA 0x242f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -399,7 +399,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2440
+				// Method begins at RVA 0x2438
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -424,7 +424,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x24a8
+				// Method begins at RVA 0x24a0
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -440,7 +440,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24b7
+				// Method begins at RVA 0x24af
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -452,7 +452,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24ba
+				// Method begins at RVA 0x24b2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -467,7 +467,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x24bd
+				// Method begins at RVA 0x24b5
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -483,7 +483,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x24c9
+				// Method begins at RVA 0x24c1
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -509,7 +509,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x24d5
+				// Method begins at RVA 0x24cd
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -528,7 +528,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x24eb
+				// Method begins at RVA 0x24e3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -540,7 +540,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x24ee
+				// Method begins at RVA 0x24e6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -552,7 +552,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x24f1
+				// Method begins at RVA 0x24e9
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -565,7 +565,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x24f9
+				// Method begins at RVA 0x24f1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -581,7 +581,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2501
+				// Method begins at RVA 0x24f9
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -609,7 +609,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2230
+			// Method begins at RVA 0x2228
 			// Header size: 1
 			// Code size: 13 (0xd)
 			.maxstack 8
@@ -627,7 +627,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2240
+			// Method begins at RVA 0x2238
 			// Header size: 12
 			// Code size: 131 (0x83)
 			.maxstack 8
@@ -691,7 +691,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x241c
+			// Method begins at RVA 0x2414
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -717,7 +717,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 460 (0x1cc)
+		// Code size: 452 (0x1c4)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Generator_Inheritance_SuperIteratorMethod/Scope,
@@ -725,8 +725,7 @@
 			[2] object,
 			[3] class [System.Runtime]System.Type,
 			[4] object[],
-			[5] object,
-			[6] class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Scope::.ctor()
@@ -824,81 +823,77 @@
 		IL_00e1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_00e6: stloc.s 4
 		IL_00e8: ldloc.s 5
-		IL_00ea: ldloc.s 4
-		IL_00ec: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run::.ctor(class [System.Runtime]System.Object, object[])
-		IL_00f1: ldc.i4.0
-		IL_00f2: conv.r8
-		IL_00f3: ldstr "run"
-		IL_00f8: ldc.i4.1
-		IL_00f9: ldc.i4.1
-		IL_00fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0, float64, string, bool, bool)
-		IL_00ff: stloc.s 6
-		IL_0101: ldloc.s 6
-		IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0)
-		IL_0108: stloc.s 6
-		IL_010a: ldloc.s 5
-		IL_010c: ldstr "run"
-		IL_0111: ldloc.s 6
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0118: pop
-		IL_0119: ldc.i4.1
-		IL_011a: newarr [System.Runtime]System.Object
-		IL_011f: dup
-		IL_0120: ldc.i4.0
-		IL_0121: ldloc.0
-		IL_0122: stelem.ref
-		IL_0123: stloc.s 4
-		IL_0125: ldloc.3
-		IL_0126: ldloc.s 4
-		IL_0128: ldc.r8 0.0
-		IL_0131: box [System.Runtime]System.Double
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_013b: stloc.s 5
-		IL_013d: ldloc.s 5
-		IL_013f: ldloc.1
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0145: stloc.s 5
-		IL_0147: ldloc.s 5
-		IL_0149: stloc.2
-		IL_014a: ldc.i4.0
-		IL_014b: newarr [System.Runtime]System.Object
-		IL_0150: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0155: ldloc.2
-		IL_0156: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_015b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0160: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived::.ctor()
-		IL_0165: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_016a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_016f: dup
-		IL_0170: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-		IL_0175: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_017a: ldstr "prototype"
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0184: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0189: stloc.s 5
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_0195: stloc.s 5
-		IL_0197: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_019c: ldloc.s 5
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a3: stloc.s 5
-		IL_01a5: ldloc.s 5
-		IL_01a7: isinst Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-		IL_01ac: dup
-		IL_01ad: brfalse IL_01bd
+		IL_00ea: ldstr "run"
+		IL_00ef: ldloc.s 5
+		IL_00f1: ldloc.s 4
+		IL_00f3: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run::.ctor(class [System.Runtime]System.Object, object[])
+		IL_00f8: ldc.i4.0
+		IL_00f9: conv.r8
+		IL_00fa: ldstr "run"
+		IL_00ff: ldc.i4.1
+		IL_0100: ldc.i4.1
+		IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0, float64, string, bool, bool)
+		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0)
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0110: pop
+		IL_0111: ldc.i4.1
+		IL_0112: newarr [System.Runtime]System.Object
+		IL_0117: dup
+		IL_0118: ldc.i4.0
+		IL_0119: ldloc.0
+		IL_011a: stelem.ref
+		IL_011b: stloc.s 4
+		IL_011d: ldloc.3
+		IL_011e: ldloc.s 4
+		IL_0120: ldc.r8 0.0
+		IL_0129: box [System.Runtime]System.Double
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0133: stloc.s 5
+		IL_0135: ldloc.s 5
+		IL_0137: ldloc.1
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_013d: stloc.s 5
+		IL_013f: ldloc.s 5
+		IL_0141: stloc.2
+		IL_0142: ldc.i4.0
+		IL_0143: newarr [System.Runtime]System.Object
+		IL_0148: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_014d: ldloc.2
+		IL_014e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0153: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0158: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived::.ctor()
+		IL_015d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_0162: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0167: dup
+		IL_0168: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
+		IL_016d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0172: ldstr "prototype"
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_017c: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0181: stloc.s 5
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_018d: stloc.s 5
+		IL_018f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_0194: ldloc.s 5
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019b: stloc.s 5
+		IL_019d: ldloc.s 5
+		IL_019f: isinst Modules.Generator_Inheritance_SuperIteratorMethod/Derived
+		IL_01a4: dup
+		IL_01a5: brfalse IL_01b5
 
-		IL_01b2: callvirt instance object Modules.Generator_Inheritance_SuperIteratorMethod/Derived::run()
-		IL_01b7: pop
-		IL_01b8: br IL_01cb
+		IL_01aa: callvirt instance object Modules.Generator_Inheritance_SuperIteratorMethod/Derived::run()
+		IL_01af: pop
+		IL_01b0: br IL_01c3
 
-		IL_01bd: pop
-		IL_01be: ldloc.s 5
-		IL_01c0: ldstr "run"
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01ca: pop
+		IL_01b5: pop
+		IL_01b6: ldloc.s 5
+		IL_01b8: ldstr "run"
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01c2: pop
 
-		IL_01cb: ret
+		IL_01c3: ret
 	} // end of method Generator_Inheritance_SuperIteratorMethod::__js_module_init__
 
 } // end of class Modules.Generator_Inheritance_SuperIteratorMethod
@@ -910,7 +905,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2525
+		// Method begins at RVA 0x251d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fcf
+						// Method begins at RVA 0x2faf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fc6
+					// Method begins at RVA 0x2fa6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fbd
+				// Method begins at RVA 0x2f9d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 					class Modules.Compile_Performance_PrimeJavaScript/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x32e9
+				// Method begins at RVA 0x32c9
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -114,7 +114,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x32f8
+				// Method begins at RVA 0x32d8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x32fb
+				// Method begins at RVA 0x32db
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -141,7 +141,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x32fe
+				// Method begins at RVA 0x32de
 				// Header size: 1
 				// Code size: 32 (0x20)
 				.maxstack 8
@@ -177,7 +177,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x235c
+			// Method begins at RVA 0x233c
 			// Header size: 12
 			// Code size: 235 (0xeb)
 			.maxstack 8
@@ -306,7 +306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fd8
+				// Method begins at RVA 0x2fb8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -331,7 +331,7 @@
 					class Modules.Compile_Performance_PrimeJavaScript/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x331f
+				// Method begins at RVA 0x32ff
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -347,7 +347,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x332e
+				// Method begins at RVA 0x330e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -359,7 +359,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3331
+				// Method begins at RVA 0x3311
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -374,7 +374,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3334
+				// Method begins at RVA 0x3314
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -405,7 +405,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2454
+			// Method begins at RVA 0x2434
 			// Header size: 12
 			// Code size: 531 (0x213)
 			.maxstack 8
@@ -625,7 +625,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2eaf
+				// Method begins at RVA 0x2e8f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -645,7 +645,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2eb8
+				// Method begins at RVA 0x2e98
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -665,7 +665,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ec1
+				// Method begins at RVA 0x2ea1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -693,7 +693,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2edc
+						// Method begins at RVA 0x2ebc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -717,7 +717,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2eee
+							// Method begins at RVA 0x2ece
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -735,7 +735,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ee5
+						// Method begins at RVA 0x2ec5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -753,7 +753,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ed3
+					// Method begins at RVA 0x2eb3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -781,7 +781,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2f09
+							// Method begins at RVA 0x2ee9
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -799,7 +799,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2f00
+						// Method begins at RVA 0x2ee0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -817,7 +817,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ef7
+					// Method begins at RVA 0x2ed7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -841,7 +841,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2f1b
+						// Method begins at RVA 0x2efb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -859,7 +859,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f12
+					// Method begins at RVA 0x2ef2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -877,7 +877,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2eca
+				// Method begins at RVA 0x2eaa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -897,7 +897,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f24
+				// Method begins at RVA 0x2f04
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -921,7 +921,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f36
+					// Method begins at RVA 0x2f16
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -939,7 +939,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f2d
+				// Method begins at RVA 0x2f0d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -964,7 +964,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x305d
+				// Method begins at RVA 0x303d
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -980,7 +980,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x306c
+				// Method begins at RVA 0x304c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -992,7 +992,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x306f
+				// Method begins at RVA 0x304f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1007,7 +1007,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3072
+				// Method begins at RVA 0x3052
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1023,7 +1023,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x307e
+				// Method begins at RVA 0x305e
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1042,7 +1042,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x308a
+				// Method begins at RVA 0x306a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1055,7 +1055,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3092
+				// Method begins at RVA 0x3072
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1067,7 +1067,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3095
+				// Method begins at RVA 0x3075
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1082,7 +1082,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3098
+				// Method begins at RVA 0x3078
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -1118,7 +1118,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x30c8
+				// Method begins at RVA 0x30a8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1134,7 +1134,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x30d7
+				// Method begins at RVA 0x30b7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1146,7 +1146,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x30da
+				// Method begins at RVA 0x30ba
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1161,7 +1161,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x30e0
+				// Method begins at RVA 0x30c0
 				// Header size: 12
 				// Code size: 71 (0x47)
 				.maxstack 8
@@ -1200,7 +1200,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3133
+				// Method begins at RVA 0x3113
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1213,7 +1213,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x313b
+				// Method begins at RVA 0x311b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1225,7 +1225,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x313e
+				// Method begins at RVA 0x311e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1240,7 +1240,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3141
+				// Method begins at RVA 0x3121
 				// Header size: 1
 				// Code size: 52 (0x34)
 				.maxstack 8
@@ -1272,7 +1272,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3176
+				// Method begins at RVA 0x3156
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1285,7 +1285,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x317e
+				// Method begins at RVA 0x315e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1297,7 +1297,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3181
+				// Method begins at RVA 0x3161
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1312,7 +1312,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3184
+				// Method begins at RVA 0x3164
 				// Header size: 1
 				// Code size: 52 (0x34)
 				.maxstack 8
@@ -1352,7 +1352,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26d8
+			// Method begins at RVA 0x26b8
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -1400,7 +1400,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2944
+			// Method begins at RVA 0x2924
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -1464,7 +1464,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x275c
+			// Method begins at RVA 0x273c
 			// Header size: 12
 			// Code size: 475 (0x1db)
 			.maxstack 8
@@ -1731,7 +1731,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29a4
+			// Method begins at RVA 0x2984
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -1788,7 +1788,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2724
+			// Method begins at RVA 0x2704
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1833,7 +1833,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f3f
+				// Method begins at RVA 0x2f1f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1853,7 +1853,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f48
+				// Method begins at RVA 0x2f28
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1877,7 +1877,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f5a
+					// Method begins at RVA 0x2f3a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1895,7 +1895,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f51
+				// Method begins at RVA 0x2f31
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1915,7 +1915,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f63
+				// Method begins at RVA 0x2f43
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1943,7 +1943,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2f7e
+						// Method begins at RVA 0x2f5e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1961,7 +1961,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f75
+					// Method begins at RVA 0x2f55
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1979,7 +1979,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f6c
+				// Method begins at RVA 0x2f4c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2003,7 +2003,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f90
+					// Method begins at RVA 0x2f70
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2027,7 +2027,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fa2
+						// Method begins at RVA 0x2f82
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2045,7 +2045,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f99
+					// Method begins at RVA 0x2f79
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2063,7 +2063,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f87
+				// Method begins at RVA 0x2f67
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2087,7 +2087,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fb4
+					// Method begins at RVA 0x2f94
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2105,7 +2105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fab
+				// Method begins at RVA 0x2f8b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2132,7 +2132,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x31b9
+				// Method begins at RVA 0x3199
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -2151,7 +2151,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x31cf
+				// Method begins at RVA 0x31af
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2163,7 +2163,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x31d2
+				// Method begins at RVA 0x31b2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2178,7 +2178,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x31d5
+				// Method begins at RVA 0x31b5
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -2194,7 +2194,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x31e1
+				// Method begins at RVA 0x31c1
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -2218,7 +2218,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x31ed
+				// Method begins at RVA 0x31cd
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2234,7 +2234,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x31fc
+				// Method begins at RVA 0x31dc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2246,7 +2246,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x31ff
+				// Method begins at RVA 0x31df
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2261,7 +2261,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3202
+				// Method begins at RVA 0x31e2
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -2293,7 +2293,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3226
+				// Method begins at RVA 0x3206
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2309,7 +2309,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3235
+				// Method begins at RVA 0x3215
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2321,7 +2321,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3238
+				// Method begins at RVA 0x3218
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2336,7 +2336,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x323b
+				// Method begins at RVA 0x321b
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -2369,7 +2369,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3264
+				// Method begins at RVA 0x3244
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2385,7 +2385,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3273
+				// Method begins at RVA 0x3253
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2397,7 +2397,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3276
+				// Method begins at RVA 0x3256
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2412,7 +2412,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3279
+				// Method begins at RVA 0x3259
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -2447,7 +2447,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x32a4
+				// Method begins at RVA 0x3284
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2463,7 +2463,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x32b3
+				// Method begins at RVA 0x3293
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2475,7 +2475,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x32b6
+				// Method begins at RVA 0x3296
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2490,7 +2490,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x32b9
+				// Method begins at RVA 0x3299
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -2531,7 +2531,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2674
+			// Method begins at RVA 0x2654
 			// Header size: 12
 			// Code size: 85 (0x55)
 			.maxstack 8
@@ -2587,7 +2587,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29f4
+			// Method begins at RVA 0x29d4
 			// Header size: 12
 			// Code size: 168 (0xa8)
 			.maxstack 8
@@ -2675,7 +2675,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d48
+			// Method begins at RVA 0x2d28
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -2740,7 +2740,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2dc0
+			// Method begins at RVA 0x2da0
 			// Header size: 12
 			// Code size: 218 (0xda)
 			.maxstack 8
@@ -2848,7 +2848,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2aa8
+			// Method begins at RVA 0x2a88
 			// Header size: 12
 			// Code size: 658 (0x292)
 			.maxstack 8
@@ -3082,7 +3082,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2ea6
+			// Method begins at RVA 0x2e86
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3112,7 +3112,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fe1
+				// Method begins at RVA 0x2fc1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3125,7 +3125,7 @@
 			.method public hidebysig 
 				instance float64 get_sieveSize () cil managed 
 			{
-				// Method begins at RVA 0x2fe9
+				// Method begins at RVA 0x2fc9
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3140,7 +3140,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ff1
+				// Method begins at RVA 0x2fd1
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3158,7 +3158,7 @@
 			.method public hidebysig 
 				instance float64 get_timeLimitSeconds () cil managed 
 			{
-				// Method begins at RVA 0x3006
+				// Method begins at RVA 0x2fe6
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3173,7 +3173,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x300e
+				// Method begins at RVA 0x2fee
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3191,7 +3191,7 @@
 			.method public hidebysig 
 				instance object get_verbose () cil managed 
 			{
-				// Method begins at RVA 0x3023
+				// Method begins at RVA 0x3003
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3206,7 +3206,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x302b
+				// Method begins at RVA 0x300b
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3224,7 +3224,7 @@
 			.method public hidebysig 
 				instance object get_runtime () cil managed 
 			{
-				// Method begins at RVA 0x3040
+				// Method begins at RVA 0x3020
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3239,7 +3239,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3048
+				// Method begins at RVA 0x3028
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3272,7 +3272,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 768 (0x300)
+		// Code size: 736 (0x2e0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_PrimeJavaScript/Scope,
@@ -3286,12 +3286,8 @@
 			[8] float64,
 			[9] class [System.Runtime]System.Type,
 			[10] object[],
-			[11] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue,
-			[12] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue,
-			[13] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue,
-			[14] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse,
-			[15] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject,
-			[16] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject
+			[11] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject,
+			[12] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Performance_PrimeJavaScript/Scope::.ctor()
@@ -3398,157 +3394,141 @@
 		IL_0169: stloc.s 6
 		IL_016b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0170: stloc.s 10
-		IL_0172: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::.ctor()
-		IL_0177: ldc.i4.1
-		IL_0178: conv.r8
-		IL_0179: ldstr "setBitTrue"
+		IL_0172: ldloc.s 6
+		IL_0174: ldstr "setBitTrue"
+		IL_0179: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::.ctor()
 		IL_017e: ldc.i4.1
-		IL_017f: ldc.i4.1
-		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
-		IL_0185: stloc.s 11
-		IL_0187: ldloc.s 11
-		IL_0189: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0)
-		IL_018e: stloc.s 11
-		IL_0190: ldloc.s 6
-		IL_0192: ldstr "setBitTrue"
-		IL_0197: ldloc.s 11
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_019e: pop
-		IL_019f: ldc.i4.1
-		IL_01a0: newarr [System.Runtime]System.Object
-		IL_01a5: dup
-		IL_01a6: ldc.i4.0
-		IL_01a7: ldloc.0
-		IL_01a8: stelem.ref
-		IL_01a9: stloc.s 10
-		IL_01ab: ldloc.s 10
-		IL_01ad: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::.ctor(object[])
-		IL_01b2: ldc.i4.3
-		IL_01b3: conv.r8
-		IL_01b4: ldstr "setBitsTrue"
+		IL_017f: conv.r8
+		IL_0180: ldstr "setBitTrue"
+		IL_0185: ldc.i4.1
+		IL_0186: ldc.i4.1
+		IL_0187: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
+		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0)
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0196: pop
+		IL_0197: ldc.i4.1
+		IL_0198: newarr [System.Runtime]System.Object
+		IL_019d: dup
+		IL_019e: ldc.i4.0
+		IL_019f: ldloc.0
+		IL_01a0: stelem.ref
+		IL_01a1: stloc.s 10
+		IL_01a3: ldloc.s 6
+		IL_01a5: ldstr "setBitsTrue"
+		IL_01aa: ldloc.s 10
+		IL_01ac: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::.ctor(object[])
+		IL_01b1: ldc.i4.3
+		IL_01b2: conv.r8
+		IL_01b3: ldstr "setBitsTrue"
+		IL_01b8: ldc.i4.1
 		IL_01b9: ldc.i4.1
-		IL_01ba: ldc.i4.1
-		IL_01bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_01c0: stloc.s 12
-		IL_01c2: ldloc.s 12
-		IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0)
-		IL_01c9: stloc.s 12
-		IL_01cb: ldloc.s 6
-		IL_01cd: ldstr "setBitsTrue"
-		IL_01d2: ldloc.s 12
-		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01d9: pop
-		IL_01da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01df: stloc.s 10
-		IL_01e1: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::.ctor()
-		IL_01e6: ldc.i4.1
-		IL_01e7: conv.r8
-		IL_01e8: ldstr "testBitTrue"
-		IL_01ed: ldc.i4.1
-		IL_01ee: ldc.i4.1
-		IL_01ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
-		IL_01f4: stloc.s 13
-		IL_01f6: ldloc.s 13
-		IL_01f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0)
-		IL_01fd: stloc.s 13
-		IL_01ff: ldloc.s 6
-		IL_0201: ldstr "testBitTrue"
-		IL_0206: ldloc.s 13
-		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_020d: pop
-		IL_020e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0213: stloc.s 10
-		IL_0215: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::.ctor()
-		IL_021a: ldc.i4.1
-		IL_021b: conv.r8
-		IL_021c: ldstr "searchBitFalse"
-		IL_0221: ldc.i4.1
+		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
+		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0)
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01c9: pop
+		IL_01ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01cf: stloc.s 10
+		IL_01d1: ldloc.s 6
+		IL_01d3: ldstr "testBitTrue"
+		IL_01d8: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::.ctor()
+		IL_01dd: ldc.i4.1
+		IL_01de: conv.r8
+		IL_01df: ldstr "testBitTrue"
+		IL_01e4: ldc.i4.1
+		IL_01e5: ldc.i4.1
+		IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
+		IL_01eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0)
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01f5: pop
+		IL_01f6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01fb: stloc.s 10
+		IL_01fd: ldloc.s 6
+		IL_01ff: ldstr "searchBitFalse"
+		IL_0204: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::.ctor()
+		IL_0209: ldc.i4.1
+		IL_020a: conv.r8
+		IL_020b: ldstr "searchBitFalse"
+		IL_0210: ldc.i4.1
+		IL_0211: ldc.i4.1
+		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
+		IL_0217: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0)
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0221: pop
 		IL_0222: ldc.i4.1
-		IL_0223: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
-		IL_0228: stloc.s 14
-		IL_022a: ldloc.s 14
-		IL_022c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0)
-		IL_0231: stloc.s 14
-		IL_0233: ldloc.s 6
-		IL_0235: ldstr "searchBitFalse"
-		IL_023a: ldloc.s 14
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0241: pop
-		IL_0242: ldc.i4.1
-		IL_0243: newarr [System.Runtime]System.Object
-		IL_0248: dup
-		IL_0249: ldc.i4.0
-		IL_024a: ldloc.0
-		IL_024b: stelem.ref
-		IL_024c: stloc.s 10
-		IL_024e: ldloc.s 9
-		IL_0250: ldloc.s 10
-		IL_0252: ldc.r8 1
-		IL_025b: box [System.Runtime]System.Double
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0265: stloc.s 6
-		IL_0267: ldloc.0
-		IL_0268: ldloc.s 6
-		IL_026a: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
-		IL_026f: nop
-		IL_0270: ldc.i4.1
-		IL_0271: newarr [System.Runtime]System.Object
-		IL_0276: dup
-		IL_0277: ldc.i4.0
-		IL_0278: ldloc.0
-		IL_0279: stelem.ref
-		IL_027a: stloc.s 10
-		IL_027c: ldloc.s 10
-		IL_027e: ldc.i4.0
-		IL_027f: ldelem.ref
-		IL_0280: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_0285: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
-		IL_028a: ldc.i4.1
-		IL_028b: conv.r8
-		IL_028c: ldstr ""
-		IL_0291: ldc.i4.0
-		IL_0292: ldc.i4.0
-		IL_0293: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0298: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0)
-		IL_029d: stloc.s 15
-		IL_029f: ldloc.s 15
-		IL_02a1: ldstr "runSieveBatch"
-		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_02ab: stloc.s 6
-		IL_02ad: ldloc.0
-		IL_02ae: ldloc.s 6
-		IL_02b0: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-		IL_02b5: ldc.i4.1
-		IL_02b6: newarr [System.Runtime]System.Object
-		IL_02bb: dup
-		IL_02bc: ldc.i4.0
-		IL_02bd: ldloc.0
-		IL_02be: stelem.ref
-		IL_02bf: stloc.s 10
-		IL_02c1: ldloc.s 10
-		IL_02c3: ldc.i4.0
-		IL_02c4: ldelem.ref
-		IL_02c5: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_02ca: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
-		IL_02cf: ldc.i4.1
-		IL_02d0: conv.r8
-		IL_02d1: ldstr ""
-		IL_02d6: ldc.i4.0
-		IL_02d7: ldc.i4.0
-		IL_02d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject>(!!0)
-		IL_02e2: stloc.s 16
-		IL_02e4: ldloc.s 16
-		IL_02e6: ldstr "main"
-		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_02f0: stloc.3
-		IL_02f1: ldloc.0
-		IL_02f2: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_02f7: ldnull
-		IL_02f8: ldloc.1
-		IL_02f9: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_02fe: pop
-		IL_02ff: ret
+		IL_0223: newarr [System.Runtime]System.Object
+		IL_0228: dup
+		IL_0229: ldc.i4.0
+		IL_022a: ldloc.0
+		IL_022b: stelem.ref
+		IL_022c: stloc.s 10
+		IL_022e: ldloc.s 9
+		IL_0230: ldloc.s 10
+		IL_0232: ldc.r8 1
+		IL_023b: box [System.Runtime]System.Double
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0245: stloc.s 6
+		IL_0247: ldloc.0
+		IL_0248: ldloc.s 6
+		IL_024a: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
+		IL_024f: nop
+		IL_0250: ldc.i4.1
+		IL_0251: newarr [System.Runtime]System.Object
+		IL_0256: dup
+		IL_0257: ldc.i4.0
+		IL_0258: ldloc.0
+		IL_0259: stelem.ref
+		IL_025a: stloc.s 10
+		IL_025c: ldloc.s 10
+		IL_025e: ldc.i4.0
+		IL_025f: ldelem.ref
+		IL_0260: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_0265: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
+		IL_026a: ldc.i4.1
+		IL_026b: conv.r8
+		IL_026c: ldstr ""
+		IL_0271: ldc.i4.0
+		IL_0272: ldc.i4.0
+		IL_0273: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0278: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0)
+		IL_027d: stloc.s 11
+		IL_027f: ldloc.s 11
+		IL_0281: ldstr "runSieveBatch"
+		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_028b: stloc.s 6
+		IL_028d: ldloc.0
+		IL_028e: ldloc.s 6
+		IL_0290: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+		IL_0295: ldc.i4.1
+		IL_0296: newarr [System.Runtime]System.Object
+		IL_029b: dup
+		IL_029c: ldc.i4.0
+		IL_029d: ldloc.0
+		IL_029e: stelem.ref
+		IL_029f: stloc.s 10
+		IL_02a1: ldloc.s 10
+		IL_02a3: ldc.i4.0
+		IL_02a4: ldelem.ref
+		IL_02a5: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_02aa: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
+		IL_02af: ldc.i4.1
+		IL_02b0: conv.r8
+		IL_02b1: ldstr ""
+		IL_02b6: ldc.i4.0
+		IL_02b7: ldc.i4.0
+		IL_02b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject>(!!0)
+		IL_02c2: stloc.s 12
+		IL_02c4: ldloc.s 12
+		IL_02c6: ldstr "main"
+		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_02d0: stloc.3
+		IL_02d1: ldloc.0
+		IL_02d2: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_02d7: ldnull
+		IL_02d8: ldloc.1
+		IL_02d9: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_02de: pop
+		IL_02df: ret
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript
@@ -3560,7 +3540,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3349
+		// Method begins at RVA 0x3329
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3122
+					// Method begins at RVA 0x3102
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x3279
+					// Method begins at RVA 0x3259
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -73,7 +73,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x3296
+					// Method begins at RVA 0x3276
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -85,7 +85,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x3299
+					// Method begins at RVA 0x3279
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -100,7 +100,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x329c
+					// Method begins at RVA 0x327c
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -125,7 +125,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ba5
+				// Method begins at RVA 0x2b85
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -155,7 +155,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3134
+						// Method begins at RVA 0x3114
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -186,7 +186,7 @@
 							object[] capture3
 						) cil managed 
 					{
-						// Method begins at RVA 0x32e3
+						// Method begins at RVA 0x32c3
 						// Header size: 1
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -211,7 +211,7 @@
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
 					{
-						// Method begins at RVA 0x3308
+						// Method begins at RVA 0x32e8
 						// Header size: 1
 						// Code size: 2 (0x2)
 						.maxstack 8
@@ -223,7 +223,7 @@
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
 					{
-						// Method begins at RVA 0x330b
+						// Method begins at RVA 0x32eb
 						// Header size: 1
 						// Code size: 2 (0x2)
 						.maxstack 8
@@ -238,7 +238,7 @@
 							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 						) cil managed 
 					{
-						// Method begins at RVA 0x330e
+						// Method begins at RVA 0x32ee
 						// Header size: 1
 						// Code size: 17 (0x11)
 						.maxstack 8
@@ -263,7 +263,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2ed4
+					// Method begins at RVA 0x2eb4
 					// Header size: 12
 					// Code size: 145 (0x91)
 					.maxstack 8
@@ -346,7 +346,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x313d
+						// Method begins at RVA 0x311d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -377,7 +377,7 @@
 							object[] capture3
 						) cil managed 
 					{
-						// Method begins at RVA 0x3320
+						// Method begins at RVA 0x3300
 						// Header size: 1
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -402,7 +402,7 @@
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
 					{
-						// Method begins at RVA 0x3345
+						// Method begins at RVA 0x3325
 						// Header size: 1
 						// Code size: 2 (0x2)
 						.maxstack 8
@@ -414,7 +414,7 @@
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
 					{
-						// Method begins at RVA 0x3348
+						// Method begins at RVA 0x3328
 						// Header size: 1
 						// Code size: 2 (0x2)
 						.maxstack 8
@@ -429,7 +429,7 @@
 							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 						) cil managed 
 					{
-						// Method begins at RVA 0x334b
+						// Method begins at RVA 0x332b
 						// Header size: 1
 						// Code size: 17 (0x11)
 						.maxstack 8
@@ -454,7 +454,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2f74
+					// Method begins at RVA 0x2f54
 					// Header size: 12
 					// Code size: 68 (0x44)
 					.maxstack 8
@@ -505,7 +505,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x312b
+					// Method begins at RVA 0x310b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -534,7 +534,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x32ae
+					// Method begins at RVA 0x328e
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -556,7 +556,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x32cb
+					// Method begins at RVA 0x32ab
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -568,7 +568,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x32ce
+					// Method begins at RVA 0x32ae
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -583,7 +583,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x32d1
+					// Method begins at RVA 0x32b1
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -608,7 +608,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bb4
+				// Method begins at RVA 0x2b94
 				// Header size: 12
 				// Code size: 214 (0xd6)
 				.maxstack 8
@@ -746,7 +746,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3119
+				// Method begins at RVA 0x30f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -771,7 +771,7 @@
 					class Modules.Iterator_Helper_Cleanup/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3227
+				// Method begins at RVA 0x3207
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -787,7 +787,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3236
+				// Method begins at RVA 0x3216
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -799,7 +799,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3239
+				// Method begins at RVA 0x3219
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -814,7 +814,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x323c
+				// Method begins at RVA 0x321c
 				// Header size: 1
 				// Code size: 24 (0x18)
 				.maxstack 8
@@ -836,7 +836,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x3255
+				// Method begins at RVA 0x3235
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -857,7 +857,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x326a
+				// Method begins at RVA 0x324a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -886,9 +886,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2894
+			// Method begins at RVA 0x288c
 			// Header size: 12
-			// Code size: 220 (0xdc)
+			// Code size: 212 (0xd4)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Iterator_Helper_Cleanup/makeIterable/Scope,
@@ -896,8 +896,7 @@
 				[2] object[],
 				[3] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18,
 				[4] object,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[6] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/Scope::.ctor()
@@ -963,38 +962,34 @@
 			IL_008e: ldloc.0
 			IL_008f: stelem.ref
 			IL_0090: stloc.2
-			IL_0091: ldloc.2
-			IL_0092: ldc.i4.0
-			IL_0093: ldelem.ref
-			IL_0094: castclass Modules.Iterator_Helper_Cleanup/Scope
-			IL_0099: ldloc.2
-			IL_009a: ldc.i4.1
-			IL_009b: ldelem.ref
-			IL_009c: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
-			IL_00a1: ldloc.2
-			IL_00a2: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, object[])
-			IL_00a7: ldc.i4.0
-			IL_00a8: conv.r8
-			IL_00a9: ldstr ""
-			IL_00ae: ldc.i4.0
-			IL_00af: ldc.i4.1
-			IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30>(!!0, float64, string, bool, bool)
-			IL_00b5: stloc.s 6
-			IL_00b7: ldloc.s 6
+			IL_0091: ldloc.s 5
+			IL_0093: ldloc.s 4
+			IL_0095: ldloc.2
+			IL_0096: ldc.i4.0
+			IL_0097: ldelem.ref
+			IL_0098: castclass Modules.Iterator_Helper_Cleanup/Scope
+			IL_009d: ldloc.2
+			IL_009e: ldc.i4.1
+			IL_009f: ldelem.ref
+			IL_00a0: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
+			IL_00a5: ldloc.2
+			IL_00a6: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, object[])
+			IL_00ab: ldc.i4.0
+			IL_00ac: conv.r8
+			IL_00ad: ldstr ""
+			IL_00b2: ldc.i4.0
+			IL_00b3: ldc.i4.1
+			IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30>(!!0, float64, string, bool, bool)
 			IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30>(!!0)
-			IL_00be: stloc.s 6
-			IL_00c0: ldloc.s 5
-			IL_00c2: ldloc.s 4
-			IL_00c4: ldloc.s 6
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-			IL_00cb: pop
-			IL_00cc: ldloc.1
-			IL_00cd: ldstr "iterable"
-			IL_00d2: ldloc.s 5
-			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_00d9: pop
-			IL_00da: ldloc.1
-			IL_00db: ret
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+			IL_00c3: pop
+			IL_00c4: ldloc.1
+			IL_00c5: ldstr "iterable"
+			IL_00ca: ldloc.s 5
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_00d1: pop
+			IL_00d2: ldloc.1
+			IL_00d3: ret
 		} // end of method makeIterable::__js_call__
 
 	} // end of class makeIterable
@@ -1017,7 +1012,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3146
+				// Method begins at RVA 0x3126
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1037,7 +1032,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x335d
+				// Method begins at RVA 0x333d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1050,7 +1045,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3365
+				// Method begins at RVA 0x3345
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1062,7 +1057,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3368
+				// Method begins at RVA 0x3348
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1077,7 +1072,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x336b
+				// Method begins at RVA 0x334b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1103,7 +1098,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x297c
+			// Method begins at RVA 0x296c
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -1132,7 +1127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x314f
+				// Method begins at RVA 0x312f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1152,7 +1147,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x337a
+				// Method begins at RVA 0x335a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1165,7 +1160,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3382
+				// Method begins at RVA 0x3362
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1177,7 +1172,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3385
+				// Method begins at RVA 0x3365
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1192,7 +1187,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3388
+				// Method begins at RVA 0x3368
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1218,7 +1213,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2980
+			// Method begins at RVA 0x2970
 			// Header size: 12
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -1265,7 +1260,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x316a
+				// Method begins at RVA 0x314a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1285,7 +1280,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3397
+				// Method begins at RVA 0x3377
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1298,7 +1293,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x339f
+				// Method begins at RVA 0x337f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1310,7 +1305,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x33a2
+				// Method begins at RVA 0x3382
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1325,7 +1320,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x33a5
+				// Method begins at RVA 0x3385
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1351,7 +1346,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29b0
+			// Method begins at RVA 0x29a0
 			// Header size: 12
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -1403,7 +1398,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x31a0
+							// Method begins at RVA 0x3180
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1421,7 +1416,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3197
+						// Method begins at RVA 0x3177
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1452,7 +1447,7 @@
 							object[] capture3
 						) cil managed 
 					{
-						// Method begins at RVA 0x3413
+						// Method begins at RVA 0x33f3
 						// Header size: 1
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -1477,7 +1472,7 @@
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
 					{
-						// Method begins at RVA 0x3438
+						// Method begins at RVA 0x3418
 						// Header size: 1
 						// Code size: 2 (0x2)
 						.maxstack 8
@@ -1489,7 +1484,7 @@
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
 					{
-						// Method begins at RVA 0x343b
+						// Method begins at RVA 0x341b
 						// Header size: 1
 						// Code size: 2 (0x2)
 						.maxstack 8
@@ -1504,7 +1499,7 @@
 							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 						) cil managed 
 					{
-						// Method begins at RVA 0x343e
+						// Method begins at RVA 0x341e
 						// Header size: 1
 						// Code size: 17 (0x11)
 						.maxstack 8
@@ -1529,7 +1524,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2fc4
+					// Method begins at RVA 0x2fa4
 					// Header size: 12
 					// Code size: 110 (0x6e)
 					.maxstack 8
@@ -1598,7 +1593,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31a9
+						// Method begins at RVA 0x3189
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1629,7 +1624,7 @@
 							object[] capture3
 						) cil managed 
 					{
-						// Method begins at RVA 0x3450
+						// Method begins at RVA 0x3430
 						// Header size: 1
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -1654,7 +1649,7 @@
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
 					{
-						// Method begins at RVA 0x3475
+						// Method begins at RVA 0x3455
 						// Header size: 1
 						// Code size: 2 (0x2)
 						.maxstack 8
@@ -1666,7 +1661,7 @@
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
 					{
-						// Method begins at RVA 0x3478
+						// Method begins at RVA 0x3458
 						// Header size: 1
 						// Code size: 2 (0x2)
 						.maxstack 8
@@ -1681,7 +1676,7 @@
 							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 						) cil managed 
 					{
-						// Method begins at RVA 0x347b
+						// Method begins at RVA 0x345b
 						// Header size: 1
 						// Code size: 17 (0x11)
 						.maxstack 8
@@ -1706,7 +1701,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3040
+					// Method begins at RVA 0x3020
 					// Header size: 12
 					// Code size: 68 (0x44)
 					.maxstack 8
@@ -1757,7 +1752,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x318e
+					// Method begins at RVA 0x316e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1786,7 +1781,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x33de
+					// Method begins at RVA 0x33be
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -1808,7 +1803,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x33fb
+					// Method begins at RVA 0x33db
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1820,7 +1815,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x33fe
+					// Method begins at RVA 0x33de
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1835,7 +1830,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x3401
+					// Method begins at RVA 0x33e1
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -1860,7 +1855,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c98
+				// Method begins at RVA 0x2c78
 				// Header size: 12
 				// Code size: 206 (0xce)
 				.maxstack 8
@@ -1996,7 +1991,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3185
+				// Method begins at RVA 0x3165
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2021,7 +2016,7 @@
 					class Modules.Iterator_Helper_Cleanup/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x33b4
+				// Method begins at RVA 0x3394
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2037,7 +2032,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x33c3
+				// Method begins at RVA 0x33a3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2049,7 +2044,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x33c6
+				// Method begins at RVA 0x33a6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2064,7 +2059,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x33c9
+				// Method begins at RVA 0x33a9
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2095,16 +2090,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x29e0
+			// Method begins at RVA 0x29d0
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 96 (0x60)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope,
 				[1] object,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[3] object[],
-				[4] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22
+				[3] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope::.ctor()
@@ -2128,33 +2122,29 @@
 			IL_002a: ldloc.0
 			IL_002b: stelem.ref
 			IL_002c: stloc.3
-			IL_002d: ldloc.3
-			IL_002e: ldc.i4.0
-			IL_002f: ldelem.ref
-			IL_0030: castclass Modules.Iterator_Helper_Cleanup/Scope
-			IL_0035: ldloc.3
-			IL_0036: ldc.i4.1
-			IL_0037: ldelem.ref
-			IL_0038: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope
-			IL_003d: ldloc.3
-			IL_003e: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope, object[])
-			IL_0043: ldc.i4.0
-			IL_0044: conv.r8
-			IL_0045: ldstr ""
-			IL_004a: ldc.i4.0
-			IL_004b: ldc.i4.1
-			IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22>(!!0, float64, string, bool, bool)
-			IL_0051: stloc.s 4
-			IL_0053: ldloc.s 4
-			IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22>(!!0)
-			IL_005a: stloc.s 4
-			IL_005c: ldloc.2
-			IL_005d: ldloc.1
-			IL_005e: ldloc.s 4
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-			IL_0065: pop
-			IL_0066: ldloc.2
-			IL_0067: ret
+			IL_002d: ldloc.2
+			IL_002e: ldloc.1
+			IL_002f: ldloc.3
+			IL_0030: ldc.i4.0
+			IL_0031: ldelem.ref
+			IL_0032: castclass Modules.Iterator_Helper_Cleanup/Scope
+			IL_0037: ldloc.3
+			IL_0038: ldc.i4.1
+			IL_0039: ldelem.ref
+			IL_003a: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope
+			IL_003f: ldloc.3
+			IL_0040: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope, object[])
+			IL_0045: ldc.i4.0
+			IL_0046: conv.r8
+			IL_0047: ldstr ""
+			IL_004c: ldc.i4.0
+			IL_004d: ldc.i4.1
+			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22>(!!0, float64, string, bool, bool)
+			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22>(!!0)
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+			IL_005d: pop
+			IL_005e: ldloc.2
+			IL_005f: ret
 		} // end of method ArrowFunction_L60C47::__js_call__
 
 	} // end of class ArrowFunction_L60C47
@@ -2177,7 +2167,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31b2
+				// Method begins at RVA 0x3192
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2197,7 +2187,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x348d
+				// Method begins at RVA 0x346d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2210,7 +2200,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3495
+				// Method begins at RVA 0x3475
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2222,7 +2212,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3498
+				// Method begins at RVA 0x3478
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2237,7 +2227,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x349b
+				// Method begins at RVA 0x347b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2263,7 +2253,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a54
+			// Method begins at RVA 0x2a3c
 			// Header size: 12
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -2311,7 +2301,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31df
+						// Method begins at RVA 0x31bf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2329,7 +2319,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31d6
+					// Method begins at RVA 0x31b6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2358,7 +2348,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x34d1
+					// Method begins at RVA 0x34b1
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -2380,7 +2370,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x34ee
+					// Method begins at RVA 0x34ce
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -2392,7 +2382,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x34f1
+					// Method begins at RVA 0x34d1
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -2407,7 +2397,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x34f4
+					// Method begins at RVA 0x34d4
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -2432,7 +2422,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d74
+				// Method begins at RVA 0x2d54
 				// Header size: 12
 				// Code size: 102 (0x66)
 				.maxstack 8
@@ -2492,7 +2482,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31e8
+					// Method begins at RVA 0x31c8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2521,7 +2511,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x3506
+					// Method begins at RVA 0x34e6
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -2543,7 +2533,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x3523
+					// Method begins at RVA 0x3503
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -2555,7 +2545,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x3526
+					// Method begins at RVA 0x3506
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -2570,7 +2560,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x3529
+					// Method begins at RVA 0x3509
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -2595,7 +2585,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2de8
+				// Method begins at RVA 0x2dc8
 				// Header size: 12
 				// Code size: 68 (0x44)
 				.maxstack 8
@@ -2646,7 +2636,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31cd
+				// Method begins at RVA 0x31ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2671,7 +2661,7 @@
 					class Modules.Iterator_Helper_Cleanup/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x34aa
+				// Method begins at RVA 0x348a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2687,7 +2677,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x34b9
+				// Method begins at RVA 0x3499
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2699,7 +2689,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x34bc
+				// Method begins at RVA 0x349c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2714,7 +2704,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x34bf
+				// Method begins at RVA 0x349f
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -2741,7 +2731,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2a84
+			// Method begins at RVA 0x2a6c
 			// Header size: 12
 			// Code size: 174 (0xae)
 			.maxstack 8
@@ -2858,7 +2848,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3203
+						// Method begins at RVA 0x31e3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2878,7 +2868,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3593
+						// Method begins at RVA 0x3573
 						// Header size: 1
 						// Code size: 7 (0x7)
 						.maxstack 8
@@ -2891,7 +2881,7 @@
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
 					{
-						// Method begins at RVA 0x359b
+						// Method begins at RVA 0x357b
 						// Header size: 1
 						// Code size: 2 (0x2)
 						.maxstack 8
@@ -2903,7 +2893,7 @@
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
 					{
-						// Method begins at RVA 0x359e
+						// Method begins at RVA 0x357e
 						// Header size: 1
 						// Code size: 2 (0x2)
 						.maxstack 8
@@ -2918,7 +2908,7 @@
 							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 						) cil managed 
 					{
-						// Method begins at RVA 0x35a1
+						// Method begins at RVA 0x3581
 						// Header size: 1
 						// Code size: 11 (0xb)
 						.maxstack 8
@@ -2940,7 +2930,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3090
+					// Method begins at RVA 0x3070
 					// Header size: 12
 					// Code size: 34 (0x22)
 					.maxstack 8
@@ -2980,7 +2970,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x320c
+						// Method begins at RVA 0x31ec
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3007,7 +2997,7 @@
 							object[] capture1
 						) cil managed 
 					{
-						// Method begins at RVA 0x35ad
+						// Method begins at RVA 0x358d
 						// Header size: 1
 						// Code size: 21 (0x15)
 						.maxstack 8
@@ -3026,7 +3016,7 @@
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
 					{
-						// Method begins at RVA 0x35c3
+						// Method begins at RVA 0x35a3
 						// Header size: 1
 						// Code size: 2 (0x2)
 						.maxstack 8
@@ -3038,7 +3028,7 @@
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
 					{
-						// Method begins at RVA 0x35c6
+						// Method begins at RVA 0x35a6
 						// Header size: 1
 						// Code size: 2 (0x2)
 						.maxstack 8
@@ -3053,7 +3043,7 @@
 							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 						) cil managed 
 					{
-						// Method begins at RVA 0x35c9
+						// Method begins at RVA 0x35a9
 						// Header size: 1
 						// Code size: 17 (0x11)
 						.maxstack 8
@@ -3078,7 +3068,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x30c0
+					// Method begins at RVA 0x30a0
 					// Header size: 12
 					// Code size: 68 (0x44)
 					.maxstack 8
@@ -3122,7 +3112,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31fa
+					// Method begins at RVA 0x31da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3149,7 +3139,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x3565
+					// Method begins at RVA 0x3545
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -3168,7 +3158,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x357b
+					// Method begins at RVA 0x355b
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -3180,7 +3170,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x357e
+					// Method begins at RVA 0x355e
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -3195,7 +3185,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x3581
+					// Method begins at RVA 0x3561
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -3220,7 +3210,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e38
+				// Method begins at RVA 0x2e18
 				// Header size: 12
 				// Code size: 143 (0x8f)
 				.maxstack 8
@@ -3321,7 +3311,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31f1
+				// Method begins at RVA 0x31d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3346,7 +3336,7 @@
 					class Modules.Iterator_Helper_Cleanup/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x353b
+				// Method begins at RVA 0x351b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3362,7 +3352,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x354a
+				// Method begins at RVA 0x352a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3374,7 +3364,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x354d
+				// Method begins at RVA 0x352d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -3389,7 +3379,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3550
+				// Method begins at RVA 0x3530
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3420,16 +3410,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2b40
+			// Method begins at RVA 0x2b28
 			// Header size: 12
-			// Code size: 89 (0x59)
+			// Code size: 81 (0x51)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/Scope,
 				[1] object,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[3] object[],
-				[4] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22
+				[3] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/Scope::.ctor()
@@ -3450,29 +3439,25 @@
 			IL_0023: ldloc.0
 			IL_0024: stelem.ref
 			IL_0025: stloc.3
-			IL_0026: ldloc.3
-			IL_0027: ldc.i4.0
-			IL_0028: ldelem.ref
-			IL_0029: castclass Modules.Iterator_Helper_Cleanup/Scope
-			IL_002e: ldloc.3
-			IL_002f: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, object[])
-			IL_0034: ldc.i4.0
-			IL_0035: conv.r8
-			IL_0036: ldstr ""
-			IL_003b: ldc.i4.0
-			IL_003c: ldc.i4.1
-			IL_003d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22>(!!0, float64, string, bool, bool)
-			IL_0042: stloc.s 4
-			IL_0044: ldloc.s 4
-			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22>(!!0)
-			IL_004b: stloc.s 4
-			IL_004d: ldloc.2
-			IL_004e: ldloc.1
-			IL_004f: ldloc.s 4
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-			IL_0056: pop
-			IL_0057: ldloc.2
-			IL_0058: ret
+			IL_0026: ldloc.2
+			IL_0027: ldloc.1
+			IL_0028: ldloc.3
+			IL_0029: ldc.i4.0
+			IL_002a: ldelem.ref
+			IL_002b: castclass Modules.Iterator_Helper_Cleanup/Scope
+			IL_0030: ldloc.3
+			IL_0031: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, object[])
+			IL_0036: ldc.i4.0
+			IL_0037: conv.r8
+			IL_0038: ldstr ""
+			IL_003d: ldc.i4.0
+			IL_003e: ldc.i4.1
+			IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22>(!!0, float64, string, bool, bool)
+			IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22>(!!0)
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+			IL_004e: pop
+			IL_004f: ldloc.2
+			IL_0050: ret
 		} // end of method ArrowFunction_L113C12::__js_call__
 
 	} // end of class ArrowFunction_L113C12
@@ -3501,7 +3486,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3158
+				// Method begins at RVA 0x3138
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3521,7 +3506,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3161
+				// Method begins at RVA 0x3141
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3541,7 +3526,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3173
+				// Method begins at RVA 0x3153
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3561,7 +3546,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x317c
+				// Method begins at RVA 0x315c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3581,7 +3566,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31bb
+				// Method begins at RVA 0x319b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3601,7 +3586,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31c4
+				// Method begins at RVA 0x31a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3621,7 +3606,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3215
+				// Method begins at RVA 0x31f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3641,7 +3626,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x321e
+				// Method begins at RVA 0x31fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3665,7 +3650,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3110
+			// Method begins at RVA 0x30f0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3691,7 +3676,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2050 (0x802)
+		// Code size: 2042 (0x7fa)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Iterator_Helper_Cleanup/Scope,
@@ -3731,8 +3716,7 @@
 			[34] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject,
 			[35] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject,
 			[36] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[37] class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22,
-			[38] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject
+			[37] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Iterator_Helper_Cleanup/Scope::.ctor()
@@ -4300,129 +4284,125 @@
 		IL_06be: ldloc.0
 		IL_06bf: stelem.ref
 		IL_06c0: stloc.s 27
-		IL_06c2: ldloc.s 27
-		IL_06c4: ldc.i4.0
-		IL_06c5: ldelem.ref
-		IL_06c6: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_06cb: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
-		IL_06d0: ldc.i4.0
-		IL_06d1: conv.r8
-		IL_06d2: ldstr ""
-		IL_06d7: ldc.i4.0
-		IL_06d8: ldc.i4.1
-		IL_06d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22>(!!0, float64, string, bool, bool)
-		IL_06de: stloc.s 37
-		IL_06e0: ldloc.s 37
+		IL_06c2: ldloc.s 36
+		IL_06c4: ldloc.s 29
+		IL_06c6: ldloc.s 27
+		IL_06c8: ldc.i4.0
+		IL_06c9: ldelem.ref
+		IL_06ca: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_06cf: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
+		IL_06d4: ldc.i4.0
+		IL_06d5: conv.r8
+		IL_06d6: ldstr ""
+		IL_06db: ldc.i4.0
+		IL_06dc: ldc.i4.1
+		IL_06dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22>(!!0, float64, string, bool, bool)
 		IL_06e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22>(!!0)
-		IL_06e7: stloc.s 37
-		IL_06e9: ldloc.s 36
-		IL_06eb: ldloc.s 29
-		IL_06ed: ldloc.s 37
-		IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_06f4: pop
-		IL_06f5: ldloc.s 28
-		IL_06f7: ldstr "from"
-		IL_06fc: ldloc.s 36
-		IL_06fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0703: stloc.s 28
-		IL_0705: ldloc.s 28
-		IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_070c: stloc.s 28
-		IL_070e: ldc.i4.1
-		IL_070f: newarr [System.Runtime]System.Object
-		IL_0714: dup
-		IL_0715: ldc.i4.0
-		IL_0716: ldloc.0
-		IL_0717: stelem.ref
-		IL_0718: stloc.s 27
-		IL_071a: ldloc.s 27
-		IL_071c: ldc.i4.0
-		IL_071d: ldelem.ref
-		IL_071e: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0723: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
-		IL_0728: ldc.i4.1
-		IL_0729: conv.r8
-		IL_072a: ldstr ""
-		IL_072f: ldc.i4.0
-		IL_0730: ldc.i4.0
-		IL_0731: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0736: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0)
-		IL_073b: stloc.s 38
-		IL_073d: ldloc.s 28
-		IL_073f: ldstr "flatMap"
-		IL_0744: ldloc.s 38
-		IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_074b: stloc.s 22
+		IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_06ec: pop
+		IL_06ed: ldloc.s 28
+		IL_06ef: ldstr "from"
+		IL_06f4: ldloc.s 36
+		IL_06f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06fb: stloc.s 28
+		IL_06fd: ldloc.s 28
+		IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0704: stloc.s 28
+		IL_0706: ldc.i4.1
+		IL_0707: newarr [System.Runtime]System.Object
+		IL_070c: dup
+		IL_070d: ldc.i4.0
+		IL_070e: ldloc.0
+		IL_070f: stelem.ref
+		IL_0710: stloc.s 27
+		IL_0712: ldloc.s 27
+		IL_0714: ldc.i4.0
+		IL_0715: ldelem.ref
+		IL_0716: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_071b: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
+		IL_0720: ldc.i4.1
+		IL_0721: conv.r8
+		IL_0722: ldstr ""
+		IL_0727: ldc.i4.0
+		IL_0728: ldc.i4.0
+		IL_0729: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_072e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0)
+		IL_0733: stloc.s 37
+		IL_0735: ldloc.s 28
+		IL_0737: ldstr "flatMap"
+		IL_073c: ldloc.s 37
+		IL_073e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0743: stloc.s 22
 		.try
 		{
-			IL_074d: nop
-			IL_074e: ldloc.s 22
-			IL_0750: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0755: ldstr "next"
-			IL_075a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_075f: pop
-			IL_0760: ldloc.s 22
-			IL_0762: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0767: ldstr "next"
-			IL_076c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0771: pop
-			IL_0772: leave IL_07ae
+			IL_0745: nop
+			IL_0746: ldloc.s 22
+			IL_0748: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_074d: ldstr "next"
+			IL_0752: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0757: pop
+			IL_0758: ldloc.s 22
+			IL_075a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_075f: ldstr "next"
+			IL_0764: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0769: pop
+			IL_076a: leave IL_07a6
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0777: stloc.s 23
-			IL_0779: ldloc.s 23
-			IL_077b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0780: dup
-			IL_0781: brtrue IL_0797
+			IL_076f: stloc.s 23
+			IL_0771: ldloc.s 23
+			IL_0773: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0778: dup
+			IL_0779: brtrue IL_078f
 
-			IL_0786: pop
-			IL_0787: ldloc.s 23
-			IL_0789: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_078e: dup
-			IL_078f: brtrue IL_07a3
+			IL_077e: pop
+			IL_077f: ldloc.s 23
+			IL_0781: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0786: dup
+			IL_0787: brtrue IL_079b
 
-			IL_0794: pop
-			IL_0795: rethrow
+			IL_078c: pop
+			IL_078d: rethrow
 
-			IL_0797: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_079c: stloc.s 24
-			IL_079e: br IL_07a5
+			IL_078f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0794: stloc.s 24
+			IL_0796: br IL_079d
 
-			IL_07a3: stloc.s 24
+			IL_079b: stloc.s 24
 
-			IL_07a5: ldloc.s 24
-			IL_07a7: stloc.s 25
-			IL_07a9: leave IL_07ae
+			IL_079d: ldloc.s 24
+			IL_079f: stloc.s 25
+			IL_07a1: leave IL_07a6
 		} // end handler
 
-		IL_07ae: ldstr "console"
-		IL_07b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07bd: stloc.s 28
-		IL_07bf: ldloc.0
-		IL_07c0: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-		IL_07c5: stloc.s 29
-		IL_07c7: ldloc.s 28
-		IL_07c9: ldstr "log"
-		IL_07ce: ldloc.s 29
-		IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07d5: pop
-		IL_07d6: ldstr "console"
-		IL_07db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07e5: stloc.s 29
-		IL_07e7: ldloc.0
-		IL_07e8: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-		IL_07ed: stloc.s 28
-		IL_07ef: ldloc.s 29
-		IL_07f1: ldstr "log"
-		IL_07f6: ldloc.s 28
-		IL_07f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07fd: pop
-		IL_07fe: ldnull
-		IL_07ff: stloc.s 26
-		IL_0801: ret
+		IL_07a6: ldstr "console"
+		IL_07ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07b5: stloc.s 28
+		IL_07b7: ldloc.0
+		IL_07b8: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+		IL_07bd: stloc.s 29
+		IL_07bf: ldloc.s 28
+		IL_07c1: ldstr "log"
+		IL_07c6: ldloc.s 29
+		IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07cd: pop
+		IL_07ce: ldstr "console"
+		IL_07d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07dd: stloc.s 29
+		IL_07df: ldloc.0
+		IL_07e0: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+		IL_07e5: stloc.s 28
+		IL_07e7: ldloc.s 29
+		IL_07e9: ldstr "log"
+		IL_07ee: ldloc.s 28
+		IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07f5: pop
+		IL_07f6: ldnull
+		IL_07f7: stloc.s 26
+		IL_07f9: ret
 	} // end of method Iterator_Helper_Cleanup::__js_module_init__
 
 } // end of class Modules.Iterator_Helper_Cleanup
@@ -4434,7 +4414,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x35db
+		// Method begins at RVA 0x35bb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Next_Return.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Next_Return.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2716
+					// Method begins at RVA 0x270e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x2758
+					// Method begins at RVA 0x2750
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -73,7 +73,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2775
+					// Method begins at RVA 0x276d
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -85,7 +85,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2778
+					// Method begins at RVA 0x2770
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -100,7 +100,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x277b
+					// Method begins at RVA 0x2773
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -125,7 +125,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2618
+				// Method begins at RVA 0x2610
 				// Header size: 12
 				// Code size: 128 (0x80)
 				.maxstack 8
@@ -197,7 +197,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x271f
+					// Method begins at RVA 0x2717
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -226,7 +226,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x278d
+					// Method begins at RVA 0x2785
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -248,7 +248,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x27aa
+					// Method begins at RVA 0x27a2
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -260,7 +260,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x27ad
+					// Method begins at RVA 0x27a5
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -275,7 +275,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x27b0
+					// Method begins at RVA 0x27a8
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -300,7 +300,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26a4
+				// Method begins at RVA 0x269c
 				// Header size: 12
 				// Code size: 84 (0x54)
 				.maxstack 8
@@ -355,7 +355,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x270d
+				// Method begins at RVA 0x2705
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -380,7 +380,7 @@
 					class Modules.Iterator_Helper_Next_Return/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2731
+				// Method begins at RVA 0x2729
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2740
+				// Method begins at RVA 0x2738
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -408,7 +408,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2743
+				// Method begins at RVA 0x273b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -423,7 +423,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2746
+				// Method begins at RVA 0x273e
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -450,7 +450,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x253c
+			// Method begins at RVA 0x2534
 			// Header size: 12
 			// Code size: 182 (0xb6)
 			.maxstack 8
@@ -566,7 +566,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2728
+				// Method begins at RVA 0x2720
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -586,7 +586,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27c2
+				// Method begins at RVA 0x27ba
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -599,7 +599,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x27ca
+				// Method begins at RVA 0x27c2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -611,7 +611,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x27cd
+				// Method begins at RVA 0x27c5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -626,7 +626,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x27d0
+				// Method begins at RVA 0x27c8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -652,7 +652,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25fe
+			// Method begins at RVA 0x25f6
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -681,7 +681,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2704
+			// Method begins at RVA 0x26fc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -707,7 +707,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1245 (0x4dd)
+		// Code size: 1237 (0x4d5)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Iterator_Helper_Next_Return/Scope,
@@ -720,14 +720,13 @@
 			[7] object,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[9] object[],
-			[10] class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22,
-			[11] class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject,
-			[12] object,
-			[13] bool,
-			[14] object,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[16] string,
-			[17] object
+			[10] class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject,
+			[11] object,
+			[12] bool,
+			[13] object,
+			[14] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[15] string,
+			[16] object
 		)
 
 		IL_0000: newobj instance void Modules.Iterator_Helper_Next_Return/Scope::.ctor()
@@ -749,353 +748,349 @@
 		IL_0036: ldloc.0
 		IL_0037: stelem.ref
 		IL_0038: stloc.s 9
-		IL_003a: ldloc.s 9
-		IL_003c: ldc.i4.0
-		IL_003d: ldelem.ref
-		IL_003e: castclass Modules.Iterator_Helper_Next_Return/Scope
-		IL_0043: newobj instance void Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22::.ctor(class Modules.Iterator_Helper_Next_Return/Scope)
-		IL_0048: ldc.i4.0
-		IL_0049: conv.r8
-		IL_004a: ldstr ""
-		IL_004f: ldc.i4.0
-		IL_0050: ldc.i4.1
-		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22>(!!0, float64, string, bool, bool)
-		IL_0056: stloc.s 10
-		IL_0058: ldloc.s 10
+		IL_003a: ldloc.s 8
+		IL_003c: ldloc.s 7
+		IL_003e: ldloc.s 9
+		IL_0040: ldc.i4.0
+		IL_0041: ldelem.ref
+		IL_0042: castclass Modules.Iterator_Helper_Next_Return/Scope
+		IL_0047: newobj instance void Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22::.ctor(class Modules.Iterator_Helper_Next_Return/Scope)
+		IL_004c: ldc.i4.0
+		IL_004d: conv.r8
+		IL_004e: ldstr ""
+		IL_0053: ldc.i4.0
+		IL_0054: ldc.i4.1
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22>(!!0, float64, string, bool, bool)
 		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22>(!!0)
-		IL_005f: stloc.s 10
-		IL_0061: ldloc.s 8
-		IL_0063: ldloc.s 7
-		IL_0065: ldloc.s 10
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_006c: pop
-		IL_006d: ldloc.s 8
-		IL_006f: stloc.1
-		IL_0070: ldstr "Iterator"
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007f: ldstr "from"
-		IL_0084: ldloc.1
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008a: stloc.s 7
-		IL_008c: ldloc.s 7
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0093: stloc.s 7
-		IL_0095: ldc.i4.1
-		IL_0096: newarr [System.Runtime]System.Object
-		IL_009b: dup
-		IL_009c: ldc.i4.0
-		IL_009d: ldloc.0
-		IL_009e: stelem.ref
-		IL_009f: stloc.s 9
-		IL_00a1: newobj instance void Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject::.ctor()
-		IL_00a6: ldc.i4.1
-		IL_00a7: conv.r8
-		IL_00a8: ldstr ""
-		IL_00ad: ldc.i4.0
-		IL_00ae: ldc.i4.0
-		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject>(!!0)
-		IL_00b9: stloc.s 11
-		IL_00bb: ldloc.s 7
-		IL_00bd: ldstr "map"
-		IL_00c2: ldloc.s 11
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c9: stloc.2
-		IL_00ca: ldstr "console"
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0064: pop
+		IL_0065: ldloc.s 8
+		IL_0067: stloc.1
+		IL_0068: ldstr "Iterator"
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0077: ldstr "from"
+		IL_007c: ldloc.1
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0082: stloc.s 7
+		IL_0084: ldloc.s 7
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008b: stloc.s 7
+		IL_008d: ldc.i4.1
+		IL_008e: newarr [System.Runtime]System.Object
+		IL_0093: dup
+		IL_0094: ldc.i4.0
+		IL_0095: ldloc.0
+		IL_0096: stelem.ref
+		IL_0097: stloc.s 9
+		IL_0099: newobj instance void Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject::.ctor()
+		IL_009e: ldc.i4.1
+		IL_009f: conv.r8
+		IL_00a0: ldstr ""
+		IL_00a5: ldc.i4.0
+		IL_00a6: ldc.i4.0
+		IL_00a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject>(!!0)
+		IL_00b1: stloc.s 10
+		IL_00b3: ldloc.s 7
+		IL_00b5: ldstr "map"
+		IL_00ba: ldloc.s 10
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c1: stloc.2
+		IL_00c2: ldstr "console"
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d1: stloc.s 7
+		IL_00d3: ldloc.2
 		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d9: stloc.s 7
-		IL_00db: ldloc.2
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e1: ldstr "iterator"
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_00eb: ldc.i4.0
-		IL_00ec: newarr [System.Runtime]System.Object
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_00f6: stloc.s 12
-		IL_00f8: ldloc.s 12
-		IL_00fa: ldloc.2
-		IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0100: stloc.s 13
-		IL_0102: ldloc.s 13
-		IL_0104: box [System.Runtime]System.Boolean
-		IL_0109: stloc.s 14
-		IL_010b: ldloc.s 7
-		IL_010d: ldstr "log"
-		IL_0112: ldloc.s 14
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0119: pop
-		IL_011a: ldloc.2
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0120: ldstr "next"
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_012a: stloc.3
-		IL_012b: ldstr "console"
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013a: stloc.s 7
-		IL_013c: ldloc.3
-		IL_013d: ldstr "value"
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0147: stloc.s 12
-		IL_0149: ldloc.s 7
-		IL_014b: ldstr "log"
-		IL_0150: ldloc.s 12
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0157: pop
-		IL_0158: ldstr "console"
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0167: stloc.s 12
-		IL_0169: ldloc.3
-		IL_016a: ldstr "done"
-		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0174: stloc.s 7
-		IL_0176: ldloc.s 12
-		IL_0178: ldstr "log"
-		IL_017d: ldloc.s 7
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0184: pop
-		IL_0185: ldloc.2
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018b: ldstr "return"
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0195: stloc.s 4
-		IL_0197: ldstr "console"
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a6: stloc.s 7
-		IL_01a8: ldloc.s 4
-		IL_01aa: ldstr "done"
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b4: stloc.s 12
-		IL_01b6: ldloc.s 7
-		IL_01b8: ldstr "log"
-		IL_01bd: ldloc.s 12
-		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c4: pop
-		IL_01c5: ldstr "console"
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d4: stloc.s 12
-		IL_01d6: ldloc.0
-		IL_01d7: ldfld object Modules.Iterator_Helper_Next_Return/Scope::closed
-		IL_01dc: stloc.s 7
-		IL_01de: ldloc.s 12
-		IL_01e0: ldstr "log"
-		IL_01e5: ldloc.s 7
-		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ec: pop
-		IL_01ed: ldloc.2
-		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f3: ldstr "next"
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01fd: stloc.s 7
-		IL_01ff: ldloc.s 7
-		IL_0201: stloc.3
-		IL_0202: ldstr "console"
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0211: stloc.s 7
-		IL_0213: ldloc.3
-		IL_0214: ldstr "done"
-		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_021e: stloc.s 12
-		IL_0220: ldloc.s 7
-		IL_0222: ldstr "log"
-		IL_0227: ldloc.s 12
-		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_022e: pop
-		IL_022f: ldc.i4.2
-		IL_0230: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0235: dup
-		IL_0236: ldc.r8 7
-		IL_023f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0244: dup
-		IL_0245: ldc.r8 8
-		IL_024e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0253: stloc.s 15
-		IL_0255: ldloc.s 15
-		IL_0257: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Array::values()
-		IL_025c: stloc.s 5
-		IL_025e: ldstr "console"
-		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026d: ldstr "Iterator"
-		IL_0272: call string [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::TypeOfGlobalBinding(string)
-		IL_0277: stloc.s 16
-		IL_0279: ldstr "log"
-		IL_027e: ldloc.s 16
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0285: pop
-		IL_0286: ldstr "console"
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0295: stloc.s 12
-		IL_0297: ldstr "Iterator"
-		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a1: ldstr "from"
-		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ab: stloc.s 7
-		IL_02ad: ldloc.s 7
-		IL_02af: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_02b4: stloc.s 16
-		IL_02b6: ldloc.s 12
-		IL_02b8: ldstr "log"
-		IL_02bd: ldloc.s 16
-		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c4: pop
-		IL_02c5: ldstr "console"
-		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d4: stloc.s 12
-		IL_02d6: ldstr "Iterator"
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e0: ldstr "prototype"
-		IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ea: stloc.s 7
-		IL_02ec: ldloc.s 7
-		IL_02ee: ldstr "map"
-		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02f8: stloc.s 7
-		IL_02fa: ldloc.s 7
-		IL_02fc: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0301: stloc.s 16
-		IL_0303: ldloc.s 12
-		IL_0305: ldstr "log"
-		IL_030a: ldloc.s 16
-		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0311: pop
-		IL_0312: ldstr "console"
-		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0321: stloc.s 12
-		IL_0323: ldloc.s 5
-		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_032a: ldstr "iterator"
-		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0334: ldc.i4.0
-		IL_0335: newarr [System.Runtime]System.Object
-		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_033f: stloc.s 7
-		IL_0341: ldloc.s 7
-		IL_0343: ldloc.s 5
-		IL_0345: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_034a: stloc.s 13
-		IL_034c: ldloc.s 13
-		IL_034e: box [System.Runtime]System.Boolean
-		IL_0353: stloc.s 14
-		IL_0355: ldloc.s 12
-		IL_0357: ldstr "log"
-		IL_035c: ldloc.s 14
-		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0363: pop
-		IL_0364: ldstr "console"
-		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0373: stloc.s 12
-		IL_0375: ldloc.s 5
-		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_037c: ldstr "next"
-		IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0386: stloc.s 7
-		IL_0388: ldloc.s 7
-		IL_038a: ldstr "value"
-		IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0394: stloc.s 7
-		IL_0396: ldloc.s 12
-		IL_0398: ldstr "log"
-		IL_039d: ldloc.s 7
-		IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03a4: pop
-		IL_03a5: ldstr "console"
-		IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b4: stloc.s 7
-		IL_03b6: ldloc.s 5
-		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03bd: ldstr "next"
-		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_03c7: stloc.s 12
-		IL_03c9: ldloc.s 12
-		IL_03cb: ldstr "value"
-		IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03d5: stloc.s 12
-		IL_03d7: ldloc.s 7
-		IL_03d9: ldstr "log"
-		IL_03de: ldloc.s 12
-		IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03e5: pop
-		IL_03e6: ldstr "console"
-		IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03f5: stloc.s 12
-		IL_03f7: ldloc.s 5
-		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03fe: ldstr "next"
-		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0408: stloc.s 7
-		IL_040a: ldloc.s 7
-		IL_040c: ldstr "done"
-		IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0416: stloc.s 7
-		IL_0418: ldloc.s 12
-		IL_041a: ldstr "log"
-		IL_041f: ldloc.s 7
-		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0426: pop
-		IL_0427: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_042c: dup
-		IL_042d: ldstr "kind"
-		IL_0432: ldstr "async"
-		IL_0437: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_043c: stloc.s 6
-		IL_043e: ldstr "console"
-		IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_044d: ldstr "AsyncIterator"
-		IL_0452: call string [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::TypeOfGlobalBinding(string)
-		IL_0457: stloc.s 16
-		IL_0459: ldstr "log"
-		IL_045e: ldloc.s 16
-		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0465: pop
-		IL_0466: ldstr "console"
-		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0475: stloc.s 7
-		IL_0477: ldstr "AsyncIterator"
-		IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0481: ldstr "prototype"
-		IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_048b: stloc.s 12
-		IL_048d: ldstr "asyncIterator"
-		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0497: stloc.s 17
-		IL_0499: ldloc.s 12
-		IL_049b: ldloc.s 17
-		IL_049d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_04a2: stloc.s 17
-		IL_04a4: ldloc.s 17
-		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04ab: ldstr "call"
-		IL_04b0: ldloc.s 6
-		IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04b7: stloc.s 17
-		IL_04b9: ldloc.s 17
-		IL_04bb: ldloc.s 6
-		IL_04bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04c2: stloc.s 13
-		IL_04c4: ldloc.s 13
-		IL_04c6: box [System.Runtime]System.Boolean
-		IL_04cb: stloc.s 14
-		IL_04cd: ldloc.s 7
-		IL_04cf: ldstr "log"
-		IL_04d4: ldloc.s 14
-		IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04db: pop
-		IL_04dc: ret
+		IL_00d9: ldstr "iterator"
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_00e3: ldc.i4.0
+		IL_00e4: newarr [System.Runtime]System.Object
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_00ee: stloc.s 11
+		IL_00f0: ldloc.s 11
+		IL_00f2: ldloc.2
+		IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00f8: stloc.s 12
+		IL_00fa: ldloc.s 12
+		IL_00fc: box [System.Runtime]System.Boolean
+		IL_0101: stloc.s 13
+		IL_0103: ldloc.s 7
+		IL_0105: ldstr "log"
+		IL_010a: ldloc.s 13
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0111: pop
+		IL_0112: ldloc.2
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0118: ldstr "next"
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0122: stloc.3
+		IL_0123: ldstr "console"
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0132: stloc.s 7
+		IL_0134: ldloc.3
+		IL_0135: ldstr "value"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013f: stloc.s 11
+		IL_0141: ldloc.s 7
+		IL_0143: ldstr "log"
+		IL_0148: ldloc.s 11
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014f: pop
+		IL_0150: ldstr "console"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015f: stloc.s 11
+		IL_0161: ldloc.3
+		IL_0162: ldstr "done"
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_016c: stloc.s 7
+		IL_016e: ldloc.s 11
+		IL_0170: ldstr "log"
+		IL_0175: ldloc.s 7
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017c: pop
+		IL_017d: ldloc.2
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0183: ldstr "return"
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_018d: stloc.s 4
+		IL_018f: ldstr "console"
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019e: stloc.s 7
+		IL_01a0: ldloc.s 4
+		IL_01a2: ldstr "done"
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ac: stloc.s 11
+		IL_01ae: ldloc.s 7
+		IL_01b0: ldstr "log"
+		IL_01b5: ldloc.s 11
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bc: pop
+		IL_01bd: ldstr "console"
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01cc: stloc.s 11
+		IL_01ce: ldloc.0
+		IL_01cf: ldfld object Modules.Iterator_Helper_Next_Return/Scope::closed
+		IL_01d4: stloc.s 7
+		IL_01d6: ldloc.s 11
+		IL_01d8: ldstr "log"
+		IL_01dd: ldloc.s 7
+		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e4: pop
+		IL_01e5: ldloc.2
+		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01eb: ldstr "next"
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01f5: stloc.s 7
+		IL_01f7: ldloc.s 7
+		IL_01f9: stloc.3
+		IL_01fa: ldstr "console"
+		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0209: stloc.s 7
+		IL_020b: ldloc.3
+		IL_020c: ldstr "done"
+		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0216: stloc.s 11
+		IL_0218: ldloc.s 7
+		IL_021a: ldstr "log"
+		IL_021f: ldloc.s 11
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0226: pop
+		IL_0227: ldc.i4.2
+		IL_0228: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_022d: dup
+		IL_022e: ldc.r8 7
+		IL_0237: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_023c: dup
+		IL_023d: ldc.r8 8
+		IL_0246: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_024b: stloc.s 14
+		IL_024d: ldloc.s 14
+		IL_024f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Array::values()
+		IL_0254: stloc.s 5
+		IL_0256: ldstr "console"
+		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0265: ldstr "Iterator"
+		IL_026a: call string [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::TypeOfGlobalBinding(string)
+		IL_026f: stloc.s 15
+		IL_0271: ldstr "log"
+		IL_0276: ldloc.s 15
+		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027d: pop
+		IL_027e: ldstr "console"
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028d: stloc.s 11
+		IL_028f: ldstr "Iterator"
+		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0299: ldstr "from"
+		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a3: stloc.s 7
+		IL_02a5: ldloc.s 7
+		IL_02a7: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_02ac: stloc.s 15
+		IL_02ae: ldloc.s 11
+		IL_02b0: ldstr "log"
+		IL_02b5: ldloc.s 15
+		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02bc: pop
+		IL_02bd: ldstr "console"
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02cc: stloc.s 11
+		IL_02ce: ldstr "Iterator"
+		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d8: ldstr "prototype"
+		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02e2: stloc.s 7
+		IL_02e4: ldloc.s 7
+		IL_02e6: ldstr "map"
+		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02f0: stloc.s 7
+		IL_02f2: ldloc.s 7
+		IL_02f4: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_02f9: stloc.s 15
+		IL_02fb: ldloc.s 11
+		IL_02fd: ldstr "log"
+		IL_0302: ldloc.s 15
+		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0309: pop
+		IL_030a: ldstr "console"
+		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0319: stloc.s 11
+		IL_031b: ldloc.s 5
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0322: ldstr "iterator"
+		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_032c: ldc.i4.0
+		IL_032d: newarr [System.Runtime]System.Object
+		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0337: stloc.s 7
+		IL_0339: ldloc.s 7
+		IL_033b: ldloc.s 5
+		IL_033d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0342: stloc.s 12
+		IL_0344: ldloc.s 12
+		IL_0346: box [System.Runtime]System.Boolean
+		IL_034b: stloc.s 13
+		IL_034d: ldloc.s 11
+		IL_034f: ldstr "log"
+		IL_0354: ldloc.s 13
+		IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_035b: pop
+		IL_035c: ldstr "console"
+		IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_036b: stloc.s 11
+		IL_036d: ldloc.s 5
+		IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0374: ldstr "next"
+		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_037e: stloc.s 7
+		IL_0380: ldloc.s 7
+		IL_0382: ldstr "value"
+		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_038c: stloc.s 7
+		IL_038e: ldloc.s 11
+		IL_0390: ldstr "log"
+		IL_0395: ldloc.s 7
+		IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_039c: pop
+		IL_039d: ldstr "console"
+		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03ac: stloc.s 7
+		IL_03ae: ldloc.s 5
+		IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03b5: ldstr "next"
+		IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_03bf: stloc.s 11
+		IL_03c1: ldloc.s 11
+		IL_03c3: ldstr "value"
+		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03cd: stloc.s 11
+		IL_03cf: ldloc.s 7
+		IL_03d1: ldstr "log"
+		IL_03d6: ldloc.s 11
+		IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03dd: pop
+		IL_03de: ldstr "console"
+		IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03ed: stloc.s 11
+		IL_03ef: ldloc.s 5
+		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03f6: ldstr "next"
+		IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0400: stloc.s 7
+		IL_0402: ldloc.s 7
+		IL_0404: ldstr "done"
+		IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_040e: stloc.s 7
+		IL_0410: ldloc.s 11
+		IL_0412: ldstr "log"
+		IL_0417: ldloc.s 7
+		IL_0419: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_041e: pop
+		IL_041f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0424: dup
+		IL_0425: ldstr "kind"
+		IL_042a: ldstr "async"
+		IL_042f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0434: stloc.s 6
+		IL_0436: ldstr "console"
+		IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0445: ldstr "AsyncIterator"
+		IL_044a: call string [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::TypeOfGlobalBinding(string)
+		IL_044f: stloc.s 15
+		IL_0451: ldstr "log"
+		IL_0456: ldloc.s 15
+		IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_045d: pop
+		IL_045e: ldstr "console"
+		IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_046d: stloc.s 7
+		IL_046f: ldstr "AsyncIterator"
+		IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0479: ldstr "prototype"
+		IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0483: stloc.s 11
+		IL_0485: ldstr "asyncIterator"
+		IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_048f: stloc.s 16
+		IL_0491: ldloc.s 11
+		IL_0493: ldloc.s 16
+		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_049a: stloc.s 16
+		IL_049c: ldloc.s 16
+		IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04a3: ldstr "call"
+		IL_04a8: ldloc.s 6
+		IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04af: stloc.s 16
+		IL_04b1: ldloc.s 16
+		IL_04b3: ldloc.s 6
+		IL_04b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04ba: stloc.s 12
+		IL_04bc: ldloc.s 12
+		IL_04be: box [System.Runtime]System.Boolean
+		IL_04c3: stloc.s 13
+		IL_04c5: ldloc.s 7
+		IL_04c7: ldstr "log"
+		IL_04cc: ldloc.s 13
+		IL_04ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04d3: pop
+		IL_04d4: ret
 	} // end of method Iterator_Helper_Next_Return::__js_module_init__
 
 } // end of class Modules.Iterator_Helper_Next_Return
@@ -1107,7 +1102,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27df
+		// Method begins at RVA 0x27d7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2946
+						// Method begins at RVA 0x292e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x293d
+					// Method begins at RVA 0x2925
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x29d0
+					// Method begins at RVA 0x29b8
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -95,7 +95,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x29ed
+					// Method begins at RVA 0x29d5
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -107,7 +107,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x29f0
+					// Method begins at RVA 0x29d8
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -122,7 +122,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x29f3
+					// Method begins at RVA 0x29db
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -147,7 +147,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26b8
+				// Method begins at RVA 0x26a0
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -257,7 +257,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2934
+				// Method begins at RVA 0x291c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -282,7 +282,7 @@
 					class Modules.Map_Constructor_Iterable/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x29a9
+				// Method begins at RVA 0x2991
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -298,7 +298,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x29b8
+				// Method begins at RVA 0x29a0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -310,7 +310,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x29bb
+				// Method begins at RVA 0x29a3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -325,7 +325,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x29be
+				// Method begins at RVA 0x29a6
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -352,7 +352,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x23e0
+			// Method begins at RVA 0x23c8
 			// Header size: 12
 			// Code size: 238 (0xee)
 			.maxstack 8
@@ -469,7 +469,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2961
+						// Method begins at RVA 0x2949
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -487,7 +487,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2958
+					// Method begins at RVA 0x2940
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -516,7 +516,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a2c
+					// Method begins at RVA 0x2a14
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -538,7 +538,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2a49
+					// Method begins at RVA 0x2a31
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -550,7 +550,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2a4c
+					// Method begins at RVA 0x2a34
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -565,7 +565,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a4f
+					// Method begins at RVA 0x2a37
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -590,7 +590,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x278c
+				// Method begins at RVA 0x2774
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -695,7 +695,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x296a
+					// Method begins at RVA 0x2952
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -724,7 +724,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a61
+					// Method begins at RVA 0x2a49
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -746,7 +746,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2a7e
+					// Method begins at RVA 0x2a66
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -758,7 +758,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2a81
+					// Method begins at RVA 0x2a69
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -773,7 +773,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a84
+					// Method begins at RVA 0x2a6c
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -798,7 +798,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x285f
+				// Method begins at RVA 0x2847
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -836,7 +836,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x294f
+				// Method begins at RVA 0x2937
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -861,7 +861,7 @@
 					class Modules.Map_Constructor_Iterable/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a05
+				// Method begins at RVA 0x29ed
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -877,7 +877,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2a14
+				// Method begins at RVA 0x29fc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -889,7 +889,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2a17
+				// Method begins at RVA 0x29ff
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -904,7 +904,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a1a
+				// Method begins at RVA 0x2a02
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -931,7 +931,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x24dc
+			// Method begins at RVA 0x24c4
 			// Header size: 12
 			// Code size: 276 (0x114)
 			.maxstack 8
@@ -1075,7 +1075,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2985
+						// Method begins at RVA 0x296d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1093,7 +1093,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x297c
+					// Method begins at RVA 0x2964
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1122,7 +1122,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x2abd
+					// Method begins at RVA 0x2aa5
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -1144,7 +1144,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2ada
+					// Method begins at RVA 0x2ac2
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1156,7 +1156,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2add
+					// Method begins at RVA 0x2ac5
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1171,7 +1171,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2ae0
+					// Method begins at RVA 0x2ac8
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -1196,7 +1196,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2888
+				// Method begins at RVA 0x2870
 				// Header size: 12
 				// Code size: 113 (0x71)
 				.maxstack 8
@@ -1262,7 +1262,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x298e
+					// Method begins at RVA 0x2976
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1291,7 +1291,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x2af2
+					// Method begins at RVA 0x2ada
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -1313,7 +1313,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2b0f
+					// Method begins at RVA 0x2af7
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1325,7 +1325,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2b12
+					// Method begins at RVA 0x2afa
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1340,7 +1340,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2b15
+					// Method begins at RVA 0x2afd
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -1365,7 +1365,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2905
+				// Method begins at RVA 0x28ed
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -1401,7 +1401,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2973
+				// Method begins at RVA 0x295b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1426,7 +1426,7 @@
 					class Modules.Map_Constructor_Iterable/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a96
+				// Method begins at RVA 0x2a7e
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1442,7 +1442,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2aa5
+				// Method begins at RVA 0x2a8d
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1454,7 +1454,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2aa8
+				// Method begins at RVA 0x2a90
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1469,7 +1469,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2aab
+				// Method begins at RVA 0x2a93
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1496,7 +1496,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x25fc
+			// Method begins at RVA 0x25e4
 			// Header size: 12
 			// Code size: 174 (0xae)
 			.maxstack 8
@@ -1615,7 +1615,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2997
+				// Method begins at RVA 0x297f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1635,7 +1635,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29a0
+				// Method begins at RVA 0x2988
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1657,7 +1657,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x292b
+			// Method begins at RVA 0x2913
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1683,7 +1683,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 884 (0x374)
+		// Code size: 860 (0x35c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Constructor_Iterable/Scope,
@@ -1700,13 +1700,10 @@
 			[11] object,
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[13] object[],
-			[14] class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22,
-			[15] object,
-			[16] class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22,
-			[17] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[18] bool,
-			[19] object,
-			[20] class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22
+			[14] object,
+			[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[16] bool,
+			[17] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Constructor_Iterable/Scope::.ctor()
@@ -1724,295 +1721,283 @@
 		IL_0022: ldloc.0
 		IL_0023: stelem.ref
 		IL_0024: stloc.s 13
-		IL_0026: ldloc.s 13
-		IL_0028: ldc.i4.0
-		IL_0029: ldelem.ref
-		IL_002a: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_002f: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
-		IL_0034: ldc.i4.0
-		IL_0035: conv.r8
-		IL_0036: ldstr ""
-		IL_003b: ldc.i4.0
-		IL_003c: ldc.i4.1
-		IL_003d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22>(!!0, float64, string, bool, bool)
-		IL_0042: stloc.s 14
-		IL_0044: ldloc.s 14
+		IL_0026: ldloc.s 12
+		IL_0028: ldloc.s 11
+		IL_002a: ldloc.s 13
+		IL_002c: ldc.i4.0
+		IL_002d: ldelem.ref
+		IL_002e: castclass Modules.Map_Constructor_Iterable/Scope
+		IL_0033: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
+		IL_0038: ldc.i4.0
+		IL_0039: conv.r8
+		IL_003a: ldstr ""
+		IL_003f: ldc.i4.0
+		IL_0040: ldc.i4.1
+		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22>(!!0, float64, string, bool, bool)
 		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22>(!!0)
-		IL_004b: stloc.s 14
-		IL_004d: ldloc.s 12
-		IL_004f: ldloc.s 11
-		IL_0051: ldloc.s 14
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_0058: pop
-		IL_0059: ldloc.s 12
-		IL_005b: stloc.1
-		IL_005c: ldloc.1
-		IL_005d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_0062: stloc.2
-		IL_0063: ldstr "console"
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0072: stloc.s 11
-		IL_0074: ldloc.2
-		IL_0075: ldstr "size"
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_007f: stloc.s 15
-		IL_0081: ldloc.s 11
-		IL_0083: ldstr "log"
-		IL_0088: ldloc.s 15
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008f: pop
-		IL_0090: ldstr "console"
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009f: stloc.s 15
-		IL_00a1: ldloc.2
-		IL_00a2: ldstr "get"
-		IL_00a7: ldstr "alpha"
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b1: stloc.s 11
-		IL_00b3: ldloc.s 15
-		IL_00b5: ldstr "log"
-		IL_00ba: ldloc.s 11
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c1: pop
-		IL_00c2: ldstr "console"
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d1: stloc.s 11
-		IL_00d3: ldloc.2
-		IL_00d4: ldstr "get"
-		IL_00d9: ldstr "beta"
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e3: stloc.s 15
-		IL_00e5: ldloc.s 11
-		IL_00e7: ldstr "log"
-		IL_00ec: ldloc.s 15
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f3: pop
-		IL_00f4: ldloc.0
-		IL_00f5: ldc.i4.0
-		IL_00f6: box [System.Runtime]System.Boolean
-		IL_00fb: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_0100: ldstr "iterator"
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_010a: stloc.s 15
-		IL_010c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0111: stloc.s 12
-		IL_0113: ldc.i4.1
-		IL_0114: newarr [System.Runtime]System.Object
-		IL_0119: dup
-		IL_011a: ldc.i4.0
-		IL_011b: ldloc.0
-		IL_011c: stelem.ref
-		IL_011d: stloc.s 13
-		IL_011f: ldloc.s 13
-		IL_0121: ldc.i4.0
-		IL_0122: ldelem.ref
-		IL_0123: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_0128: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
-		IL_012d: ldc.i4.0
-		IL_012e: conv.r8
-		IL_012f: ldstr ""
-		IL_0134: ldc.i4.0
-		IL_0135: ldc.i4.1
-		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22>(!!0, float64, string, bool, bool)
-		IL_013b: stloc.s 16
-		IL_013d: ldloc.s 16
-		IL_013f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22>(!!0)
-		IL_0144: stloc.s 16
-		IL_0146: ldloc.s 12
-		IL_0148: ldloc.s 15
-		IL_014a: ldloc.s 16
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_0151: pop
-		IL_0152: ldloc.s 12
-		IL_0154: stloc.3
-		IL_0155: ldloc.3
-		IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_015b: stloc.s 4
-		IL_015d: ldstr "console"
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016c: stloc.s 15
-		IL_016e: ldloc.0
-		IL_016f: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_0174: stloc.s 11
-		IL_0176: ldloc.s 15
-		IL_0178: ldstr "log"
-		IL_017d: ldloc.s 11
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0184: pop
-		IL_0185: ldstr "console"
-		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0194: stloc.s 11
-		IL_0196: ldloc.s 4
-		IL_0198: ldstr "size"
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a2: stloc.s 15
-		IL_01a4: ldloc.s 11
-		IL_01a6: ldstr "log"
-		IL_01ab: ldloc.s 15
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b2: pop
-		IL_01b3: ldc.i4.1
-		IL_01b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01b9: dup
-		IL_01ba: ldc.i4.1
-		IL_01bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01c0: dup
-		IL_01c1: ldstr "short"
-		IL_01c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_01cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_01d0: stloc.s 17
-		IL_01d2: ldloc.s 17
-		IL_01d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_01d9: stloc.s 5
-		IL_01db: ldstr "console"
-		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ea: stloc.s 15
-		IL_01ec: ldloc.s 5
-		IL_01ee: ldstr "has"
-		IL_01f3: ldstr "short"
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0050: pop
+		IL_0051: ldloc.s 12
+		IL_0053: stloc.1
+		IL_0054: ldloc.1
+		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+		IL_005a: stloc.2
+		IL_005b: ldstr "console"
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006a: stloc.s 11
+		IL_006c: ldloc.2
+		IL_006d: ldstr "size"
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0077: stloc.s 14
+		IL_0079: ldloc.s 11
+		IL_007b: ldstr "log"
+		IL_0080: ldloc.s 14
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0087: pop
+		IL_0088: ldstr "console"
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0097: stloc.s 14
+		IL_0099: ldloc.2
+		IL_009a: ldstr "get"
+		IL_009f: ldstr "alpha"
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a9: stloc.s 11
+		IL_00ab: ldloc.s 14
+		IL_00ad: ldstr "log"
+		IL_00b2: ldloc.s 11
+		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b9: pop
+		IL_00ba: ldstr "console"
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c9: stloc.s 11
+		IL_00cb: ldloc.2
+		IL_00cc: ldstr "get"
+		IL_00d1: ldstr "beta"
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00db: stloc.s 14
+		IL_00dd: ldloc.s 11
+		IL_00df: ldstr "log"
+		IL_00e4: ldloc.s 14
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00eb: pop
+		IL_00ec: ldloc.0
+		IL_00ed: ldc.i4.0
+		IL_00ee: box [System.Runtime]System.Boolean
+		IL_00f3: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_00f8: ldstr "iterator"
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0102: stloc.s 14
+		IL_0104: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0109: stloc.s 12
+		IL_010b: ldc.i4.1
+		IL_010c: newarr [System.Runtime]System.Object
+		IL_0111: dup
+		IL_0112: ldc.i4.0
+		IL_0113: ldloc.0
+		IL_0114: stelem.ref
+		IL_0115: stloc.s 13
+		IL_0117: ldloc.s 12
+		IL_0119: ldloc.s 14
+		IL_011b: ldloc.s 13
+		IL_011d: ldc.i4.0
+		IL_011e: ldelem.ref
+		IL_011f: castclass Modules.Map_Constructor_Iterable/Scope
+		IL_0124: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
+		IL_0129: ldc.i4.0
+		IL_012a: conv.r8
+		IL_012b: ldstr ""
+		IL_0130: ldc.i4.0
+		IL_0131: ldc.i4.1
+		IL_0132: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22>(!!0, float64, string, bool, bool)
+		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22>(!!0)
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0141: pop
+		IL_0142: ldloc.s 12
+		IL_0144: stloc.3
+		IL_0145: ldloc.3
+		IL_0146: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+		IL_014b: stloc.s 4
+		IL_014d: ldstr "console"
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015c: stloc.s 14
+		IL_015e: ldloc.0
+		IL_015f: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_0164: stloc.s 11
+		IL_0166: ldloc.s 14
+		IL_0168: ldstr "log"
+		IL_016d: ldloc.s 11
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0174: pop
+		IL_0175: ldstr "console"
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0184: stloc.s 11
+		IL_0186: ldloc.s 4
+		IL_0188: ldstr "size"
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0192: stloc.s 14
+		IL_0194: ldloc.s 11
+		IL_0196: ldstr "log"
+		IL_019b: ldloc.s 14
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a2: pop
+		IL_01a3: ldc.i4.1
+		IL_01a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01a9: dup
+		IL_01aa: ldc.i4.1
+		IL_01ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01b0: dup
+		IL_01b1: ldstr "short"
+		IL_01b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01c0: stloc.s 15
+		IL_01c2: ldloc.s 15
+		IL_01c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+		IL_01c9: stloc.s 5
+		IL_01cb: ldstr "console"
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01da: stloc.s 14
+		IL_01dc: ldloc.s 5
+		IL_01de: ldstr "has"
+		IL_01e3: ldstr "short"
+		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ed: stloc.s 11
+		IL_01ef: ldloc.s 14
+		IL_01f1: ldstr "log"
+		IL_01f6: ldloc.s 11
 		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fd: stloc.s 11
-		IL_01ff: ldloc.s 15
-		IL_0201: ldstr "log"
-		IL_0206: ldloc.s 11
-		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020d: pop
-		IL_020e: ldstr "console"
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021d: stloc.s 11
-		IL_021f: ldloc.s 5
-		IL_0221: ldstr "get"
-		IL_0226: ldstr "short"
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0230: stloc.s 15
-		IL_0232: ldloc.s 15
-		IL_0234: ldnull
-		IL_0235: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_023a: stloc.s 18
-		IL_023c: ldloc.s 18
-		IL_023e: box [System.Runtime]System.Boolean
-		IL_0243: stloc.s 19
-		IL_0245: ldloc.s 11
-		IL_0247: ldstr "log"
-		IL_024c: ldloc.s 19
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0253: pop
-		IL_0254: ldloc.0
-		IL_0255: ldc.i4.0
-		IL_0256: box [System.Runtime]System.Boolean
-		IL_025b: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
-		IL_0260: ldstr "iterator"
-		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_026a: stloc.s 11
-		IL_026c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0271: stloc.s 12
-		IL_0273: ldc.i4.1
-		IL_0274: newarr [System.Runtime]System.Object
-		IL_0279: dup
-		IL_027a: ldc.i4.0
-		IL_027b: ldloc.0
-		IL_027c: stelem.ref
-		IL_027d: stloc.s 13
-		IL_027f: ldloc.s 13
+		IL_01fd: pop
+		IL_01fe: ldstr "console"
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020d: stloc.s 11
+		IL_020f: ldloc.s 5
+		IL_0211: ldstr "get"
+		IL_0216: ldstr "short"
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0220: stloc.s 14
+		IL_0222: ldloc.s 14
+		IL_0224: ldnull
+		IL_0225: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_022a: stloc.s 16
+		IL_022c: ldloc.s 16
+		IL_022e: box [System.Runtime]System.Boolean
+		IL_0233: stloc.s 17
+		IL_0235: ldloc.s 11
+		IL_0237: ldstr "log"
+		IL_023c: ldloc.s 17
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0243: pop
+		IL_0244: ldloc.0
+		IL_0245: ldc.i4.0
+		IL_0246: box [System.Runtime]System.Boolean
+		IL_024b: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
+		IL_0250: ldstr "iterator"
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_025a: stloc.s 11
+		IL_025c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0261: stloc.s 12
+		IL_0263: ldc.i4.1
+		IL_0264: newarr [System.Runtime]System.Object
+		IL_0269: dup
+		IL_026a: ldc.i4.0
+		IL_026b: ldloc.0
+		IL_026c: stelem.ref
+		IL_026d: stloc.s 13
+		IL_026f: ldloc.s 12
+		IL_0271: ldloc.s 11
+		IL_0273: ldloc.s 13
+		IL_0275: ldc.i4.0
+		IL_0276: ldelem.ref
+		IL_0277: castclass Modules.Map_Constructor_Iterable/Scope
+		IL_027c: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
 		IL_0281: ldc.i4.0
-		IL_0282: ldelem.ref
-		IL_0283: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_0288: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
-		IL_028d: ldc.i4.0
-		IL_028e: conv.r8
-		IL_028f: ldstr ""
-		IL_0294: ldc.i4.0
-		IL_0295: ldc.i4.1
-		IL_0296: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22>(!!0, float64, string, bool, bool)
-		IL_029b: stloc.s 20
-		IL_029d: ldloc.s 20
-		IL_029f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22>(!!0)
-		IL_02a4: stloc.s 20
-		IL_02a6: ldloc.s 12
-		IL_02a8: ldloc.s 11
-		IL_02aa: ldloc.s 20
-		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_02b1: pop
-		IL_02b2: ldloc.s 12
-		IL_02b4: stloc.s 6
+		IL_0282: conv.r8
+		IL_0283: ldstr ""
+		IL_0288: ldc.i4.0
+		IL_0289: ldc.i4.1
+		IL_028a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22>(!!0, float64, string, bool, bool)
+		IL_028f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22>(!!0)
+		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0299: pop
+		IL_029a: ldloc.s 12
+		IL_029c: stloc.s 6
 		.try
 		{
-			IL_02b6: nop
-			IL_02b7: ldloc.s 6
-			IL_02b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-			IL_02be: pop
-			IL_02bf: ldstr "console"
-			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ce: ldstr "log"
-			IL_02d3: ldstr "no error"
-			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02dd: pop
-			IL_02de: leave IL_0348
+			IL_029e: nop
+			IL_029f: ldloc.s 6
+			IL_02a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+			IL_02a6: pop
+			IL_02a7: ldstr "console"
+			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02b6: ldstr "log"
+			IL_02bb: ldstr "no error"
+			IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02c5: pop
+			IL_02c6: leave IL_0330
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02e3: stloc.s 7
-			IL_02e5: ldloc.s 7
-			IL_02e7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02ec: dup
-			IL_02ed: brtrue IL_0303
+			IL_02cb: stloc.s 7
+			IL_02cd: ldloc.s 7
+			IL_02cf: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02d4: dup
+			IL_02d5: brtrue IL_02eb
 
-			IL_02f2: pop
-			IL_02f3: ldloc.s 7
-			IL_02f5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02fa: dup
-			IL_02fb: brtrue IL_030f
+			IL_02da: pop
+			IL_02db: ldloc.s 7
+			IL_02dd: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02e2: dup
+			IL_02e3: brtrue IL_02f7
 
-			IL_0300: pop
-			IL_0301: rethrow
+			IL_02e8: pop
+			IL_02e9: rethrow
 
-			IL_0303: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0308: stloc.s 8
-			IL_030a: br IL_0311
+			IL_02eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02f0: stloc.s 8
+			IL_02f2: br IL_02f9
 
-			IL_030f: stloc.s 8
+			IL_02f7: stloc.s 8
 
-			IL_0311: ldloc.s 8
-			IL_0313: stloc.s 9
-			IL_0315: ldstr "console"
-			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0324: stloc.s 11
-			IL_0326: ldloc.s 9
-			IL_0328: ldstr "name"
-			IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0332: stloc.s 15
-			IL_0334: ldloc.s 11
-			IL_0336: ldstr "log"
-			IL_033b: ldloc.s 15
-			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0342: pop
-			IL_0343: leave IL_0348
+			IL_02f9: ldloc.s 8
+			IL_02fb: stloc.s 9
+			IL_02fd: ldstr "console"
+			IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_030c: stloc.s 11
+			IL_030e: ldloc.s 9
+			IL_0310: ldstr "name"
+			IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_031a: stloc.s 14
+			IL_031c: ldloc.s 11
+			IL_031e: ldstr "log"
+			IL_0323: ldloc.s 14
+			IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_032a: pop
+			IL_032b: leave IL_0330
 		} // end handler
 
-		IL_0348: ldstr "console"
-		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0357: stloc.s 15
-		IL_0359: ldloc.0
-		IL_035a: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
-		IL_035f: stloc.s 11
-		IL_0361: ldloc.s 15
-		IL_0363: ldstr "log"
-		IL_0368: ldloc.s 11
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_036f: pop
-		IL_0370: ldnull
-		IL_0371: stloc.s 10
-		IL_0373: ret
+		IL_0330: ldstr "console"
+		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_033f: stloc.s 14
+		IL_0341: ldloc.0
+		IL_0342: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
+		IL_0347: stloc.s 11
+		IL_0349: ldloc.s 14
+		IL_034b: ldstr "log"
+		IL_0350: ldloc.s 11
+		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0357: pop
+		IL_0358: ldnull
+		IL_0359: stloc.s 10
+		IL_035b: ret
 	} // end of method Map_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Map_Constructor_Iterable
@@ -2024,7 +2009,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b27
+		// Method begins at RVA 0x2b0f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x308f
+						// Method begins at RVA 0x304f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3086
+					// Method begins at RVA 0x3046
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x307d
+				// Method begins at RVA 0x303d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 					class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x33a9
+				// Method begins at RVA 0x3369
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -114,7 +114,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x33b8
+				// Method begins at RVA 0x3378
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x33bb
+				// Method begins at RVA 0x337b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -141,7 +141,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x33be
+				// Method begins at RVA 0x337e
 				// Header size: 1
 				// Code size: 27 (0x1b)
 				.maxstack 8
@@ -176,7 +176,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2490
+			// Method begins at RVA 0x2450
 			// Header size: 12
 			// Code size: 230 (0xe6)
 			.maxstack 8
@@ -304,7 +304,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3098
+				// Method begins at RVA 0x3058
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -329,7 +329,7 @@
 					class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x33da
+				// Method begins at RVA 0x339a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -345,7 +345,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x33e9
+				// Method begins at RVA 0x33a9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -357,7 +357,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x33ec
+				// Method begins at RVA 0x33ac
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -372,7 +372,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x33ef
+				// Method begins at RVA 0x33af
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -403,7 +403,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2584
+			// Method begins at RVA 0x2544
 			// Header size: 12
 			// Code size: 431 (0x1af)
 			.maxstack 8
@@ -578,7 +578,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f6f
+				// Method begins at RVA 0x2f2f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -598,7 +598,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f78
+				// Method begins at RVA 0x2f38
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -618,7 +618,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f81
+				// Method begins at RVA 0x2f41
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -646,7 +646,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2f9c
+						// Method begins at RVA 0x2f5c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -670,7 +670,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2fae
+							// Method begins at RVA 0x2f6e
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -688,7 +688,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fa5
+						// Method begins at RVA 0x2f65
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -706,7 +706,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f93
+					// Method begins at RVA 0x2f53
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -734,7 +734,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2fc9
+							// Method begins at RVA 0x2f89
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -752,7 +752,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fc0
+						// Method begins at RVA 0x2f80
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -770,7 +770,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fb7
+					// Method begins at RVA 0x2f77
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -794,7 +794,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fdb
+						// Method begins at RVA 0x2f9b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -812,7 +812,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fd2
+					// Method begins at RVA 0x2f92
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -830,7 +830,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f8a
+				// Method begins at RVA 0x2f4a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -850,7 +850,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fe4
+				// Method begins at RVA 0x2fa4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -874,7 +874,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ff6
+					// Method begins at RVA 0x2fb6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -892,7 +892,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fed
+				// Method begins at RVA 0x2fad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -917,7 +917,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x311d
+				// Method begins at RVA 0x30dd
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -933,7 +933,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x312c
+				// Method begins at RVA 0x30ec
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -945,7 +945,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x312f
+				// Method begins at RVA 0x30ef
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -960,7 +960,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3132
+				// Method begins at RVA 0x30f2
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -976,7 +976,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x313e
+				// Method begins at RVA 0x30fe
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -995,7 +995,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x314a
+				// Method begins at RVA 0x310a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1008,7 +1008,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3152
+				// Method begins at RVA 0x3112
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1020,7 +1020,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3155
+				// Method begins at RVA 0x3115
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1035,7 +1035,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3158
+				// Method begins at RVA 0x3118
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -1071,7 +1071,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3188
+				// Method begins at RVA 0x3148
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1087,7 +1087,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3197
+				// Method begins at RVA 0x3157
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1099,7 +1099,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x319a
+				// Method begins at RVA 0x315a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1114,7 +1114,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x31a0
+				// Method begins at RVA 0x3160
 				// Header size: 12
 				// Code size: 71 (0x47)
 				.maxstack 8
@@ -1153,7 +1153,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31f3
+				// Method begins at RVA 0x31b3
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1166,7 +1166,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x31fb
+				// Method begins at RVA 0x31bb
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1178,7 +1178,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x31fe
+				// Method begins at RVA 0x31be
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1193,7 +1193,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3201
+				// Method begins at RVA 0x31c1
 				// Header size: 1
 				// Code size: 52 (0x34)
 				.maxstack 8
@@ -1225,7 +1225,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3236
+				// Method begins at RVA 0x31f6
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1238,7 +1238,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x323e
+				// Method begins at RVA 0x31fe
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1250,7 +1250,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3241
+				// Method begins at RVA 0x3201
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1265,7 +1265,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3244
+				// Method begins at RVA 0x3204
 				// Header size: 1
 				// Code size: 52 (0x34)
 				.maxstack 8
@@ -1305,7 +1305,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27a8
+			// Method begins at RVA 0x2768
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -1353,7 +1353,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a14
+			// Method begins at RVA 0x29d4
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -1417,7 +1417,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x282c
+			// Method begins at RVA 0x27ec
 			// Header size: 12
 			// Code size: 475 (0x1db)
 			.maxstack 8
@@ -1684,7 +1684,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a74
+			// Method begins at RVA 0x2a34
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -1741,7 +1741,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27f4
+			// Method begins at RVA 0x27b4
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1786,7 +1786,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fff
+				// Method begins at RVA 0x2fbf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1806,7 +1806,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3008
+				// Method begins at RVA 0x2fc8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1830,7 +1830,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x301a
+					// Method begins at RVA 0x2fda
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1848,7 +1848,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3011
+				// Method begins at RVA 0x2fd1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1868,7 +1868,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3023
+				// Method begins at RVA 0x2fe3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1896,7 +1896,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x303e
+						// Method begins at RVA 0x2ffe
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1914,7 +1914,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3035
+					// Method begins at RVA 0x2ff5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1932,7 +1932,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x302c
+				// Method begins at RVA 0x2fec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1956,7 +1956,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3050
+					// Method begins at RVA 0x3010
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1980,7 +1980,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3062
+						// Method begins at RVA 0x3022
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1998,7 +1998,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3059
+					// Method begins at RVA 0x3019
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2016,7 +2016,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3047
+				// Method begins at RVA 0x3007
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2040,7 +2040,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3074
+					// Method begins at RVA 0x3034
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2058,7 +2058,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x306b
+				// Method begins at RVA 0x302b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2085,7 +2085,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x3279
+				// Method begins at RVA 0x3239
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -2104,7 +2104,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x328f
+				// Method begins at RVA 0x324f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2116,7 +2116,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3292
+				// Method begins at RVA 0x3252
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2131,7 +2131,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3295
+				// Method begins at RVA 0x3255
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -2147,7 +2147,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x32a1
+				// Method begins at RVA 0x3261
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -2171,7 +2171,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x32ad
+				// Method begins at RVA 0x326d
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2187,7 +2187,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x32bc
+				// Method begins at RVA 0x327c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2199,7 +2199,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x32bf
+				// Method begins at RVA 0x327f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2214,7 +2214,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x32c2
+				// Method begins at RVA 0x3282
 				// Header size: 1
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -2246,7 +2246,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x32e6
+				// Method begins at RVA 0x32a6
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2262,7 +2262,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x32f5
+				// Method begins at RVA 0x32b5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2274,7 +2274,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x32f8
+				// Method begins at RVA 0x32b8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2289,7 +2289,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x32fb
+				// Method begins at RVA 0x32bb
 				// Header size: 1
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -2322,7 +2322,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3324
+				// Method begins at RVA 0x32e4
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2338,7 +2338,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3333
+				// Method begins at RVA 0x32f3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2350,7 +2350,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3336
+				// Method begins at RVA 0x32f6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2365,7 +2365,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3339
+				// Method begins at RVA 0x32f9
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -2400,7 +2400,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x3364
+				// Method begins at RVA 0x3324
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2416,7 +2416,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x3373
+				// Method begins at RVA 0x3333
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2428,7 +2428,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x3376
+				// Method begins at RVA 0x3336
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -2443,7 +2443,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x3379
+				// Method begins at RVA 0x3339
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -2484,7 +2484,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2740
+			// Method begins at RVA 0x2700
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -2543,7 +2543,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ac4
+			// Method begins at RVA 0x2a84
 			// Header size: 12
 			// Code size: 168 (0xa8)
 			.maxstack 8
@@ -2631,7 +2631,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e08
+			// Method begins at RVA 0x2dc8
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -2696,7 +2696,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e80
+			// Method begins at RVA 0x2e40
 			// Header size: 12
 			// Code size: 218 (0xda)
 			.maxstack 8
@@ -2804,7 +2804,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b78
+			// Method begins at RVA 0x2b38
 			// Header size: 12
 			// Code size: 643 (0x283)
 			.maxstack 8
@@ -3033,7 +3033,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2f66
+			// Method begins at RVA 0x2f26
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3063,7 +3063,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30a1
+				// Method begins at RVA 0x3061
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3076,7 +3076,7 @@
 			.method public hidebysig 
 				instance float64 get_sieveSize () cil managed 
 			{
-				// Method begins at RVA 0x30a9
+				// Method begins at RVA 0x3069
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3091,7 +3091,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x30b1
+				// Method begins at RVA 0x3071
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3109,7 +3109,7 @@
 			.method public hidebysig 
 				instance float64 get_timeLimitSeconds () cil managed 
 			{
-				// Method begins at RVA 0x30c6
+				// Method begins at RVA 0x3086
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3124,7 +3124,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x30ce
+				// Method begins at RVA 0x308e
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3142,7 +3142,7 @@
 			.method public hidebysig 
 				instance object get_verbose () cil managed 
 			{
-				// Method begins at RVA 0x30e3
+				// Method begins at RVA 0x30a3
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3157,7 +3157,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x30eb
+				// Method begins at RVA 0x30ab
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3175,7 +3175,7 @@
 			.method public hidebysig 
 				instance object get_runtime () cil managed 
 			{
-				// Method begins at RVA 0x3100
+				// Method begins at RVA 0x30c0
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -3190,7 +3190,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3108
+				// Method begins at RVA 0x30c8
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3223,7 +3223,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1076 (0x434)
+		// Code size: 1012 (0x3f4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope,
@@ -3238,16 +3238,8 @@
 			[9] float64,
 			[10] class [System.Runtime]System.Type,
 			[11] object[],
-			[12] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue,
-			[13] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue,
-			[14] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue,
-			[15] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse,
-			[16] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve,
-			[17] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes,
-			[18] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes,
-			[19] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount,
-			[20] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject,
-			[21] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject
+			[12] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject,
+			[13] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::.ctor()
@@ -3354,274 +3346,242 @@
 		IL_0169: stloc.s 7
 		IL_016b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0170: stloc.s 11
-		IL_0172: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::.ctor()
-		IL_0177: ldc.i4.1
-		IL_0178: conv.r8
-		IL_0179: ldstr "setBitTrue"
+		IL_0172: ldloc.s 7
+		IL_0174: ldstr "setBitTrue"
+		IL_0179: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::.ctor()
 		IL_017e: ldc.i4.1
-		IL_017f: ldc.i4.1
-		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
-		IL_0185: stloc.s 12
-		IL_0187: ldloc.s 12
-		IL_0189: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0)
-		IL_018e: stloc.s 12
-		IL_0190: ldloc.s 7
-		IL_0192: ldstr "setBitTrue"
-		IL_0197: ldloc.s 12
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_019e: pop
-		IL_019f: ldc.i4.1
-		IL_01a0: newarr [System.Runtime]System.Object
-		IL_01a5: dup
-		IL_01a6: ldc.i4.0
-		IL_01a7: ldloc.0
-		IL_01a8: stelem.ref
-		IL_01a9: stloc.s 11
-		IL_01ab: ldloc.s 11
-		IL_01ad: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::.ctor(object[])
-		IL_01b2: ldc.i4.3
-		IL_01b3: conv.r8
-		IL_01b4: ldstr "setBitsTrue"
+		IL_017f: conv.r8
+		IL_0180: ldstr "setBitTrue"
+		IL_0185: ldc.i4.1
+		IL_0186: ldc.i4.1
+		IL_0187: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
+		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0)
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0196: pop
+		IL_0197: ldc.i4.1
+		IL_0198: newarr [System.Runtime]System.Object
+		IL_019d: dup
+		IL_019e: ldc.i4.0
+		IL_019f: ldloc.0
+		IL_01a0: stelem.ref
+		IL_01a1: stloc.s 11
+		IL_01a3: ldloc.s 7
+		IL_01a5: ldstr "setBitsTrue"
+		IL_01aa: ldloc.s 11
+		IL_01ac: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::.ctor(object[])
+		IL_01b1: ldc.i4.3
+		IL_01b2: conv.r8
+		IL_01b3: ldstr "setBitsTrue"
+		IL_01b8: ldc.i4.1
 		IL_01b9: ldc.i4.1
-		IL_01ba: ldc.i4.1
-		IL_01bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_01c0: stloc.s 13
-		IL_01c2: ldloc.s 13
-		IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0)
-		IL_01c9: stloc.s 13
-		IL_01cb: ldloc.s 7
-		IL_01cd: ldstr "setBitsTrue"
-		IL_01d2: ldloc.s 13
-		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01d9: pop
-		IL_01da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01df: stloc.s 11
-		IL_01e1: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::.ctor()
-		IL_01e6: ldc.i4.1
-		IL_01e7: conv.r8
-		IL_01e8: ldstr "testBitTrue"
-		IL_01ed: ldc.i4.1
-		IL_01ee: ldc.i4.1
-		IL_01ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
-		IL_01f4: stloc.s 14
-		IL_01f6: ldloc.s 14
-		IL_01f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0)
-		IL_01fd: stloc.s 14
-		IL_01ff: ldloc.s 7
-		IL_0201: ldstr "testBitTrue"
-		IL_0206: ldloc.s 14
-		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_020d: pop
-		IL_020e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0213: stloc.s 11
-		IL_0215: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::.ctor()
-		IL_021a: ldc.i4.1
-		IL_021b: conv.r8
-		IL_021c: ldstr "searchBitFalse"
-		IL_0221: ldc.i4.1
+		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
+		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0)
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01c9: pop
+		IL_01ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01cf: stloc.s 11
+		IL_01d1: ldloc.s 7
+		IL_01d3: ldstr "testBitTrue"
+		IL_01d8: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::.ctor()
+		IL_01dd: ldc.i4.1
+		IL_01de: conv.r8
+		IL_01df: ldstr "testBitTrue"
+		IL_01e4: ldc.i4.1
+		IL_01e5: ldc.i4.1
+		IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
+		IL_01eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0)
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01f5: pop
+		IL_01f6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01fb: stloc.s 11
+		IL_01fd: ldloc.s 7
+		IL_01ff: ldstr "searchBitFalse"
+		IL_0204: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::.ctor()
+		IL_0209: ldc.i4.1
+		IL_020a: conv.r8
+		IL_020b: ldstr "searchBitFalse"
+		IL_0210: ldc.i4.1
+		IL_0211: ldc.i4.1
+		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
+		IL_0217: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0)
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0221: pop
 		IL_0222: ldc.i4.1
-		IL_0223: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
-		IL_0228: stloc.s 15
-		IL_022a: ldloc.s 15
-		IL_022c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0)
-		IL_0231: stloc.s 15
-		IL_0233: ldloc.s 7
-		IL_0235: ldstr "searchBitFalse"
-		IL_023a: ldloc.s 15
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0241: pop
-		IL_0242: ldc.i4.1
-		IL_0243: newarr [System.Runtime]System.Object
-		IL_0248: dup
-		IL_0249: ldc.i4.0
-		IL_024a: ldloc.0
-		IL_024b: stelem.ref
-		IL_024c: stloc.s 11
-		IL_024e: ldloc.s 10
-		IL_0250: ldloc.s 11
-		IL_0252: ldc.r8 1
-		IL_025b: box [System.Runtime]System.Double
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0265: stloc.s 7
-		IL_0267: ldloc.0
-		IL_0268: ldloc.s 7
-		IL_026a: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
-		IL_026f: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0274: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0279: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_027e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0283: stloc.s 10
-		IL_0285: ldloc.s 10
-		IL_0287: ldstr "prototype"
-		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0291: stloc.s 7
-		IL_0293: ldc.i4.1
-		IL_0294: newarr [System.Runtime]System.Object
-		IL_0299: dup
-		IL_029a: ldc.i4.0
-		IL_029b: ldloc.0
-		IL_029c: stelem.ref
-		IL_029d: stloc.s 11
-		IL_029f: ldloc.s 11
-		IL_02a1: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::.ctor(object[])
-		IL_02a6: ldc.i4.0
-		IL_02a7: conv.r8
-		IL_02a8: ldstr "runSieve"
-		IL_02ad: ldc.i4.1
-		IL_02ae: ldc.i4.1
-		IL_02af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0, float64, string, bool, bool)
-		IL_02b4: stloc.s 16
-		IL_02b6: ldloc.s 16
-		IL_02b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0)
-		IL_02bd: stloc.s 16
-		IL_02bf: ldloc.s 7
-		IL_02c1: ldstr "runSieve"
-		IL_02c6: ldloc.s 16
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02cd: pop
-		IL_02ce: ldc.i4.1
-		IL_02cf: newarr [System.Runtime]System.Object
-		IL_02d4: dup
-		IL_02d5: ldc.i4.0
-		IL_02d6: ldloc.0
-		IL_02d7: stelem.ref
-		IL_02d8: stloc.s 11
-		IL_02da: ldloc.s 11
-		IL_02dc: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::.ctor(object[])
-		IL_02e1: ldc.i4.0
-		IL_02e2: conv.r8
-		IL_02e3: ldstr "countPrimes"
-		IL_02e8: ldc.i4.1
-		IL_02e9: ldc.i4.1
-		IL_02ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0, float64, string, bool, bool)
-		IL_02ef: stloc.s 17
-		IL_02f1: ldloc.s 17
-		IL_02f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0)
-		IL_02f8: stloc.s 17
-		IL_02fa: ldloc.s 7
-		IL_02fc: ldstr "countPrimes"
-		IL_0301: ldloc.s 17
-		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0308: pop
-		IL_0309: ldc.i4.1
-		IL_030a: newarr [System.Runtime]System.Object
-		IL_030f: dup
-		IL_0310: ldc.i4.0
-		IL_0311: ldloc.0
-		IL_0312: stelem.ref
-		IL_0313: stloc.s 11
-		IL_0315: ldloc.s 11
-		IL_0317: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::.ctor(object[])
-		IL_031c: ldc.i4.0
-		IL_031d: conv.r8
-		IL_031e: ldstr "getPrimes"
-		IL_0323: ldc.i4.1
-		IL_0324: ldc.i4.1
-		IL_0325: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0, float64, string, bool, bool)
-		IL_032a: stloc.s 18
-		IL_032c: ldloc.s 18
-		IL_032e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0)
-		IL_0333: stloc.s 18
-		IL_0335: ldloc.s 7
-		IL_0337: ldstr "getPrimes"
-		IL_033c: ldloc.s 18
-		IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0343: pop
-		IL_0344: ldc.i4.1
-		IL_0345: newarr [System.Runtime]System.Object
-		IL_034a: dup
-		IL_034b: ldc.i4.0
-		IL_034c: ldloc.0
-		IL_034d: stelem.ref
-		IL_034e: stloc.s 11
-		IL_0350: ldloc.s 11
-		IL_0352: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::.ctor(object[])
-		IL_0357: ldc.i4.1
-		IL_0358: conv.r8
-		IL_0359: ldstr "validatePrimeCount"
-		IL_035e: ldc.i4.1
-		IL_035f: ldc.i4.1
-		IL_0360: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0, float64, string, bool, bool)
-		IL_0365: stloc.s 19
-		IL_0367: ldloc.s 19
-		IL_0369: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0)
-		IL_036e: stloc.s 19
-		IL_0370: ldloc.s 7
-		IL_0372: ldstr "validatePrimeCount"
-		IL_0377: ldloc.s 19
-		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_037e: pop
-		IL_037f: ldc.i4.1
-		IL_0380: newarr [System.Runtime]System.Object
-		IL_0385: dup
-		IL_0386: ldc.i4.0
-		IL_0387: ldloc.0
-		IL_0388: stelem.ref
-		IL_0389: stloc.s 11
-		IL_038b: ldloc.s 10
-		IL_038d: ldloc.s 11
-		IL_038f: ldc.r8 1
-		IL_0398: box [System.Runtime]System.Double
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_03a2: stloc.s 7
-		IL_03a4: ldloc.0
-		IL_03a5: ldloc.s 7
-		IL_03a7: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
-		IL_03ac: ldc.i4.1
-		IL_03ad: newarr [System.Runtime]System.Object
-		IL_03b2: dup
-		IL_03b3: ldc.i4.0
-		IL_03b4: ldloc.0
-		IL_03b5: stelem.ref
-		IL_03b6: stloc.s 11
-		IL_03b8: ldloc.s 11
-		IL_03ba: ldc.i4.0
-		IL_03bb: ldelem.ref
-		IL_03bc: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_03c1: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope)
-		IL_03c6: ldc.i4.1
-		IL_03c7: conv.r8
-		IL_03c8: ldstr ""
-		IL_03cd: ldc.i4.0
-		IL_03ce: ldc.i4.0
-		IL_03cf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject>(!!0)
-		IL_03d9: stloc.s 20
-		IL_03db: ldloc.s 20
-		IL_03dd: ldstr "runSieveBatch"
-		IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_03e7: stloc.3
-		IL_03e8: ldc.i4.1
-		IL_03e9: newarr [System.Runtime]System.Object
-		IL_03ee: dup
-		IL_03ef: ldc.i4.0
-		IL_03f0: ldloc.0
-		IL_03f1: stelem.ref
-		IL_03f2: stloc.s 11
-		IL_03f4: ldloc.s 11
-		IL_03f6: ldc.i4.0
-		IL_03f7: ldelem.ref
-		IL_03f8: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_03fd: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope)
-		IL_0402: ldc.i4.1
-		IL_0403: conv.r8
-		IL_0404: ldstr ""
-		IL_0409: ldc.i4.0
-		IL_040a: ldc.i4.0
-		IL_040b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0410: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject>(!!0)
-		IL_0415: stloc.s 21
-		IL_0417: ldloc.s 21
-		IL_0419: ldstr "main"
-		IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0423: stloc.s 4
-		IL_0425: ldloc.0
-		IL_0426: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_042b: ldnull
-		IL_042c: ldloc.1
-		IL_042d: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_0432: pop
-		IL_0433: ret
+		IL_0223: newarr [System.Runtime]System.Object
+		IL_0228: dup
+		IL_0229: ldc.i4.0
+		IL_022a: ldloc.0
+		IL_022b: stelem.ref
+		IL_022c: stloc.s 11
+		IL_022e: ldloc.s 10
+		IL_0230: ldloc.s 11
+		IL_0232: ldc.r8 1
+		IL_023b: box [System.Runtime]System.Double
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0245: stloc.s 7
+		IL_0247: ldloc.0
+		IL_0248: ldloc.s 7
+		IL_024a: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
+		IL_024f: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_0254: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0259: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_025e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0263: stloc.s 10
+		IL_0265: ldloc.s 10
+		IL_0267: ldstr "prototype"
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0271: stloc.s 7
+		IL_0273: ldc.i4.1
+		IL_0274: newarr [System.Runtime]System.Object
+		IL_0279: dup
+		IL_027a: ldc.i4.0
+		IL_027b: ldloc.0
+		IL_027c: stelem.ref
+		IL_027d: stloc.s 11
+		IL_027f: ldloc.s 7
+		IL_0281: ldstr "runSieve"
+		IL_0286: ldloc.s 11
+		IL_0288: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::.ctor(object[])
+		IL_028d: ldc.i4.0
+		IL_028e: conv.r8
+		IL_028f: ldstr "runSieve"
+		IL_0294: ldc.i4.1
+		IL_0295: ldc.i4.1
+		IL_0296: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0, float64, string, bool, bool)
+		IL_029b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0)
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02a5: pop
+		IL_02a6: ldc.i4.1
+		IL_02a7: newarr [System.Runtime]System.Object
+		IL_02ac: dup
+		IL_02ad: ldc.i4.0
+		IL_02ae: ldloc.0
+		IL_02af: stelem.ref
+		IL_02b0: stloc.s 11
+		IL_02b2: ldloc.s 7
+		IL_02b4: ldstr "countPrimes"
+		IL_02b9: ldloc.s 11
+		IL_02bb: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::.ctor(object[])
+		IL_02c0: ldc.i4.0
+		IL_02c1: conv.r8
+		IL_02c2: ldstr "countPrimes"
+		IL_02c7: ldc.i4.1
+		IL_02c8: ldc.i4.1
+		IL_02c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0, float64, string, bool, bool)
+		IL_02ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0)
+		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02d8: pop
+		IL_02d9: ldc.i4.1
+		IL_02da: newarr [System.Runtime]System.Object
+		IL_02df: dup
+		IL_02e0: ldc.i4.0
+		IL_02e1: ldloc.0
+		IL_02e2: stelem.ref
+		IL_02e3: stloc.s 11
+		IL_02e5: ldloc.s 7
+		IL_02e7: ldstr "getPrimes"
+		IL_02ec: ldloc.s 11
+		IL_02ee: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::.ctor(object[])
+		IL_02f3: ldc.i4.0
+		IL_02f4: conv.r8
+		IL_02f5: ldstr "getPrimes"
+		IL_02fa: ldc.i4.1
+		IL_02fb: ldc.i4.1
+		IL_02fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0, float64, string, bool, bool)
+		IL_0301: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0)
+		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_030b: pop
+		IL_030c: ldc.i4.1
+		IL_030d: newarr [System.Runtime]System.Object
+		IL_0312: dup
+		IL_0313: ldc.i4.0
+		IL_0314: ldloc.0
+		IL_0315: stelem.ref
+		IL_0316: stloc.s 11
+		IL_0318: ldloc.s 7
+		IL_031a: ldstr "validatePrimeCount"
+		IL_031f: ldloc.s 11
+		IL_0321: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::.ctor(object[])
+		IL_0326: ldc.i4.1
+		IL_0327: conv.r8
+		IL_0328: ldstr "validatePrimeCount"
+		IL_032d: ldc.i4.1
+		IL_032e: ldc.i4.1
+		IL_032f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0, float64, string, bool, bool)
+		IL_0334: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0)
+		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_033e: pop
+		IL_033f: ldc.i4.1
+		IL_0340: newarr [System.Runtime]System.Object
+		IL_0345: dup
+		IL_0346: ldc.i4.0
+		IL_0347: ldloc.0
+		IL_0348: stelem.ref
+		IL_0349: stloc.s 11
+		IL_034b: ldloc.s 10
+		IL_034d: ldloc.s 11
+		IL_034f: ldc.r8 1
+		IL_0358: box [System.Runtime]System.Double
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0362: stloc.s 7
+		IL_0364: ldloc.0
+		IL_0365: ldloc.s 7
+		IL_0367: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
+		IL_036c: ldc.i4.1
+		IL_036d: newarr [System.Runtime]System.Object
+		IL_0372: dup
+		IL_0373: ldc.i4.0
+		IL_0374: ldloc.0
+		IL_0375: stelem.ref
+		IL_0376: stloc.s 11
+		IL_0378: ldloc.s 11
+		IL_037a: ldc.i4.0
+		IL_037b: ldelem.ref
+		IL_037c: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_0381: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope)
+		IL_0386: ldc.i4.1
+		IL_0387: conv.r8
+		IL_0388: ldstr ""
+		IL_038d: ldc.i4.0
+		IL_038e: ldc.i4.0
+		IL_038f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0394: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject>(!!0)
+		IL_0399: stloc.s 12
+		IL_039b: ldloc.s 12
+		IL_039d: ldstr "runSieveBatch"
+		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_03a7: stloc.3
+		IL_03a8: ldc.i4.1
+		IL_03a9: newarr [System.Runtime]System.Object
+		IL_03ae: dup
+		IL_03af: ldc.i4.0
+		IL_03b0: ldloc.0
+		IL_03b1: stelem.ref
+		IL_03b2: stloc.s 11
+		IL_03b4: ldloc.s 11
+		IL_03b6: ldc.i4.0
+		IL_03b7: ldelem.ref
+		IL_03b8: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_03bd: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope)
+		IL_03c2: ldc.i4.1
+		IL_03c3: conv.r8
+		IL_03c4: ldstr ""
+		IL_03c9: ldc.i4.0
+		IL_03ca: ldc.i4.0
+		IL_03cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject>(!!0)
+		IL_03d5: stloc.s 13
+		IL_03d7: ldloc.s 13
+		IL_03d9: ldstr "main"
+		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_03e3: stloc.s 4
+		IL_03e5: ldloc.0
+		IL_03e6: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_03eb: ldnull
+		IL_03ec: ldloc.1
+		IL_03ed: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_03f2: pop
+		IL_03f3: ret
 	} // end of method Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes::__js_module_init__
 
 } // end of class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
@@ -3633,7 +3593,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3404
+		// Method begins at RVA 0x33c4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_AccessorDefinitions.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_AccessorDefinitions.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x257a
+				// Method begins at RVA 0x256a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25a7
+				// Method begins at RVA 0x2597
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x25af
+				// Method begins at RVA 0x259f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x25b2
+				// Method begins at RVA 0x25a2
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -78,7 +78,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x25b5
+				// Method begins at RVA 0x25a5
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -100,7 +100,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24b8
+			// Method begins at RVA 0x24a8
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -135,7 +135,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2583
+				// Method begins at RVA 0x2573
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -155,7 +155,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25c1
+				// Method begins at RVA 0x25b1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -168,7 +168,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x25c9
+				// Method begins at RVA 0x25b9
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -180,7 +180,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x25cc
+				// Method begins at RVA 0x25bc
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -195,7 +195,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x25cf
+				// Method begins at RVA 0x25bf
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -221,7 +221,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24ec
+			// Method begins at RVA 0x24dc
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -258,7 +258,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x258c
+				// Method begins at RVA 0x257c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -278,7 +278,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25e2
+				// Method begins at RVA 0x25d2
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -291,7 +291,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x25ea
+				// Method begins at RVA 0x25da
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -303,7 +303,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x25ed
+				// Method begins at RVA 0x25dd
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -318,7 +318,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x25f0
+				// Method begins at RVA 0x25e0
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -340,7 +340,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2524
+			// Method begins at RVA 0x2514
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -374,7 +374,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2595
+				// Method begins at RVA 0x2585
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -394,7 +394,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25fc
+				// Method begins at RVA 0x25ec
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -407,7 +407,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2604
+				// Method begins at RVA 0x25f4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -419,7 +419,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2607
+				// Method begins at RVA 0x25f7
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -434,7 +434,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x260a
+				// Method begins at RVA 0x25fa
 				// Header size: 1
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -457,7 +457,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x255b
+			// Method begins at RVA 0x254b
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -479,7 +479,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x259e
+				// Method begins at RVA 0x258e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -499,7 +499,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x261b
+				// Method begins at RVA 0x260b
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -512,7 +512,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2623
+				// Method begins at RVA 0x2613
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -524,7 +524,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2626
+				// Method begins at RVA 0x2616
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -539,7 +539,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2629
+				// Method begins at RVA 0x2619
 				// Header size: 1
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -562,7 +562,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2566
+			// Method begins at RVA 0x2556
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -580,7 +580,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2571
+			// Method begins at RVA 0x2561
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -606,7 +606,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1113 (0x459)
+		// Code size: 1097 (0x449)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.ObjectLiteral_AccessorDefinitions/Scope,
@@ -618,13 +618,12 @@
 			[6] object[],
 			[7] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject_FunctionExpression_131FC9A5_L5C12,
 			[8] object,
-			[9] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12,
-			[10] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17,
-			[11] object,
-			[12] string,
-			[13] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8,
-			[14] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[9] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17,
+			[10] object,
+			[11] string,
+			[12] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8,
+			[13] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8,
+			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
 		IL_0000: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/Scope::.ctor()
@@ -676,315 +675,307 @@
 		IL_0082: ldloc.0
 		IL_0083: stelem.ref
 		IL_0084: stloc.s 6
-		IL_0086: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12::.ctor()
-		IL_008b: ldc.i4.1
-		IL_008c: conv.r8
-		IL_008d: ldstr ""
-		IL_0092: ldc.i4.1
+		IL_0086: ldloc.s 5
+		IL_0088: ldstr "value"
+		IL_008d: ldnull
+		IL_008e: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12::.ctor()
 		IL_0093: ldc.i4.1
-		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0, float64, string, bool, bool)
-		IL_0099: stloc.s 9
-		IL_009b: ldloc.s 9
-		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0)
-		IL_00a2: stloc.s 9
-		IL_00a4: ldloc.s 9
+		IL_0094: conv.r8
+		IL_0095: ldstr ""
+		IL_009a: ldc.i4.1
+		IL_009b: ldc.i4.1
+		IL_009c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0)
 		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0)
-		IL_00ab: stloc.s 9
-		IL_00ad: ldloc.s 9
-		IL_00af: ldstr "value"
-		IL_00b4: ldstr "set"
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_00be: stloc.s 8
-		IL_00c0: ldloc.s 5
-		IL_00c2: ldstr "value"
-		IL_00c7: ldnull
-		IL_00c8: ldloc.s 8
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_00cf: pop
-		IL_00d0: ldc.i4.1
-		IL_00d1: newarr [System.Runtime]System.Object
-		IL_00d6: dup
-		IL_00d7: ldc.i4.0
-		IL_00d8: ldloc.0
-		IL_00d9: stelem.ref
-		IL_00da: stloc.s 6
-		IL_00dc: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17::.ctor()
-		IL_00e1: ldc.i4.0
-		IL_00e2: conv.r8
-		IL_00e3: ldstr ""
-		IL_00e8: ldc.i4.1
-		IL_00e9: ldc.i4.1
-		IL_00ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0, float64, string, bool, bool)
-		IL_00ef: stloc.s 10
-		IL_00f1: ldloc.s 10
-		IL_00f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0)
-		IL_00f8: stloc.s 10
-		IL_00fa: ldloc.s 10
-		IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0)
-		IL_0101: stloc.s 10
-		IL_0103: ldloc.s 10
-		IL_0105: ldstr "double"
-		IL_010a: ldstr "get"
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_0114: stloc.s 8
+		IL_00ab: ldstr "value"
+		IL_00b0: ldstr "set"
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_00bf: pop
+		IL_00c0: ldc.i4.1
+		IL_00c1: newarr [System.Runtime]System.Object
+		IL_00c6: dup
+		IL_00c7: ldc.i4.0
+		IL_00c8: ldloc.0
+		IL_00c9: stelem.ref
+		IL_00ca: stloc.s 6
+		IL_00cc: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17::.ctor()
+		IL_00d1: ldc.i4.0
+		IL_00d2: conv.r8
+		IL_00d3: ldstr ""
+		IL_00d8: ldc.i4.1
+		IL_00d9: ldc.i4.1
+		IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0, float64, string, bool, bool)
+		IL_00df: stloc.s 9
+		IL_00e1: ldloc.s 9
+		IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0)
+		IL_00e8: stloc.s 9
+		IL_00ea: ldloc.s 9
+		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0)
+		IL_00f1: stloc.s 9
+		IL_00f3: ldloc.s 9
+		IL_00f5: ldstr "double"
+		IL_00fa: ldstr "get"
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_0104: stloc.s 8
+		IL_0106: ldloc.s 5
+		IL_0108: ldstr "double"
+		IL_010d: ldloc.s 8
+		IL_010f: ldnull
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_0115: pop
 		IL_0116: ldloc.s 5
-		IL_0118: ldstr "double"
-		IL_011d: ldloc.s 8
-		IL_011f: ldnull
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_0125: pop
-		IL_0126: ldloc.s 5
-		IL_0128: stloc.1
-		IL_0129: ldstr "console"
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0138: stloc.s 8
-		IL_013a: ldloc.1
-		IL_013b: ldstr "value"
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0145: stloc.s 11
-		IL_0147: ldloc.s 8
-		IL_0149: ldstr "log"
-		IL_014e: ldloc.s 11
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0155: pop
-		IL_0156: ldloc.1
-		IL_0157: ldstr "value"
-		IL_015c: ldc.r8 7
-		IL_0165: ldc.i4.1
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_016b: pop
-		IL_016c: ldstr "console"
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017b: stloc.s 11
-		IL_017d: ldloc.1
-		IL_017e: ldstr "base"
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0188: stloc.s 8
-		IL_018a: ldloc.s 11
-		IL_018c: ldstr "log"
-		IL_0191: ldloc.s 8
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0198: pop
-		IL_0199: ldstr "console"
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a8: stloc.s 8
-		IL_01aa: ldloc.1
-		IL_01ab: ldstr "value"
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b5: stloc.s 11
-		IL_01b7: ldloc.s 8
-		IL_01b9: ldstr "log"
-		IL_01be: ldloc.s 11
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c5: pop
-		IL_01c6: ldstr "console"
-		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d5: stloc.s 11
-		IL_01d7: ldloc.1
-		IL_01d8: ldstr "double"
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e2: stloc.s 8
-		IL_01e4: ldloc.s 11
-		IL_01e6: ldstr "log"
-		IL_01eb: ldloc.s 8
-		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f2: pop
-		IL_01f3: ldloc.1
-		IL_01f4: ldstr "value"
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_01fe: stloc.2
-		IL_01ff: ldstr "console"
-		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020e: stloc.s 8
-		IL_0210: ldloc.2
-		IL_0211: ldstr "get"
-		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_021b: stloc.s 11
+		IL_0118: stloc.1
+		IL_0119: ldstr "console"
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0128: stloc.s 8
+		IL_012a: ldloc.1
+		IL_012b: ldstr "value"
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0135: stloc.s 10
+		IL_0137: ldloc.s 8
+		IL_0139: ldstr "log"
+		IL_013e: ldloc.s 10
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0145: pop
+		IL_0146: ldloc.1
+		IL_0147: ldstr "value"
+		IL_014c: ldc.r8 7
+		IL_0155: ldc.i4.1
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_015b: pop
+		IL_015c: ldstr "console"
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016b: stloc.s 10
+		IL_016d: ldloc.1
+		IL_016e: ldstr "base"
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0178: stloc.s 8
+		IL_017a: ldloc.s 10
+		IL_017c: ldstr "log"
+		IL_0181: ldloc.s 8
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0188: pop
+		IL_0189: ldstr "console"
+		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0198: stloc.s 8
+		IL_019a: ldloc.1
+		IL_019b: ldstr "value"
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a5: stloc.s 10
+		IL_01a7: ldloc.s 8
+		IL_01a9: ldstr "log"
+		IL_01ae: ldloc.s 10
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b5: pop
+		IL_01b6: ldstr "console"
+		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c5: stloc.s 10
+		IL_01c7: ldloc.1
+		IL_01c8: ldstr "double"
+		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d2: stloc.s 8
+		IL_01d4: ldloc.s 10
+		IL_01d6: ldstr "log"
+		IL_01db: ldloc.s 8
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e2: pop
+		IL_01e3: ldloc.1
+		IL_01e4: ldstr "value"
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_01ee: stloc.2
+		IL_01ef: ldstr "console"
+		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01fe: stloc.s 8
+		IL_0200: ldloc.2
+		IL_0201: ldstr "get"
+		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_020b: stloc.s 10
+		IL_020d: ldloc.s 10
+		IL_020f: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0214: stloc.s 11
+		IL_0216: ldloc.s 8
+		IL_0218: ldstr "log"
 		IL_021d: ldloc.s 11
-		IL_021f: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0224: stloc.s 12
-		IL_0226: ldloc.s 8
-		IL_0228: ldstr "log"
-		IL_022d: ldloc.s 12
-		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0234: pop
-		IL_0235: ldstr "console"
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0244: stloc.s 8
-		IL_0246: ldloc.2
-		IL_0247: ldstr "set"
-		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0251: stloc.s 11
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0224: pop
+		IL_0225: ldstr "console"
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0234: stloc.s 8
+		IL_0236: ldloc.2
+		IL_0237: ldstr "set"
+		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0241: stloc.s 10
+		IL_0243: ldloc.s 10
+		IL_0245: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_024a: stloc.s 11
+		IL_024c: ldloc.s 8
+		IL_024e: ldstr "log"
 		IL_0253: ldloc.s 11
-		IL_0255: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_025a: stloc.s 12
-		IL_025c: ldloc.s 8
-		IL_025e: ldstr "log"
-		IL_0263: ldloc.s 12
-		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026a: pop
-		IL_026b: ldstr "console"
-		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027a: stloc.s 8
-		IL_027c: ldloc.2
-		IL_027d: ldstr "enumerable"
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0287: stloc.s 11
-		IL_0289: ldloc.s 8
-		IL_028b: ldstr "log"
-		IL_0290: ldloc.s 11
-		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0297: pop
-		IL_0298: ldstr "console"
-		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a7: stloc.s 11
-		IL_02a9: ldloc.2
-		IL_02aa: ldstr "configurable"
-		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b4: stloc.s 8
-		IL_02b6: ldloc.s 11
-		IL_02b8: ldstr "log"
-		IL_02bd: ldloc.s 8
-		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c4: pop
-		IL_02c5: ldstr "console"
-		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d4: stloc.s 8
-		IL_02d6: ldloc.1
-		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e1: ldstr "join"
-		IL_02e6: ldstr ","
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025a: pop
+		IL_025b: ldstr "console"
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_026a: stloc.s 8
+		IL_026c: ldloc.2
+		IL_026d: ldstr "enumerable"
+		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0277: stloc.s 10
+		IL_0279: ldloc.s 8
+		IL_027b: ldstr "log"
+		IL_0280: ldloc.s 10
+		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0287: pop
+		IL_0288: ldstr "console"
+		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0297: stloc.s 10
+		IL_0299: ldloc.2
+		IL_029a: ldstr "configurable"
+		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a4: stloc.s 8
+		IL_02a6: ldloc.s 10
+		IL_02a8: ldstr "log"
+		IL_02ad: ldloc.s 8
+		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b4: pop
+		IL_02b5: ldstr "console"
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c4: stloc.s 8
+		IL_02c6: ldloc.1
+		IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d1: ldstr "join"
+		IL_02d6: ldstr ","
+		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02e0: stloc.s 10
+		IL_02e2: ldloc.s 8
+		IL_02e4: ldstr "log"
+		IL_02e9: ldloc.s 10
 		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02f0: stloc.s 11
-		IL_02f2: ldloc.s 8
-		IL_02f4: ldstr "log"
-		IL_02f9: ldloc.s 11
-		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0300: pop
-		IL_0301: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0306: stloc.s 5
-		IL_0308: ldc.i4.1
-		IL_0309: newarr [System.Runtime]System.Object
-		IL_030e: dup
-		IL_030f: ldc.i4.0
-		IL_0310: ldloc.0
-		IL_0311: stelem.ref
-		IL_0312: stloc.s 6
-		IL_0314: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8::.ctor()
-		IL_0319: ldc.i4.0
-		IL_031a: conv.r8
-		IL_031b: ldstr ""
-		IL_0320: ldc.i4.0
-		IL_0321: ldc.i4.1
-		IL_0322: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0, float64, string, bool, bool)
-		IL_0327: stloc.s 13
-		IL_0329: ldloc.s 13
-		IL_032b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0)
-		IL_0330: stloc.s 13
-		IL_0332: ldloc.s 13
-		IL_0334: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0)
-		IL_0339: stloc.s 13
-		IL_033b: ldloc.s 13
-		IL_033d: ldstr "x"
-		IL_0342: ldstr "get"
-		IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_034c: stloc.s 11
+		IL_02f0: pop
+		IL_02f1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02f6: stloc.s 5
+		IL_02f8: ldc.i4.1
+		IL_02f9: newarr [System.Runtime]System.Object
+		IL_02fe: dup
+		IL_02ff: ldc.i4.0
+		IL_0300: ldloc.0
+		IL_0301: stelem.ref
+		IL_0302: stloc.s 6
+		IL_0304: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8::.ctor()
+		IL_0309: ldc.i4.0
+		IL_030a: conv.r8
+		IL_030b: ldstr ""
+		IL_0310: ldc.i4.0
+		IL_0311: ldc.i4.1
+		IL_0312: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0, float64, string, bool, bool)
+		IL_0317: stloc.s 12
+		IL_0319: ldloc.s 12
+		IL_031b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0)
+		IL_0320: stloc.s 12
+		IL_0322: ldloc.s 12
+		IL_0324: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0)
+		IL_0329: stloc.s 12
+		IL_032b: ldloc.s 12
+		IL_032d: ldstr "x"
+		IL_0332: ldstr "get"
+		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_033c: stloc.s 10
+		IL_033e: ldloc.s 5
+		IL_0340: ldstr "x"
+		IL_0345: ldloc.s 10
+		IL_0347: ldnull
+		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_034d: pop
 		IL_034e: ldloc.s 5
 		IL_0350: ldstr "x"
-		IL_0355: ldloc.s 11
-		IL_0357: ldnull
-		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_035d: pop
-		IL_035e: ldloc.s 5
-		IL_0360: ldstr "x"
-		IL_0365: ldc.r8 5
-		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
-		IL_0373: pop
-		IL_0374: ldloc.s 5
-		IL_0376: stloc.3
-		IL_0377: ldstr "console"
-		IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0386: stloc.s 11
-		IL_0388: ldloc.3
-		IL_0389: ldstr "x"
-		IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0393: stloc.s 8
-		IL_0395: ldloc.s 11
-		IL_0397: ldstr "log"
-		IL_039c: ldloc.s 8
-		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03a3: pop
-		IL_03a4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03a9: stloc.s 5
-		IL_03ab: ldc.i4.1
-		IL_03ac: newarr [System.Runtime]System.Object
-		IL_03b1: dup
-		IL_03b2: ldc.i4.0
-		IL_03b3: ldloc.0
-		IL_03b4: stelem.ref
-		IL_03b5: stloc.s 6
-		IL_03b7: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8::.ctor()
-		IL_03bc: ldc.i4.0
-		IL_03bd: conv.r8
-		IL_03be: ldstr ""
-		IL_03c3: ldc.i4.0
-		IL_03c4: ldc.i4.1
-		IL_03c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0, float64, string, bool, bool)
-		IL_03ca: stloc.s 14
-		IL_03cc: ldloc.s 14
-		IL_03ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0)
-		IL_03d3: stloc.s 14
-		IL_03d5: ldloc.s 14
-		IL_03d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0)
-		IL_03dc: stloc.s 14
-		IL_03de: ldloc.s 14
-		IL_03e0: ldstr "x"
-		IL_03e5: ldstr "get"
-		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_03ef: stloc.s 8
-		IL_03f1: ldloc.s 5
-		IL_03f3: ldstr "x"
-		IL_03f8: ldloc.s 8
-		IL_03fa: ldnull
-		IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_0400: pop
-		IL_0401: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0406: dup
-		IL_0407: ldstr "x"
-		IL_040c: ldc.r8 9
-		IL_0415: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_041a: stloc.s 15
-		IL_041c: ldloc.s 5
-		IL_041e: ldloc.s 15
-		IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
-		IL_0425: pop
-		IL_0426: ldloc.s 5
-		IL_0428: stloc.s 4
-		IL_042a: ldstr "console"
-		IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0439: stloc.s 8
-		IL_043b: ldloc.s 4
-		IL_043d: ldstr "x"
-		IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0447: stloc.s 11
-		IL_0449: ldloc.s 8
-		IL_044b: ldstr "log"
-		IL_0450: ldloc.s 11
-		IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0457: pop
-		IL_0458: ret
+		IL_0355: ldc.r8 5
+		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
+		IL_0363: pop
+		IL_0364: ldloc.s 5
+		IL_0366: stloc.3
+		IL_0367: ldstr "console"
+		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0376: stloc.s 10
+		IL_0378: ldloc.3
+		IL_0379: ldstr "x"
+		IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0383: stloc.s 8
+		IL_0385: ldloc.s 10
+		IL_0387: ldstr "log"
+		IL_038c: ldloc.s 8
+		IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0393: pop
+		IL_0394: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0399: stloc.s 5
+		IL_039b: ldc.i4.1
+		IL_039c: newarr [System.Runtime]System.Object
+		IL_03a1: dup
+		IL_03a2: ldc.i4.0
+		IL_03a3: ldloc.0
+		IL_03a4: stelem.ref
+		IL_03a5: stloc.s 6
+		IL_03a7: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8::.ctor()
+		IL_03ac: ldc.i4.0
+		IL_03ad: conv.r8
+		IL_03ae: ldstr ""
+		IL_03b3: ldc.i4.0
+		IL_03b4: ldc.i4.1
+		IL_03b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0, float64, string, bool, bool)
+		IL_03ba: stloc.s 13
+		IL_03bc: ldloc.s 13
+		IL_03be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0)
+		IL_03c3: stloc.s 13
+		IL_03c5: ldloc.s 13
+		IL_03c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0)
+		IL_03cc: stloc.s 13
+		IL_03ce: ldloc.s 13
+		IL_03d0: ldstr "x"
+		IL_03d5: ldstr "get"
+		IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_03df: stloc.s 8
+		IL_03e1: ldloc.s 5
+		IL_03e3: ldstr "x"
+		IL_03e8: ldloc.s 8
+		IL_03ea: ldnull
+		IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_03f0: pop
+		IL_03f1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03f6: dup
+		IL_03f7: ldstr "x"
+		IL_03fc: ldc.r8 9
+		IL_0405: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_040a: stloc.s 14
+		IL_040c: ldloc.s 5
+		IL_040e: ldloc.s 14
+		IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
+		IL_0415: pop
+		IL_0416: ldloc.s 5
+		IL_0418: stloc.s 4
+		IL_041a: ldstr "console"
+		IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0429: stloc.s 8
+		IL_042b: ldloc.s 4
+		IL_042d: ldstr "x"
+		IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0437: stloc.s 10
+		IL_0439: ldloc.s 8
+		IL_043b: ldstr "log"
+		IL_0440: ldloc.s 10
+		IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0447: pop
+		IL_0448: ret
 	} // end of method ObjectLiteral_AccessorDefinitions::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_AccessorDefinitions
@@ -996,7 +987,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x263a
+		// Method begins at RVA 0x262a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_GeneratedMethodFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_GeneratedMethodFunctionObjects.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2955
+					// Method begins at RVA 0x293d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -49,7 +49,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x29ef
+					// Method begins at RVA 0x29d7
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2a05
+					// Method begins at RVA 0x29ed
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -80,7 +80,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2a08
+					// Method begins at RVA 0x29f0
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -95,7 +95,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a0b
+					// Method begins at RVA 0x29f3
 					// Header size: 1
 					// Code size: 24 (0x18)
 					.maxstack 8
@@ -124,7 +124,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2854
+				// Method begins at RVA 0x283c
 				// Header size: 12
 				// Code size: 53 (0x35)
 				.maxstack 8
@@ -169,7 +169,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x295e
+					// Method begins at RVA 0x2946
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -196,7 +196,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a24
+					// Method begins at RVA 0x2a0c
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -215,7 +215,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2a3a
+					// Method begins at RVA 0x2a22
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -227,7 +227,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2a3d
+					// Method begins at RVA 0x2a25
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -242,7 +242,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a40
+					// Method begins at RVA 0x2a28
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -267,7 +267,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2898
+				// Method begins at RVA 0x2880
 				// Header size: 12
 				// Code size: 45 (0x2d)
 				.maxstack 8
@@ -309,7 +309,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2967
+					// Method begins at RVA 0x294f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -336,7 +336,7 @@
 						object[] capture1
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a52
+					// Method begins at RVA 0x2a3a
 					// Header size: 1
 					// Code size: 21 (0x15)
 					.maxstack 8
@@ -355,7 +355,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2a68
+					// Method begins at RVA 0x2a50
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -367,7 +367,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2a6b
+					// Method begins at RVA 0x2a53
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -382,7 +382,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a6e
+					// Method begins at RVA 0x2a56
 					// Header size: 1
 					// Code size: 24 (0x18)
 					.maxstack 8
@@ -411,7 +411,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x28d4
+				// Method begins at RVA 0x28bc
 				// Header size: 12
 				// Code size: 53 (0x35)
 				.maxstack 8
@@ -456,7 +456,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2970
+					// Method begins at RVA 0x2958
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -476,7 +476,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a87
+					// Method begins at RVA 0x2a6f
 					// Header size: 1
 					// Code size: 7 (0x7)
 					.maxstack 8
@@ -489,7 +489,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2a8f
+					// Method begins at RVA 0x2a77
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -501,7 +501,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2a92
+					// Method begins at RVA 0x2a7a
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -516,7 +516,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a95
+					// Method begins at RVA 0x2a7d
 					// Header size: 1
 					// Code size: 18 (0x12)
 					.maxstack 8
@@ -542,7 +542,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2918
+				// Method begins at RVA 0x2900
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -580,7 +580,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x294c
+				// Method begins at RVA 0x2934
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -605,7 +605,7 @@
 					class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x299d
+				// Method begins at RVA 0x2985
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -621,7 +621,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x29ac
+				// Method begins at RVA 0x2994
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -633,7 +633,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x29af
+				// Method begins at RVA 0x2997
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -648,7 +648,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x29b2
+				// Method begins at RVA 0x299a
 				// Header size: 1
 				// Code size: 24 (0x18)
 				.maxstack 8
@@ -670,7 +670,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x29cb
+				// Method begins at RVA 0x29b3
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -691,7 +691,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x29e0
+				// Method begins at RVA 0x29c8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -722,7 +722,7 @@
 			)
 			// Method begins at RVA 0x26b0
 			// Header size: 12
-			// Code size: 355 (0x163)
+			// Code size: 331 (0x14b)
 			.maxstack 13
 			.locals init (
 				[0] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope,
@@ -730,9 +730,7 @@
 				[2] object[],
 				[3] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject_FunctionExpression_B788F5CE_L7C12,
 				[4] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20,
-				[5] object,
-				[6] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20,
-				[7] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21
+				[5] object
 			)
 
 			IL_0000: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope::.ctor()
@@ -831,61 +829,49 @@
 			IL_00d5: ldloc.0
 			IL_00d6: stelem.ref
 			IL_00d7: stloc.2
-			IL_00d8: ldloc.2
-			IL_00d9: ldc.i4.1
-			IL_00da: ldelem.ref
-			IL_00db: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope
-			IL_00e0: ldloc.2
-			IL_00e1: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope, object[])
-			IL_00e6: ldc.i4.1
-			IL_00e7: conv.r8
-			IL_00e8: ldstr ""
+			IL_00d8: ldloc.1
+			IL_00d9: ldstr "current"
+			IL_00de: ldnull
+			IL_00df: ldloc.2
+			IL_00e0: ldc.i4.1
+			IL_00e1: ldelem.ref
+			IL_00e2: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope
+			IL_00e7: ldloc.2
+			IL_00e8: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope, object[])
 			IL_00ed: ldc.i4.1
-			IL_00ee: ldc.i4.1
-			IL_00ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0, float64, string, bool, bool)
-			IL_00f4: stloc.s 6
-			IL_00f6: ldloc.s 6
-			IL_00f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0)
-			IL_00fd: stloc.s 6
-			IL_00ff: ldloc.s 6
-			IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0)
-			IL_0106: stloc.s 6
-			IL_0108: ldloc.s 6
-			IL_010a: ldstr "current"
-			IL_010f: ldstr "set"
-			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-			IL_0119: stloc.s 5
-			IL_011b: ldloc.1
-			IL_011c: ldstr "current"
-			IL_0121: ldnull
-			IL_0122: ldloc.s 5
-			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-			IL_0129: pop
-			IL_012a: ldc.i4.1
-			IL_012b: newarr [System.Runtime]System.Object
-			IL_0130: dup
-			IL_0131: ldc.i4.0
-			IL_0132: ldarg.0
-			IL_0133: stelem.ref
-			IL_0134: stloc.2
-			IL_0135: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21::.ctor()
-			IL_013a: ldc.i4.1
-			IL_013b: conv.r8
-			IL_013c: ldstr ""
-			IL_0141: ldc.i4.1
-			IL_0142: ldc.i4.1
-			IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21>(!!0, float64, string, bool, bool)
-			IL_0148: stloc.s 7
-			IL_014a: ldloc.s 7
-			IL_014c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21>(!!0)
-			IL_0151: stloc.s 7
-			IL_0153: ldloc.1
-			IL_0154: ldstr "computed"
-			IL_0159: ldloc.s 7
-			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0160: pop
-			IL_0161: ldloc.1
-			IL_0162: ret
+			IL_00ee: conv.r8
+			IL_00ef: ldstr ""
+			IL_00f4: ldc.i4.1
+			IL_00f5: ldc.i4.1
+			IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0, float64, string, bool, bool)
+			IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0)
+			IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0)
+			IL_0105: ldstr "current"
+			IL_010a: ldstr "set"
+			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+			IL_0119: pop
+			IL_011a: ldc.i4.1
+			IL_011b: newarr [System.Runtime]System.Object
+			IL_0120: dup
+			IL_0121: ldc.i4.0
+			IL_0122: ldarg.0
+			IL_0123: stelem.ref
+			IL_0124: stloc.2
+			IL_0125: ldloc.1
+			IL_0126: ldstr "computed"
+			IL_012b: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21::.ctor()
+			IL_0130: ldc.i4.1
+			IL_0131: conv.r8
+			IL_0132: ldstr ""
+			IL_0137: ldc.i4.1
+			IL_0138: ldc.i4.1
+			IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21>(!!0, float64, string, bool, bool)
+			IL_013e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21>(!!0)
+			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0148: pop
+			IL_0149: ldloc.1
+			IL_014a: ret
 		} // end of method makeObject::__js_call__
 
 	} // end of class makeObject
@@ -901,7 +887,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x298b
+				// Method begins at RVA 0x2973
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -921,7 +907,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa8
+				// Method begins at RVA 0x2a90
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -934,7 +920,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2ab0
+				// Method begins at RVA 0x2a98
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -946,7 +932,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2ab3
+				// Method begins at RVA 0x2a9b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -961,7 +947,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ab6
+				// Method begins at RVA 0x2a9e
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -983,7 +969,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x281f
+			// Method begins at RVA 0x2807
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -1005,7 +991,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2994
+				// Method begins at RVA 0x297c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1032,7 +1018,7 @@
 					object[] capture1
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ac2
+				// Method begins at RVA 0x2aaa
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -1051,7 +1037,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2ad8
+				// Method begins at RVA 0x2ac0
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1063,7 +1049,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2adb
+				// Method begins at RVA 0x2ac3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1075,7 +1061,7 @@
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
 			{
-				// Method begins at RVA 0x2ade
+				// Method begins at RVA 0x2ac6
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1088,7 +1074,7 @@
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
 			{
-				// Method begins at RVA 0x2ae6
+				// Method begins at RVA 0x2ace
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1104,7 +1090,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2aee
+				// Method begins at RVA 0x2ad6
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -1126,7 +1112,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2828
+			// Method begins at RVA 0x2810
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -1166,7 +1152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2979
+				// Method begins at RVA 0x2961
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1186,7 +1172,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2982
+				// Method begins at RVA 0x296a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1207,7 +1193,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2943
+			// Method begins at RVA 0x292b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1805,7 +1791,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2afa
+		// Method begins at RVA 0x2ae2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x29a4
+						// Method begins at RVA 0x2994
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x299b
+					// Method begins at RVA 0x298b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a25
+					// Method begins at RVA 0x2a15
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -95,7 +95,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2a42
+					// Method begins at RVA 0x2a32
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -107,7 +107,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2a45
+					// Method begins at RVA 0x2a35
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -122,7 +122,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a48
+					// Method begins at RVA 0x2a38
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -147,7 +147,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26c0
+				// Method begins at RVA 0x26b0
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -257,7 +257,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2992
+				// Method begins at RVA 0x2982
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -282,7 +282,7 @@
 					class Modules.Set_Constructor_Iterable/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x29fe
+				// Method begins at RVA 0x29ee
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -298,7 +298,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2a0d
+				// Method begins at RVA 0x29fd
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -310,7 +310,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2a10
+				// Method begins at RVA 0x2a00
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -325,7 +325,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a13
+				// Method begins at RVA 0x2a03
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -352,7 +352,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x23c0
+			// Method begins at RVA 0x23b0
 			// Header size: 12
 			// Code size: 184 (0xb8)
 			.maxstack 8
@@ -451,7 +451,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x29bf
+						// Method begins at RVA 0x29af
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -469,7 +469,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29b6
+					// Method begins at RVA 0x29a6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -498,7 +498,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x2a81
+					// Method begins at RVA 0x2a71
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -520,7 +520,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2a9e
+					// Method begins at RVA 0x2a8e
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -532,7 +532,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2aa1
+					// Method begins at RVA 0x2a91
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -547,7 +547,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2aa4
+					// Method begins at RVA 0x2a94
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -572,7 +572,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2794
+				// Method begins at RVA 0x2784
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -677,7 +677,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29c8
+					// Method begins at RVA 0x29b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -706,7 +706,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x2ab6
+					// Method begins at RVA 0x2aa6
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -728,7 +728,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2ad3
+					// Method begins at RVA 0x2ac3
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -740,7 +740,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2ad6
+					// Method begins at RVA 0x2ac6
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -755,7 +755,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2ad9
+					// Method begins at RVA 0x2ac9
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -780,7 +780,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2867
+				// Method begins at RVA 0x2857
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -818,7 +818,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29ad
+				// Method begins at RVA 0x299d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -843,7 +843,7 @@
 					class Modules.Set_Constructor_Iterable/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a5a
+				// Method begins at RVA 0x2a4a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -859,7 +859,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2a69
+				// Method begins at RVA 0x2a59
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -871,7 +871,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2a6c
+				// Method begins at RVA 0x2a5c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -886,7 +886,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a6f
+				// Method begins at RVA 0x2a5f
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -913,7 +913,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2484
+			// Method begins at RVA 0x2474
 			// Header size: 12
 			// Code size: 230 (0xe6)
 			.maxstack 8
@@ -1035,7 +1035,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29d1
+				// Method begins at RVA 0x29c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1055,7 +1055,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aeb
+				// Method begins at RVA 0x2adb
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1068,7 +1068,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2af3
+				// Method begins at RVA 0x2ae3
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1080,7 +1080,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2af6
+				// Method begins at RVA 0x2ae6
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1095,7 +1095,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2af9
+				// Method begins at RVA 0x2ae9
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -1121,7 +1121,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2578
+			// Method begins at RVA 0x2568
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -1178,7 +1178,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x29ec
+						// Method begins at RVA 0x29dc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1196,7 +1196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29e3
+					// Method begins at RVA 0x29d3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1225,7 +1225,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x2b33
+					// Method begins at RVA 0x2b23
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -1247,7 +1247,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2b50
+					// Method begins at RVA 0x2b40
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1259,7 +1259,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2b53
+					// Method begins at RVA 0x2b43
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1274,7 +1274,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2b56
+					// Method begins at RVA 0x2b46
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -1299,7 +1299,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2890
+				// Method begins at RVA 0x2880
 				// Header size: 12
 				// Code size: 199 (0xc7)
 				.maxstack 8
@@ -1404,7 +1404,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29f5
+					// Method begins at RVA 0x29e5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1433,7 +1433,7 @@
 						object[] capture2
 					) cil managed 
 				{
-					// Method begins at RVA 0x2b68
+					// Method begins at RVA 0x2b58
 					// Header size: 1
 					// Code size: 28 (0x1c)
 					.maxstack 8
@@ -1455,7 +1455,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
 				{
-					// Method begins at RVA 0x2b85
+					// Method begins at RVA 0x2b75
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1467,7 +1467,7 @@
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
 				{
-					// Method begins at RVA 0x2b88
+					// Method begins at RVA 0x2b78
 					// Header size: 1
 					// Code size: 2 (0x2)
 					.maxstack 8
@@ -1482,7 +1482,7 @@
 						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 					) cil managed 
 				{
-					// Method begins at RVA 0x2b8b
+					// Method begins at RVA 0x2b7b
 					// Header size: 1
 					// Code size: 17 (0x11)
 					.maxstack 8
@@ -1507,7 +1507,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2963
+				// Method begins at RVA 0x2953
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -1545,7 +1545,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29da
+				// Method begins at RVA 0x29ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1570,7 +1570,7 @@
 					class Modules.Set_Constructor_Iterable/Scope capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b0c
+				// Method begins at RVA 0x2afc
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1586,7 +1586,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2b1b
+				// Method begins at RVA 0x2b0b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1598,7 +1598,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2b1e
+				// Method begins at RVA 0x2b0e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -1613,7 +1613,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b21
+				// Method begins at RVA 0x2b11
 				// Header size: 1
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -1640,7 +1640,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x25cc
+			// Method begins at RVA 0x25bc
 			// Header size: 12
 			// Code size: 230 (0xe6)
 			.maxstack 8
@@ -1772,7 +1772,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2989
+			// Method begins at RVA 0x2979
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1798,7 +1798,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 867 (0x363)
+		// Code size: 851 (0x353)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Constructor_Iterable/Scope,
@@ -1811,11 +1811,9 @@
 			[7] object,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[9] object[],
-			[10] class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22,
-			[11] object,
-			[12] class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22,
-			[13] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8,
-			[14] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9
+			[10] object,
+			[11] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8,
+			[12] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9
 		)
 
 		IL_0000: newobj instance void Modules.Set_Constructor_Iterable/Scope::.ctor()
@@ -1833,268 +1831,260 @@
 		IL_0022: ldloc.0
 		IL_0023: stelem.ref
 		IL_0024: stloc.s 9
-		IL_0026: ldloc.s 9
-		IL_0028: ldc.i4.0
-		IL_0029: ldelem.ref
-		IL_002a: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_002f: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22::.ctor(class Modules.Set_Constructor_Iterable/Scope)
-		IL_0034: ldc.i4.0
-		IL_0035: conv.r8
-		IL_0036: ldstr ""
-		IL_003b: ldc.i4.0
-		IL_003c: ldc.i4.1
-		IL_003d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22>(!!0, float64, string, bool, bool)
-		IL_0042: stloc.s 10
-		IL_0044: ldloc.s 10
+		IL_0026: ldloc.s 8
+		IL_0028: ldloc.s 7
+		IL_002a: ldloc.s 9
+		IL_002c: ldc.i4.0
+		IL_002d: ldelem.ref
+		IL_002e: castclass Modules.Set_Constructor_Iterable/Scope
+		IL_0033: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22::.ctor(class Modules.Set_Constructor_Iterable/Scope)
+		IL_0038: ldc.i4.0
+		IL_0039: conv.r8
+		IL_003a: ldstr ""
+		IL_003f: ldc.i4.0
+		IL_0040: ldc.i4.1
+		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22>(!!0, float64, string, bool, bool)
 		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22>(!!0)
-		IL_004b: stloc.s 10
-		IL_004d: ldloc.s 8
-		IL_004f: ldloc.s 7
-		IL_0051: ldloc.s 10
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_0058: pop
-		IL_0059: ldloc.s 8
-		IL_005b: stloc.1
-		IL_005c: ldloc.1
-		IL_005d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_0062: stloc.2
-		IL_0063: ldstr "console"
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0072: stloc.s 7
-		IL_0074: ldloc.2
-		IL_0075: ldstr "size"
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_007f: stloc.s 11
-		IL_0081: ldloc.s 7
-		IL_0083: ldstr "log"
-		IL_0088: ldloc.s 11
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008f: pop
-		IL_0090: ldstr "console"
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009f: stloc.s 11
-		IL_00a1: ldloc.2
-		IL_00a2: ldstr "has"
-		IL_00a7: ldc.r8 1
-		IL_00b0: box [System.Runtime]System.Double
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ba: stloc.s 7
-		IL_00bc: ldloc.s 11
-		IL_00be: ldstr "log"
-		IL_00c3: ldloc.s 7
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ca: pop
-		IL_00cb: ldstr "console"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00da: stloc.s 7
-		IL_00dc: ldloc.2
-		IL_00dd: ldstr "has"
-		IL_00e2: ldc.r8 3
-		IL_00eb: box [System.Runtime]System.Double
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f5: stloc.s 11
-		IL_00f7: ldloc.s 7
-		IL_00f9: ldstr "log"
-		IL_00fe: ldloc.s 11
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0105: pop
-		IL_0106: ldstr "console"
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0115: stloc.s 11
-		IL_0117: ldloc.2
-		IL_0118: ldstr "has"
-		IL_011d: ldc.r8 4
-		IL_0126: box [System.Runtime]System.Double
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0130: stloc.s 7
-		IL_0132: ldloc.s 11
-		IL_0134: ldstr "log"
-		IL_0139: ldloc.s 7
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0140: pop
-		IL_0141: ldloc.0
-		IL_0142: ldc.i4.0
-		IL_0143: box [System.Runtime]System.Boolean
-		IL_0148: stfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_014d: ldstr "iterator"
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0157: stloc.s 7
-		IL_0159: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_015e: stloc.s 8
-		IL_0160: ldc.i4.1
-		IL_0161: newarr [System.Runtime]System.Object
-		IL_0166: dup
-		IL_0167: ldc.i4.0
-		IL_0168: ldloc.0
-		IL_0169: stelem.ref
-		IL_016a: stloc.s 9
-		IL_016c: ldloc.s 9
-		IL_016e: ldc.i4.0
-		IL_016f: ldelem.ref
-		IL_0170: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_0175: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22::.ctor(class Modules.Set_Constructor_Iterable/Scope)
-		IL_017a: ldc.i4.0
-		IL_017b: conv.r8
-		IL_017c: ldstr ""
-		IL_0181: ldc.i4.0
-		IL_0182: ldc.i4.1
-		IL_0183: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22>(!!0, float64, string, bool, bool)
-		IL_0188: stloc.s 12
-		IL_018a: ldloc.s 12
-		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22>(!!0)
-		IL_0191: stloc.s 12
-		IL_0193: ldloc.s 8
-		IL_0195: ldloc.s 7
-		IL_0197: ldloc.s 12
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_019e: pop
-		IL_019f: ldloc.s 8
-		IL_01a1: stloc.3
-		IL_01a2: ldloc.3
-		IL_01a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_01a8: stloc.s 4
-		IL_01aa: ldstr "console"
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b9: stloc.s 7
-		IL_01bb: ldloc.0
-		IL_01bc: ldfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_01c1: stloc.s 11
-		IL_01c3: ldloc.s 7
-		IL_01c5: ldstr "log"
-		IL_01ca: ldloc.s 11
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d1: pop
-		IL_01d2: ldstr "console"
-		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e1: stloc.s 11
-		IL_01e3: ldloc.s 4
-		IL_01e5: ldstr "size"
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ef: stloc.s 7
-		IL_01f1: ldloc.s 11
-		IL_01f3: ldstr "log"
-		IL_01f8: ldloc.s 7
-		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ff: pop
-		IL_0200: ldloc.0
-		IL_0201: ldc.i4.0
-		IL_0202: box [System.Runtime]System.Boolean
-		IL_0207: stfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
-		IL_020c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0211: stloc.s 8
-		IL_0213: ldloc.s 8
-		IL_0215: ldstr "size"
-		IL_021a: ldc.r8 2
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
-		IL_0228: pop
-		IL_0229: ldc.i4.1
-		IL_022a: newarr [System.Runtime]System.Object
-		IL_022f: dup
-		IL_0230: ldc.i4.0
-		IL_0231: ldloc.0
-		IL_0232: stelem.ref
-		IL_0233: stloc.s 9
-		IL_0235: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8::.ctor()
-		IL_023a: ldc.i4.1
-		IL_023b: conv.r8
-		IL_023c: ldstr ""
-		IL_0241: ldc.i4.0
-		IL_0242: ldc.i4.1
-		IL_0243: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8>(!!0, float64, string, bool, bool)
-		IL_0248: stloc.s 13
-		IL_024a: ldloc.s 13
-		IL_024c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8>(!!0)
-		IL_0251: stloc.s 13
-		IL_0253: ldloc.s 8
-		IL_0255: ldstr "has"
-		IL_025a: ldloc.s 13
-		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0261: pop
-		IL_0262: ldc.i4.1
-		IL_0263: newarr [System.Runtime]System.Object
-		IL_0268: dup
-		IL_0269: ldc.i4.0
-		IL_026a: ldloc.0
-		IL_026b: stelem.ref
-		IL_026c: stloc.s 9
-		IL_026e: ldloc.s 9
-		IL_0270: ldc.i4.0
-		IL_0271: ldelem.ref
-		IL_0272: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_0277: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9::.ctor(class Modules.Set_Constructor_Iterable/Scope)
-		IL_027c: ldc.i4.0
-		IL_027d: conv.r8
-		IL_027e: ldstr ""
-		IL_0283: ldc.i4.0
-		IL_0284: ldc.i4.1
-		IL_0285: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9>(!!0, float64, string, bool, bool)
-		IL_028a: stloc.s 14
-		IL_028c: ldloc.s 14
-		IL_028e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9>(!!0)
-		IL_0293: stloc.s 14
-		IL_0295: ldloc.s 8
-		IL_0297: ldstr "keys"
-		IL_029c: ldloc.s 14
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_02a3: pop
-		IL_02a4: ldloc.s 8
-		IL_02a6: stloc.s 5
-		IL_02a8: ldloc.s 4
-		IL_02aa: ldstr "union"
-		IL_02af: ldloc.s 5
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b6: stloc.s 6
-		IL_02b8: ldstr "console"
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c7: stloc.s 7
-		IL_02c9: ldloc.0
-		IL_02ca: ldfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
-		IL_02cf: stloc.s 11
-		IL_02d1: ldloc.s 7
-		IL_02d3: ldstr "log"
-		IL_02d8: ldloc.s 11
-		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02df: pop
-		IL_02e0: ldstr "console"
-		IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ef: stloc.s 11
-		IL_02f1: ldloc.s 6
-		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f8: ldstr "has"
-		IL_02fd: ldc.r8 4
-		IL_0306: box [System.Runtime]System.Double
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0050: pop
+		IL_0051: ldloc.s 8
+		IL_0053: stloc.1
+		IL_0054: ldloc.1
+		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_005a: stloc.2
+		IL_005b: ldstr "console"
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006a: stloc.s 7
+		IL_006c: ldloc.2
+		IL_006d: ldstr "size"
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0077: stloc.s 10
+		IL_0079: ldloc.s 7
+		IL_007b: ldstr "log"
+		IL_0080: ldloc.s 10
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0087: pop
+		IL_0088: ldstr "console"
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0097: stloc.s 10
+		IL_0099: ldloc.2
+		IL_009a: ldstr "has"
+		IL_009f: ldc.r8 1
+		IL_00a8: box [System.Runtime]System.Double
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b2: stloc.s 7
+		IL_00b4: ldloc.s 10
+		IL_00b6: ldstr "log"
+		IL_00bb: ldloc.s 7
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c2: pop
+		IL_00c3: ldstr "console"
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d2: stloc.s 7
+		IL_00d4: ldloc.2
+		IL_00d5: ldstr "has"
+		IL_00da: ldc.r8 3
+		IL_00e3: box [System.Runtime]System.Double
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ed: stloc.s 10
+		IL_00ef: ldloc.s 7
+		IL_00f1: ldstr "log"
+		IL_00f6: ldloc.s 10
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fd: pop
+		IL_00fe: ldstr "console"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010d: stloc.s 10
+		IL_010f: ldloc.2
+		IL_0110: ldstr "has"
+		IL_0115: ldc.r8 4
+		IL_011e: box [System.Runtime]System.Double
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0128: stloc.s 7
+		IL_012a: ldloc.s 10
+		IL_012c: ldstr "log"
+		IL_0131: ldloc.s 7
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0138: pop
+		IL_0139: ldloc.0
+		IL_013a: ldc.i4.0
+		IL_013b: box [System.Runtime]System.Boolean
+		IL_0140: stfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_0145: ldstr "iterator"
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_014f: stloc.s 7
+		IL_0151: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0156: stloc.s 8
+		IL_0158: ldc.i4.1
+		IL_0159: newarr [System.Runtime]System.Object
+		IL_015e: dup
+		IL_015f: ldc.i4.0
+		IL_0160: ldloc.0
+		IL_0161: stelem.ref
+		IL_0162: stloc.s 9
+		IL_0164: ldloc.s 8
+		IL_0166: ldloc.s 7
+		IL_0168: ldloc.s 9
+		IL_016a: ldc.i4.0
+		IL_016b: ldelem.ref
+		IL_016c: castclass Modules.Set_Constructor_Iterable/Scope
+		IL_0171: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22::.ctor(class Modules.Set_Constructor_Iterable/Scope)
+		IL_0176: ldc.i4.0
+		IL_0177: conv.r8
+		IL_0178: ldstr ""
+		IL_017d: ldc.i4.0
+		IL_017e: ldc.i4.1
+		IL_017f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22>(!!0, float64, string, bool, bool)
+		IL_0184: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22>(!!0)
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_018e: pop
+		IL_018f: ldloc.s 8
+		IL_0191: stloc.3
+		IL_0192: ldloc.3
+		IL_0193: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_0198: stloc.s 4
+		IL_019a: ldstr "console"
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a9: stloc.s 7
+		IL_01ab: ldloc.0
+		IL_01ac: ldfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_01b1: stloc.s 10
+		IL_01b3: ldloc.s 7
+		IL_01b5: ldstr "log"
+		IL_01ba: ldloc.s 10
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c1: pop
+		IL_01c2: ldstr "console"
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d1: stloc.s 10
+		IL_01d3: ldloc.s 4
+		IL_01d5: ldstr "size"
+		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01df: stloc.s 7
+		IL_01e1: ldloc.s 10
+		IL_01e3: ldstr "log"
+		IL_01e8: ldloc.s 7
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ef: pop
+		IL_01f0: ldloc.0
+		IL_01f1: ldc.i4.0
+		IL_01f2: box [System.Runtime]System.Boolean
+		IL_01f7: stfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
+		IL_01fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0201: stloc.s 8
+		IL_0203: ldloc.s 8
+		IL_0205: ldstr "size"
+		IL_020a: ldc.r8 2
+		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
+		IL_0218: pop
+		IL_0219: ldc.i4.1
+		IL_021a: newarr [System.Runtime]System.Object
+		IL_021f: dup
+		IL_0220: ldc.i4.0
+		IL_0221: ldloc.0
+		IL_0222: stelem.ref
+		IL_0223: stloc.s 9
+		IL_0225: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8::.ctor()
+		IL_022a: ldc.i4.1
+		IL_022b: conv.r8
+		IL_022c: ldstr ""
+		IL_0231: ldc.i4.0
+		IL_0232: ldc.i4.1
+		IL_0233: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8>(!!0, float64, string, bool, bool)
+		IL_0238: stloc.s 11
+		IL_023a: ldloc.s 11
+		IL_023c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8>(!!0)
+		IL_0241: stloc.s 11
+		IL_0243: ldloc.s 8
+		IL_0245: ldstr "has"
+		IL_024a: ldloc.s 11
+		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0251: pop
+		IL_0252: ldc.i4.1
+		IL_0253: newarr [System.Runtime]System.Object
+		IL_0258: dup
+		IL_0259: ldc.i4.0
+		IL_025a: ldloc.0
+		IL_025b: stelem.ref
+		IL_025c: stloc.s 9
+		IL_025e: ldloc.s 9
+		IL_0260: ldc.i4.0
+		IL_0261: ldelem.ref
+		IL_0262: castclass Modules.Set_Constructor_Iterable/Scope
+		IL_0267: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9::.ctor(class Modules.Set_Constructor_Iterable/Scope)
+		IL_026c: ldc.i4.0
+		IL_026d: conv.r8
+		IL_026e: ldstr ""
+		IL_0273: ldc.i4.0
+		IL_0274: ldc.i4.1
+		IL_0275: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9>(!!0, float64, string, bool, bool)
+		IL_027a: stloc.s 12
+		IL_027c: ldloc.s 12
+		IL_027e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9>(!!0)
+		IL_0283: stloc.s 12
+		IL_0285: ldloc.s 8
+		IL_0287: ldstr "keys"
+		IL_028c: ldloc.s 12
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0293: pop
+		IL_0294: ldloc.s 8
+		IL_0296: stloc.s 5
+		IL_0298: ldloc.s 4
+		IL_029a: ldstr "union"
+		IL_029f: ldloc.s 5
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a6: stloc.s 6
+		IL_02a8: ldstr "console"
+		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b7: stloc.s 7
+		IL_02b9: ldloc.0
+		IL_02ba: ldfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
+		IL_02bf: stloc.s 10
+		IL_02c1: ldloc.s 7
+		IL_02c3: ldstr "log"
+		IL_02c8: ldloc.s 10
+		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02cf: pop
+		IL_02d0: ldstr "console"
+		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02df: stloc.s 10
+		IL_02e1: ldloc.s 6
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02e8: ldstr "has"
+		IL_02ed: ldc.r8 4
+		IL_02f6: box [System.Runtime]System.Double
+		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0300: stloc.s 7
+		IL_0302: ldloc.s 10
+		IL_0304: ldstr "log"
+		IL_0309: ldloc.s 7
 		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0310: stloc.s 7
-		IL_0312: ldloc.s 11
-		IL_0314: ldstr "log"
-		IL_0319: ldloc.s 7
-		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0320: pop
-		IL_0321: ldstr "console"
-		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0330: stloc.s 7
-		IL_0332: ldloc.s 6
-		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0339: ldstr "has"
-		IL_033e: ldc.r8 6
-		IL_0347: box [System.Runtime]System.Double
+		IL_0310: pop
+		IL_0311: ldstr "console"
+		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0320: stloc.s 7
+		IL_0322: ldloc.s 6
+		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0329: ldstr "has"
+		IL_032e: ldc.r8 6
+		IL_0337: box [System.Runtime]System.Double
+		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0341: stloc.s 10
+		IL_0343: ldloc.s 7
+		IL_0345: ldstr "log"
+		IL_034a: ldloc.s 10
 		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0351: stloc.s 11
-		IL_0353: ldloc.s 7
-		IL_0355: ldstr "log"
-		IL_035a: ldloc.s 11
-		IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0361: pop
-		IL_0362: ret
+		IL_0351: pop
+		IL_0352: ret
 	} // end of method Set_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Set_Constructor_Iterable
@@ -2106,7 +2096,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b9d
+		// Method begins at RVA 0x2b8d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.BeanCounter_Class_Index_Assign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.BeanCounter_Class_Index_Assign.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c3
+				// Method begins at RVA 0x21bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cc
+				// Method begins at RVA 0x21c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d5
+				// Method begins at RVA 0x21cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x21de
+				// Method begins at RVA 0x21d6
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x21ed
+				// Method begins at RVA 0x21e5
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x21f0
+				// Method begins at RVA 0x21e8
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -126,7 +126,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x21f3
+				// Method begins at RVA 0x21eb
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -142,7 +142,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x21ff
+				// Method begins at RVA 0x21f7
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x220b
+				// Method begins at RVA 0x2203
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -174,7 +174,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2213
+				// Method begins at RVA 0x220b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -186,7 +186,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2216
+				// Method begins at RVA 0x220e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -201,7 +201,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2219
+				// Method begins at RVA 0x2211
 				// Header size: 1
 				// Code size: 49 (0x31)
 				.maxstack 8
@@ -238,7 +238,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x217c
+			// Method begins at RVA 0x2174
 			// Header size: 12
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -265,7 +265,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a8
+			// Method begins at RVA 0x21a0
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -290,7 +290,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ba
+			// Method begins at RVA 0x21b2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -316,7 +316,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 288 (0x120)
+		// Code size: 280 (0x118)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BeanCounter_Class_Index_Assign/Scope,
@@ -325,9 +325,8 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount,
-			[7] class Modules.BeanCounter_Class_Index_Assign/BeanCounter,
-			[8] object
+			[6] class Modules.BeanCounter_Class_Index_Assign/BeanCounter,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.BeanCounter_Class_Index_Assign/Scope::.ctor()
@@ -344,77 +343,73 @@
 		IL_0027: stloc.s 4
 		IL_0029: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002e: stloc.s 5
-		IL_0030: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::.ctor()
-		IL_0035: ldc.i4.2
-		IL_0036: conv.r8
-		IL_0037: ldstr "setBeanCount"
-		IL_003c: ldc.i4.1
-		IL_003d: ldc.i4.1
-		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0, float64, string, bool, bool)
-		IL_0043: stloc.s 6
-		IL_0045: ldloc.s 6
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0)
-		IL_004c: stloc.s 6
-		IL_004e: ldloc.s 4
-		IL_0050: ldstr "setBeanCount"
-		IL_0055: ldloc.s 6
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005c: pop
-		IL_005d: ldc.i4.1
-		IL_005e: newarr [System.Runtime]System.Object
-		IL_0063: dup
-		IL_0064: ldc.i4.0
-		IL_0065: ldloc.0
-		IL_0066: stelem.ref
-		IL_0067: stloc.s 5
-		IL_0069: ldloc.3
-		IL_006a: ldloc.s 5
-		IL_006c: ldc.r8 0.0
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007f: stloc.s 4
-		IL_0081: ldloc.s 4
-		IL_0083: stloc.1
-		IL_0084: ldc.i4.0
-		IL_0085: newarr [System.Runtime]System.Object
-		IL_008a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_008f: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter::.ctor()
-		IL_0094: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0099: stloc.2
-		IL_009a: ldloc.2
-		IL_009b: ldtoken Modules.BeanCounter_Class_Index_Assign/BeanCounter
-		IL_00a0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00a5: ldstr "prototype"
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00af: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00b4: ldloc.2
-		IL_00b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.BeanCounter_Class_Index_Assign/BeanCounter>(!!0)
-		IL_00ba: stloc.s 7
-		IL_00bc: ldloc.s 7
-		IL_00be: ldc.r8 1
-		IL_00c7: box [System.Runtime]System.Double
-		IL_00cc: ldc.r8 42
-		IL_00d5: box [System.Runtime]System.Double
-		IL_00da: callvirt instance object Modules.BeanCounter_Class_Index_Assign/BeanCounter::setBeanCount(object, object)
-		IL_00df: pop
-		IL_00e0: ldstr "console"
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ef: stloc.s 4
-		IL_00f1: ldloc.2
-		IL_00f2: ldstr "beanCounts"
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fc: stloc.s 8
-		IL_00fe: ldloc.s 8
-		IL_0100: ldc.r8 1
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_010e: stloc.s 8
-		IL_0110: ldloc.s 4
-		IL_0112: ldstr "log"
-		IL_0117: ldloc.s 8
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011e: pop
-		IL_011f: ret
+		IL_0030: ldloc.s 4
+		IL_0032: ldstr "setBeanCount"
+		IL_0037: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::.ctor()
+		IL_003c: ldc.i4.2
+		IL_003d: conv.r8
+		IL_003e: ldstr "setBeanCount"
+		IL_0043: ldc.i4.1
+		IL_0044: ldc.i4.1
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0)
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0054: pop
+		IL_0055: ldc.i4.1
+		IL_0056: newarr [System.Runtime]System.Object
+		IL_005b: dup
+		IL_005c: ldc.i4.0
+		IL_005d: ldloc.0
+		IL_005e: stelem.ref
+		IL_005f: stloc.s 5
+		IL_0061: ldloc.3
+		IL_0062: ldloc.s 5
+		IL_0064: ldc.r8 0.0
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.s 4
+		IL_007b: stloc.1
+		IL_007c: ldc.i4.0
+		IL_007d: newarr [System.Runtime]System.Object
+		IL_0082: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0087: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter::.ctor()
+		IL_008c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0091: stloc.2
+		IL_0092: ldloc.2
+		IL_0093: ldtoken Modules.BeanCounter_Class_Index_Assign/BeanCounter
+		IL_0098: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_009d: ldstr "prototype"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00a7: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00ac: ldloc.2
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.BeanCounter_Class_Index_Assign/BeanCounter>(!!0)
+		IL_00b2: stloc.s 6
+		IL_00b4: ldloc.s 6
+		IL_00b6: ldc.r8 1
+		IL_00bf: box [System.Runtime]System.Double
+		IL_00c4: ldc.r8 42
+		IL_00cd: box [System.Runtime]System.Double
+		IL_00d2: callvirt instance object Modules.BeanCounter_Class_Index_Assign/BeanCounter::setBeanCount(object, object)
+		IL_00d7: pop
+		IL_00d8: ldstr "console"
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e7: stloc.s 4
+		IL_00e9: ldloc.2
+		IL_00ea: ldstr "beanCounts"
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f4: stloc.s 7
+		IL_00f6: ldloc.s 7
+		IL_00f8: ldc.r8 1
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0106: stloc.s 7
+		IL_0108: ldloc.s 4
+		IL_010a: ldstr "log"
+		IL_010f: ldloc.s 7
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0116: pop
+		IL_0117: ret
 	} // end of method BeanCounter_Class_Index_Assign::__js_module_init__
 
 } // end of class Modules.BeanCounter_Class_Index_Assign
@@ -426,7 +421,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x224b
+		// Method begins at RVA 0x2243
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a2a
+				// Method begins at RVA 0x2a12
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a33
+				// Method begins at RVA 0x2a1b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a45
+					// Method begins at RVA 0x2a2d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a3c
+				// Method begins at RVA 0x2a24
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a60
+						// Method begins at RVA 0x2a48
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -132,7 +132,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2a72
+							// Method begins at RVA 0x2a5a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -150,7 +150,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a69
+						// Method begins at RVA 0x2a51
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -168,7 +168,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a57
+					// Method begins at RVA 0x2a3f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -196,7 +196,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2a8d
+							// Method begins at RVA 0x2a75
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -214,7 +214,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a84
+						// Method begins at RVA 0x2a6c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -232,7 +232,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a7b
+					// Method begins at RVA 0x2a63
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a4e
+				// Method begins at RVA 0x2a36
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +274,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a9f
+					// Method begins at RVA 0x2a87
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -292,7 +292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a96
+				// Method begins at RVA 0x2a7e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -312,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa8
+				// Method begins at RVA 0x2a90
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -336,7 +336,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aba
+					// Method begins at RVA 0x2aa2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -354,7 +354,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab1
+				// Method begins at RVA 0x2a99
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -379,7 +379,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ae7
+				// Method begins at RVA 0x2acf
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -395,7 +395,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2af6
+				// Method begins at RVA 0x2ade
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -407,7 +407,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2af9
+				// Method begins at RVA 0x2ae1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -422,7 +422,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2afc
+				// Method begins at RVA 0x2ae4
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -438,7 +438,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b08
+				// Method begins at RVA 0x2af0
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -457,7 +457,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b14
+				// Method begins at RVA 0x2afc
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -470,7 +470,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2b1c
+				// Method begins at RVA 0x2b04
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -482,7 +482,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2b1f
+				// Method begins at RVA 0x2b07
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -497,7 +497,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b22
+				// Method begins at RVA 0x2b0a
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -533,7 +533,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b52
+				// Method begins at RVA 0x2b3a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -549,7 +549,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2b61
+				// Method begins at RVA 0x2b49
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -561,7 +561,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2b64
+				// Method begins at RVA 0x2b4c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -576,7 +576,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b67
+				// Method begins at RVA 0x2b4f
 				// Header size: 1
 				// Code size: 56 (0x38)
 				.maxstack 8
@@ -617,7 +617,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2ba0
+				// Method begins at RVA 0x2b88
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -633,7 +633,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2baf
+				// Method begins at RVA 0x2b97
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -645,7 +645,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2bb2
+				// Method begins at RVA 0x2b9a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -660,7 +660,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bb5
+				// Method begins at RVA 0x2b9d
 				// Header size: 1
 				// Code size: 56 (0x38)
 				.maxstack 8
@@ -704,7 +704,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26f0
+			// Method begins at RVA 0x26d8
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -752,7 +752,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2944
+			// Method begins at RVA 0x292c
 			// Header size: 12
 			// Code size: 165 (0xa5)
 			.maxstack 8
@@ -849,7 +849,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x273c
+			// Method begins at RVA 0x2724
 			// Header size: 12
 			// Code size: 391 (0x187)
 			.maxstack 8
@@ -1061,7 +1061,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28d0
+			// Method begins at RVA 0x28b8
 			// Header size: 12
 			// Code size: 102 (0x66)
 			.maxstack 8
@@ -1147,7 +1147,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ade
+				// Method begins at RVA 0x2ac6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1171,7 +1171,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29f5
+			// Method begins at RVA 0x29dd
 			// Header size: 1
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -1211,7 +1211,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ad5
+					// Method begins at RVA 0x2abd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1229,7 +1229,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2acc
+				// Method begins at RVA 0x2ab4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1247,7 +1247,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2ac3
+			// Method begins at RVA 0x2aab
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1273,7 +1273,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1682 (0x692)
+		// Code size: 1658 (0x67a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope,
@@ -1286,19 +1286,16 @@
 			[7] class [System.Runtime]System.Type,
 			[8] object,
 			[9] object[],
-			[10] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue,
-			[11] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue,
-			[12] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive,
+			[10] object,
+			[11] string,
+			[12] string,
 			[13] object,
-			[14] string,
-			[15] string,
-			[16] object,
-			[17] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray,
-			[18] float64,
-			[19] float64,
-			[20] bool,
-			[21] object,
-			[22] object
+			[14] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray,
+			[15] float64,
+			[16] float64,
+			[17] bool,
+			[18] object,
+			[19] object
 		)
 
 		IL_0000: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::.ctor()
@@ -1315,522 +1312,510 @@
 		IL_0029: stloc.s 8
 		IL_002b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0030: stloc.s 9
-		IL_0032: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::.ctor()
-		IL_0037: ldc.i4.1
-		IL_0038: conv.r8
-		IL_0039: ldstr "setBitTrue"
+		IL_0032: ldloc.s 8
+		IL_0034: ldstr "setBitTrue"
+		IL_0039: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::.ctor()
 		IL_003e: ldc.i4.1
-		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
-		IL_0045: stloc.s 10
-		IL_0047: ldloc.s 10
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0)
-		IL_004e: stloc.s 10
-		IL_0050: ldloc.s 8
-		IL_0052: ldstr "setBitTrue"
-		IL_0057: ldloc.s 10
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005e: pop
-		IL_005f: ldc.i4.1
-		IL_0060: newarr [System.Runtime]System.Object
-		IL_0065: dup
-		IL_0066: ldc.i4.0
-		IL_0067: ldloc.0
-		IL_0068: stelem.ref
-		IL_0069: stloc.s 9
-		IL_006b: ldloc.s 9
-		IL_006d: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::.ctor(object[])
-		IL_0072: ldc.i4.3
-		IL_0073: conv.r8
-		IL_0074: ldstr "setBitsTrue"
+		IL_003f: conv.r8
+		IL_0040: ldstr "setBitTrue"
+		IL_0045: ldc.i4.1
+		IL_0046: ldc.i4.1
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0)
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0056: pop
+		IL_0057: ldc.i4.1
+		IL_0058: newarr [System.Runtime]System.Object
+		IL_005d: dup
+		IL_005e: ldc.i4.0
+		IL_005f: ldloc.0
+		IL_0060: stelem.ref
+		IL_0061: stloc.s 9
+		IL_0063: ldloc.s 8
+		IL_0065: ldstr "setBitsTrue"
+		IL_006a: ldloc.s 9
+		IL_006c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::.ctor(object[])
+		IL_0071: ldc.i4.3
+		IL_0072: conv.r8
+		IL_0073: ldstr "setBitsTrue"
+		IL_0078: ldc.i4.1
 		IL_0079: ldc.i4.1
-		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_0080: stloc.s 11
-		IL_0082: ldloc.s 11
-		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0)
-		IL_0089: stloc.s 11
-		IL_008b: ldloc.s 8
-		IL_008d: ldstr "setBitsTrue"
-		IL_0092: ldloc.s 11
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0099: pop
-		IL_009a: ldc.i4.1
-		IL_009b: newarr [System.Runtime]System.Object
-		IL_00a0: dup
-		IL_00a1: ldc.i4.0
-		IL_00a2: ldloc.0
-		IL_00a3: stelem.ref
-		IL_00a4: stloc.s 9
-		IL_00a6: ldloc.s 9
-		IL_00a8: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::.ctor(object[])
-		IL_00ad: ldc.i4.3
-		IL_00ae: conv.r8
-		IL_00af: ldstr "setBitsTrue_Naive"
-		IL_00b4: ldc.i4.1
-		IL_00b5: ldc.i4.1
-		IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0, float64, string, bool, bool)
-		IL_00bb: stloc.s 12
-		IL_00bd: ldloc.s 12
-		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0)
-		IL_00c4: stloc.s 12
-		IL_00c6: ldloc.s 8
-		IL_00c8: ldstr "setBitsTrue_Naive"
-		IL_00cd: ldloc.s 12
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00d4: pop
-		IL_00d5: ldc.i4.1
-		IL_00d6: newarr [System.Runtime]System.Object
-		IL_00db: dup
-		IL_00dc: ldc.i4.0
-		IL_00dd: ldloc.0
-		IL_00de: stelem.ref
-		IL_00df: stloc.s 9
-		IL_00e1: ldloc.s 7
-		IL_00e3: ldloc.s 9
-		IL_00e5: ldc.r8 1
-		IL_00ee: box [System.Runtime]System.Double
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00f8: stloc.s 8
-		IL_00fa: ldloc.s 8
-		IL_00fc: stloc.1
-		IL_00fd: ldloc.0
-		IL_00fe: ldc.r8 2048
-		IL_0107: box [System.Runtime]System.Double
-		IL_010c: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_0111: ldloc.0
-		IL_0112: ldc.r8 1
-		IL_011b: box [System.Runtime]System.Double
-		IL_0120: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_0125: ldloc.0
-		IL_0126: ldc.r8 17
-		IL_012f: box [System.Runtime]System.Double
-		IL_0134: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_0139: ldloc.0
-		IL_013a: ldc.r8 600
-		IL_0143: box [System.Runtime]System.Double
-		IL_0148: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_014d: ldc.i4.1
-		IL_014e: newarr [System.Runtime]System.Object
-		IL_0153: dup
-		IL_0154: ldc.i4.0
-		IL_0155: ldloc.0
-		IL_0156: stelem.ref
-		IL_0157: stloc.s 9
-		IL_0159: ldloc.0
-		IL_015a: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_015f: ldstr "Cannot access 'size' before initialization"
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0169: stloc.s 8
-		IL_016b: ldloc.s 9
-		IL_016d: ldc.i4.1
-		IL_016e: newarr [System.Runtime]System.Object
-		IL_0173: dup
-		IL_0174: ldc.i4.0
-		IL_0175: ldloc.s 8
-		IL_0177: stelem.ref
-		IL_0178: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_017d: ldloc.s 8
-		IL_017f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0184: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
-		IL_0189: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_018e: stloc.2
-		IL_018f: ldloc.2
-		IL_0190: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0195: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_019a: ldstr "prototype"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_01a4: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_01a9: ldc.i4.1
-		IL_01aa: newarr [System.Runtime]System.Object
-		IL_01af: dup
-		IL_01b0: ldc.i4.0
-		IL_01b1: ldloc.0
-		IL_01b2: stelem.ref
-		IL_01b3: stloc.s 9
-		IL_01b5: ldloc.0
-		IL_01b6: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_01bb: ldstr "Cannot access 'size' before initialization"
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01c5: stloc.s 8
-		IL_01c7: ldloc.s 9
-		IL_01c9: ldc.i4.1
-		IL_01ca: newarr [System.Runtime]System.Object
-		IL_01cf: dup
-		IL_01d0: ldc.i4.0
-		IL_01d1: ldloc.s 8
-		IL_01d3: stelem.ref
-		IL_01d4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_01d9: ldloc.s 8
-		IL_01db: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_01e0: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
-		IL_01e5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_01ea: stloc.3
-		IL_01eb: ldloc.3
-		IL_01ec: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_01f1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01f6: ldstr "prototype"
-		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0200: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0205: ldstr "console"
-		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0214: stloc.s 8
-		IL_0216: ldloc.2
-		IL_0217: ldstr "wordArray"
-		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0221: stloc.s 13
-		IL_0223: ldloc.s 13
-		IL_0225: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_022a: stloc.s 14
-		IL_022c: ldloc.3
-		IL_022d: ldstr "wordArray"
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0237: stloc.s 13
-		IL_0239: ldloc.s 13
-		IL_023b: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0240: stloc.s 15
-		IL_0242: ldloc.s 8
-		IL_0244: ldstr "log"
-		IL_0249: ldstr "types"
-		IL_024e: ldloc.s 14
-		IL_0250: ldloc.s 15
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0257: pop
-		IL_0258: ldstr "console"
-		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0267: stloc.s 8
-		IL_0269: ldloc.2
-		IL_026a: ldstr "wordArray"
-		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0274: stloc.s 13
-		IL_0276: ldloc.s 13
-		IL_0278: ldstr "length"
-		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0282: stloc.s 13
-		IL_0284: ldloc.3
-		IL_0285: ldstr "wordArray"
-		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_028f: stloc.s 16
-		IL_0291: ldloc.s 16
-		IL_0293: ldstr "length"
-		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_029d: stloc.s 16
-		IL_029f: ldloc.s 8
-		IL_02a1: ldstr "log"
-		IL_02a6: ldstr "lens"
-		IL_02ab: ldloc.s 13
-		IL_02ad: ldloc.s 16
-		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_02b4: pop
-		IL_02b5: ldloc.2
-		IL_02b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
-		IL_02bb: stloc.s 17
-		IL_02bd: ldloc.0
-		IL_02be: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_02c3: ldstr "Cannot access 'range_start' before initialization"
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02cd: stloc.s 16
-		IL_02cf: ldloc.0
-		IL_02d0: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_02d5: ldstr "Cannot access 'step' before initialization"
-		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02df: stloc.s 13
-		IL_02e1: ldloc.0
-		IL_02e2: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_02e7: ldstr "Cannot access 'range_stop' before initialization"
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02f1: stloc.s 8
-		IL_02f3: ldloc.s 17
-		IL_02f5: ldloc.s 16
-		IL_02f7: ldloc.s 13
-		IL_02f9: ldloc.s 8
-		IL_02fb: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
-		IL_0300: pop
-		IL_0301: ldloc.3
-		IL_0302: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
-		IL_0307: stloc.s 17
-		IL_0309: ldloc.0
-		IL_030a: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_030f: ldstr "Cannot access 'range_start' before initialization"
-		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0319: stloc.s 8
-		IL_031b: ldloc.0
-		IL_031c: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_0321: ldstr "Cannot access 'step' before initialization"
-		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_032b: stloc.s 13
-		IL_032d: ldloc.0
-		IL_032e: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_0333: ldstr "Cannot access 'range_stop' before initialization"
-		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_033d: stloc.s 16
-		IL_033f: ldloc.s 17
-		IL_0341: ldloc.s 8
-		IL_0343: ldloc.s 13
-		IL_0345: ldloc.s 16
-		IL_0347: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
-		IL_034c: pop
-		IL_034d: ldc.r8 0.0
-		IL_0356: stloc.s 4
-		IL_0358: ldc.r8 1
-		IL_0361: neg
-		IL_0362: stloc.s 18
-		IL_0364: ldloc.s 18
-		IL_0366: box [System.Runtime]System.Double
-		IL_036b: stloc.s 5
-		IL_036d: ldc.r8 0.0
-		IL_0376: stloc.s 6
-		// loop start (head: IL_0378)
-			IL_0378: ldloc.s 6
-			IL_037a: stloc.s 18
-			IL_037c: ldloc.2
-			IL_037d: ldstr "wordArray"
-			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0387: stloc.s 16
-			IL_0389: ldloc.s 16
-			IL_038b: ldstr "length"
-			IL_0390: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_0395: stloc.s 19
-			IL_0397: ldloc.s 18
-			IL_0399: ldloc.s 19
-			IL_039b: clt
-			IL_039d: brfalse IL_043d
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0)
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0089: pop
+		IL_008a: ldc.i4.1
+		IL_008b: newarr [System.Runtime]System.Object
+		IL_0090: dup
+		IL_0091: ldc.i4.0
+		IL_0092: ldloc.0
+		IL_0093: stelem.ref
+		IL_0094: stloc.s 9
+		IL_0096: ldloc.s 8
+		IL_0098: ldstr "setBitsTrue_Naive"
+		IL_009d: ldloc.s 9
+		IL_009f: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::.ctor(object[])
+		IL_00a4: ldc.i4.3
+		IL_00a5: conv.r8
+		IL_00a6: ldstr "setBitsTrue_Naive"
+		IL_00ab: ldc.i4.1
+		IL_00ac: ldc.i4.1
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0, float64, string, bool, bool)
+		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0)
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00bc: pop
+		IL_00bd: ldc.i4.1
+		IL_00be: newarr [System.Runtime]System.Object
+		IL_00c3: dup
+		IL_00c4: ldc.i4.0
+		IL_00c5: ldloc.0
+		IL_00c6: stelem.ref
+		IL_00c7: stloc.s 9
+		IL_00c9: ldloc.s 7
+		IL_00cb: ldloc.s 9
+		IL_00cd: ldc.r8 1
+		IL_00d6: box [System.Runtime]System.Double
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00e0: stloc.s 8
+		IL_00e2: ldloc.s 8
+		IL_00e4: stloc.1
+		IL_00e5: ldloc.0
+		IL_00e6: ldc.r8 2048
+		IL_00ef: box [System.Runtime]System.Double
+		IL_00f4: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_00f9: ldloc.0
+		IL_00fa: ldc.r8 1
+		IL_0103: box [System.Runtime]System.Double
+		IL_0108: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_010d: ldloc.0
+		IL_010e: ldc.r8 17
+		IL_0117: box [System.Runtime]System.Double
+		IL_011c: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_0121: ldloc.0
+		IL_0122: ldc.r8 600
+		IL_012b: box [System.Runtime]System.Double
+		IL_0130: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_0135: ldc.i4.1
+		IL_0136: newarr [System.Runtime]System.Object
+		IL_013b: dup
+		IL_013c: ldc.i4.0
+		IL_013d: ldloc.0
+		IL_013e: stelem.ref
+		IL_013f: stloc.s 9
+		IL_0141: ldloc.0
+		IL_0142: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_0147: ldstr "Cannot access 'size' before initialization"
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0151: stloc.s 8
+		IL_0153: ldloc.s 9
+		IL_0155: ldc.i4.1
+		IL_0156: newarr [System.Runtime]System.Object
+		IL_015b: dup
+		IL_015c: ldc.i4.0
+		IL_015d: ldloc.s 8
+		IL_015f: stelem.ref
+		IL_0160: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0165: ldloc.s 8
+		IL_0167: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_016c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
+		IL_0171: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0176: stloc.2
+		IL_0177: ldloc.2
+		IL_0178: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_017d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0182: ldstr "prototype"
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_018c: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0191: ldc.i4.1
+		IL_0192: newarr [System.Runtime]System.Object
+		IL_0197: dup
+		IL_0198: ldc.i4.0
+		IL_0199: ldloc.0
+		IL_019a: stelem.ref
+		IL_019b: stloc.s 9
+		IL_019d: ldloc.0
+		IL_019e: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_01a3: ldstr "Cannot access 'size' before initialization"
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_01ad: stloc.s 8
+		IL_01af: ldloc.s 9
+		IL_01b1: ldc.i4.1
+		IL_01b2: newarr [System.Runtime]System.Object
+		IL_01b7: dup
+		IL_01b8: ldc.i4.0
+		IL_01b9: ldloc.s 8
+		IL_01bb: stelem.ref
+		IL_01bc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_01c1: ldloc.s 8
+		IL_01c3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_01c8: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
+		IL_01cd: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_01d2: stloc.3
+		IL_01d3: ldloc.3
+		IL_01d4: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_01d9: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_01de: ldstr "prototype"
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_01e8: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_01ed: ldstr "console"
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01fc: stloc.s 8
+		IL_01fe: ldloc.2
+		IL_01ff: ldstr "wordArray"
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0209: stloc.s 10
+		IL_020b: ldloc.s 10
+		IL_020d: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0212: stloc.s 11
+		IL_0214: ldloc.3
+		IL_0215: ldstr "wordArray"
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_021f: stloc.s 10
+		IL_0221: ldloc.s 10
+		IL_0223: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0228: stloc.s 12
+		IL_022a: ldloc.s 8
+		IL_022c: ldstr "log"
+		IL_0231: ldstr "types"
+		IL_0236: ldloc.s 11
+		IL_0238: ldloc.s 12
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_023f: pop
+		IL_0240: ldstr "console"
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024f: stloc.s 8
+		IL_0251: ldloc.2
+		IL_0252: ldstr "wordArray"
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_025c: stloc.s 10
+		IL_025e: ldloc.s 10
+		IL_0260: ldstr "length"
+		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_026a: stloc.s 10
+		IL_026c: ldloc.3
+		IL_026d: ldstr "wordArray"
+		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0277: stloc.s 13
+		IL_0279: ldloc.s 13
+		IL_027b: ldstr "length"
+		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0285: stloc.s 13
+		IL_0287: ldloc.s 8
+		IL_0289: ldstr "log"
+		IL_028e: ldstr "lens"
+		IL_0293: ldloc.s 10
+		IL_0295: ldloc.s 13
+		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_029c: pop
+		IL_029d: ldloc.2
+		IL_029e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
+		IL_02a3: stloc.s 14
+		IL_02a5: ldloc.0
+		IL_02a6: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_02ab: ldstr "Cannot access 'range_start' before initialization"
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_02b5: stloc.s 13
+		IL_02b7: ldloc.0
+		IL_02b8: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_02bd: ldstr "Cannot access 'step' before initialization"
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_02c7: stloc.s 10
+		IL_02c9: ldloc.0
+		IL_02ca: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_02cf: ldstr "Cannot access 'range_stop' before initialization"
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_02d9: stloc.s 8
+		IL_02db: ldloc.s 14
+		IL_02dd: ldloc.s 13
+		IL_02df: ldloc.s 10
+		IL_02e1: ldloc.s 8
+		IL_02e3: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
+		IL_02e8: pop
+		IL_02e9: ldloc.3
+		IL_02ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
+		IL_02ef: stloc.s 14
+		IL_02f1: ldloc.0
+		IL_02f2: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_02f7: ldstr "Cannot access 'range_start' before initialization"
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0301: stloc.s 8
+		IL_0303: ldloc.0
+		IL_0304: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_0309: ldstr "Cannot access 'step' before initialization"
+		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0313: stloc.s 10
+		IL_0315: ldloc.0
+		IL_0316: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_031b: ldstr "Cannot access 'range_stop' before initialization"
+		IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0325: stloc.s 13
+		IL_0327: ldloc.s 14
+		IL_0329: ldloc.s 8
+		IL_032b: ldloc.s 10
+		IL_032d: ldloc.s 13
+		IL_032f: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
+		IL_0334: pop
+		IL_0335: ldc.r8 0.0
+		IL_033e: stloc.s 4
+		IL_0340: ldc.r8 1
+		IL_0349: neg
+		IL_034a: stloc.s 15
+		IL_034c: ldloc.s 15
+		IL_034e: box [System.Runtime]System.Double
+		IL_0353: stloc.s 5
+		IL_0355: ldc.r8 0.0
+		IL_035e: stloc.s 6
+		// loop start (head: IL_0360)
+			IL_0360: ldloc.s 6
+			IL_0362: stloc.s 15
+			IL_0364: ldloc.2
+			IL_0365: ldstr "wordArray"
+			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_036f: stloc.s 13
+			IL_0371: ldloc.s 13
+			IL_0373: ldstr "length"
+			IL_0378: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_037d: stloc.s 16
+			IL_037f: ldloc.s 15
+			IL_0381: ldloc.s 16
+			IL_0383: clt
+			IL_0385: brfalse IL_0425
 
-			IL_03a2: ldloc.2
+			IL_038a: ldloc.2
+			IL_038b: ldstr "wordArray"
+			IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0395: stloc.s 13
+			IL_0397: ldloc.s 13
+			IL_0399: ldloc.s 6
+			IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_03a0: stloc.s 13
+			IL_03a2: ldloc.3
 			IL_03a3: ldstr "wordArray"
 			IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ad: stloc.s 16
-			IL_03af: ldloc.s 16
+			IL_03ad: stloc.s 10
+			IL_03af: ldloc.s 10
 			IL_03b1: ldloc.s 6
 			IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03b8: stloc.s 16
-			IL_03ba: ldloc.3
-			IL_03bb: ldstr "wordArray"
-			IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03c5: stloc.s 13
-			IL_03c7: ldloc.s 13
-			IL_03c9: ldloc.s 6
-			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03d0: stloc.s 13
-			IL_03d2: ldloc.s 16
-			IL_03d4: ldloc.s 13
-			IL_03d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_03db: stloc.s 20
-			IL_03dd: ldloc.s 20
-			IL_03df: brfalse IL_042a
+			IL_03b8: stloc.s 10
+			IL_03ba: ldloc.s 13
+			IL_03bc: ldloc.s 10
+			IL_03be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_03c3: stloc.s 17
+			IL_03c5: ldloc.s 17
+			IL_03c7: brfalse IL_0412
 
-			IL_03e4: ldloc.s 4
-			IL_03e6: ldc.r8 1
-			IL_03ef: add
-			IL_03f0: stloc.s 4
-			IL_03f2: ldloc.s 5
-			IL_03f4: stloc.s 21
-			IL_03f6: ldc.r8 1
-			IL_03ff: neg
-			IL_0400: stloc.s 19
-			IL_0402: ldloc.s 19
-			IL_0404: box [System.Runtime]System.Double
-			IL_0409: stloc.s 22
-			IL_040b: ldloc.s 21
-			IL_040d: ldloc.s 22
-			IL_040f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0414: stloc.s 20
-			IL_0416: ldloc.s 20
-			IL_0418: brfalse IL_042a
+			IL_03cc: ldloc.s 4
+			IL_03ce: ldc.r8 1
+			IL_03d7: add
+			IL_03d8: stloc.s 4
+			IL_03da: ldloc.s 5
+			IL_03dc: stloc.s 18
+			IL_03de: ldc.r8 1
+			IL_03e7: neg
+			IL_03e8: stloc.s 16
+			IL_03ea: ldloc.s 16
+			IL_03ec: box [System.Runtime]System.Double
+			IL_03f1: stloc.s 19
+			IL_03f3: ldloc.s 18
+			IL_03f5: ldloc.s 19
+			IL_03f7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_03fc: stloc.s 17
+			IL_03fe: ldloc.s 17
+			IL_0400: brfalse IL_0412
 
-			IL_041d: ldloc.s 6
-			IL_041f: box [System.Runtime]System.Double
-			IL_0424: stloc.s 22
-			IL_0426: ldloc.s 22
-			IL_0428: stloc.s 5
+			IL_0405: ldloc.s 6
+			IL_0407: box [System.Runtime]System.Double
+			IL_040c: stloc.s 19
+			IL_040e: ldloc.s 19
+			IL_0410: stloc.s 5
 
-			IL_042a: ldloc.s 6
-			IL_042c: ldc.r8 1
-			IL_0435: add
-			IL_0436: stloc.s 6
-			IL_0438: br IL_0378
+			IL_0412: ldloc.s 6
+			IL_0414: ldc.r8 1
+			IL_041d: add
+			IL_041e: stloc.s 6
+			IL_0420: br IL_0360
 		// end loop
 
-		IL_043d: ldstr "console"
-		IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_044c: ldloc.s 4
-		IL_044e: box [System.Runtime]System.Double
-		IL_0453: stloc.s 22
-		IL_0455: ldstr "log"
-		IL_045a: ldstr "diffs"
-		IL_045f: ldloc.s 22
-		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0466: pop
-		IL_0467: ldloc.s 5
-		IL_0469: stloc.s 22
-		IL_046b: ldc.r8 1
-		IL_0474: neg
-		IL_0475: stloc.s 19
-		IL_0477: ldloc.s 19
-		IL_0479: box [System.Runtime]System.Double
-		IL_047e: stloc.s 21
-		IL_0480: ldloc.s 22
-		IL_0482: ldloc.s 21
-		IL_0484: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0489: stloc.s 20
-		IL_048b: ldloc.s 20
-		IL_048d: brfalse IL_04fd
+		IL_0425: ldstr "console"
+		IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0434: ldloc.s 4
+		IL_0436: box [System.Runtime]System.Double
+		IL_043b: stloc.s 19
+		IL_043d: ldstr "log"
+		IL_0442: ldstr "diffs"
+		IL_0447: ldloc.s 19
+		IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_044e: pop
+		IL_044f: ldloc.s 5
+		IL_0451: stloc.s 19
+		IL_0453: ldc.r8 1
+		IL_045c: neg
+		IL_045d: stloc.s 16
+		IL_045f: ldloc.s 16
+		IL_0461: box [System.Runtime]System.Double
+		IL_0466: stloc.s 18
+		IL_0468: ldloc.s 19
+		IL_046a: ldloc.s 18
+		IL_046c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0471: stloc.s 17
+		IL_0473: ldloc.s 17
+		IL_0475: brfalse IL_04e5
 
-		IL_0492: ldstr "console"
-		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_047a: ldstr "console"
+		IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0489: stloc.s 10
+		IL_048b: ldloc.2
+		IL_048c: ldstr "wordArray"
+		IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0496: stloc.s 13
+		IL_0498: ldloc.s 13
+		IL_049a: ldloc.s 5
+		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
 		IL_04a1: stloc.s 13
-		IL_04a3: ldloc.2
+		IL_04a3: ldloc.3
 		IL_04a4: ldstr "wordArray"
 		IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04ae: stloc.s 16
-		IL_04b0: ldloc.s 16
+		IL_04ae: stloc.s 8
+		IL_04b0: ldloc.s 8
 		IL_04b2: ldloc.s 5
 		IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_04b9: stloc.s 16
-		IL_04bb: ldloc.3
-		IL_04bc: ldstr "wordArray"
-		IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04c6: stloc.s 8
-		IL_04c8: ldloc.s 8
-		IL_04ca: ldloc.s 5
-		IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_04d1: stloc.s 8
-		IL_04d3: ldloc.s 13
-		IL_04d5: ldstr "log"
-		IL_04da: ldc.i4.4
-		IL_04db: newarr [System.Runtime]System.Object
-		IL_04e0: dup
-		IL_04e1: ldc.i4.0
-		IL_04e2: ldstr "first"
-		IL_04e7: stelem.ref
-		IL_04e8: dup
-		IL_04e9: ldc.i4.1
-		IL_04ea: ldloc.s 5
-		IL_04ec: stelem.ref
-		IL_04ed: dup
-		IL_04ee: ldc.i4.2
-		IL_04ef: ldloc.s 16
-		IL_04f1: stelem.ref
-		IL_04f2: dup
-		IL_04f3: ldc.i4.3
-		IL_04f4: ldloc.s 8
-		IL_04f6: stelem.ref
-		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_04fc: pop
+		IL_04b9: stloc.s 8
+		IL_04bb: ldloc.s 10
+		IL_04bd: ldstr "log"
+		IL_04c2: ldc.i4.4
+		IL_04c3: newarr [System.Runtime]System.Object
+		IL_04c8: dup
+		IL_04c9: ldc.i4.0
+		IL_04ca: ldstr "first"
+		IL_04cf: stelem.ref
+		IL_04d0: dup
+		IL_04d1: ldc.i4.1
+		IL_04d2: ldloc.s 5
+		IL_04d4: stelem.ref
+		IL_04d5: dup
+		IL_04d6: ldc.i4.2
+		IL_04d7: ldloc.s 13
+		IL_04d9: stelem.ref
+		IL_04da: dup
+		IL_04db: ldc.i4.3
+		IL_04dc: ldloc.s 8
+		IL_04de: stelem.ref
+		IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_04e4: pop
 
-		IL_04fd: ldstr "console"
-		IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_050c: stloc.s 13
-		IL_050e: ldloc.2
-		IL_050f: ldstr "wordArray"
-		IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0519: stloc.s 8
-		IL_051b: ldloc.s 8
-		IL_051d: ldc.r8 0.0
-		IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_052b: stloc.s 8
-		IL_052d: ldloc.3
-		IL_052e: ldstr "wordArray"
-		IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0538: stloc.s 16
-		IL_053a: ldloc.s 16
-		IL_053c: ldc.r8 0.0
-		IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_054a: stloc.s 16
-		IL_054c: ldloc.s 13
-		IL_054e: ldstr "log"
-		IL_0553: ldstr "w0"
-		IL_0558: ldloc.s 8
-		IL_055a: ldloc.s 16
-		IL_055c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0561: pop
-		IL_0562: ldstr "console"
-		IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0571: stloc.s 16
-		IL_0573: ldloc.2
-		IL_0574: ldstr "wordArray"
-		IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_057e: stloc.s 8
-		IL_0580: ldloc.s 8
-		IL_0582: ldc.r8 1
-		IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0590: stloc.s 8
-		IL_0592: ldloc.3
-		IL_0593: ldstr "wordArray"
-		IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_059d: stloc.s 13
-		IL_059f: ldloc.s 13
-		IL_05a1: ldc.r8 1
-		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05af: stloc.s 13
-		IL_05b1: ldloc.s 16
-		IL_05b3: ldstr "log"
-		IL_05b8: ldstr "w1"
-		IL_05bd: ldloc.s 8
-		IL_05bf: ldloc.s 13
-		IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_05c6: pop
-		IL_05c7: ldstr "console"
-		IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05d6: stloc.s 13
-		IL_05d8: ldloc.2
-		IL_05d9: ldstr "wordArray"
-		IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05e3: stloc.s 8
-		IL_05e5: ldloc.s 8
-		IL_05e7: ldc.r8 2
-		IL_05f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05f5: stloc.s 8
-		IL_05f7: ldloc.3
-		IL_05f8: ldstr "wordArray"
-		IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0602: stloc.s 16
-		IL_0604: ldloc.s 16
-		IL_0606: ldc.r8 2
-		IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0614: stloc.s 16
-		IL_0616: ldloc.s 13
-		IL_0618: ldstr "log"
-		IL_061d: ldstr "w2"
-		IL_0622: ldloc.s 8
-		IL_0624: ldloc.s 16
-		IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_062b: pop
-		IL_062c: ldstr "console"
-		IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0636: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_063b: stloc.s 16
-		IL_063d: ldloc.2
-		IL_063e: ldstr "wordArray"
-		IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0648: stloc.s 8
-		IL_064a: ldloc.s 8
-		IL_064c: ldc.r8 3
-		IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_065a: stloc.s 8
-		IL_065c: ldloc.3
-		IL_065d: ldstr "wordArray"
-		IL_0662: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0667: stloc.s 13
-		IL_0669: ldloc.s 13
-		IL_066b: ldc.r8 3
-		IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0679: stloc.s 13
-		IL_067b: ldloc.s 16
-		IL_067d: ldstr "log"
-		IL_0682: ldstr "w3"
-		IL_0687: ldloc.s 8
-		IL_0689: ldloc.s 13
-		IL_068b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0690: pop
-		IL_0691: ret
+		IL_04e5: ldstr "console"
+		IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04f4: stloc.s 10
+		IL_04f6: ldloc.2
+		IL_04f7: ldstr "wordArray"
+		IL_04fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0501: stloc.s 8
+		IL_0503: ldloc.s 8
+		IL_0505: ldc.r8 0.0
+		IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0513: stloc.s 8
+		IL_0515: ldloc.3
+		IL_0516: ldstr "wordArray"
+		IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0520: stloc.s 13
+		IL_0522: ldloc.s 13
+		IL_0524: ldc.r8 0.0
+		IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0532: stloc.s 13
+		IL_0534: ldloc.s 10
+		IL_0536: ldstr "log"
+		IL_053b: ldstr "w0"
+		IL_0540: ldloc.s 8
+		IL_0542: ldloc.s 13
+		IL_0544: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0549: pop
+		IL_054a: ldstr "console"
+		IL_054f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0559: stloc.s 13
+		IL_055b: ldloc.2
+		IL_055c: ldstr "wordArray"
+		IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0566: stloc.s 8
+		IL_0568: ldloc.s 8
+		IL_056a: ldc.r8 1
+		IL_0573: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0578: stloc.s 8
+		IL_057a: ldloc.3
+		IL_057b: ldstr "wordArray"
+		IL_0580: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0585: stloc.s 10
+		IL_0587: ldloc.s 10
+		IL_0589: ldc.r8 1
+		IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0597: stloc.s 10
+		IL_0599: ldloc.s 13
+		IL_059b: ldstr "log"
+		IL_05a0: ldstr "w1"
+		IL_05a5: ldloc.s 8
+		IL_05a7: ldloc.s 10
+		IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_05ae: pop
+		IL_05af: ldstr "console"
+		IL_05b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05be: stloc.s 10
+		IL_05c0: ldloc.2
+		IL_05c1: ldstr "wordArray"
+		IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05cb: stloc.s 8
+		IL_05cd: ldloc.s 8
+		IL_05cf: ldc.r8 2
+		IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05dd: stloc.s 8
+		IL_05df: ldloc.3
+		IL_05e0: ldstr "wordArray"
+		IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ea: stloc.s 13
+		IL_05ec: ldloc.s 13
+		IL_05ee: ldc.r8 2
+		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05fc: stloc.s 13
+		IL_05fe: ldloc.s 10
+		IL_0600: ldstr "log"
+		IL_0605: ldstr "w2"
+		IL_060a: ldloc.s 8
+		IL_060c: ldloc.s 13
+		IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0613: pop
+		IL_0614: ldstr "console"
+		IL_0619: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_061e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0623: stloc.s 13
+		IL_0625: ldloc.2
+		IL_0626: ldstr "wordArray"
+		IL_062b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0630: stloc.s 8
+		IL_0632: ldloc.s 8
+		IL_0634: ldc.r8 3
+		IL_063d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0642: stloc.s 8
+		IL_0644: ldloc.3
+		IL_0645: ldstr "wordArray"
+		IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_064f: stloc.s 10
+		IL_0651: ldloc.s 10
+		IL_0653: ldc.r8 3
+		IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0661: stloc.s 10
+		IL_0663: ldloc.s 13
+		IL_0665: ldstr "log"
+		IL_066a: ldstr "w3"
+		IL_066f: ldloc.s 8
+		IL_0671: ldloc.s 10
+		IL_0673: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0678: pop
+		IL_0679: ret
 	} // end of method Prime_SetBitsTrue_LargeStep_OptimizedVsNaive::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive
@@ -1842,7 +1827,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2bee
+		// Method begins at RVA 0x2bd6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2930
+				// Method begins at RVA 0x2918
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2939
+				// Method begins at RVA 0x2921
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2942
+				// Method begins at RVA 0x292a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2954
+					// Method begins at RVA 0x293c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2966
+						// Method begins at RVA 0x294e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x296f
+						// Method begins at RVA 0x2957
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -144,7 +144,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x295d
+					// Method begins at RVA 0x2945
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x294b
+				// Method begins at RVA 0x2933
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2978
+				// Method begins at RVA 0x2960
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -207,7 +207,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x2981
+				// Method begins at RVA 0x2969
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -223,7 +223,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2990
+				// Method begins at RVA 0x2978
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -235,7 +235,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2993
+				// Method begins at RVA 0x297b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -250,7 +250,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2996
+				// Method begins at RVA 0x297e
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -266,7 +266,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x29a2
+				// Method begins at RVA 0x298a
 				// Header size: 1
 				// Code size: 11 (0xb)
 				.maxstack 8
@@ -285,7 +285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29ae
+				// Method begins at RVA 0x2996
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -298,7 +298,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x29b6
+				// Method begins at RVA 0x299e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -310,7 +310,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x29b9
+				// Method begins at RVA 0x29a1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -325,7 +325,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x29bc
+				// Method begins at RVA 0x29a4
 				// Header size: 1
 				// Code size: 42 (0x2a)
 				.maxstack 8
@@ -360,7 +360,7 @@
 					object[] capture0
 				) cil managed 
 			{
-				// Method begins at RVA 0x29e7
+				// Method begins at RVA 0x29cf
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -376,7 +376,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x29f6
+				// Method begins at RVA 0x29de
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -388,7 +388,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x29f9
+				// Method begins at RVA 0x29e1
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -403,7 +403,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x29fc
+				// Method begins at RVA 0x29e4
 				// Header size: 1
 				// Code size: 56 (0x38)
 				.maxstack 8
@@ -439,7 +439,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a35
+				// Method begins at RVA 0x2a1d
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -452,7 +452,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
 			{
-				// Method begins at RVA 0x2a3d
+				// Method begins at RVA 0x2a25
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -464,7 +464,7 @@
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
 			{
-				// Method begins at RVA 0x2a40
+				// Method begins at RVA 0x2a28
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -479,7 +479,7 @@
 					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a43
+				// Method begins at RVA 0x2a2b
 				// Header size: 1
 				// Code size: 47 (0x2f)
 				.maxstack 8
@@ -518,7 +518,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24b8
+			// Method begins at RVA 0x24a0
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -566,7 +566,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2504
+			// Method begins at RVA 0x24ec
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -633,7 +633,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2568
+			// Method begins at RVA 0x2550
 			// Header size: 12
 			// Code size: 858 (0x35a)
 			.maxstack 8
@@ -1005,7 +1005,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28d0
+			// Method begins at RVA 0x28b8
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -1066,7 +1066,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2927
+			// Method begins at RVA 0x290f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1092,7 +1092,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1116 (0x45c)
+		// Code size: 1092 (0x444)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope,
@@ -1107,14 +1107,11 @@
 			[9] class [System.Runtime]System.Type,
 			[10] object,
 			[11] object[],
-			[12] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue,
-			[13] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue,
-			[14] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue,
-			[15] object,
-			[16] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray,
-			[17] float64,
-			[18] bool,
-			[19] object
+			[12] object,
+			[13] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray,
+			[14] float64,
+			[15] bool,
+			[16] object
 		)
 
 		IL_0000: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::.ctor()
@@ -1131,309 +1128,297 @@
 		IL_0029: stloc.s 10
 		IL_002b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0030: stloc.s 11
-		IL_0032: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::.ctor()
-		IL_0037: ldc.i4.1
-		IL_0038: conv.r8
-		IL_0039: ldstr "setBitTrue"
+		IL_0032: ldloc.s 10
+		IL_0034: ldstr "setBitTrue"
+		IL_0039: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::.ctor()
 		IL_003e: ldc.i4.1
-		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
-		IL_0045: stloc.s 12
-		IL_0047: ldloc.s 12
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0)
-		IL_004e: stloc.s 12
-		IL_0050: ldloc.s 10
-		IL_0052: ldstr "setBitTrue"
-		IL_0057: ldloc.s 12
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005e: pop
-		IL_005f: ldc.i4.1
-		IL_0060: newarr [System.Runtime]System.Object
-		IL_0065: dup
-		IL_0066: ldc.i4.0
-		IL_0067: ldloc.0
-		IL_0068: stelem.ref
-		IL_0069: stloc.s 11
-		IL_006b: ldloc.s 11
-		IL_006d: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::.ctor(object[])
-		IL_0072: ldc.i4.3
-		IL_0073: conv.r8
-		IL_0074: ldstr "setBitsTrue"
+		IL_003f: conv.r8
+		IL_0040: ldstr "setBitTrue"
+		IL_0045: ldc.i4.1
+		IL_0046: ldc.i4.1
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0)
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0056: pop
+		IL_0057: ldc.i4.1
+		IL_0058: newarr [System.Runtime]System.Object
+		IL_005d: dup
+		IL_005e: ldc.i4.0
+		IL_005f: ldloc.0
+		IL_0060: stelem.ref
+		IL_0061: stloc.s 11
+		IL_0063: ldloc.s 10
+		IL_0065: ldstr "setBitsTrue"
+		IL_006a: ldloc.s 11
+		IL_006c: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::.ctor(object[])
+		IL_0071: ldc.i4.3
+		IL_0072: conv.r8
+		IL_0073: ldstr "setBitsTrue"
+		IL_0078: ldc.i4.1
 		IL_0079: ldc.i4.1
-		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_0080: stloc.s 13
-		IL_0082: ldloc.s 13
-		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0)
-		IL_0089: stloc.s 13
-		IL_008b: ldloc.s 10
-		IL_008d: ldstr "setBitsTrue"
-		IL_0092: ldloc.s 13
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0099: pop
-		IL_009a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_009f: stloc.s 11
-		IL_00a1: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::.ctor()
-		IL_00a6: ldc.i4.1
-		IL_00a7: conv.r8
-		IL_00a8: ldstr "testBitTrue"
-		IL_00ad: ldc.i4.1
-		IL_00ae: ldc.i4.1
-		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
-		IL_00b4: stloc.s 14
-		IL_00b6: ldloc.s 14
-		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0)
-		IL_00bd: stloc.s 14
-		IL_00bf: ldloc.s 10
-		IL_00c1: ldstr "testBitTrue"
-		IL_00c6: ldloc.s 14
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00cd: pop
-		IL_00ce: ldc.i4.1
-		IL_00cf: newarr [System.Runtime]System.Object
-		IL_00d4: dup
-		IL_00d5: ldc.i4.0
-		IL_00d6: ldloc.0
-		IL_00d7: stelem.ref
-		IL_00d8: stloc.s 11
-		IL_00da: ldloc.s 9
-		IL_00dc: ldloc.s 11
-		IL_00de: ldc.r8 1
-		IL_00e7: box [System.Runtime]System.Double
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00f1: stloc.s 10
-		IL_00f3: ldloc.s 10
-		IL_00f5: stloc.1
-		IL_00f6: ldc.i4.1
-		IL_00f7: newarr [System.Runtime]System.Object
-		IL_00fc: dup
-		IL_00fd: ldc.i4.0
-		IL_00fe: ldloc.0
-		IL_00ff: stelem.ref
-		IL_0100: stloc.s 11
-		IL_0102: ldloc.s 11
-		IL_0104: ldc.i4.1
-		IL_0105: newarr [System.Runtime]System.Object
-		IL_010a: dup
-		IL_010b: ldc.i4.0
-		IL_010c: ldc.r8 64
-		IL_0115: box [System.Runtime]System.Double
-		IL_011a: stelem.ref
-		IL_011b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0120: ldc.r8 64
-		IL_0129: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::.ctor(object[], float64)
-		IL_012e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0133: stloc.2
-		IL_0134: ldloc.2
-		IL_0135: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_013a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_013f: ldstr "prototype"
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0149: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_014e: ldc.r8 3
-		IL_0157: box [System.Runtime]System.Double
-		IL_015c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_0161: stloc.3
-		IL_0162: ldc.r8 0.0
-		IL_016b: stloc.s 4
-		IL_016d: ldloc.3
-		IL_016e: ldloc.s 4
-		IL_0170: ldc.r8 16
-		IL_0179: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-		IL_017e: ldstr "console"
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018d: ldloc.3
-		IL_018e: ldc.r8 0.0
-		IL_0197: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_019c: box [System.Runtime]System.Double
-		IL_01a1: stloc.s 15
-		IL_01a3: ldstr "log"
-		IL_01a8: ldstr "varIndexSet"
-		IL_01ad: ldloc.s 15
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01b4: pop
-		IL_01b5: ldloc.2
-		IL_01b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_01bb: stloc.s 16
-		IL_01bd: ldloc.s 16
-		IL_01bf: ldc.r8 4
-		IL_01c8: box [System.Runtime]System.Double
-		IL_01cd: ldc.r8 3
-		IL_01d6: box [System.Runtime]System.Double
-		IL_01db: ldc.r8 64
-		IL_01e4: box [System.Runtime]System.Double
-		IL_01e9: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
-		IL_01ee: pop
-		IL_01ef: ldstr "console"
-		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01fe: stloc.s 10
-		IL_0200: ldloc.2
-		IL_0201: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_0206: stloc.s 16
-		IL_0208: ldloc.s 16
-		IL_020a: ldc.r8 4
-		IL_0213: box [System.Runtime]System.Double
-		IL_0218: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_021d: stloc.s 17
-		IL_021f: ldloc.s 17
-		IL_0221: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_0226: stloc.s 18
-		IL_0228: ldloc.s 18
-		IL_022a: brfalse IL_0244
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0)
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0089: pop
+		IL_008a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_008f: stloc.s 11
+		IL_0091: ldloc.s 10
+		IL_0093: ldstr "testBitTrue"
+		IL_0098: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::.ctor()
+		IL_009d: ldc.i4.1
+		IL_009e: conv.r8
+		IL_009f: ldstr "testBitTrue"
+		IL_00a4: ldc.i4.1
+		IL_00a5: ldc.i4.1
+		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
+		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0)
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00b5: pop
+		IL_00b6: ldc.i4.1
+		IL_00b7: newarr [System.Runtime]System.Object
+		IL_00bc: dup
+		IL_00bd: ldc.i4.0
+		IL_00be: ldloc.0
+		IL_00bf: stelem.ref
+		IL_00c0: stloc.s 11
+		IL_00c2: ldloc.s 9
+		IL_00c4: ldloc.s 11
+		IL_00c6: ldc.r8 1
+		IL_00cf: box [System.Runtime]System.Double
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00d9: stloc.s 10
+		IL_00db: ldloc.s 10
+		IL_00dd: stloc.1
+		IL_00de: ldc.i4.1
+		IL_00df: newarr [System.Runtime]System.Object
+		IL_00e4: dup
+		IL_00e5: ldc.i4.0
+		IL_00e6: ldloc.0
+		IL_00e7: stelem.ref
+		IL_00e8: stloc.s 11
+		IL_00ea: ldloc.s 11
+		IL_00ec: ldc.i4.1
+		IL_00ed: newarr [System.Runtime]System.Object
+		IL_00f2: dup
+		IL_00f3: ldc.i4.0
+		IL_00f4: ldc.r8 64
+		IL_00fd: box [System.Runtime]System.Double
+		IL_0102: stelem.ref
+		IL_0103: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0108: ldc.r8 64
+		IL_0111: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::.ctor(object[], float64)
+		IL_0116: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_011b: stloc.2
+		IL_011c: ldloc.2
+		IL_011d: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_0122: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0127: ldstr "prototype"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0131: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0136: ldc.r8 3
+		IL_013f: box [System.Runtime]System.Double
+		IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_0149: stloc.3
+		IL_014a: ldc.r8 0.0
+		IL_0153: stloc.s 4
+		IL_0155: ldloc.3
+		IL_0156: ldloc.s 4
+		IL_0158: ldc.r8 16
+		IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+		IL_0166: ldstr "console"
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0175: ldloc.3
+		IL_0176: ldc.r8 0.0
+		IL_017f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_0184: box [System.Runtime]System.Double
+		IL_0189: stloc.s 12
+		IL_018b: ldstr "log"
+		IL_0190: ldstr "varIndexSet"
+		IL_0195: ldloc.s 12
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_019c: pop
+		IL_019d: ldloc.2
+		IL_019e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_01a3: stloc.s 13
+		IL_01a5: ldloc.s 13
+		IL_01a7: ldc.r8 4
+		IL_01b0: box [System.Runtime]System.Double
+		IL_01b5: ldc.r8 3
+		IL_01be: box [System.Runtime]System.Double
+		IL_01c3: ldc.r8 64
+		IL_01cc: box [System.Runtime]System.Double
+		IL_01d1: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
+		IL_01d6: pop
+		IL_01d7: ldstr "console"
+		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e6: stloc.s 10
+		IL_01e8: ldloc.2
+		IL_01e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_01ee: stloc.s 13
+		IL_01f0: ldloc.s 13
+		IL_01f2: ldc.r8 4
+		IL_01fb: box [System.Runtime]System.Double
+		IL_0200: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0205: stloc.s 14
+		IL_0207: ldloc.s 14
+		IL_0209: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_020e: stloc.s 15
+		IL_0210: ldloc.s 15
+		IL_0212: brfalse IL_022c
 
-		IL_022f: ldc.r8 1
-		IL_0238: box [System.Runtime]System.Double
-		IL_023d: stloc.s 5
-		IL_023f: br IL_0254
+		IL_0217: ldc.r8 1
+		IL_0220: box [System.Runtime]System.Double
+		IL_0225: stloc.s 5
+		IL_0227: br IL_023c
 
-		IL_0244: ldc.r8 0.0
-		IL_024d: box [System.Runtime]System.Double
-		IL_0252: stloc.s 5
+		IL_022c: ldc.r8 0.0
+		IL_0235: box [System.Runtime]System.Double
+		IL_023a: stloc.s 5
 
-		IL_0254: ldloc.s 10
-		IL_0256: ldstr "log"
-		IL_025b: ldstr "bit4"
-		IL_0260: ldloc.s 5
-		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0267: pop
-		IL_0268: ldstr "console"
-		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0277: stloc.s 10
-		IL_0279: ldloc.2
-		IL_027a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_027f: stloc.s 16
-		IL_0281: ldloc.s 16
-		IL_0283: ldc.r8 7
-		IL_028c: box [System.Runtime]System.Double
-		IL_0291: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_0296: stloc.s 17
-		IL_0298: ldloc.s 17
-		IL_029a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_029f: stloc.s 18
-		IL_02a1: ldloc.s 18
-		IL_02a3: brfalse IL_02bd
+		IL_023c: ldloc.s 10
+		IL_023e: ldstr "log"
+		IL_0243: ldstr "bit4"
+		IL_0248: ldloc.s 5
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_024f: pop
+		IL_0250: ldstr "console"
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025f: stloc.s 10
+		IL_0261: ldloc.2
+		IL_0262: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0267: stloc.s 13
+		IL_0269: ldloc.s 13
+		IL_026b: ldc.r8 7
+		IL_0274: box [System.Runtime]System.Double
+		IL_0279: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_027e: stloc.s 14
+		IL_0280: ldloc.s 14
+		IL_0282: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_0287: stloc.s 15
+		IL_0289: ldloc.s 15
+		IL_028b: brfalse IL_02a5
 
-		IL_02a8: ldc.r8 1
-		IL_02b1: box [System.Runtime]System.Double
-		IL_02b6: stloc.s 6
-		IL_02b8: br IL_02cd
+		IL_0290: ldc.r8 1
+		IL_0299: box [System.Runtime]System.Double
+		IL_029e: stloc.s 6
+		IL_02a0: br IL_02b5
 
-		IL_02bd: ldc.r8 0.0
-		IL_02c6: box [System.Runtime]System.Double
-		IL_02cb: stloc.s 6
+		IL_02a5: ldc.r8 0.0
+		IL_02ae: box [System.Runtime]System.Double
+		IL_02b3: stloc.s 6
 
-		IL_02cd: ldloc.s 10
-		IL_02cf: ldstr "log"
-		IL_02d4: ldstr "bit7"
-		IL_02d9: ldloc.s 6
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02e0: pop
-		IL_02e1: ldstr "console"
-		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f0: stloc.s 10
-		IL_02f2: ldloc.2
-		IL_02f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_02f8: stloc.s 16
-		IL_02fa: ldloc.s 16
-		IL_02fc: ldc.r8 31
-		IL_0305: box [System.Runtime]System.Double
-		IL_030a: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_030f: stloc.s 17
-		IL_0311: ldloc.s 17
-		IL_0313: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_0318: stloc.s 18
-		IL_031a: ldloc.s 18
-		IL_031c: brfalse IL_0336
+		IL_02b5: ldloc.s 10
+		IL_02b7: ldstr "log"
+		IL_02bc: ldstr "bit7"
+		IL_02c1: ldloc.s 6
+		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02c8: pop
+		IL_02c9: ldstr "console"
+		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d8: stloc.s 10
+		IL_02da: ldloc.2
+		IL_02db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_02e0: stloc.s 13
+		IL_02e2: ldloc.s 13
+		IL_02e4: ldc.r8 31
+		IL_02ed: box [System.Runtime]System.Double
+		IL_02f2: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_02f7: stloc.s 14
+		IL_02f9: ldloc.s 14
+		IL_02fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_0300: stloc.s 15
+		IL_0302: ldloc.s 15
+		IL_0304: brfalse IL_031e
 
-		IL_0321: ldc.r8 1
-		IL_032a: box [System.Runtime]System.Double
-		IL_032f: stloc.s 7
-		IL_0331: br IL_0346
+		IL_0309: ldc.r8 1
+		IL_0312: box [System.Runtime]System.Double
+		IL_0317: stloc.s 7
+		IL_0319: br IL_032e
 
-		IL_0336: ldc.r8 0.0
-		IL_033f: box [System.Runtime]System.Double
-		IL_0344: stloc.s 7
+		IL_031e: ldc.r8 0.0
+		IL_0327: box [System.Runtime]System.Double
+		IL_032c: stloc.s 7
 
-		IL_0346: ldloc.s 10
-		IL_0348: ldstr "log"
-		IL_034d: ldstr "bit31"
-		IL_0352: ldloc.s 7
-		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0359: pop
-		IL_035a: ldstr "console"
-		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0369: stloc.s 10
-		IL_036b: ldloc.2
-		IL_036c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_0371: stloc.s 16
-		IL_0373: ldloc.s 16
-		IL_0375: ldc.r8 5
-		IL_037e: box [System.Runtime]System.Double
-		IL_0383: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_0388: stloc.s 17
-		IL_038a: ldloc.s 17
-		IL_038c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_0391: stloc.s 18
-		IL_0393: ldloc.s 18
-		IL_0395: brfalse IL_03af
+		IL_032e: ldloc.s 10
+		IL_0330: ldstr "log"
+		IL_0335: ldstr "bit31"
+		IL_033a: ldloc.s 7
+		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0341: pop
+		IL_0342: ldstr "console"
+		IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0351: stloc.s 10
+		IL_0353: ldloc.2
+		IL_0354: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0359: stloc.s 13
+		IL_035b: ldloc.s 13
+		IL_035d: ldc.r8 5
+		IL_0366: box [System.Runtime]System.Double
+		IL_036b: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0370: stloc.s 14
+		IL_0372: ldloc.s 14
+		IL_0374: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_0379: stloc.s 15
+		IL_037b: ldloc.s 15
+		IL_037d: brfalse IL_0397
 
-		IL_039a: ldc.r8 1
-		IL_03a3: box [System.Runtime]System.Double
-		IL_03a8: stloc.s 8
-		IL_03aa: br IL_03bf
+		IL_0382: ldc.r8 1
+		IL_038b: box [System.Runtime]System.Double
+		IL_0390: stloc.s 8
+		IL_0392: br IL_03a7
 
-		IL_03af: ldc.r8 0.0
-		IL_03b8: box [System.Runtime]System.Double
-		IL_03bd: stloc.s 8
+		IL_0397: ldc.r8 0.0
+		IL_03a0: box [System.Runtime]System.Double
+		IL_03a5: stloc.s 8
 
-		IL_03bf: ldloc.s 10
-		IL_03c1: ldstr "log"
-		IL_03c6: ldstr "bit5"
-		IL_03cb: ldloc.s 8
-		IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03d2: pop
-		IL_03d3: ldstr "console"
-		IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03e2: stloc.s 10
-		IL_03e4: ldloc.2
-		IL_03e5: ldstr "wordArray"
-		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03ef: stloc.s 19
-		IL_03f1: ldloc.s 19
-		IL_03f3: ldc.r8 0.0
-		IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0401: stloc.s 19
-		IL_0403: ldloc.s 10
-		IL_0405: ldstr "log"
-		IL_040a: ldstr "word0"
-		IL_040f: ldloc.s 19
-		IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0416: pop
-		IL_0417: ldstr "console"
-		IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0426: stloc.s 19
-		IL_0428: ldloc.2
-		IL_0429: ldstr "wordArray"
-		IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0433: stloc.s 10
-		IL_0435: ldloc.s 10
-		IL_0437: ldc.r8 1
-		IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0445: stloc.s 10
-		IL_0447: ldloc.s 19
-		IL_0449: ldstr "log"
-		IL_044e: ldstr "word1"
-		IL_0453: ldloc.s 10
-		IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_045a: pop
-		IL_045b: ret
+		IL_03a7: ldloc.s 10
+		IL_03a9: ldstr "log"
+		IL_03ae: ldstr "bit5"
+		IL_03b3: ldloc.s 8
+		IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03ba: pop
+		IL_03bb: ldstr "console"
+		IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03ca: stloc.s 10
+		IL_03cc: ldloc.2
+		IL_03cd: ldstr "wordArray"
+		IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03d7: stloc.s 16
+		IL_03d9: ldloc.s 16
+		IL_03db: ldc.r8 0.0
+		IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_03e9: stloc.s 16
+		IL_03eb: ldloc.s 10
+		IL_03ed: ldstr "log"
+		IL_03f2: ldstr "word0"
+		IL_03f7: ldloc.s 16
+		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03fe: pop
+		IL_03ff: ldstr "console"
+		IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_040e: stloc.s 16
+		IL_0410: ldloc.2
+		IL_0411: ldstr "wordArray"
+		IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_041b: stloc.s 10
+		IL_041d: ldloc.s 10
+		IL_041f: ldc.r8 1
+		IL_0428: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_042d: stloc.s 10
+		IL_042f: ldloc.s 16
+		IL_0431: ldstr "log"
+		IL_0436: ldstr "word1"
+		IL_043b: ldloc.s 10
+		IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0442: pop
+		IL_0443: ret
 	} // end of method Prime_SetBitsTrue_SmallStep_WordValueOrAssign::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign
@@ -1445,7 +1430,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a73
+		// Method begins at RVA 0x2a5b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
Closes #1739

## Summary
- stack-schedule contiguous, single-use generated callable construction, initialization, prototype marking, optional accessor naming, and descriptor installation
- retain concrete generated wrapper types across generic runtime calls while leaving captures, targets, and keys materialized
- preserve accessor initialization order by materializing the missing accessor before the callable chain

## Validation
- focused execution coverage for class methods/accessors, object-literal methods/accessors, and lexical super passes
- generator snapshots are intentionally delegated to the `update-generator-snapshots` workflow

## Artifact comparison
Representative class/module initializers shrink: `ArrowFunction_LexicalSuper_MethodAndConstructor` 617 -> 601 bytes (-16), `Classes_GeneratedMethodFunctionObjects` 3200 -> 3152 bytes (-48), and `Classes_AccessorMethods_InstanceAndStatic` 827 -> 787 bytes (-40).