### PR TITLE
fix(compiler): emit one nonconstructible prototype mark

### DIFF
--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
@@ -1364,6 +1364,21 @@ internal sealed partial class LIRToILCompiler
                     EmitInitializeFunctionInstance(createFunc.CallableId, createFunc.IsAsync, ilEncoder);
                     EmitInitializeGeneratorFunctionSurfaceIfNeeded(callableId, ilEncoder);
 
+                    if (createFunc.IsNonConstructible
+                        && !IsGeneratorCallable(callableId))
+                    {
+                        // Generated function objects mark their prototype during initialization;
+                        // this branch handles only the delegate-backed fallback.
+                        var delegateType = CallableDelegateTypeResolver.GetMaterializedDelegateType(
+                            callableId,
+                            signature);
+                        ilEncoder.OpCode(ILOpCode.Call);
+                        ilEncoder.Token(_memberRefRegistry.GetOrAddGenericUnaryMethod(
+                            typeof(JavaScriptRuntime.Function),
+                            nameof(JavaScriptRuntime.Function.MarkUndefinedPrototype),
+                            delegateType));
+                    }
+
                     if (createFunc.IsAsyncGeneratorFunction)
                     {
                         var initAsyncGeneratorFunctionRef = _memberRefRegistry.GetOrAddMethod(

--- a/src/Compiler/IR/LIR/HIRToLIRLower.Utilities.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLower.Utilities.cs
@@ -4,24 +4,6 @@ namespace Jroc.IR;
 
 public sealed partial class HIRToLIRLowerer
 {
-    private TempVariable EmitMarkUndefinedPrototype(TempVariable functionValueTemp)
-    {
-        var functionStorage = GetTempStorage(functionValueTemp);
-        var argumentTemp = functionStorage.Kind == ValueStorageKind.Reference
-            ? functionValueTemp
-            : EnsureObject(functionValueTemp);
-        var markedStorage = GetTempStorage(argumentTemp);
-        var markedTemp = CreateTempVariable();
-        _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStatic(
-            IntrinsicName: nameof(JavaScriptRuntime.Function),
-            MethodName: nameof(JavaScriptRuntime.Function.MarkUndefinedPrototype),
-            Arguments: new List<TempVariable> { argumentTemp },
-            Result: markedTemp,
-            GenericTypeArgument: markedStorage));
-        DefineTempStorage(markedTemp, markedStorage);
-        return markedTemp;
-    }
-
     /// <summary>
     /// Attaches the active <c>with</c>-object to a newly created function/arrow value.
     /// This is the creation-time side of <c>with</c> support and only records callable metadata.

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.ArrayObject.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.ArrayObject.cs
@@ -490,7 +490,6 @@ public sealed partial class HIRToLIRLowerer
             return false;
         }
 
-        accessorTemp = EmitMarkUndefinedPrototype(accessorTemp);
         var namedAccessor = CreateTempVariable();
         _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStatic(
             IntrinsicName: nameof(JavaScriptRuntime.Function),

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.ClassDefinitions.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.ClassDefinitions.cs
@@ -349,9 +349,7 @@ public sealed partial class HIRToLIRLowerer
             GetMaterializedCallableStorage(
                 callableId,
                 allowGeneratedFunctionObject: true));
-        return IsGeneratorCallable(callableId)
-            ? result
-            : EmitMarkUndefinedPrototype(result);
+        return result;
     }
 
     private static Scope? ResolveClassMethodScope(

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
@@ -1267,12 +1267,6 @@ public sealed partial class HIRToLIRLowerer
                     !funcExpr.IsNonConstructible
                     || supportsGeneratedMethodObject));
 
-        if (funcExpr.IsNonConstructible
-            && !IsGeneratorCallable(funcExpr.CallableId))
-        {
-            resultTempVar = EmitMarkUndefinedPrototype(resultTempVar);
-        }
-
         resultTempVar = EmitBindWithObjectIfNeeded(resultTempVar);
 
         return true;

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_StableLoadReceiver_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_StableLoadReceiver_EvaluationOrder.verified.txt
@@ -323,8 +323,8 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 379 (0x17b)
-		.maxstack 13
+		// Code size: 352 (0x160)
+		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -379,97 +379,88 @@
 		IL_006b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14>(!!0)
 		IL_0070: stloc.s 5
 		IL_0072: ldloc.s 5
-		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14>(!!0)
-		IL_0079: stloc.s 5
-		IL_007b: ldloc.s 5
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14>(!!0)
-		IL_0082: stloc.s 5
-		IL_0084: ldloc.s 5
+		IL_0074: ldstr "value"
+		IL_0079: ldstr "get"
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_0083: stloc.s 6
+		IL_0085: ldloc.3
 		IL_0086: ldstr "value"
-		IL_008b: ldstr "get"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_0095: stloc.s 6
-		IL_0097: ldloc.3
-		IL_0098: ldstr "value"
-		IL_009d: ldloc.s 6
-		IL_009f: ldnull
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_00a5: pop
-		IL_00a6: ldloc.0
-		IL_00a7: ldloc.3
-		IL_00a8: stfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::'nested'
-		IL_00ad: ldc.i4.0
-		IL_00ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00b3: stloc.1
-		IL_00b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00b9: stloc.3
-		IL_00ba: ldc.i4.1
-		IL_00bb: newarr [System.Runtime]System.Object
-		IL_00c0: dup
-		IL_00c1: ldc.i4.0
-		IL_00c2: ldloc.0
-		IL_00c3: stelem.ref
-		IL_00c4: stloc.s 4
-		IL_00c6: ldloc.s 4
-		IL_00c8: ldc.i4.0
-		IL_00c9: ldelem.ref
-		IL_00ca: castclass Modules.Array_StableLoadReceiver_EvaluationOrder/Scope
-		IL_00cf: newobj instance void Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8::.ctor(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope)
-		IL_00d4: ldc.i4.0
-		IL_00d5: conv.r8
-		IL_00d6: ldstr ""
-		IL_00db: ldc.i4.0
-		IL_00dc: ldc.i4.1
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8>(!!0, float64, string, bool, bool)
-		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8>(!!0)
-		IL_00e7: stloc.s 7
-		IL_00e9: ldloc.s 7
-		IL_00eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8>(!!0)
-		IL_00f0: stloc.s 7
-		IL_00f2: ldloc.3
-		IL_00f3: ldstr "get"
-		IL_00f8: ldloc.s 7
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_00ff: pop
-		IL_0100: ldloc.1
-		IL_0101: ldstr "0"
-		IL_0106: ldloc.3
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_010c: pop
-		IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0112: stloc.s 8
-		IL_0114: ldloc.1
-		IL_0115: ldc.r8 0.0
-		IL_011e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0123: ldstr "value"
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012d: stloc.s 6
-		IL_012f: ldloc.s 8
-		IL_0131: ldloc.s 6
-		IL_0133: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0138: pop
-		IL_0139: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013e: stloc.s 8
-		IL_0140: ldloc.0
-		IL_0141: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::order
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014b: ldstr "join"
-		IL_0150: ldstr ","
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015a: stloc.s 6
-		IL_015c: ldloc.0
-		IL_015d: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::innerReadCount
-		IL_0162: stloc.s 9
-		IL_0164: ldloc.0
-		IL_0165: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::outerReadCount
-		IL_016a: stloc.s 10
-		IL_016c: ldloc.s 8
-		IL_016e: ldloc.s 6
-		IL_0170: ldloc.s 9
-		IL_0172: ldloc.s 10
-		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0179: pop
-		IL_017a: ret
+		IL_008b: ldloc.s 6
+		IL_008d: ldnull
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_0093: pop
+		IL_0094: ldloc.0
+		IL_0095: ldloc.3
+		IL_0096: stfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::'nested'
+		IL_009b: ldc.i4.0
+		IL_009c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00a1: stloc.1
+		IL_00a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00a7: stloc.3
+		IL_00a8: ldc.i4.1
+		IL_00a9: newarr [System.Runtime]System.Object
+		IL_00ae: dup
+		IL_00af: ldc.i4.0
+		IL_00b0: ldloc.0
+		IL_00b1: stelem.ref
+		IL_00b2: stloc.s 4
+		IL_00b4: ldloc.s 4
+		IL_00b6: ldc.i4.0
+		IL_00b7: ldelem.ref
+		IL_00b8: castclass Modules.Array_StableLoadReceiver_EvaluationOrder/Scope
+		IL_00bd: newobj instance void Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8::.ctor(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope)
+		IL_00c2: ldc.i4.0
+		IL_00c3: conv.r8
+		IL_00c4: ldstr ""
+		IL_00c9: ldc.i4.0
+		IL_00ca: ldc.i4.1
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8>(!!0, float64, string, bool, bool)
+		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8>(!!0)
+		IL_00d5: stloc.s 7
+		IL_00d7: ldloc.3
+		IL_00d8: ldstr "get"
+		IL_00dd: ldloc.s 7
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_00e4: pop
+		IL_00e5: ldloc.1
+		IL_00e6: ldstr "0"
+		IL_00eb: ldloc.3
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_00f1: pop
+		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f7: stloc.s 8
+		IL_00f9: ldloc.1
+		IL_00fa: ldc.r8 0.0
+		IL_0103: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0108: ldstr "value"
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0112: stloc.s 6
+		IL_0114: ldloc.s 8
+		IL_0116: ldloc.s 6
+		IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011d: pop
+		IL_011e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0123: stloc.s 8
+		IL_0125: ldloc.0
+		IL_0126: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::order
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0130: ldstr "join"
+		IL_0135: ldstr ","
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013f: stloc.s 6
+		IL_0141: ldloc.0
+		IL_0142: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::innerReadCount
+		IL_0147: stloc.s 9
+		IL_0149: ldloc.0
+		IL_014a: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::outerReadCount
+		IL_014f: stloc.s 10
+		IL_0151: ldloc.s 8
+		IL_0153: ldloc.s 6
+		IL_0155: ldloc.s 9
+		IL_0157: ldloc.s 10
+		IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_015e: pop
+		IL_015f: ret
 	} // end of method Array_StableLoadReceiver_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.Array_StableLoadReceiver_EvaluationOrder

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalSuper_MethodAndConstructor.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalSuper_MethodAndConstructor.verified.txt
@@ -972,7 +972,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 581 (0x245)
+		// Code size: 571 (0x23b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Scope,
@@ -1012,161 +1012,159 @@
 		IL_0046: ldc.i4.1
 		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0, float64, string, bool, bool)
 		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0)
-		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0)
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005b: pop
-		IL_005c: ldc.i4.1
-		IL_005d: newarr [System.Runtime]System.Object
-		IL_0062: dup
-		IL_0063: ldc.i4.0
-		IL_0064: ldloc.0
-		IL_0065: stelem.ref
-		IL_0066: stloc.s 8
-		IL_0068: ldloc.s 6
-		IL_006a: ldloc.s 8
-		IL_006c: ldc.r8 1
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007f: stloc.s 7
-		IL_0081: ldloc.s 7
-		IL_0083: stloc.1
-		IL_0084: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_0089: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_008e: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_0093: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0098: stloc.s 6
-		IL_009a: ldloc.s 6
-		IL_009c: ldstr "prototype"
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a6: stloc.s 7
-		IL_00a8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ad: stloc.s 8
-		IL_00af: ldloc.s 7
-		IL_00b1: ldstr "makeReader"
-		IL_00b6: ldloc.s 8
-		IL_00b8: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader::.ctor(object[])
-		IL_00bd: ldc.i4.0
-		IL_00be: conv.r8
-		IL_00bf: ldstr "makeReader"
-		IL_00c4: ldc.i4.0
-		IL_00c5: ldc.i4.1
-		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0, float64, string, bool, bool)
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0)
-		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0)
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00da: pop
-		IL_00db: ldc.i4.1
-		IL_00dc: newarr [System.Runtime]System.Object
-		IL_00e1: dup
-		IL_00e2: ldc.i4.0
-		IL_00e3: ldloc.0
-		IL_00e4: stelem.ref
-		IL_00e5: stloc.s 8
-		IL_00e7: ldloc.s 6
-		IL_00e9: ldloc.s 8
-		IL_00eb: ldc.r8 1
-		IL_00f4: box [System.Runtime]System.Double
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0056: pop
+		IL_0057: ldc.i4.1
+		IL_0058: newarr [System.Runtime]System.Object
+		IL_005d: dup
+		IL_005e: ldc.i4.0
+		IL_005f: ldloc.0
+		IL_0060: stelem.ref
+		IL_0061: stloc.s 8
+		IL_0063: ldloc.s 6
+		IL_0065: ldloc.s 8
+		IL_0067: ldc.r8 1
+		IL_0070: box [System.Runtime]System.Double
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_007a: stloc.s 7
+		IL_007c: ldloc.s 7
+		IL_007e: stloc.1
+		IL_007f: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+		IL_0084: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0089: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+		IL_008e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0093: stloc.s 6
+		IL_0095: ldloc.s 6
+		IL_0097: ldstr "prototype"
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a1: stloc.s 7
+		IL_00a3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a8: stloc.s 8
+		IL_00aa: ldloc.s 7
+		IL_00ac: ldstr "makeReader"
+		IL_00b1: ldloc.s 8
+		IL_00b3: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader::.ctor(object[])
+		IL_00b8: ldc.i4.0
+		IL_00b9: conv.r8
+		IL_00ba: ldstr "makeReader"
+		IL_00bf: ldc.i4.0
+		IL_00c0: ldc.i4.1
+		IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0, float64, string, bool, bool)
+		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0)
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00d0: pop
+		IL_00d1: ldc.i4.1
+		IL_00d2: newarr [System.Runtime]System.Object
+		IL_00d7: dup
+		IL_00d8: ldc.i4.0
+		IL_00d9: ldloc.0
+		IL_00da: stelem.ref
+		IL_00db: stloc.s 8
+		IL_00dd: ldloc.s 6
+		IL_00df: ldloc.s 8
+		IL_00e1: ldc.r8 1
+		IL_00ea: box [System.Runtime]System.Double
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00f4: stloc.s 7
+		IL_00f6: ldloc.s 7
+		IL_00f8: ldloc.1
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
 		IL_00fe: stloc.s 7
 		IL_0100: ldloc.s 7
-		IL_0102: ldloc.1
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0108: stloc.s 7
-		IL_010a: ldloc.s 7
-		IL_010c: stloc.2
-		IL_010d: ldc.i4.1
-		IL_010e: newarr [System.Runtime]System.Object
-		IL_0113: dup
-		IL_0114: ldc.i4.0
-		IL_0115: ldloc.0
-		IL_0116: stelem.ref
-		IL_0117: stloc.s 8
-		IL_0119: ldloc.s 8
-		IL_011b: ldc.i4.1
-		IL_011c: newarr [System.Runtime]System.Object
-		IL_0121: dup
-		IL_0122: ldc.i4.0
-		IL_0123: ldc.r8 11
-		IL_012c: box [System.Runtime]System.Double
-		IL_0131: stelem.ref
-		IL_0132: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0137: ldloc.2
-		IL_0138: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_013d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0142: ldc.r8 11
-		IL_014b: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::.ctor(object[], float64)
-		IL_0150: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_0155: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_015a: dup
-		IL_015b: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_0160: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0165: ldstr "prototype"
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_016f: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0174: stloc.3
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_017f: stloc.3
-		IL_0180: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_0185: ldloc.3
-		IL_0186: ldstr "fromConstructor"
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0190: stloc.s 4
-		IL_0192: ldloc.3
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0198: stloc.s 7
-		IL_019a: ldloc.s 7
-		IL_019c: isinst Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_01a1: dup
-		IL_01a2: brfalse IL_01b3
+		IL_0102: stloc.2
+		IL_0103: ldc.i4.1
+		IL_0104: newarr [System.Runtime]System.Object
+		IL_0109: dup
+		IL_010a: ldc.i4.0
+		IL_010b: ldloc.0
+		IL_010c: stelem.ref
+		IL_010d: stloc.s 8
+		IL_010f: ldloc.s 8
+		IL_0111: ldc.i4.1
+		IL_0112: newarr [System.Runtime]System.Object
+		IL_0117: dup
+		IL_0118: ldc.i4.0
+		IL_0119: ldc.r8 11
+		IL_0122: box [System.Runtime]System.Double
+		IL_0127: stelem.ref
+		IL_0128: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_012d: ldloc.2
+		IL_012e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0133: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0138: ldc.r8 11
+		IL_0141: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::.ctor(object[], float64)
+		IL_0146: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_014b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0150: dup
+		IL_0151: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+		IL_0156: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_015b: ldstr "prototype"
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0165: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_016a: stloc.3
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0175: stloc.3
+		IL_0176: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_017b: ldloc.3
+		IL_017c: ldstr "fromConstructor"
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0186: stloc.s 4
+		IL_0188: ldloc.3
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018e: stloc.s 7
+		IL_0190: ldloc.s 7
+		IL_0192: isinst Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+		IL_0197: dup
+		IL_0198: brfalse IL_01a9
 
-		IL_01a7: callvirt instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::makeReader()
-		IL_01ac: stloc.s 5
-		IL_01ae: br IL_01c2
+		IL_019d: callvirt instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::makeReader()
+		IL_01a2: stloc.s 5
+		IL_01a4: br IL_01b8
 
-		IL_01b3: pop
-		IL_01b4: ldloc.s 7
-		IL_01b6: ldstr "makeReader"
-		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01c0: stloc.s 5
+		IL_01a9: pop
+		IL_01aa: ldloc.s 7
+		IL_01ac: ldstr "makeReader"
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01b6: stloc.s 5
 
-		IL_01c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c7: stloc.s 9
-		IL_01c9: ldloc.s 4
-		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01d5: dup
-		IL_01d6: ldstr "value"
-		IL_01db: ldc.r8 99
-		IL_01e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_01e9: stloc.s 10
-		IL_01eb: ldstr "call"
-		IL_01f0: ldloc.s 10
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f7: stloc.s 7
-		IL_01f9: ldloc.s 9
-		IL_01fb: ldloc.s 7
-		IL_01fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0202: pop
-		IL_0203: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0208: stloc.s 9
-		IL_020a: ldloc.s 5
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0211: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0216: dup
-		IL_0217: ldstr "value"
-		IL_021c: ldc.r8 99
-		IL_0225: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_022a: stloc.s 10
-		IL_022c: ldstr "call"
-		IL_0231: ldloc.s 10
-		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0238: stloc.s 7
-		IL_023a: ldloc.s 9
-		IL_023c: ldloc.s 7
-		IL_023e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0243: pop
-		IL_0244: ret
+		IL_01b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01bd: stloc.s 9
+		IL_01bf: ldloc.s 4
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01cb: dup
+		IL_01cc: ldstr "value"
+		IL_01d1: ldc.r8 99
+		IL_01da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_01df: stloc.s 10
+		IL_01e1: ldstr "call"
+		IL_01e6: ldloc.s 10
+		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ed: stloc.s 7
+		IL_01ef: ldloc.s 9
+		IL_01f1: ldloc.s 7
+		IL_01f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01f8: pop
+		IL_01f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01fe: stloc.s 9
+		IL_0200: ldloc.s 5
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0207: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_020c: dup
+		IL_020d: ldstr "value"
+		IL_0212: ldc.r8 99
+		IL_021b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0220: stloc.s 10
+		IL_0222: ldstr "call"
+		IL_0227: ldloc.s 10
+		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_022e: stloc.s 7
+		IL_0230: ldloc.s 9
+		IL_0232: ldloc.s 7
+		IL_0234: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0239: pop
+		IL_023a: ret
 	} // end of method ArrowFunction_LexicalSuper_MethodAndConstructor::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
@@ -1250,7 +1250,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 207 (0xcf)
+		// Code size: 202 (0xca)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope,
@@ -1311,42 +1311,41 @@
 		IL_0069: ldc.i4.1
 		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27>(!!0, float64, string, bool, bool)
 		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27>(!!0)
-		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27>(!!0)
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_007e: pop
-		IL_007f: ldloc.0
-		IL_0080: ldloc.s 4
-		IL_0082: stfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope::iterable
-		IL_0087: nop
-		IL_0088: ldloc.1
-		IL_0089: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0093: stloc.3
-		IL_0094: ldloc.3
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009a: stloc.3
-		IL_009b: ldc.i4.1
-		IL_009c: newarr [System.Runtime]System.Object
-		IL_00a1: dup
-		IL_00a2: ldc.i4.0
-		IL_00a3: ldloc.0
-		IL_00a4: stelem.ref
-		IL_00a5: stloc.2
-		IL_00a6: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject::.ctor()
-		IL_00ab: ldc.i4.0
-		IL_00ac: conv.r8
-		IL_00ad: ldstr ""
-		IL_00b2: ldc.i4.0
-		IL_00b3: ldc.i4.0
-		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject>(!!0)
-		IL_00be: stloc.s 5
-		IL_00c0: ldloc.3
-		IL_00c1: ldstr "then"
-		IL_00c6: ldloc.s 5
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cd: pop
-		IL_00ce: ret
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0079: pop
+		IL_007a: ldloc.0
+		IL_007b: ldloc.s 4
+		IL_007d: stfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope::iterable
+		IL_0082: nop
+		IL_0083: ldloc.1
+		IL_0084: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_008e: stloc.3
+		IL_008f: ldloc.3
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0095: stloc.3
+		IL_0096: ldc.i4.1
+		IL_0097: newarr [System.Runtime]System.Object
+		IL_009c: dup
+		IL_009d: ldc.i4.0
+		IL_009e: ldloc.0
+		IL_009f: stelem.ref
+		IL_00a0: stloc.2
+		IL_00a1: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject::.ctor()
+		IL_00a6: ldc.i4.0
+		IL_00a7: conv.r8
+		IL_00a8: ldstr ""
+		IL_00ad: ldc.i4.0
+		IL_00ae: ldc.i4.0
+		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject>(!!0)
+		IL_00b9: stloc.s 5
+		IL_00bb: ldloc.3
+		IL_00bc: ldstr "then"
+		IL_00c1: ldloc.s 5
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c8: pop
+		IL_00c9: ret
 	} // end of method Async_ForAwaitOf_AsyncIterator_BreakCloses::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
@@ -1244,7 +1244,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 207 (0xcf)
+		// Code size: 202 (0xca)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope,
@@ -1305,42 +1305,41 @@
 		IL_0069: ldc.i4.1
 		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22>(!!0, float64, string, bool, bool)
 		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22>(!!0)
-		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22>(!!0)
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_007e: pop
-		IL_007f: ldloc.0
-		IL_0080: ldloc.s 4
-		IL_0082: stfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope::iterable
-		IL_0087: nop
-		IL_0088: ldloc.1
-		IL_0089: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0093: stloc.3
-		IL_0094: ldloc.3
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009a: stloc.3
-		IL_009b: ldc.i4.1
-		IL_009c: newarr [System.Runtime]System.Object
-		IL_00a1: dup
-		IL_00a2: ldc.i4.0
-		IL_00a3: ldloc.0
-		IL_00a4: stelem.ref
-		IL_00a5: stloc.2
-		IL_00a6: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject::.ctor()
-		IL_00ab: ldc.i4.0
-		IL_00ac: conv.r8
-		IL_00ad: ldstr ""
-		IL_00b2: ldc.i4.0
-		IL_00b3: ldc.i4.0
-		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject>(!!0)
-		IL_00be: stloc.s 5
-		IL_00c0: ldloc.3
-		IL_00c1: ldstr "then"
-		IL_00c6: ldloc.s 5
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cd: pop
-		IL_00ce: ret
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0079: pop
+		IL_007a: ldloc.0
+		IL_007b: ldloc.s 4
+		IL_007d: stfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope::iterable
+		IL_0082: nop
+		IL_0083: ldloc.1
+		IL_0084: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_008e: stloc.3
+		IL_008f: ldloc.3
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0095: stloc.3
+		IL_0096: ldc.i4.1
+		IL_0097: newarr [System.Runtime]System.Object
+		IL_009c: dup
+		IL_009d: ldc.i4.0
+		IL_009e: ldloc.0
+		IL_009f: stelem.ref
+		IL_00a0: stloc.2
+		IL_00a1: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject::.ctor()
+		IL_00a6: ldc.i4.0
+		IL_00a7: conv.r8
+		IL_00a8: ldstr ""
+		IL_00ad: ldc.i4.0
+		IL_00ae: ldc.i4.0
+		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject>(!!0)
+		IL_00b9: stloc.s 5
+		IL_00bb: ldloc.3
+		IL_00bc: ldstr "then"
+		IL_00c1: ldloc.s 5
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c8: pop
+		IL_00c9: ret
 	} // end of method Async_ForAwaitOf_SyncIteratorFallback_BreakCloses::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_GeneratedFunctionObject_Semantics.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_GeneratedFunctionObject_Semantics.verified.txt
@@ -6144,7 +6144,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 673 (0x2a1)
+		// Code size: 663 (0x297)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope,
@@ -6316,93 +6316,91 @@
 		IL_0194: ldc.i4.1
 		IL_0195: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_4A6554A3_AsyncGeneratorClass_callRun>(!!0, float64, string, bool, bool)
 		IL_019a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_4A6554A3_AsyncGeneratorClass_callRun>(!!0)
-		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_4A6554A3_AsyncGeneratorClass_callRun>(!!0)
-		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01a9: pop
-		IL_01aa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01af: stloc.2
-		IL_01b0: ldloc.s 8
-		IL_01b2: ldstr "twice"
-		IL_01b7: ldloc.2
-		IL_01b8: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice::.ctor(object[])
-		IL_01bd: ldc.i4.1
-		IL_01be: conv.r8
-		IL_01bf: ldstr "twice"
-		IL_01c4: ldc.i4.1
-		IL_01c5: ldc.i4.1
-		IL_01c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice>(!!0, float64, string, bool, bool)
-		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-		IL_01d0: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01da: pop
-		IL_01db: ldc.i4.1
-		IL_01dc: newarr [System.Runtime]System.Object
-		IL_01e1: dup
-		IL_01e2: ldc.i4.0
-		IL_01e3: ldloc.0
-		IL_01e4: stelem.ref
-		IL_01e5: stloc.2
-		IL_01e6: ldloc.s 8
-		IL_01e8: ldloc.2
-		IL_01e9: ldc.r8 1
-		IL_01f2: box [System.Runtime]System.Double
-		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_01fc: stloc.s 9
-		IL_01fe: ldloc.0
-		IL_01ff: ldloc.s 9
-		IL_0201: stfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::AsyncGeneratorClass
-		IL_0206: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass
-		IL_020b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0210: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass
-		IL_0215: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_021a: stloc.s 8
-		IL_021c: ldloc.s 8
-		IL_021e: ldstr "prototype"
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0228: stloc.s 10
-		IL_022a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_022f: stloc.2
-		IL_0230: ldloc.s 10
-		IL_0232: ldstr "callSuper"
-		IL_0237: ldloc.s 10
-		IL_0239: ldloc.2
-		IL_023a: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::.ctor(class [System.Runtime]System.Object, object[])
-		IL_023f: ldc.i4.1
-		IL_0240: conv.r8
-		IL_0241: ldstr "callSuper"
-		IL_0246: ldc.i4.1
-		IL_0247: ldc.i4.1
-		IL_0248: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper>(!!0, float64, string, bool, bool)
-		IL_024d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper>(!!0)
-		IL_0252: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper>(!!0)
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_025c: pop
-		IL_025d: ldc.i4.1
-		IL_025e: newarr [System.Runtime]System.Object
-		IL_0263: dup
-		IL_0264: ldc.i4.0
-		IL_0265: ldloc.0
-		IL_0266: stelem.ref
-		IL_0267: stloc.2
-		IL_0268: ldloc.s 8
-		IL_026a: ldloc.2
-		IL_026b: ldc.r8 0.0
-		IL_0274: box [System.Runtime]System.Double
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_027e: stloc.s 10
-		IL_0280: ldloc.s 10
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01a4: pop
+		IL_01a5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01aa: stloc.2
+		IL_01ab: ldloc.s 8
+		IL_01ad: ldstr "twice"
+		IL_01b2: ldloc.2
+		IL_01b3: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice::.ctor(object[])
+		IL_01b8: ldc.i4.1
+		IL_01b9: conv.r8
+		IL_01ba: ldstr "twice"
+		IL_01bf: ldc.i4.1
+		IL_01c0: ldc.i4.1
+		IL_01c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice>(!!0, float64, string, bool, bool)
+		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
+		IL_01cb: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01d5: pop
+		IL_01d6: ldc.i4.1
+		IL_01d7: newarr [System.Runtime]System.Object
+		IL_01dc: dup
+		IL_01dd: ldc.i4.0
+		IL_01de: ldloc.0
+		IL_01df: stelem.ref
+		IL_01e0: stloc.2
+		IL_01e1: ldloc.s 8
+		IL_01e3: ldloc.2
+		IL_01e4: ldc.r8 1
+		IL_01ed: box [System.Runtime]System.Double
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_01f7: stloc.s 9
+		IL_01f9: ldloc.0
+		IL_01fa: ldloc.s 9
+		IL_01fc: stfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::AsyncGeneratorClass
+		IL_0201: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass
+		IL_0206: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_020b: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass
+		IL_0210: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0215: stloc.s 8
+		IL_0217: ldloc.s 8
+		IL_0219: ldstr "prototype"
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0223: stloc.s 10
+		IL_0225: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_022a: stloc.2
+		IL_022b: ldloc.s 10
+		IL_022d: ldstr "callSuper"
+		IL_0232: ldloc.s 10
+		IL_0234: ldloc.2
+		IL_0235: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::.ctor(class [System.Runtime]System.Object, object[])
+		IL_023a: ldc.i4.1
+		IL_023b: conv.r8
+		IL_023c: ldstr "callSuper"
+		IL_0241: ldc.i4.1
+		IL_0242: ldc.i4.1
+		IL_0243: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper>(!!0, float64, string, bool, bool)
+		IL_0248: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper>(!!0)
+		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0252: pop
+		IL_0253: ldc.i4.1
+		IL_0254: newarr [System.Runtime]System.Object
+		IL_0259: dup
+		IL_025a: ldc.i4.0
+		IL_025b: ldloc.0
+		IL_025c: stelem.ref
+		IL_025d: stloc.2
+		IL_025e: ldloc.s 8
+		IL_0260: ldloc.2
+		IL_0261: ldc.r8 0.0
+		IL_026a: box [System.Runtime]System.Double
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0274: stloc.s 10
+		IL_0276: ldloc.s 10
+		IL_0278: ldloc.s 9
+		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_027f: stloc.s 9
+		IL_0281: ldloc.0
 		IL_0282: ldloc.s 9
-		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0289: stloc.s 9
-		IL_028b: ldloc.0
-		IL_028c: ldloc.s 9
-		IL_028e: stfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::DerivedAsyncGeneratorClass
-		IL_0293: nop
-		IL_0294: ldloc.1
-		IL_0295: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_029f: pop
-		IL_02a0: ret
+		IL_0284: stfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::DerivedAsyncGeneratorClass
+		IL_0289: nop
+		IL_028a: ldloc.1
+		IL_028b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0295: pop
+		IL_0296: ret
 	} // end of method AsyncGenerator_GeneratedFunctionObject_Semantics::__js_module_init__
 
 } // end of class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_AccessorMethods_InstanceAndStatic.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_AccessorMethods_InstanceAndStatic.verified.txt
@@ -740,7 +740,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 737 (0x2e1)
+		// Code size: 712 (0x2c8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_AccessorMethods_InstanceAndStatic/Scope,
@@ -800,194 +800,189 @@
 		IL_0094: ldc.i4.1
 		IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0, float64, string, bool, bool)
 		IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0)
-		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0)
-		IL_00a4: ldnull
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_00aa: pop
-		IL_00ab: ldloc.s 4
-		IL_00ad: ldstr "prototype"
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b7: stloc.s 5
-		IL_00b9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00be: stloc.3
-		IL_00bf: ldloc.s 5
-		IL_00c1: ldstr "count"
-		IL_00c6: ldnull
-		IL_00c7: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::.ctor()
-		IL_00cc: ldc.i4.1
-		IL_00cd: conv.r8
-		IL_00ce: ldstr "set count"
-		IL_00d3: ldc.i4.1
-		IL_00d4: ldc.i4.1
-		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0, float64, string, bool, bool)
-		IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0)
-		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0)
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_00e9: pop
-		IL_00ea: ldloc.s 4
-		IL_00ec: ldstr "prototype"
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f6: stloc.s 5
-		IL_00f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00fd: stloc.3
-		IL_00fe: ldloc.s 5
-		IL_0100: ldstr "label"
-		IL_0105: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label::.ctor()
-		IL_010a: ldc.i4.0
-		IL_010b: conv.r8
-		IL_010c: ldstr "get label"
-		IL_0111: ldc.i4.1
-		IL_0112: ldc.i4.1
-		IL_0113: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0, float64, string, bool, bool)
-		IL_0118: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0)
-		IL_011d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0)
-		IL_0122: ldnull
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_0128: pop
-		IL_0129: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_012e: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0133: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0138: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_013d: stloc.s 6
-		IL_013f: ldc.i4.1
-		IL_0140: newarr [System.Runtime]System.Object
-		IL_0145: dup
-		IL_0146: ldc.i4.0
-		IL_0147: ldloc.0
-		IL_0148: stelem.ref
-		IL_0149: stloc.3
-		IL_014a: ldloc.s 6
-		IL_014c: ldstr "total"
-		IL_0151: ldloc.3
-		IL_0152: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::.ctor(object[])
-		IL_0157: ldc.i4.0
-		IL_0158: conv.r8
-		IL_0159: ldstr "get total"
-		IL_015e: ldc.i4.0
-		IL_015f: ldc.i4.1
-		IL_0160: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0, float64, string, bool, bool)
-		IL_0165: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0)
-		IL_016a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0)
-		IL_016f: ldnull
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_0175: pop
-		IL_0176: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_017b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0180: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0185: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_018a: stloc.s 6
-		IL_018c: ldc.i4.1
-		IL_018d: newarr [System.Runtime]System.Object
-		IL_0192: dup
-		IL_0193: ldc.i4.0
-		IL_0194: ldloc.0
-		IL_0195: stelem.ref
-		IL_0196: stloc.3
-		IL_0197: ldloc.s 6
-		IL_0199: ldstr "total"
-		IL_019e: ldnull
-		IL_019f: ldloc.3
-		IL_01a0: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::.ctor(object[])
-		IL_01a5: ldc.i4.1
-		IL_01a6: conv.r8
-		IL_01a7: ldstr "set total"
-		IL_01ac: ldc.i4.0
-		IL_01ad: ldc.i4.1
-		IL_01ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0, float64, string, bool, bool)
-		IL_01b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0)
-		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0)
-		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_01c2: pop
-		IL_01c3: ldc.i4.1
-		IL_01c4: newarr [System.Runtime]System.Object
-		IL_01c9: dup
-		IL_01ca: ldc.i4.0
-		IL_01cb: ldloc.0
+		IL_009f: ldnull
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_00a5: pop
+		IL_00a6: ldloc.s 4
+		IL_00a8: ldstr "prototype"
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b2: stloc.s 5
+		IL_00b4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00b9: stloc.3
+		IL_00ba: ldloc.s 5
+		IL_00bc: ldstr "count"
+		IL_00c1: ldnull
+		IL_00c2: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::.ctor()
+		IL_00c7: ldc.i4.1
+		IL_00c8: conv.r8
+		IL_00c9: ldstr "set count"
+		IL_00ce: ldc.i4.1
+		IL_00cf: ldc.i4.1
+		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0, float64, string, bool, bool)
+		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0)
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_00df: pop
+		IL_00e0: ldloc.s 4
+		IL_00e2: ldstr "prototype"
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ec: stloc.s 5
+		IL_00ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00f3: stloc.3
+		IL_00f4: ldloc.s 5
+		IL_00f6: ldstr "label"
+		IL_00fb: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label::.ctor()
+		IL_0100: ldc.i4.0
+		IL_0101: conv.r8
+		IL_0102: ldstr "get label"
+		IL_0107: ldc.i4.1
+		IL_0108: ldc.i4.1
+		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0, float64, string, bool, bool)
+		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0)
+		IL_0113: ldnull
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0119: pop
+		IL_011a: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_011f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0124: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_0129: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_012e: stloc.s 6
+		IL_0130: ldc.i4.1
+		IL_0131: newarr [System.Runtime]System.Object
+		IL_0136: dup
+		IL_0137: ldc.i4.0
+		IL_0138: ldloc.0
+		IL_0139: stelem.ref
+		IL_013a: stloc.3
+		IL_013b: ldloc.s 6
+		IL_013d: ldstr "total"
+		IL_0142: ldloc.3
+		IL_0143: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::.ctor(object[])
+		IL_0148: ldc.i4.0
+		IL_0149: conv.r8
+		IL_014a: ldstr "get total"
+		IL_014f: ldc.i4.0
+		IL_0150: ldc.i4.1
+		IL_0151: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0, float64, string, bool, bool)
+		IL_0156: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0)
+		IL_015b: ldnull
+		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0161: pop
+		IL_0162: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_0167: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_016c: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_0171: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0176: stloc.s 6
+		IL_0178: ldc.i4.1
+		IL_0179: newarr [System.Runtime]System.Object
+		IL_017e: dup
+		IL_017f: ldc.i4.0
+		IL_0180: ldloc.0
+		IL_0181: stelem.ref
+		IL_0182: stloc.3
+		IL_0183: ldloc.s 6
+		IL_0185: ldstr "total"
+		IL_018a: ldnull
+		IL_018b: ldloc.3
+		IL_018c: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::.ctor(object[])
+		IL_0191: ldc.i4.1
+		IL_0192: conv.r8
+		IL_0193: ldstr "set total"
+		IL_0198: ldc.i4.0
+		IL_0199: ldc.i4.1
+		IL_019a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0, float64, string, bool, bool)
+		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0)
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_01a9: pop
+		IL_01aa: ldc.i4.1
+		IL_01ab: newarr [System.Runtime]System.Object
+		IL_01b0: dup
+		IL_01b1: ldc.i4.0
+		IL_01b2: ldloc.0
+		IL_01b3: stelem.ref
+		IL_01b4: stloc.3
+		IL_01b5: ldloc.3
+		IL_01b6: ldc.i4.1
+		IL_01b7: newarr [System.Runtime]System.Object
+		IL_01bc: dup
+		IL_01bd: ldc.i4.0
+		IL_01be: ldc.r8 4
+		IL_01c7: box [System.Runtime]System.Double
 		IL_01cc: stelem.ref
-		IL_01cd: stloc.3
-		IL_01ce: ldloc.3
-		IL_01cf: ldc.i4.1
-		IL_01d0: newarr [System.Runtime]System.Object
-		IL_01d5: dup
-		IL_01d6: ldc.i4.0
-		IL_01d7: ldc.r8 4
-		IL_01e0: box [System.Runtime]System.Double
-		IL_01e5: stelem.ref
-		IL_01e6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_01eb: ldc.r8 4
-		IL_01f4: box [System.Runtime]System.Double
-		IL_01f9: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::.ctor(object[], object)
-		IL_01fe: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0203: stloc.2
-		IL_0204: ldloc.2
-		IL_0205: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_020a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_020f: ldstr "prototype"
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0219: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_021e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0223: stloc.s 7
-		IL_0225: ldloc.2
-		IL_0226: ldstr "count"
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0230: stloc.s 5
-		IL_0232: ldloc.s 7
-		IL_0234: ldloc.s 5
-		IL_0236: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_023b: pop
-		IL_023c: ldloc.2
-		IL_023d: ldstr "count"
-		IL_0242: ldc.r8 10
-		IL_024b: ldc.i4.1
-		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0251: pop
-		IL_0252: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0257: stloc.s 7
-		IL_0259: ldloc.2
-		IL_025a: ldstr "count"
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0264: stloc.s 5
-		IL_0266: ldloc.s 7
-		IL_0268: ldloc.s 5
-		IL_026a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_026f: pop
-		IL_0270: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0275: stloc.s 7
-		IL_0277: ldloc.2
-		IL_0278: ldstr "label"
-		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0282: stloc.s 5
-		IL_0284: ldloc.s 7
-		IL_0286: ldloc.s 5
-		IL_0288: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_028d: pop
-		IL_028e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0293: stloc.s 7
-		IL_0295: ldloc.1
-		IL_0296: ldstr "total"
-		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a0: stloc.s 5
-		IL_02a2: ldloc.s 7
-		IL_02a4: ldloc.s 5
-		IL_02a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ab: pop
-		IL_02ac: ldloc.1
-		IL_02ad: ldstr "total"
-		IL_02b2: ldc.r8 5
-		IL_02bb: ldc.i4.1
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_02c1: pop
-		IL_02c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02c7: stloc.s 7
-		IL_02c9: ldloc.1
-		IL_02ca: ldstr "total"
-		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02d4: stloc.s 5
-		IL_02d6: ldloc.s 7
-		IL_02d8: ldloc.s 5
-		IL_02da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02df: pop
-		IL_02e0: ret
+		IL_01cd: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_01d2: ldc.r8 4
+		IL_01db: box [System.Runtime]System.Double
+		IL_01e0: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::.ctor(object[], object)
+		IL_01e5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_01ea: stloc.2
+		IL_01eb: ldloc.2
+		IL_01ec: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+		IL_01f1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_01f6: ldstr "prototype"
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0200: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0205: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_020a: stloc.s 7
+		IL_020c: ldloc.2
+		IL_020d: ldstr "count"
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0217: stloc.s 5
+		IL_0219: ldloc.s 7
+		IL_021b: ldloc.s 5
+		IL_021d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0222: pop
+		IL_0223: ldloc.2
+		IL_0224: ldstr "count"
+		IL_0229: ldc.r8 10
+		IL_0232: ldc.i4.1
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0238: pop
+		IL_0239: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_023e: stloc.s 7
+		IL_0240: ldloc.2
+		IL_0241: ldstr "count"
+		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_024b: stloc.s 5
+		IL_024d: ldloc.s 7
+		IL_024f: ldloc.s 5
+		IL_0251: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0256: pop
+		IL_0257: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_025c: stloc.s 7
+		IL_025e: ldloc.2
+		IL_025f: ldstr "label"
+		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0269: stloc.s 5
+		IL_026b: ldloc.s 7
+		IL_026d: ldloc.s 5
+		IL_026f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0274: pop
+		IL_0275: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_027a: stloc.s 7
+		IL_027c: ldloc.1
+		IL_027d: ldstr "total"
+		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0287: stloc.s 5
+		IL_0289: ldloc.s 7
+		IL_028b: ldloc.s 5
+		IL_028d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0292: pop
+		IL_0293: ldloc.1
+		IL_0294: ldstr "total"
+		IL_0299: ldc.r8 5
+		IL_02a2: ldc.i4.1
+		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_02a8: pop
+		IL_02a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02ae: stloc.s 7
+		IL_02b0: ldloc.1
+		IL_02b1: ldstr "total"
+		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02bb: stloc.s 5
+		IL_02bd: ldloc.s 7
+		IL_02bf: ldloc.s 5
+		IL_02c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c6: pop
+		IL_02c7: ret
 	} // end of method Classes_AccessorMethods_InstanceAndStatic::__js_module_init__
 
 } // end of class Modules.Classes_AccessorMethods_InstanceAndStatic

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DeclarationOrder.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DeclarationOrder.verified.txt
@@ -285,7 +285,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 256 (0x100)
+		// Code size: 251 (0xfb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Scope,
@@ -322,67 +322,66 @@
 		IL_0044: ldc.i4.1
 		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0, float64, string, bool, bool)
 		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0)
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0)
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0059: pop
-		IL_005a: ldc.i4.1
-		IL_005b: newarr [System.Runtime]System.Object
-		IL_0060: dup
-		IL_0061: ldc.i4.0
-		IL_0062: ldloc.0
-		IL_0063: stelem.ref
-		IL_0064: stloc.s 5
-		IL_0066: ldloc.3
-		IL_0067: ldloc.s 5
-		IL_0069: ldc.r8 0.0
-		IL_0072: box [System.Runtime]System.Double
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007c: stloc.s 4
-		IL_007e: ldloc.s 4
-		IL_0080: stloc.1
-		IL_0081: ldc.i4.1
-		IL_0082: newarr [System.Runtime]System.Object
-		IL_0087: dup
-		IL_0088: ldc.i4.0
-		IL_0089: ldloc.0
-		IL_008a: stelem.ref
-		IL_008b: stloc.s 5
-		IL_008d: ldloc.s 5
-		IL_008f: ldc.i4.0
-		IL_0090: newarr [System.Runtime]System.Object
-		IL_0095: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_009a: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::.ctor(object[])
-		IL_009f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00a4: stloc.2
-		IL_00a5: ldloc.2
-		IL_00a6: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
-		IL_00ab: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00b0: ldstr "prototype"
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00ba: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c4: stloc.s 6
-		IL_00c6: ldloc.2
-		IL_00c7: ldstr "field"
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d1: stloc.s 4
-		IL_00d3: ldloc.s 6
-		IL_00d5: ldloc.s 4
-		IL_00d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00dc: pop
-		IL_00dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e2: stloc.s 6
-		IL_00e4: ldloc.2
-		IL_00e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example>(!!0)
-		IL_00ea: stloc.s 7
-		IL_00ec: ldloc.s 7
-		IL_00ee: callvirt instance object Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::'method'()
-		IL_00f3: stloc.s 4
-		IL_00f5: ldloc.s 6
-		IL_00f7: ldloc.s 4
-		IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fe: pop
-		IL_00ff: ret
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0054: pop
+		IL_0055: ldc.i4.1
+		IL_0056: newarr [System.Runtime]System.Object
+		IL_005b: dup
+		IL_005c: ldc.i4.0
+		IL_005d: ldloc.0
+		IL_005e: stelem.ref
+		IL_005f: stloc.s 5
+		IL_0061: ldloc.3
+		IL_0062: ldloc.s 5
+		IL_0064: ldc.r8 0.0
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.s 4
+		IL_007b: stloc.1
+		IL_007c: ldc.i4.1
+		IL_007d: newarr [System.Runtime]System.Object
+		IL_0082: dup
+		IL_0083: ldc.i4.0
+		IL_0084: ldloc.0
+		IL_0085: stelem.ref
+		IL_0086: stloc.s 5
+		IL_0088: ldloc.s 5
+		IL_008a: ldc.i4.0
+		IL_008b: newarr [System.Runtime]System.Object
+		IL_0090: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0095: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::.ctor(object[])
+		IL_009a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_009f: stloc.2
+		IL_00a0: ldloc.2
+		IL_00a1: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
+		IL_00a6: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00ab: ldstr "prototype"
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00b5: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bf: stloc.s 6
+		IL_00c1: ldloc.2
+		IL_00c2: ldstr "field"
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00cc: stloc.s 4
+		IL_00ce: ldloc.s 6
+		IL_00d0: ldloc.s 4
+		IL_00d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d7: pop
+		IL_00d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00dd: stloc.s 6
+		IL_00df: ldloc.2
+		IL_00e0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example>(!!0)
+		IL_00e5: stloc.s 7
+		IL_00e7: ldloc.s 7
+		IL_00e9: callvirt instance object Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::'method'()
+		IL_00ee: stloc.s 4
+		IL_00f0: ldloc.s 6
+		IL_00f2: ldloc.s 4
+		IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f9: pop
+		IL_00fa: ret
 	} // end of method Classes_ClassComputedFieldAndMethod_DeclarationOrder::__js_module_init__
 
 } // end of class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
@@ -301,7 +301,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 385 (0x181)
+		// Code size: 380 (0x17c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope,
@@ -349,104 +349,103 @@
 		IL_0052: ldc.i4.1
 		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14>(!!0, float64, string, bool, bool)
 		IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14>(!!0)
-		IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14>(!!0)
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0067: pop
-		IL_0068: ldc.i4.1
-		IL_0069: newarr [System.Runtime]System.Object
-		IL_006e: dup
-		IL_006f: ldc.i4.0
-		IL_0070: ldloc.0
-		IL_0071: stelem.ref
-		IL_0072: stloc.s 5
-		IL_0074: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_0079: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_007e: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_0083: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0088: stloc.3
-		IL_0089: ldloc.3
-		IL_008a: ldloc.s 5
-		IL_008c: ldc.r8 0.0
-		IL_0095: box [System.Runtime]System.Double
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_009f: stloc.s 4
-		IL_00a1: ldloc.s 4
-		IL_00a3: stloc.1
-		IL_00a4: ldc.i4.1
-		IL_00a5: newarr [System.Runtime]System.Object
-		IL_00aa: dup
-		IL_00ab: ldc.i4.0
-		IL_00ac: ldloc.0
-		IL_00ad: stelem.ref
-		IL_00ae: stloc.s 5
-		IL_00b0: ldloc.s 5
-		IL_00b2: ldc.i4.0
-		IL_00b3: newarr [System.Runtime]System.Object
-		IL_00b8: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00bd: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example::.ctor(object[])
-		IL_00c2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00c7: stloc.2
-		IL_00c8: ldloc.2
-		IL_00c9: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_00ce: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00d3: ldstr "prototype"
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00dd: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e7: stloc.s 6
-		IL_00e9: ldloc.2
-		IL_00ea: ldstr "value"
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f4: stloc.s 4
-		IL_00f6: ldloc.s 6
-		IL_00f8: ldloc.s 4
-		IL_00fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ff: pop
-		IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0105: stloc.s 6
-		IL_0107: ldloc.2
-		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example>(!!0)
-		IL_010d: stloc.s 7
-		IL_010f: ldc.i4.0
-		IL_0110: newarr [System.Runtime]System.Object
-		IL_0115: stloc.s 5
-		IL_0117: ldloc.s 7
-		IL_0119: ldstr "bump"
-		IL_011e: ldloc.s 5
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0125: stloc.s 4
-		IL_0127: ldloc.s 6
-		IL_0129: ldloc.s 4
-		IL_012b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0130: pop
-		IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0136: stloc.s 6
-		IL_0138: ldloc.2
-		IL_0139: ldstr "value"
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0143: stloc.s 4
-		IL_0145: ldloc.s 6
-		IL_0147: ldloc.s 4
-		IL_0149: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_014e: pop
-		IL_014f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0154: stloc.s 6
-		IL_0156: ldloc.2
-		IL_0157: ldstr "fieldKey"
-		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0161: stloc.s 4
-		IL_0163: ldloc.s 4
-		IL_0165: ldnull
-		IL_0166: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_016b: stloc.s 8
-		IL_016d: ldloc.s 8
-		IL_016f: box [System.Runtime]System.Boolean
-		IL_0174: stloc.s 9
-		IL_0176: ldloc.s 6
-		IL_0178: ldloc.s 9
-		IL_017a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017f: pop
-		IL_0180: ret
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0062: pop
+		IL_0063: ldc.i4.1
+		IL_0064: newarr [System.Runtime]System.Object
+		IL_0069: dup
+		IL_006a: ldc.i4.0
+		IL_006b: ldloc.0
+		IL_006c: stelem.ref
+		IL_006d: stloc.s 5
+		IL_006f: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_0074: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0079: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_007e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0083: stloc.3
+		IL_0084: ldloc.3
+		IL_0085: ldloc.s 5
+		IL_0087: ldc.r8 0.0
+		IL_0090: box [System.Runtime]System.Double
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_009a: stloc.s 4
+		IL_009c: ldloc.s 4
+		IL_009e: stloc.1
+		IL_009f: ldc.i4.1
+		IL_00a0: newarr [System.Runtime]System.Object
+		IL_00a5: dup
+		IL_00a6: ldc.i4.0
+		IL_00a7: ldloc.0
+		IL_00a8: stelem.ref
+		IL_00a9: stloc.s 5
+		IL_00ab: ldloc.s 5
+		IL_00ad: ldc.i4.0
+		IL_00ae: newarr [System.Runtime]System.Object
+		IL_00b3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00b8: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example::.ctor(object[])
+		IL_00bd: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00c2: stloc.2
+		IL_00c3: ldloc.2
+		IL_00c4: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_00c9: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00ce: ldstr "prototype"
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00d8: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e2: stloc.s 6
+		IL_00e4: ldloc.2
+		IL_00e5: ldstr "value"
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ef: stloc.s 4
+		IL_00f1: ldloc.s 6
+		IL_00f3: ldloc.s 4
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fa: pop
+		IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0100: stloc.s 6
+		IL_0102: ldloc.2
+		IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example>(!!0)
+		IL_0108: stloc.s 7
+		IL_010a: ldc.i4.0
+		IL_010b: newarr [System.Runtime]System.Object
+		IL_0110: stloc.s 5
+		IL_0112: ldloc.s 7
+		IL_0114: ldstr "bump"
+		IL_0119: ldloc.s 5
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0120: stloc.s 4
+		IL_0122: ldloc.s 6
+		IL_0124: ldloc.s 4
+		IL_0126: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_012b: pop
+		IL_012c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0131: stloc.s 6
+		IL_0133: ldloc.2
+		IL_0134: ldstr "value"
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013e: stloc.s 4
+		IL_0140: ldloc.s 6
+		IL_0142: ldloc.s 4
+		IL_0144: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0149: pop
+		IL_014a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014f: stloc.s 6
+		IL_0151: ldloc.2
+		IL_0152: ldstr "fieldKey"
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015c: stloc.s 4
+		IL_015e: ldloc.s 4
+		IL_0160: ldnull
+		IL_0161: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0166: stloc.s 8
+		IL_0168: ldloc.s 8
+		IL_016a: box [System.Runtime]System.Boolean
+		IL_016f: stloc.s 9
+		IL_0171: ldloc.s 6
+		IL_0173: ldloc.s 9
+		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_017a: pop
+		IL_017b: ret
 	} // end of method Classes_ClassComputedFieldAndMethod_DynamicKey_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassExpression_LazyPrototypeMetadata.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassExpression_LazyPrototypeMetadata.verified.txt
@@ -254,7 +254,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 488 (0x1e8)
+		// Code size: 483 (0x1e3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassExpression_LazyPrototypeMetadata/Scope,
@@ -304,128 +304,127 @@
 		IL_006d: ldc.i4.1
 		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0, float64, string, bool, bool)
 		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0)
-		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0)
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0082: pop
-		IL_0083: ldc.i4.1
-		IL_0084: newarr [System.Runtime]System.Object
-		IL_0089: dup
-		IL_008a: ldc.i4.0
-		IL_008b: ldloc.0
-		IL_008c: stelem.ref
-		IL_008d: stloc.s 6
-		IL_008f: ldloc.s 4
-		IL_0091: ldloc.s 6
-		IL_0093: ldc.r8 0.0
-		IL_009c: box [System.Runtime]System.Double
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
-		IL_00a6: stloc.s 5
-		IL_00a8: ldloc.s 5
-		IL_00aa: ldstr "Greeter"
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
-		IL_00b4: stloc.s 5
-		IL_00b6: ldloc.s 5
-		IL_00b8: ldstr "Greeter"
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
-		IL_00c2: stloc.2
-		IL_00c3: ldloc.2
-		IL_00c4: ldc.i4.0
-		IL_00c5: newarr [System.Runtime]System.Object
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_00cf: stloc.3
-		IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d5: stloc.s 7
-		IL_00d7: ldloc.3
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00dd: stloc.s 5
-		IL_00df: ldloc.s 5
-		IL_00e1: isinst Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
-		IL_00e6: dup
-		IL_00e7: brfalse IL_00f8
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_007d: pop
+		IL_007e: ldc.i4.1
+		IL_007f: newarr [System.Runtime]System.Object
+		IL_0084: dup
+		IL_0085: ldc.i4.0
+		IL_0086: ldloc.0
+		IL_0087: stelem.ref
+		IL_0088: stloc.s 6
+		IL_008a: ldloc.s 4
+		IL_008c: ldloc.s 6
+		IL_008e: ldc.r8 0.0
+		IL_0097: box [System.Runtime]System.Double
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
+		IL_00a1: stloc.s 5
+		IL_00a3: ldloc.s 5
+		IL_00a5: ldstr "Greeter"
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
+		IL_00af: stloc.s 5
+		IL_00b1: ldloc.s 5
+		IL_00b3: ldstr "Greeter"
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
+		IL_00bd: stloc.2
+		IL_00be: ldloc.2
+		IL_00bf: ldc.i4.0
+		IL_00c0: newarr [System.Runtime]System.Object
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_00ca: stloc.3
+		IL_00cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d0: stloc.s 7
+		IL_00d2: ldloc.3
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d8: stloc.s 5
+		IL_00da: ldloc.s 5
+		IL_00dc: isinst Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
+		IL_00e1: dup
+		IL_00e2: brfalse IL_00f3
 
-		IL_00ec: callvirt instance object Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17::greet()
-		IL_00f1: stloc.s 5
-		IL_00f3: br IL_0107
+		IL_00e7: callvirt instance object Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17::greet()
+		IL_00ec: stloc.s 5
+		IL_00ee: br IL_0102
 
-		IL_00f8: pop
-		IL_00f9: ldloc.s 5
-		IL_00fb: ldstr "greet"
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0105: stloc.s 5
+		IL_00f3: pop
+		IL_00f4: ldloc.s 5
+		IL_00f6: ldstr "greet"
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0100: stloc.s 5
 
-		IL_0107: ldloc.s 7
-		IL_0109: ldloc.s 5
-		IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0110: pop
-		IL_0111: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0116: stloc.s 7
-		IL_0118: ldloc.3
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_011e: stloc.s 5
-		IL_0120: ldloc.2
-		IL_0121: ldstr "prototype"
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012b: stloc.s 8
-		IL_012d: ldloc.s 5
-		IL_012f: ldloc.s 8
-		IL_0131: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0136: stloc.s 9
-		IL_0138: ldloc.s 9
-		IL_013a: box [System.Runtime]System.Boolean
-		IL_013f: stloc.s 10
-		IL_0141: ldloc.s 7
-		IL_0143: ldloc.s 10
-		IL_0145: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_014a: pop
-		IL_014b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0150: stloc.s 7
-		IL_0152: ldloc.2
-		IL_0153: ldstr "prototype"
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015d: stloc.s 8
-		IL_015f: ldloc.s 8
-		IL_0161: ldstr "greet"
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_016b: stloc.s 8
-		IL_016d: ldloc.s 8
-		IL_016f: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0174: stloc.s 11
-		IL_0176: ldloc.s 7
-		IL_0178: ldloc.s 11
-		IL_017a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017f: pop
-		IL_0180: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0185: stloc.s 7
-		IL_0187: ldloc.2
-		IL_0188: ldstr "prototype"
-		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0192: stloc.s 8
-		IL_0194: ldloc.s 8
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_019b: ldstr "length"
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a5: stloc.s 8
-		IL_01a7: ldloc.s 7
-		IL_01a9: ldloc.s 8
-		IL_01ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b0: pop
-		IL_01b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b6: stloc.s 7
-		IL_01b8: ldloc.2
-		IL_01b9: ldstr "prototype"
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c3: stloc.s 8
-		IL_01c5: ldloc.s 8
-		IL_01c7: ldstr "greet"
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_01d1: ldstr "enumerable"
-		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01db: stloc.s 8
-		IL_01dd: ldloc.s 7
-		IL_01df: ldloc.s 8
-		IL_01e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e6: pop
-		IL_01e7: ret
+		IL_0102: ldloc.s 7
+		IL_0104: ldloc.s 5
+		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010b: pop
+		IL_010c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0111: stloc.s 7
+		IL_0113: ldloc.3
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0119: stloc.s 5
+		IL_011b: ldloc.2
+		IL_011c: ldstr "prototype"
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0126: stloc.s 8
+		IL_0128: ldloc.s 5
+		IL_012a: ldloc.s 8
+		IL_012c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0131: stloc.s 9
+		IL_0133: ldloc.s 9
+		IL_0135: box [System.Runtime]System.Boolean
+		IL_013a: stloc.s 10
+		IL_013c: ldloc.s 7
+		IL_013e: ldloc.s 10
+		IL_0140: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0145: pop
+		IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014b: stloc.s 7
+		IL_014d: ldloc.2
+		IL_014e: ldstr "prototype"
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0158: stloc.s 8
+		IL_015a: ldloc.s 8
+		IL_015c: ldstr "greet"
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0166: stloc.s 8
+		IL_0168: ldloc.s 8
+		IL_016a: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_016f: stloc.s 11
+		IL_0171: ldloc.s 7
+		IL_0173: ldloc.s 11
+		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_017a: pop
+		IL_017b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0180: stloc.s 7
+		IL_0182: ldloc.2
+		IL_0183: ldstr "prototype"
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018d: stloc.s 8
+		IL_018f: ldloc.s 8
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0196: ldstr "length"
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a0: stloc.s 8
+		IL_01a2: ldloc.s 7
+		IL_01a4: ldloc.s 8
+		IL_01a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ab: pop
+		IL_01ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b1: stloc.s 7
+		IL_01b3: ldloc.2
+		IL_01b4: ldstr "prototype"
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01be: stloc.s 8
+		IL_01c0: ldloc.s 8
+		IL_01c2: ldstr "greet"
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_01cc: ldstr "enumerable"
+		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d6: stloc.s 8
+		IL_01d8: ldloc.s 7
+		IL_01da: ldloc.s 8
+		IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01e1: pop
+		IL_01e2: ret
 	} // end of method Classes_ClassExpression_LazyPrototypeMetadata::__js_module_init__
 
 } // end of class Modules.Classes_ClassExpression_LazyPrototypeMetadata

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassFieldTypeInference_Primitives.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassFieldTypeInference_Primitives.verified.txt
@@ -298,7 +298,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 300 (0x12c)
+		// Code size: 295 (0x127)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassFieldTypeInference_Primitives/Scope,
@@ -335,79 +335,78 @@
 		IL_0044: ldc.i4.1
 		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0, float64, string, bool, bool)
 		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0)
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0)
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0059: pop
-		IL_005a: ldc.i4.1
-		IL_005b: newarr [System.Runtime]System.Object
-		IL_0060: dup
-		IL_0061: ldc.i4.0
-		IL_0062: ldloc.0
-		IL_0063: stelem.ref
-		IL_0064: stloc.s 5
-		IL_0066: ldloc.3
-		IL_0067: ldloc.s 5
-		IL_0069: ldc.r8 0.0
-		IL_0072: box [System.Runtime]System.Double
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007c: stloc.s 4
-		IL_007e: ldloc.s 4
-		IL_0080: stloc.1
-		IL_0081: ldc.i4.0
-		IL_0082: newarr [System.Runtime]System.Object
-		IL_0087: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_008c: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter::.ctor()
-		IL_0091: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0096: stloc.2
-		IL_0097: ldloc.2
-		IL_0098: ldtoken Modules.Classes_ClassFieldTypeInference_Primitives/Counter
-		IL_009d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00a2: ldstr "prototype"
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00ac: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00b1: ldloc.2
-		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter>(!!0)
-		IL_00b7: stloc.s 6
-		IL_00b9: ldloc.s 6
-		IL_00bb: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
-		IL_00c0: pop
-		IL_00c1: ldloc.2
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter>(!!0)
-		IL_00c7: stloc.s 6
-		IL_00c9: ldloc.s 6
-		IL_00cb: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
-		IL_00d0: pop
-		IL_00d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d6: stloc.s 7
-		IL_00d8: ldloc.2
-		IL_00d9: ldstr "value"
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e3: stloc.s 4
-		IL_00e5: ldloc.s 7
-		IL_00e7: ldloc.s 4
-		IL_00e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ee: pop
-		IL_00ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f4: stloc.s 7
-		IL_00f6: ldloc.2
-		IL_00f7: ldstr "name"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0101: stloc.s 4
-		IL_0103: ldloc.s 7
-		IL_0105: ldloc.s 4
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010c: pop
-		IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0112: stloc.s 7
-		IL_0114: ldloc.2
-		IL_0115: ldstr "active"
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_011f: stloc.s 4
-		IL_0121: ldloc.s 7
-		IL_0123: ldloc.s 4
-		IL_0125: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_012a: pop
-		IL_012b: ret
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0054: pop
+		IL_0055: ldc.i4.1
+		IL_0056: newarr [System.Runtime]System.Object
+		IL_005b: dup
+		IL_005c: ldc.i4.0
+		IL_005d: ldloc.0
+		IL_005e: stelem.ref
+		IL_005f: stloc.s 5
+		IL_0061: ldloc.3
+		IL_0062: ldloc.s 5
+		IL_0064: ldc.r8 0.0
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.s 4
+		IL_007b: stloc.1
+		IL_007c: ldc.i4.0
+		IL_007d: newarr [System.Runtime]System.Object
+		IL_0082: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0087: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter::.ctor()
+		IL_008c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0091: stloc.2
+		IL_0092: ldloc.2
+		IL_0093: ldtoken Modules.Classes_ClassFieldTypeInference_Primitives/Counter
+		IL_0098: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_009d: ldstr "prototype"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00a7: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00ac: ldloc.2
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter>(!!0)
+		IL_00b2: stloc.s 6
+		IL_00b4: ldloc.s 6
+		IL_00b6: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
+		IL_00bb: pop
+		IL_00bc: ldloc.2
+		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter>(!!0)
+		IL_00c2: stloc.s 6
+		IL_00c4: ldloc.s 6
+		IL_00c6: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
+		IL_00cb: pop
+		IL_00cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d1: stloc.s 7
+		IL_00d3: ldloc.2
+		IL_00d4: ldstr "value"
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00de: stloc.s 4
+		IL_00e0: ldloc.s 7
+		IL_00e2: ldloc.s 4
+		IL_00e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e9: pop
+		IL_00ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ef: stloc.s 7
+		IL_00f1: ldloc.2
+		IL_00f2: ldstr "name"
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00fc: stloc.s 4
+		IL_00fe: ldloc.s 7
+		IL_0100: ldloc.s 4
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0107: pop
+		IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010d: stloc.s 7
+		IL_010f: ldloc.2
+		IL_0110: ldstr "active"
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011a: stloc.s 4
+		IL_011c: ldloc.s 7
+		IL_011e: ldloc.s 4
+		IL_0120: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0125: pop
+		IL_0126: ret
 	} // end of method Classes_ClassFieldTypeInference_Primitives::__js_module_init__
 
 } // end of class Modules.Classes_ClassFieldTypeInference_Primitives

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassLocal_ReassignedClass_FallsBack.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassLocal_ReassignedClass_FallsBack.verified.txt
@@ -529,7 +529,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 184 (0xb8)
+		// Code size: 179 (0xb3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope,
@@ -581,32 +581,31 @@
 		IL_0069: ldc.i4.1
 		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0, float64, string, bool, bool)
 		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0)
-		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0)
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_007e: pop
-		IL_007f: ldc.i4.1
-		IL_0080: newarr [System.Runtime]System.Object
-		IL_0085: dup
-		IL_0086: ldc.i4.0
-		IL_0087: ldloc.0
-		IL_0088: stelem.ref
-		IL_0089: stloc.2
-		IL_008a: ldloc.3
-		IL_008b: ldloc.2
-		IL_008c: ldc.r8 0.0
-		IL_0095: box [System.Runtime]System.Double
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_009f: stloc.s 4
-		IL_00a1: ldloc.0
-		IL_00a2: ldloc.s 4
-		IL_00a4: stfld object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope::Box
-		IL_00a9: nop
-		IL_00aa: ldloc.0
-		IL_00ab: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope
-		IL_00b0: ldnull
-		IL_00b1: call object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test::__js_call__(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope, object)
-		IL_00b6: pop
-		IL_00b7: ret
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0079: pop
+		IL_007a: ldc.i4.1
+		IL_007b: newarr [System.Runtime]System.Object
+		IL_0080: dup
+		IL_0081: ldc.i4.0
+		IL_0082: ldloc.0
+		IL_0083: stelem.ref
+		IL_0084: stloc.2
+		IL_0085: ldloc.3
+		IL_0086: ldloc.2
+		IL_0087: ldc.r8 0.0
+		IL_0090: box [System.Runtime]System.Double
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_009a: stloc.s 4
+		IL_009c: ldloc.0
+		IL_009d: ldloc.s 4
+		IL_009f: stfld object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope::Box
+		IL_00a4: nop
+		IL_00a5: ldloc.0
+		IL_00a6: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope
+		IL_00ab: ldnull
+		IL_00ac: call object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test::__js_call__(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope, object)
+		IL_00b1: pop
+		IL_00b2: ret
 	} // end of method Classes_ClassLocal_ReassignedClass_FallsBack::__js_module_init__
 
 } // end of class Modules.Classes_ClassLocal_ReassignedClass_FallsBack

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall.verified.txt
@@ -603,7 +603,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 277 (0x115)
+		// Code size: 272 (0x110)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope,
@@ -641,75 +641,74 @@
 		IL_0044: ldc.i4.1
 		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0, float64, string, bool, bool)
 		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0)
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0)
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0059: pop
-		IL_005a: ldc.i4.1
-		IL_005b: newarr [System.Runtime]System.Object
-		IL_0060: dup
-		IL_0061: ldc.i4.0
-		IL_0062: ldloc.0
-		IL_0063: stelem.ref
-		IL_0064: stloc.s 5
-		IL_0066: ldloc.3
-		IL_0067: ldloc.s 5
-		IL_0069: ldc.r8 0.0
-		IL_0072: box [System.Runtime]System.Double
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007c: stloc.s 4
-		IL_007e: ldloc.0
-		IL_007f: ldloc.s 4
-		IL_0081: stfld object Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope::Counter
-		IL_0086: nop
-		IL_0087: ldc.i4.1
-		IL_0088: newarr [System.Runtime]System.Object
-		IL_008d: dup
-		IL_008e: ldc.i4.0
-		IL_008f: ldloc.0
-		IL_0090: stelem.ref
-		IL_0091: stloc.s 5
-		IL_0093: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
-		IL_0098: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_009d: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
-		IL_00a2: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00a7: stloc.3
-		IL_00a8: ldc.i4.1
-		IL_00a9: newarr [System.Runtime]System.Object
-		IL_00ae: dup
-		IL_00af: ldc.i4.0
-		IL_00b0: ldloc.0
-		IL_00b1: stelem.ref
-		IL_00b2: stloc.s 5
-		IL_00b4: ldloc.s 5
-		IL_00b6: ldc.i4.0
-		IL_00b7: newarr [System.Runtime]System.Object
-		IL_00bc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00c1: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::.ctor(object[])
-		IL_00c6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00cb: stloc.1
-		IL_00cc: ldloc.1
-		IL_00cd: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
-		IL_00d2: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00d7: ldstr "prototype"
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00e1: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00e6: ldloc.1
-		IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator>(!!0)
-		IL_00ec: stloc.s 6
-		IL_00ee: ldloc.s 6
-		IL_00f0: callvirt instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::compute()
-		IL_00f5: stloc.s 7
-		IL_00f7: ldloc.s 7
-		IL_00f9: box [System.Runtime]System.Double
-		IL_00fe: stloc.2
-		IL_00ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0104: stloc.s 8
-		IL_0106: ldloc.s 8
-		IL_0108: ldstr "final output:"
-		IL_010d: ldloc.2
-		IL_010e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0113: pop
-		IL_0114: ret
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0054: pop
+		IL_0055: ldc.i4.1
+		IL_0056: newarr [System.Runtime]System.Object
+		IL_005b: dup
+		IL_005c: ldc.i4.0
+		IL_005d: ldloc.0
+		IL_005e: stelem.ref
+		IL_005f: stloc.s 5
+		IL_0061: ldloc.3
+		IL_0062: ldloc.s 5
+		IL_0064: ldc.r8 0.0
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.0
+		IL_007a: ldloc.s 4
+		IL_007c: stfld object Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope::Counter
+		IL_0081: nop
+		IL_0082: ldc.i4.1
+		IL_0083: newarr [System.Runtime]System.Object
+		IL_0088: dup
+		IL_0089: ldc.i4.0
+		IL_008a: ldloc.0
+		IL_008b: stelem.ref
+		IL_008c: stloc.s 5
+		IL_008e: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+		IL_0093: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0098: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+		IL_009d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00a2: stloc.3
+		IL_00a3: ldc.i4.1
+		IL_00a4: newarr [System.Runtime]System.Object
+		IL_00a9: dup
+		IL_00aa: ldc.i4.0
+		IL_00ab: ldloc.0
+		IL_00ac: stelem.ref
+		IL_00ad: stloc.s 5
+		IL_00af: ldloc.s 5
+		IL_00b1: ldc.i4.0
+		IL_00b2: newarr [System.Runtime]System.Object
+		IL_00b7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00bc: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::.ctor(object[])
+		IL_00c1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00c6: stloc.1
+		IL_00c7: ldloc.1
+		IL_00c8: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+		IL_00cd: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00d2: ldstr "prototype"
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00dc: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00e1: ldloc.1
+		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator>(!!0)
+		IL_00e7: stloc.s 6
+		IL_00e9: ldloc.s 6
+		IL_00eb: callvirt instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::compute()
+		IL_00f0: stloc.s 7
+		IL_00f2: ldloc.s 7
+		IL_00f4: box [System.Runtime]System.Double
+		IL_00f9: stloc.2
+		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ff: stloc.s 8
+		IL_0101: ldloc.s 8
+		IL_0103: ldstr "final output:"
+		IL_0108: ldloc.2
+		IL_0109: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_010e: pop
+		IL_010f: ret
 	} // end of method Classes_ClassMethod_LocalVar_ReassignedFromMethodCall::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MethodValueRequiresMetadata.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MethodValueRequiresMetadata.verified.txt
@@ -357,7 +357,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 269 (0x10d)
+		// Code size: 259 (0x103)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Scope,
@@ -394,67 +394,65 @@
 		IL_0043: ldc.i4.1
 		IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0, float64, string, bool, bool)
 		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0)
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0)
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0058: pop
-		IL_0059: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_005e: stloc.s 5
-		IL_0060: ldloc.s 4
-		IL_0062: ldstr "getGreet"
-		IL_0067: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::.ctor()
-		IL_006c: ldc.i4.0
-		IL_006d: conv.r8
-		IL_006e: ldstr "getGreet"
-		IL_0073: ldc.i4.1
-		IL_0074: ldc.i4.1
-		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0, float64, string, bool, bool)
-		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0)
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0)
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0089: pop
-		IL_008a: ldc.i4.1
-		IL_008b: newarr [System.Runtime]System.Object
-		IL_0090: dup
-		IL_0091: ldc.i4.0
-		IL_0092: ldloc.0
-		IL_0093: stelem.ref
-		IL_0094: stloc.s 5
-		IL_0096: ldloc.3
-		IL_0097: ldloc.s 5
-		IL_0099: ldc.r8 0.0
-		IL_00a2: box [System.Runtime]System.Double
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00ac: stloc.s 4
-		IL_00ae: ldloc.s 4
-		IL_00b0: stloc.1
-		IL_00b1: ldc.i4.0
-		IL_00b2: newarr [System.Runtime]System.Object
-		IL_00b7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00bc: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::.ctor()
-		IL_00c1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00c6: stloc.2
-		IL_00c7: ldloc.2
-		IL_00c8: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
-		IL_00cd: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00d2: ldstr "prototype"
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00dc: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e6: stloc.s 6
-		IL_00e8: ldloc.2
-		IL_00e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter>(!!0)
-		IL_00ee: stloc.s 7
-		IL_00f0: ldloc.s 7
-		IL_00f2: callvirt instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::getGreet()
-		IL_00f7: stloc.s 4
-		IL_00f9: ldloc.s 4
-		IL_00fb: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0100: stloc.s 8
-		IL_0102: ldloc.s 6
-		IL_0104: ldloc.s 8
-		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010b: pop
-		IL_010c: ret
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0053: pop
+		IL_0054: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0059: stloc.s 5
+		IL_005b: ldloc.s 4
+		IL_005d: ldstr "getGreet"
+		IL_0062: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::.ctor()
+		IL_0067: ldc.i4.0
+		IL_0068: conv.r8
+		IL_0069: ldstr "getGreet"
+		IL_006e: ldc.i4.1
+		IL_006f: ldc.i4.1
+		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0, float64, string, bool, bool)
+		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0)
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_007f: pop
+		IL_0080: ldc.i4.1
+		IL_0081: newarr [System.Runtime]System.Object
+		IL_0086: dup
+		IL_0087: ldc.i4.0
+		IL_0088: ldloc.0
+		IL_0089: stelem.ref
+		IL_008a: stloc.s 5
+		IL_008c: ldloc.3
+		IL_008d: ldloc.s 5
+		IL_008f: ldc.r8 0.0
+		IL_0098: box [System.Runtime]System.Double
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00a2: stloc.s 4
+		IL_00a4: ldloc.s 4
+		IL_00a6: stloc.1
+		IL_00a7: ldc.i4.0
+		IL_00a8: newarr [System.Runtime]System.Object
+		IL_00ad: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00b2: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::.ctor()
+		IL_00b7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00bc: stloc.2
+		IL_00bd: ldloc.2
+		IL_00be: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
+		IL_00c3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00c8: ldstr "prototype"
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00d2: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00dc: stloc.s 6
+		IL_00de: ldloc.2
+		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter>(!!0)
+		IL_00e4: stloc.s 7
+		IL_00e6: ldloc.s 7
+		IL_00e8: callvirt instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::getGreet()
+		IL_00ed: stloc.s 4
+		IL_00ef: ldloc.s 4
+		IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_00f6: stloc.s 8
+		IL_00f8: ldloc.s 6
+		IL_00fa: ldloc.s 8
+		IL_00fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0101: pop
+		IL_0102: ret
 	} // end of method Classes_ClassMethod_MethodValueRequiresMetadata::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_MethodValueRequiresMetadata

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_ClassExpression_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_ClassExpression_Log.verified.txt
@@ -379,7 +379,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 312 (0x138)
+		// Code size: 302 (0x12e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/Scope,
@@ -423,75 +423,73 @@
 		IL_0065: ldc.i4.1
 		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0, float64, string, bool, bool)
 		IL_006b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0)
-		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0)
-		IL_0075: ldnull
-		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_007b: pop
-		IL_007c: ldloc.3
-		IL_007d: ldstr "prototype"
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0087: stloc.s 4
-		IL_0089: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_008e: stloc.s 5
-		IL_0090: ldloc.s 4
-		IL_0092: ldstr "log"
-		IL_0097: ldloc.3
-		IL_0098: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::.ctor(class [System.Runtime]System.Object)
-		IL_009d: ldc.i4.0
-		IL_009e: conv.r8
-		IL_009f: ldstr "log"
-		IL_00a4: ldc.i4.1
-		IL_00a5: ldc.i4.1
-		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0, float64, string, bool, bool)
-		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0)
-		IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0)
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00ba: pop
-		IL_00bb: ldc.i4.1
-		IL_00bc: newarr [System.Runtime]System.Object
-		IL_00c1: dup
-		IL_00c2: ldc.i4.0
-		IL_00c3: ldloc.0
-		IL_00c4: stelem.ref
-		IL_00c5: stloc.s 5
-		IL_00c7: ldloc.3
-		IL_00c8: ldloc.s 5
-		IL_00ca: ldc.r8 0.0
-		IL_00d3: box [System.Runtime]System.Double
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
-		IL_00dd: stloc.s 4
-		IL_00df: ldloc.s 4
-		IL_00e1: ldstr "Counter"
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
-		IL_00eb: stloc.s 4
-		IL_00ed: ldloc.s 4
-		IL_00ef: ldstr "Counter"
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
-		IL_00f9: stloc.2
-		IL_00fa: ldloc.2
-		IL_00fb: ldc.i4.0
-		IL_00fc: newarr [System.Runtime]System.Object
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_0106: stloc.s 4
-		IL_0108: ldloc.s 4
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010f: stloc.s 4
-		IL_0111: ldloc.s 4
-		IL_0113: isinst Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-		IL_0118: dup
-		IL_0119: brfalse IL_0129
+		IL_0070: ldnull
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0076: pop
+		IL_0077: ldloc.3
+		IL_0078: ldstr "prototype"
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0082: stloc.s 4
+		IL_0084: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0089: stloc.s 5
+		IL_008b: ldloc.s 4
+		IL_008d: ldstr "log"
+		IL_0092: ldloc.3
+		IL_0093: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::.ctor(class [System.Runtime]System.Object)
+		IL_0098: ldc.i4.0
+		IL_0099: conv.r8
+		IL_009a: ldstr "log"
+		IL_009f: ldc.i4.1
+		IL_00a0: ldc.i4.1
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0, float64, string, bool, bool)
+		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0)
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00b0: pop
+		IL_00b1: ldc.i4.1
+		IL_00b2: newarr [System.Runtime]System.Object
+		IL_00b7: dup
+		IL_00b8: ldc.i4.0
+		IL_00b9: ldloc.0
+		IL_00ba: stelem.ref
+		IL_00bb: stloc.s 5
+		IL_00bd: ldloc.3
+		IL_00be: ldloc.s 5
+		IL_00c0: ldc.r8 0.0
+		IL_00c9: box [System.Runtime]System.Double
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
+		IL_00d3: stloc.s 4
+		IL_00d5: ldloc.s 4
+		IL_00d7: ldstr "Counter"
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
+		IL_00e1: stloc.s 4
+		IL_00e3: ldloc.s 4
+		IL_00e5: ldstr "Counter"
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorInferredName(object, object)
+		IL_00ef: stloc.2
+		IL_00f0: ldloc.2
+		IL_00f1: ldc.i4.0
+		IL_00f2: newarr [System.Runtime]System.Object
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_00fc: stloc.s 4
+		IL_00fe: ldloc.s 4
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0105: stloc.s 4
+		IL_0107: ldloc.s 4
+		IL_0109: isinst Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
+		IL_010e: dup
+		IL_010f: brfalse IL_011f
 
-		IL_011e: callvirt instance object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::log()
-		IL_0123: pop
-		IL_0124: br IL_0137
+		IL_0114: callvirt instance object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::log()
+		IL_0119: pop
+		IL_011a: br IL_012d
 
-		IL_0129: pop
-		IL_012a: ldloc.s 4
-		IL_012c: ldstr "log"
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0136: pop
+		IL_011f: pop
+		IL_0120: ldloc.s 4
+		IL_0122: ldstr "log"
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_012c: pop
 
-		IL_0137: ret
+		IL_012d: ret
 	} // end of method Classes_ClassPrivateAccessor_ClassExpression_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
@@ -624,7 +624,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 343 (0x157)
+		// Code size: 328 (0x148)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/Scope,
@@ -659,96 +659,93 @@
 		IL_0042: ldc.i4.1
 		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0, float64, string, bool, bool)
 		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0)
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0)
-		IL_0052: ldnull
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_0058: pop
-		IL_0059: ldloc.2
-		IL_005a: ldstr "prototype"
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0064: stloc.3
-		IL_0065: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006a: stloc.s 4
-		IL_006c: ldloc.3
-		IL_006d: ldstr "writeOnly"
-		IL_0072: ldnull
-		IL_0073: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::.ctor()
-		IL_0078: ldc.i4.1
-		IL_0079: conv.r8
-		IL_007a: ldstr "set writeOnly"
-		IL_007f: ldc.i4.1
-		IL_0080: ldc.i4.1
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0, float64, string, bool, bool)
-		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0)
-		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0)
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_0095: pop
-		IL_0096: ldloc.2
-		IL_0097: ldstr "prototype"
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a1: stloc.3
-		IL_00a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00a7: stloc.s 4
-		IL_00a9: ldloc.3
-		IL_00aa: ldstr "log"
-		IL_00af: ldloc.2
-		IL_00b0: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log::.ctor(class [System.Runtime]System.Object)
-		IL_00b5: ldc.i4.0
-		IL_00b6: conv.r8
-		IL_00b7: ldstr "log"
-		IL_00bc: ldc.i4.1
-		IL_00bd: ldc.i4.1
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0, float64, string, bool, bool)
-		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0)
-		IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0)
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00d2: pop
-		IL_00d3: ldc.i4.1
-		IL_00d4: newarr [System.Runtime]System.Object
-		IL_00d9: dup
-		IL_00da: ldc.i4.0
-		IL_00db: ldloc.0
-		IL_00dc: stelem.ref
-		IL_00dd: stloc.s 4
-		IL_00df: ldloc.2
-		IL_00e0: ldloc.s 4
-		IL_00e2: ldc.r8 0.0
-		IL_00eb: box [System.Runtime]System.Double
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00f5: stloc.3
-		IL_00f6: ldloc.3
-		IL_00f7: stloc.1
-		IL_00f8: ldc.i4.0
-		IL_00f9: newarr [System.Runtime]System.Object
-		IL_00fe: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0103: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::.ctor()
-		IL_0108: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_010d: stloc.s 5
-		IL_010f: ldloc.s 5
-		IL_0111: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_0116: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_011b: ldstr "prototype"
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0125: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_012a: ldloc.s 5
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0131: stloc.3
-		IL_0132: ldloc.3
-		IL_0133: isinst Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_0138: dup
-		IL_0139: brfalse IL_0149
+		IL_004d: ldnull
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0053: pop
+		IL_0054: ldloc.2
+		IL_0055: ldstr "prototype"
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_005f: stloc.3
+		IL_0060: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0065: stloc.s 4
+		IL_0067: ldloc.3
+		IL_0068: ldstr "writeOnly"
+		IL_006d: ldnull
+		IL_006e: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::.ctor()
+		IL_0073: ldc.i4.1
+		IL_0074: conv.r8
+		IL_0075: ldstr "set writeOnly"
+		IL_007a: ldc.i4.1
+		IL_007b: ldc.i4.1
+		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0, float64, string, bool, bool)
+		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0)
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_008b: pop
+		IL_008c: ldloc.2
+		IL_008d: ldstr "prototype"
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0097: stloc.3
+		IL_0098: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_009d: stloc.s 4
+		IL_009f: ldloc.3
+		IL_00a0: ldstr "log"
+		IL_00a5: ldloc.2
+		IL_00a6: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log::.ctor(class [System.Runtime]System.Object)
+		IL_00ab: ldc.i4.0
+		IL_00ac: conv.r8
+		IL_00ad: ldstr "log"
+		IL_00b2: ldc.i4.1
+		IL_00b3: ldc.i4.1
+		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0, float64, string, bool, bool)
+		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0)
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00c3: pop
+		IL_00c4: ldc.i4.1
+		IL_00c5: newarr [System.Runtime]System.Object
+		IL_00ca: dup
+		IL_00cb: ldc.i4.0
+		IL_00cc: ldloc.0
+		IL_00cd: stelem.ref
+		IL_00ce: stloc.s 4
+		IL_00d0: ldloc.2
+		IL_00d1: ldloc.s 4
+		IL_00d3: ldc.r8 0.0
+		IL_00dc: box [System.Runtime]System.Double
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00e6: stloc.3
+		IL_00e7: ldloc.3
+		IL_00e8: stloc.1
+		IL_00e9: ldc.i4.0
+		IL_00ea: newarr [System.Runtime]System.Object
+		IL_00ef: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00f4: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::.ctor()
+		IL_00f9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00fe: stloc.s 5
+		IL_0100: ldloc.s 5
+		IL_0102: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+		IL_0107: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_010c: ldstr "prototype"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0116: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_011b: ldloc.s 5
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0122: stloc.3
+		IL_0123: ldloc.3
+		IL_0124: isinst Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+		IL_0129: dup
+		IL_012a: brfalse IL_013a
 
-		IL_013e: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::log()
-		IL_0143: pop
-		IL_0144: br IL_0156
+		IL_012f: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::log()
+		IL_0134: pop
+		IL_0135: br IL_0147
 
-		IL_0149: pop
-		IL_014a: ldloc.3
-		IL_014b: ldstr "log"
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0155: pop
+		IL_013a: pop
+		IL_013b: ldloc.3
+		IL_013c: ldstr "log"
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0146: pop
 
-		IL_0156: ret
+		IL_0147: ret
 	} // end of method Classes_ClassPrivateAccessor_EdgeCases_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
@@ -295,7 +295,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 209 (0xd1)
+		// Code size: 204 (0xcc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Scope,
@@ -332,51 +332,50 @@
 		IL_0045: ldc.i4.1
 		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0, float64, string, bool, bool)
 		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0)
-		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0)
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005a: pop
-		IL_005b: ldc.i4.1
-		IL_005c: newarr [System.Runtime]System.Object
-		IL_0061: dup
-		IL_0062: ldc.i4.0
-		IL_0063: ldloc.0
-		IL_0064: stelem.ref
-		IL_0065: stloc.s 5
-		IL_0067: ldloc.3
-		IL_0068: ldloc.s 5
-		IL_006a: ldc.r8 0.0
-		IL_0073: box [System.Runtime]System.Double
-		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007d: stloc.s 4
-		IL_007f: ldloc.s 4
-		IL_0081: stloc.1
-		IL_0082: ldc.i4.1
-		IL_0083: newarr [System.Runtime]System.Object
-		IL_0088: dup
-		IL_0089: ldc.i4.0
-		IL_008a: ldloc.0
-		IL_008b: stelem.ref
-		IL_008c: stloc.s 5
-		IL_008e: ldloc.s 5
-		IL_0090: ldc.i4.0
-		IL_0091: newarr [System.Runtime]System.Object
-		IL_0096: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_009b: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::.ctor(object[])
-		IL_00a0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00a5: stloc.2
-		IL_00a6: ldloc.2
-		IL_00a7: ldtoken Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
-		IL_00ac: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00b1: ldstr "prototype"
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00bb: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00c0: ldloc.2
-		IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter>(!!0)
-		IL_00c6: stloc.s 6
-		IL_00c8: ldloc.s 6
-		IL_00ca: callvirt instance object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::logSecret()
-		IL_00cf: pop
-		IL_00d0: ret
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0055: pop
+		IL_0056: ldc.i4.1
+		IL_0057: newarr [System.Runtime]System.Object
+		IL_005c: dup
+		IL_005d: ldc.i4.0
+		IL_005e: ldloc.0
+		IL_005f: stelem.ref
+		IL_0060: stloc.s 5
+		IL_0062: ldloc.3
+		IL_0063: ldloc.s 5
+		IL_0065: ldc.r8 0.0
+		IL_006e: box [System.Runtime]System.Double
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0078: stloc.s 4
+		IL_007a: ldloc.s 4
+		IL_007c: stloc.1
+		IL_007d: ldc.i4.1
+		IL_007e: newarr [System.Runtime]System.Object
+		IL_0083: dup
+		IL_0084: ldc.i4.0
+		IL_0085: ldloc.0
+		IL_0086: stelem.ref
+		IL_0087: stloc.s 5
+		IL_0089: ldloc.s 5
+		IL_008b: ldc.i4.0
+		IL_008c: newarr [System.Runtime]System.Object
+		IL_0091: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0096: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::.ctor(object[])
+		IL_009b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00a0: stloc.2
+		IL_00a1: ldloc.2
+		IL_00a2: ldtoken Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
+		IL_00a7: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00ac: ldstr "prototype"
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00b6: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00bb: ldloc.2
+		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter>(!!0)
+		IL_00c1: stloc.s 6
+		IL_00c3: ldloc.s 6
+		IL_00c5: callvirt instance object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::logSecret()
+		IL_00ca: pop
+		IL_00cb: ret
 	} // end of method Classes_ClassPrivateField_HelperMethod_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateField_HelperMethod_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
@@ -662,7 +662,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 490 (0x1ea)
+		// Code size: 470 (0x1d6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Scope,
@@ -700,139 +700,135 @@
 		IL_0045: ldc.i4.1
 		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0, float64, string, bool, bool)
 		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0)
-		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0)
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005a: pop
-		IL_005b: ldloc.3
-		IL_005c: ldstr "prototype"
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0066: stloc.s 4
-		IL_0068: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006d: stloc.s 5
-		IL_006f: ldloc.s 4
-		IL_0071: ldstr "secret"
-		IL_0076: ldloc.3
-		IL_0077: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::.ctor(class [System.Runtime]System.Object)
-		IL_007c: ldc.i4.0
-		IL_007d: conv.r8
-		IL_007e: ldstr "get secret"
-		IL_0083: ldc.i4.1
-		IL_0084: ldc.i4.1
-		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0, float64, string, bool, bool)
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0)
-		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0)
-		IL_0094: ldnull
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_009a: pop
-		IL_009b: ldloc.3
-		IL_009c: ldstr "prototype"
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a6: stloc.s 4
-		IL_00a8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ad: stloc.s 5
-		IL_00af: ldloc.s 4
-		IL_00b1: ldstr "secret"
-		IL_00b6: ldnull
-		IL_00b7: ldloc.3
-		IL_00b8: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::.ctor(class [System.Runtime]System.Object)
-		IL_00bd: ldc.i4.1
-		IL_00be: conv.r8
-		IL_00bf: ldstr "set secret"
-		IL_00c4: ldc.i4.1
-		IL_00c5: ldc.i4.1
-		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0, float64, string, bool, bool)
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0)
-		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0)
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_00da: pop
-		IL_00db: ldloc.3
-		IL_00dc: ldstr "prototype"
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e6: stloc.s 4
-		IL_00e8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ed: stloc.s 5
-		IL_00ef: ldloc.s 4
-		IL_00f1: ldstr "log"
-		IL_00f6: ldloc.3
-		IL_00f7: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log::.ctor(class [System.Runtime]System.Object)
-		IL_00fc: ldc.i4.0
-		IL_00fd: conv.r8
-		IL_00fe: ldstr "log"
-		IL_0103: ldc.i4.1
-		IL_0104: ldc.i4.1
-		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0, float64, string, bool, bool)
-		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0)
-		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0)
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0119: pop
-		IL_011a: ldc.i4.1
-		IL_011b: newarr [System.Runtime]System.Object
-		IL_0120: dup
-		IL_0121: ldc.i4.0
-		IL_0122: ldloc.0
-		IL_0123: stelem.ref
-		IL_0124: stloc.s 5
-		IL_0126: ldloc.3
-		IL_0127: ldloc.s 5
-		IL_0129: ldc.r8 0.0
-		IL_0132: box [System.Runtime]System.Double
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_013c: stloc.s 4
-		IL_013e: ldloc.s 4
-		IL_0140: stloc.1
-		IL_0141: ldc.i4.1
-		IL_0142: newarr [System.Runtime]System.Object
-		IL_0147: dup
-		IL_0148: ldc.i4.0
-		IL_0149: ldloc.0
-		IL_014a: stelem.ref
-		IL_014b: stloc.s 5
-		IL_014d: ldloc.s 5
-		IL_014f: ldc.i4.0
-		IL_0150: newarr [System.Runtime]System.Object
-		IL_0155: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_015a: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::.ctor(object[])
-		IL_015f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0164: stloc.2
-		IL_0165: ldloc.2
-		IL_0166: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_016b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0170: ldstr "prototype"
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_017a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_017f: ldloc.2
-		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter>(!!0)
-		IL_0185: stloc.s 6
-		IL_0187: ldloc.s 6
-		IL_0189: callvirt instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::log()
-		IL_018e: pop
-		IL_018f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0194: stloc.s 7
-		IL_0196: ldloc.2
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a1: ldstr "includes"
-		IL_01a6: ldstr "#double"
-		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b0: stloc.s 4
-		IL_01b2: ldloc.s 7
-		IL_01b4: ldloc.s 4
-		IL_01b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01bb: pop
-		IL_01bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c1: stloc.s 7
-		IL_01c3: ldloc.2
-		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ce: ldstr "includes"
-		IL_01d3: ldstr "#secret"
-		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01dd: stloc.s 4
-		IL_01df: ldloc.s 7
-		IL_01e1: ldloc.s 4
-		IL_01e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e8: pop
-		IL_01e9: ret
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0055: pop
+		IL_0056: ldloc.3
+		IL_0057: ldstr "prototype"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0061: stloc.s 4
+		IL_0063: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0068: stloc.s 5
+		IL_006a: ldloc.s 4
+		IL_006c: ldstr "secret"
+		IL_0071: ldloc.3
+		IL_0072: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::.ctor(class [System.Runtime]System.Object)
+		IL_0077: ldc.i4.0
+		IL_0078: conv.r8
+		IL_0079: ldstr "get secret"
+		IL_007e: ldc.i4.1
+		IL_007f: ldc.i4.1
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0, float64, string, bool, bool)
+		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0)
+		IL_008a: ldnull
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0090: pop
+		IL_0091: ldloc.3
+		IL_0092: ldstr "prototype"
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009c: stloc.s 4
+		IL_009e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a3: stloc.s 5
+		IL_00a5: ldloc.s 4
+		IL_00a7: ldstr "secret"
+		IL_00ac: ldnull
+		IL_00ad: ldloc.3
+		IL_00ae: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::.ctor(class [System.Runtime]System.Object)
+		IL_00b3: ldc.i4.1
+		IL_00b4: conv.r8
+		IL_00b5: ldstr "set secret"
+		IL_00ba: ldc.i4.1
+		IL_00bb: ldc.i4.1
+		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0, float64, string, bool, bool)
+		IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0)
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_00cb: pop
+		IL_00cc: ldloc.3
+		IL_00cd: ldstr "prototype"
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d7: stloc.s 4
+		IL_00d9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00de: stloc.s 5
+		IL_00e0: ldloc.s 4
+		IL_00e2: ldstr "log"
+		IL_00e7: ldloc.3
+		IL_00e8: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log::.ctor(class [System.Runtime]System.Object)
+		IL_00ed: ldc.i4.0
+		IL_00ee: conv.r8
+		IL_00ef: ldstr "log"
+		IL_00f4: ldc.i4.1
+		IL_00f5: ldc.i4.1
+		IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0, float64, string, bool, bool)
+		IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0)
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0105: pop
+		IL_0106: ldc.i4.1
+		IL_0107: newarr [System.Runtime]System.Object
+		IL_010c: dup
+		IL_010d: ldc.i4.0
+		IL_010e: ldloc.0
+		IL_010f: stelem.ref
+		IL_0110: stloc.s 5
+		IL_0112: ldloc.3
+		IL_0113: ldloc.s 5
+		IL_0115: ldc.r8 0.0
+		IL_011e: box [System.Runtime]System.Double
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0128: stloc.s 4
+		IL_012a: ldloc.s 4
+		IL_012c: stloc.1
+		IL_012d: ldc.i4.1
+		IL_012e: newarr [System.Runtime]System.Object
+		IL_0133: dup
+		IL_0134: ldc.i4.0
+		IL_0135: ldloc.0
+		IL_0136: stelem.ref
+		IL_0137: stloc.s 5
+		IL_0139: ldloc.s 5
+		IL_013b: ldc.i4.0
+		IL_013c: newarr [System.Runtime]System.Object
+		IL_0141: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0146: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::.ctor(object[])
+		IL_014b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0150: stloc.2
+		IL_0151: ldloc.2
+		IL_0152: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+		IL_0157: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_015c: ldstr "prototype"
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0166: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_016b: ldloc.2
+		IL_016c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter>(!!0)
+		IL_0171: stloc.s 6
+		IL_0173: ldloc.s 6
+		IL_0175: callvirt instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::log()
+		IL_017a: pop
+		IL_017b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0180: stloc.s 7
+		IL_0182: ldloc.2
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018d: ldstr "includes"
+		IL_0192: ldstr "#double"
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019c: stloc.s 4
+		IL_019e: ldloc.s 7
+		IL_01a0: ldloc.s 4
+		IL_01a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a7: pop
+		IL_01a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ad: stloc.s 7
+		IL_01af: ldloc.2
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ba: ldstr "includes"
+		IL_01bf: ldstr "#secret"
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c9: stloc.s 4
+		IL_01cb: ldloc.s 7
+		IL_01cd: ldloc.s 4
+		IL_01cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d4: pop
+		IL_01d5: ret
 	} // end of method Classes_ClassPrivateMethodAndAccessor_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateMethodAndAccessor_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticMethod_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticMethod_HelloWorld.verified.txt
@@ -254,7 +254,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 139 (0x8b)
+		// Code size: 134 (0x86)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassWithStaticMethod_HelloWorld/Scope,
@@ -288,30 +288,29 @@
 		IL_0041: ldc.i4.1
 		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0, float64, string, bool, bool)
 		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0)
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0)
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0056: pop
-		IL_0057: ldc.i4.1
-		IL_0058: newarr [System.Runtime]System.Object
-		IL_005d: dup
-		IL_005e: ldc.i4.0
-		IL_005f: ldloc.0
-		IL_0060: stelem.ref
-		IL_0061: stloc.3
-		IL_0062: ldloc.2
-		IL_0063: ldloc.3
-		IL_0064: ldc.r8 0.0
-		IL_006d: box [System.Runtime]System.Double
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0077: stloc.s 4
-		IL_0079: ldloc.s 4
-		IL_007b: stloc.1
-		IL_007c: ldloc.1
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_0082: stloc.s 4
-		IL_0084: call object Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter::helloWorld()
-		IL_0089: pop
-		IL_008a: ret
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0051: pop
+		IL_0052: ldc.i4.1
+		IL_0053: newarr [System.Runtime]System.Object
+		IL_0058: dup
+		IL_0059: ldc.i4.0
+		IL_005a: ldloc.0
+		IL_005b: stelem.ref
+		IL_005c: stloc.3
+		IL_005d: ldloc.2
+		IL_005e: ldloc.3
+		IL_005f: ldc.r8 0.0
+		IL_0068: box [System.Runtime]System.Double
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0072: stloc.s 4
+		IL_0074: ldloc.s 4
+		IL_0076: stloc.1
+		IL_0077: ldloc.1
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_007d: stloc.s 4
+		IL_007f: call object Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter::helloWorld()
+		IL_0084: pop
+		IL_0085: ret
 	} // end of method Classes_ClassWithStaticMethod_HelloWorld::__js_module_init__
 
 } // end of class Modules.Classes_ClassWithStaticMethod_HelloWorld

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
@@ -347,7 +347,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 116 (0x74)
+			// Code size: 111 (0x6f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/Scope,
@@ -379,19 +379,18 @@
 			IL_0040: ldc.i4.1
 			IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0, float64, string, bool, bool)
 			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0)
-			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0)
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_0055: pop
-			IL_0056: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_005b: stloc.3
-			IL_005c: ldloc.1
-			IL_005d: ldloc.3
-			IL_005e: ldc.r8 0.0
-			IL_0067: box [System.Runtime]System.Double
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
-			IL_0071: stloc.2
-			IL_0072: ldloc.2
-			IL_0073: ret
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_0050: pop
+			IL_0051: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0056: stloc.3
+			IL_0057: ldloc.1
+			IL_0058: ldloc.3
+			IL_0059: ldc.r8 0.0
+			IL_0062: box [System.Runtime]System.Double
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
+			IL_006c: stloc.2
+			IL_006d: ldloc.2
+			IL_006e: ret
 		} // end of method makeClass::__js_call__
 
 	} // end of class makeClass
@@ -998,7 +997,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 215 (0xd7)
+			// Code size: 200 (0xc8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/Scope,
@@ -1034,48 +1033,45 @@
 			IL_0048: ldc.i4.1
 			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0, float64, string, bool, bool)
 			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0)
-			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0)
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_005d: pop
-			IL_005e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0063: stloc.s 4
-			IL_0065: ldloc.1
-			IL_0066: ldstr "__jroc_priv_method_hidden"
-			IL_006b: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden::.ctor()
-			IL_0070: ldc.i4.0
-			IL_0071: conv.r8
-			IL_0072: ldstr "#hidden"
-			IL_0077: ldc.i4.0
-			IL_0078: ldc.i4.1
-			IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0, float64, string, bool, bool)
-			IL_007e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0)
-			IL_0083: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0)
-			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_008d: pop
-			IL_008e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0093: stloc.s 4
-			IL_0095: ldloc.1
-			IL_0096: ldstr "readStatic"
-			IL_009b: ldloc.1
-			IL_009c: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::.ctor(class [System.Runtime]System.Object)
-			IL_00a1: ldc.i4.0
-			IL_00a2: conv.r8
-			IL_00a3: ldstr "readStatic"
-			IL_00a8: ldc.i4.1
-			IL_00a9: ldc.i4.1
-			IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0, float64, string, bool, bool)
-			IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0)
-			IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0)
-			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_00be: pop
-			IL_00bf: ldloc.1
-			IL_00c0: ldloc.3
-			IL_00c1: ldc.r8 1
-			IL_00ca: box [System.Runtime]System.Double
-			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
-			IL_00d4: stloc.2
-			IL_00d5: ldloc.2
-			IL_00d6: ret
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_0058: pop
+			IL_0059: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_005e: stloc.s 4
+			IL_0060: ldloc.1
+			IL_0061: ldstr "__jroc_priv_method_hidden"
+			IL_0066: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden::.ctor()
+			IL_006b: ldc.i4.0
+			IL_006c: conv.r8
+			IL_006d: ldstr "#hidden"
+			IL_0072: ldc.i4.0
+			IL_0073: ldc.i4.1
+			IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0, float64, string, bool, bool)
+			IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0)
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_0083: pop
+			IL_0084: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0089: stloc.s 4
+			IL_008b: ldloc.1
+			IL_008c: ldstr "readStatic"
+			IL_0091: ldloc.1
+			IL_0092: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::.ctor(class [System.Runtime]System.Object)
+			IL_0097: ldc.i4.0
+			IL_0098: conv.r8
+			IL_0099: ldstr "readStatic"
+			IL_009e: ldc.i4.1
+			IL_009f: ldc.i4.1
+			IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0, float64, string, bool, bool)
+			IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0)
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_00af: pop
+			IL_00b0: ldloc.1
+			IL_00b1: ldloc.3
+			IL_00b2: ldc.r8 1
+			IL_00bb: box [System.Runtime]System.Double
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateFreshClassConstructorValue(object, object, object)
+			IL_00c5: stloc.2
+			IL_00c6: ldloc.2
+			IL_00c7: ret
 		} // end of method makeSecretClass::__js_call__
 
 	} // end of class makeSecretClass
@@ -2405,7 +2401,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 3021 (0xbcd)
+		// Code size: 2991 (0xbaf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_GeneratedMethodFunctionObjects/Scope,
@@ -2513,980 +2509,974 @@
 		IL_0086: ldc.i4.1
 		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0, float64, string, bool, bool)
 		IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0)
-		IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0)
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_009b: pop
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
-		IL_00a6: stloc.s 35
-		IL_00a8: ldloc.s 36
-		IL_00aa: ldloc.s 35
-		IL_00ac: ldc.r8 0.0
-		IL_00b5: box [System.Runtime]System.Double
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00bf: stloc.s 37
-		IL_00c1: ldloc.s 37
-		IL_00c3: stloc.3
-		IL_00c4: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_00c9: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00ce: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_00d3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00d8: stloc.s 36
-		IL_00da: ldloc.s 36
-		IL_00dc: ldstr "prototype"
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e6: stloc.s 37
-		IL_00e8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ed: stloc.s 35
-		IL_00ef: ldloc.s 37
-		IL_00f1: ldstr "add"
-		IL_00f6: ldloc.s 37
-		IL_00f8: ldloc.s 35
-		IL_00fa: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add::.ctor(class [System.Runtime]System.Object, object[])
-		IL_00ff: ldc.i4.1
-		IL_0100: conv.r8
-		IL_0101: ldstr "add"
-		IL_0106: ldc.i4.1
-		IL_0107: ldc.i4.1
-		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0, float64, string, bool, bool)
-		IL_010d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0)
-		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0)
-		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_011c: pop
-		IL_011d: ldloc.s 36
-		IL_011f: ldstr "prototype"
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0129: stloc.s 37
-		IL_012b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0130: stloc.s 35
-		IL_0132: ldloc.s 37
-		IL_0134: ldstr "current"
-		IL_0139: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current::.ctor()
-		IL_013e: ldc.i4.0
-		IL_013f: conv.r8
-		IL_0140: ldstr "get current"
-		IL_0145: ldc.i4.1
-		IL_0146: ldc.i4.1
-		IL_0147: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0, float64, string, bool, bool)
-		IL_014c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0)
-		IL_0151: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0)
-		IL_0156: ldnull
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_015c: pop
-		IL_015d: ldloc.s 36
-		IL_015f: ldstr "prototype"
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0169: stloc.s 37
-		IL_016b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0170: stloc.s 35
-		IL_0172: ldloc.s 37
-		IL_0174: ldstr "current"
-		IL_0179: ldnull
-		IL_017a: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current::.ctor()
-		IL_017f: ldc.i4.1
-		IL_0180: conv.r8
-		IL_0181: ldstr "set current"
-		IL_0186: ldc.i4.1
-		IL_0187: ldc.i4.1
-		IL_0188: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0, float64, string, bool, bool)
-		IL_018d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0)
-		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0)
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
-		IL_019c: pop
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0096: pop
+		IL_0097: ldc.i4.1
+		IL_0098: newarr [System.Runtime]System.Object
+		IL_009d: dup
+		IL_009e: ldc.i4.0
+		IL_009f: ldloc.0
+		IL_00a0: stelem.ref
+		IL_00a1: stloc.s 35
+		IL_00a3: ldloc.s 36
+		IL_00a5: ldloc.s 35
+		IL_00a7: ldc.r8 0.0
+		IL_00b0: box [System.Runtime]System.Double
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00ba: stloc.s 37
+		IL_00bc: ldloc.s 37
+		IL_00be: stloc.3
+		IL_00bf: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
+		IL_00c4: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00c9: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
+		IL_00ce: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00d3: stloc.s 36
+		IL_00d5: ldloc.s 36
+		IL_00d7: ldstr "prototype"
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e1: stloc.s 37
+		IL_00e3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e8: stloc.s 35
+		IL_00ea: ldloc.s 37
+		IL_00ec: ldstr "add"
+		IL_00f1: ldloc.s 37
+		IL_00f3: ldloc.s 35
+		IL_00f5: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add::.ctor(class [System.Runtime]System.Object, object[])
+		IL_00fa: ldc.i4.1
+		IL_00fb: conv.r8
+		IL_00fc: ldstr "add"
+		IL_0101: ldc.i4.1
+		IL_0102: ldc.i4.1
+		IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0, float64, string, bool, bool)
+		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0)
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0112: pop
+		IL_0113: ldloc.s 36
+		IL_0115: ldstr "prototype"
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011f: stloc.s 37
+		IL_0121: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0126: stloc.s 35
+		IL_0128: ldloc.s 37
+		IL_012a: ldstr "current"
+		IL_012f: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current::.ctor()
+		IL_0134: ldc.i4.0
+		IL_0135: conv.r8
+		IL_0136: ldstr "get current"
+		IL_013b: ldc.i4.1
+		IL_013c: ldc.i4.1
+		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0, float64, string, bool, bool)
+		IL_0142: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0)
+		IL_0147: ldnull
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_014d: pop
+		IL_014e: ldloc.s 36
+		IL_0150: ldstr "prototype"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015a: stloc.s 37
+		IL_015c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0161: stloc.s 35
+		IL_0163: ldloc.s 37
+		IL_0165: ldstr "current"
+		IL_016a: ldnull
+		IL_016b: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current::.ctor()
+		IL_0170: ldc.i4.1
+		IL_0171: conv.r8
+		IL_0172: ldstr "set current"
+		IL_0177: ldc.i4.1
+		IL_0178: ldc.i4.1
+		IL_0179: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0, float64, string, bool, bool)
+		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0)
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
+		IL_0188: pop
+		IL_0189: ldloc.s 36
+		IL_018b: ldstr "prototype"
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0195: pop
+		IL_0196: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_019b: stloc.s 35
 		IL_019d: ldloc.s 36
-		IL_019f: ldstr "prototype"
-		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a9: pop
-		IL_01aa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01af: stloc.s 35
-		IL_01b1: ldloc.s 36
-		IL_01b3: ldstr "identify"
-		IL_01b8: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify::.ctor()
-		IL_01bd: ldc.i4.1
-		IL_01be: conv.r8
-		IL_01bf: ldstr "identify"
-		IL_01c4: ldc.i4.1
-		IL_01c5: ldc.i4.1
-		IL_01c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0, float64, string, bool, bool)
-		IL_01cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0)
-		IL_01d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0)
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01da: pop
-		IL_01db: ldc.i4.1
-		IL_01dc: newarr [System.Runtime]System.Object
-		IL_01e1: dup
-		IL_01e2: ldc.i4.0
-		IL_01e3: ldloc.0
-		IL_01e4: stelem.ref
-		IL_01e5: stloc.s 35
-		IL_01e7: ldloc.s 36
-		IL_01e9: ldloc.s 35
-		IL_01eb: ldc.r8 1
-		IL_01f4: box [System.Runtime]System.Double
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_01fe: stloc.s 37
-		IL_0200: ldloc.s 37
-		IL_0202: ldloc.3
-		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0208: stloc.s 37
-		IL_020a: ldloc.s 37
-		IL_020c: stloc.s 4
-		IL_020e: ldloc.s 4
-		IL_0210: ldstr "prefix"
-		IL_0215: ldstr "static:"
-		IL_021a: ldc.i4.1
-		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0220: pop
-		IL_0221: ldc.i4.1
-		IL_0222: newarr [System.Runtime]System.Object
-		IL_0227: dup
-		IL_0228: ldc.i4.0
-		IL_0229: ldc.r8 3
-		IL_0232: box [System.Runtime]System.Double
-		IL_0237: stelem.ref
-		IL_0238: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_023d: ldloc.s 4
-		IL_023f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_0244: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0249: ldc.r8 3
-		IL_0252: box [System.Runtime]System.Double
-		IL_0257: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example::.ctor(object)
-		IL_025c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_0261: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0266: dup
-		IL_0267: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_026c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0271: ldstr "prototype"
-		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_027b: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0280: stloc.s 5
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_028c: stloc.s 5
-		IL_028e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_0293: ldloc.s 4
-		IL_0295: ldstr "prototype"
-		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_029f: stloc.s 37
-		IL_02a1: ldloc.s 37
-		IL_02a3: ldstr "add"
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_02ad: stloc.s 6
-		IL_02af: ldloc.s 4
-		IL_02b1: ldstr "prototype"
-		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02bb: stloc.s 37
-		IL_02bd: ldloc.s 37
-		IL_02bf: ldstr "current"
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_02c9: stloc.s 7
-		IL_02cb: ldloc.s 4
-		IL_02cd: ldstr "identify"
-		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_02d7: stloc.s 8
-		IL_02d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02de: stloc.s 38
-		IL_02e0: ldloc.s 5
-		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e7: stloc.s 37
-		IL_02e9: ldloc.s 37
-		IL_02eb: isinst Modules.Classes_GeneratedMethodFunctionObjects/Example
-		IL_02f0: dup
-		IL_02f1: brfalse IL_0310
+		IL_019f: ldstr "identify"
+		IL_01a4: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify::.ctor()
+		IL_01a9: ldc.i4.1
+		IL_01aa: conv.r8
+		IL_01ab: ldstr "identify"
+		IL_01b0: ldc.i4.1
+		IL_01b1: ldc.i4.1
+		IL_01b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0, float64, string, bool, bool)
+		IL_01b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0)
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01c1: pop
+		IL_01c2: ldc.i4.1
+		IL_01c3: newarr [System.Runtime]System.Object
+		IL_01c8: dup
+		IL_01c9: ldc.i4.0
+		IL_01ca: ldloc.0
+		IL_01cb: stelem.ref
+		IL_01cc: stloc.s 35
+		IL_01ce: ldloc.s 36
+		IL_01d0: ldloc.s 35
+		IL_01d2: ldc.r8 1
+		IL_01db: box [System.Runtime]System.Double
+		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_01e5: stloc.s 37
+		IL_01e7: ldloc.s 37
+		IL_01e9: ldloc.3
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_01ef: stloc.s 37
+		IL_01f1: ldloc.s 37
+		IL_01f3: stloc.s 4
+		IL_01f5: ldloc.s 4
+		IL_01f7: ldstr "prefix"
+		IL_01fc: ldstr "static:"
+		IL_0201: ldc.i4.1
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0207: pop
+		IL_0208: ldc.i4.1
+		IL_0209: newarr [System.Runtime]System.Object
+		IL_020e: dup
+		IL_020f: ldc.i4.0
+		IL_0210: ldc.r8 3
+		IL_0219: box [System.Runtime]System.Double
+		IL_021e: stelem.ref
+		IL_021f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0224: ldloc.s 4
+		IL_0226: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_022b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0230: ldc.r8 3
+		IL_0239: box [System.Runtime]System.Double
+		IL_023e: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example::.ctor(object)
+		IL_0243: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_0248: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_024d: dup
+		IL_024e: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
+		IL_0253: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0258: ldstr "prototype"
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0262: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0267: stloc.s 5
+		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0273: stloc.s 5
+		IL_0275: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_027a: ldloc.s 4
+		IL_027c: ldstr "prototype"
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0286: stloc.s 37
+		IL_0288: ldloc.s 37
+		IL_028a: ldstr "add"
+		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0294: stloc.s 6
+		IL_0296: ldloc.s 4
+		IL_0298: ldstr "prototype"
+		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a2: stloc.s 37
+		IL_02a4: ldloc.s 37
+		IL_02a6: ldstr "current"
+		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_02b0: stloc.s 7
+		IL_02b2: ldloc.s 4
+		IL_02b4: ldstr "identify"
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_02be: stloc.s 8
+		IL_02c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02c5: stloc.s 38
+		IL_02c7: ldloc.s 5
+		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ce: stloc.s 37
+		IL_02d0: ldloc.s 37
+		IL_02d2: isinst Modules.Classes_GeneratedMethodFunctionObjects/Example
+		IL_02d7: dup
+		IL_02d8: brfalse IL_02f7
 
-		IL_02f6: ldc.r8 4
-		IL_02ff: box [System.Runtime]System.Double
-		IL_0304: callvirt instance object Modules.Classes_GeneratedMethodFunctionObjects/Example::'add'(object)
-		IL_0309: stloc.s 37
-		IL_030b: br IL_032d
+		IL_02dd: ldc.r8 4
+		IL_02e6: box [System.Runtime]System.Double
+		IL_02eb: callvirt instance object Modules.Classes_GeneratedMethodFunctionObjects/Example::'add'(object)
+		IL_02f0: stloc.s 37
+		IL_02f2: br IL_0314
 
-		IL_0310: pop
-		IL_0311: ldloc.s 37
-		IL_0313: ldstr "add"
-		IL_0318: ldc.r8 4
-		IL_0321: box [System.Runtime]System.Double
-		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_032b: stloc.s 37
+		IL_02f7: pop
+		IL_02f8: ldloc.s 37
+		IL_02fa: ldstr "add"
+		IL_02ff: ldc.r8 4
+		IL_0308: box [System.Runtime]System.Double
+		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0312: stloc.s 37
 
-		IL_032d: ldloc.s 6
-		IL_032f: ldstr "value"
-		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0339: stloc.s 39
-		IL_033b: ldloc.s 39
-		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0342: ldstr "call"
-		IL_0347: ldloc.s 5
-		IL_0349: ldc.r8 5
-		IL_0352: box [System.Runtime]System.Double
-		IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_035c: stloc.s 39
-		IL_035e: ldloc.s 38
-		IL_0360: ldstr "calls"
-		IL_0365: ldloc.s 37
-		IL_0367: ldloc.s 39
-		IL_0369: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_036e: pop
-		IL_036f: ldloc.s 5
-		IL_0371: ldstr "current"
-		IL_0376: ldc.r8 9
-		IL_037f: ldc.i4.1
-		IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0385: pop
-		IL_0386: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_038b: stloc.s 38
-		IL_038d: ldloc.s 5
-		IL_038f: ldstr "current"
-		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0399: stloc.s 39
-		IL_039b: ldloc.s 7
-		IL_039d: ldstr "get"
-		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03a7: stloc.s 37
-		IL_03a9: ldloc.s 37
-		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b0: ldstr "call"
-		IL_03b5: ldloc.s 5
-		IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03bc: stloc.s 37
-		IL_03be: ldloc.s 38
-		IL_03c0: ldstr "accessors"
-		IL_03c5: ldloc.s 39
-		IL_03c7: ldloc.s 37
-		IL_03c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_03ce: pop
-		IL_03cf: ldloc.s 7
-		IL_03d1: ldstr "set"
-		IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03db: stloc.s 37
-		IL_03dd: ldloc.s 37
-		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03e4: ldstr "call"
-		IL_03e9: ldloc.s 5
-		IL_03eb: ldc.r8 11
-		IL_03f4: box [System.Runtime]System.Double
-		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03fe: pop
-		IL_03ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0404: stloc.s 38
-		IL_0406: ldloc.s 5
-		IL_0408: ldstr "current"
-		IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0412: stloc.s 37
-		IL_0414: ldloc.s 38
-		IL_0416: ldstr "setter"
-		IL_041b: ldloc.s 37
-		IL_041d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0422: pop
-		IL_0423: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0428: stloc.s 38
-		IL_042a: ldloc.s 4
-		IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_0431: stloc.s 37
-		IL_0433: ldstr "ok"
-		IL_0438: call object Modules.Classes_GeneratedMethodFunctionObjects/Example::identify(object)
-		IL_043d: stloc.s 39
-		IL_043f: ldloc.s 8
-		IL_0441: ldstr "value"
-		IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_044b: stloc.s 37
-		IL_044d: ldloc.s 37
-		IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0454: ldstr "call"
-		IL_0459: ldloc.s 4
-		IL_045b: ldstr "call"
-		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0465: stloc.s 37
-		IL_0467: ldloc.s 38
-		IL_0469: ldstr "static"
-		IL_046e: ldloc.s 39
-		IL_0470: ldloc.s 37
-		IL_0472: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0477: pop
-		IL_0478: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_047d: stloc.s 38
-		IL_047f: ldloc.s 6
-		IL_0481: ldstr "value"
-		IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_048b: stloc.s 37
-		IL_048d: ldloc.s 37
-		IL_048f: ldstr "name"
-		IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0499: stloc.s 37
-		IL_049b: ldloc.s 6
-		IL_049d: ldstr "value"
-		IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04a7: stloc.s 39
-		IL_04a9: ldloc.s 39
-		IL_04ab: ldstr "length"
-		IL_04b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04b5: stloc.s 39
-		IL_04b7: ldloc.s 7
-		IL_04b9: ldstr "get"
-		IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04c3: stloc.s 40
-		IL_04c5: ldloc.s 40
-		IL_04c7: ldstr "name"
-		IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04d1: stloc.s 40
-		IL_04d3: ldloc.s 7
-		IL_04d5: ldstr "set"
-		IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04df: stloc.s 41
-		IL_04e1: ldloc.s 41
-		IL_04e3: ldstr "name"
-		IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04ed: stloc.s 41
-		IL_04ef: ldloc.s 8
-		IL_04f1: ldstr "value"
-		IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04fb: stloc.s 42
-		IL_04fd: ldloc.s 42
-		IL_04ff: ldstr "name"
-		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0509: stloc.s 42
-		IL_050b: ldloc.s 38
-		IL_050d: ldc.i4.6
-		IL_050e: newarr [System.Runtime]System.Object
-		IL_0513: dup
-		IL_0514: ldc.i4.0
-		IL_0515: ldstr "metadata"
+		IL_0314: ldloc.s 6
+		IL_0316: ldstr "value"
+		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0320: stloc.s 39
+		IL_0322: ldloc.s 39
+		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0329: ldstr "call"
+		IL_032e: ldloc.s 5
+		IL_0330: ldc.r8 5
+		IL_0339: box [System.Runtime]System.Double
+		IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0343: stloc.s 39
+		IL_0345: ldloc.s 38
+		IL_0347: ldstr "calls"
+		IL_034c: ldloc.s 37
+		IL_034e: ldloc.s 39
+		IL_0350: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0355: pop
+		IL_0356: ldloc.s 5
+		IL_0358: ldstr "current"
+		IL_035d: ldc.r8 9
+		IL_0366: ldc.i4.1
+		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_036c: pop
+		IL_036d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0372: stloc.s 38
+		IL_0374: ldloc.s 5
+		IL_0376: ldstr "current"
+		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0380: stloc.s 39
+		IL_0382: ldloc.s 7
+		IL_0384: ldstr "get"
+		IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_038e: stloc.s 37
+		IL_0390: ldloc.s 37
+		IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0397: ldstr "call"
+		IL_039c: ldloc.s 5
+		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a3: stloc.s 37
+		IL_03a5: ldloc.s 38
+		IL_03a7: ldstr "accessors"
+		IL_03ac: ldloc.s 39
+		IL_03ae: ldloc.s 37
+		IL_03b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_03b5: pop
+		IL_03b6: ldloc.s 7
+		IL_03b8: ldstr "set"
+		IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03c2: stloc.s 37
+		IL_03c4: ldloc.s 37
+		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03cb: ldstr "call"
+		IL_03d0: ldloc.s 5
+		IL_03d2: ldc.r8 11
+		IL_03db: box [System.Runtime]System.Double
+		IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03e5: pop
+		IL_03e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03eb: stloc.s 38
+		IL_03ed: ldloc.s 5
+		IL_03ef: ldstr "current"
+		IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03f9: stloc.s 37
+		IL_03fb: ldloc.s 38
+		IL_03fd: ldstr "setter"
+		IL_0402: ldloc.s 37
+		IL_0404: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0409: pop
+		IL_040a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_040f: stloc.s 38
+		IL_0411: ldloc.s 4
+		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_0418: stloc.s 37
+		IL_041a: ldstr "ok"
+		IL_041f: call object Modules.Classes_GeneratedMethodFunctionObjects/Example::identify(object)
+		IL_0424: stloc.s 39
+		IL_0426: ldloc.s 8
+		IL_0428: ldstr "value"
+		IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0432: stloc.s 37
+		IL_0434: ldloc.s 37
+		IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_043b: ldstr "call"
+		IL_0440: ldloc.s 4
+		IL_0442: ldstr "call"
+		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_044c: stloc.s 37
+		IL_044e: ldloc.s 38
+		IL_0450: ldstr "static"
+		IL_0455: ldloc.s 39
+		IL_0457: ldloc.s 37
+		IL_0459: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_045e: pop
+		IL_045f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0464: stloc.s 38
+		IL_0466: ldloc.s 6
+		IL_0468: ldstr "value"
+		IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0472: stloc.s 37
+		IL_0474: ldloc.s 37
+		IL_0476: ldstr "name"
+		IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0480: stloc.s 37
+		IL_0482: ldloc.s 6
+		IL_0484: ldstr "value"
+		IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_048e: stloc.s 39
+		IL_0490: ldloc.s 39
+		IL_0492: ldstr "length"
+		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_049c: stloc.s 39
+		IL_049e: ldloc.s 7
+		IL_04a0: ldstr "get"
+		IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04aa: stloc.s 40
+		IL_04ac: ldloc.s 40
+		IL_04ae: ldstr "name"
+		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04b8: stloc.s 40
+		IL_04ba: ldloc.s 7
+		IL_04bc: ldstr "set"
+		IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04c6: stloc.s 41
+		IL_04c8: ldloc.s 41
+		IL_04ca: ldstr "name"
+		IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04d4: stloc.s 41
+		IL_04d6: ldloc.s 8
+		IL_04d8: ldstr "value"
+		IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04e2: stloc.s 42
+		IL_04e4: ldloc.s 42
+		IL_04e6: ldstr "name"
+		IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04f0: stloc.s 42
+		IL_04f2: ldloc.s 38
+		IL_04f4: ldc.i4.6
+		IL_04f5: newarr [System.Runtime]System.Object
+		IL_04fa: dup
+		IL_04fb: ldc.i4.0
+		IL_04fc: ldstr "metadata"
+		IL_0501: stelem.ref
+		IL_0502: dup
+		IL_0503: ldc.i4.1
+		IL_0504: ldloc.s 37
+		IL_0506: stelem.ref
+		IL_0507: dup
+		IL_0508: ldc.i4.2
+		IL_0509: ldloc.s 39
+		IL_050b: stelem.ref
+		IL_050c: dup
+		IL_050d: ldc.i4.3
+		IL_050e: ldloc.s 40
+		IL_0510: stelem.ref
+		IL_0511: dup
+		IL_0512: ldc.i4.4
+		IL_0513: ldloc.s 41
+		IL_0515: stelem.ref
+		IL_0516: dup
+		IL_0517: ldc.i4.5
+		IL_0518: ldloc.s 42
 		IL_051a: stelem.ref
-		IL_051b: dup
-		IL_051c: ldc.i4.1
-		IL_051d: ldloc.s 37
-		IL_051f: stelem.ref
-		IL_0520: dup
-		IL_0521: ldc.i4.2
-		IL_0522: ldloc.s 39
-		IL_0524: stelem.ref
-		IL_0525: dup
-		IL_0526: ldc.i4.3
-		IL_0527: ldloc.s 40
-		IL_0529: stelem.ref
-		IL_052a: dup
-		IL_052b: ldc.i4.4
-		IL_052c: ldloc.s 41
-		IL_052e: stelem.ref
-		IL_052f: dup
-		IL_0530: ldc.i4.5
-		IL_0531: ldloc.s 42
-		IL_0533: stelem.ref
-		IL_0534: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0539: pop
-		IL_053a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_053f: stloc.s 38
-		IL_0541: ldloc.s 6
-		IL_0543: ldstr "value"
-		IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_054d: stloc.s 42
-		IL_054f: ldloc.s 4
-		IL_0551: ldstr "prototype"
-		IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_055b: stloc.s 41
-		IL_055d: ldloc.s 41
-		IL_055f: ldstr "add"
-		IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0569: stloc.s 41
-		IL_056b: ldloc.s 42
-		IL_056d: ldloc.s 41
-		IL_056f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0574: stloc.s 43
-		IL_0576: ldloc.s 43
-		IL_0578: box [System.Runtime]System.Boolean
-		IL_057d: stloc.s 44
-		IL_057f: ldloc.s 7
-		IL_0581: ldstr "get"
-		IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_058b: stloc.s 41
-		IL_058d: ldloc.s 4
-		IL_058f: ldstr "prototype"
-		IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0599: stloc.s 42
-		IL_059b: ldloc.s 42
-		IL_059d: ldstr "current"
-		IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_05a7: ldstr "get"
-		IL_05ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05b1: stloc.s 42
-		IL_05b3: ldloc.s 41
-		IL_05b5: ldloc.s 42
-		IL_05b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_05bc: stloc.s 43
-		IL_05be: ldloc.s 43
-		IL_05c0: box [System.Runtime]System.Boolean
-		IL_05c5: stloc.s 45
-		IL_05c7: ldloc.s 6
-		IL_05c9: ldstr "value"
-		IL_05ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05d3: stloc.s 42
-		IL_05d5: ldloc.s 42
-		IL_05d7: ldstr "prototype"
-		IL_05dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_05e1: box [System.Runtime]System.Boolean
-		IL_05e6: stloc.s 46
-		IL_05e8: ldloc.s 38
-		IL_05ea: ldc.i4.4
-		IL_05eb: newarr [System.Runtime]System.Object
-		IL_05f0: dup
-		IL_05f1: ldc.i4.0
-		IL_05f2: ldstr "descriptors"
-		IL_05f7: stelem.ref
-		IL_05f8: dup
-		IL_05f9: ldc.i4.1
-		IL_05fa: ldloc.s 44
-		IL_05fc: stelem.ref
-		IL_05fd: dup
-		IL_05fe: ldc.i4.2
-		IL_05ff: ldloc.s 45
-		IL_0601: stelem.ref
-		IL_0602: dup
-		IL_0603: ldc.i4.3
-		IL_0604: ldloc.s 46
-		IL_0606: stelem.ref
-		IL_0607: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_060c: pop
-		IL_060d: ldc.i4.0
-		IL_060e: box [System.Runtime]System.Boolean
-		IL_0613: stloc.s 9
+		IL_051b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0520: pop
+		IL_0521: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0526: stloc.s 38
+		IL_0528: ldloc.s 6
+		IL_052a: ldstr "value"
+		IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0534: stloc.s 42
+		IL_0536: ldloc.s 4
+		IL_0538: ldstr "prototype"
+		IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0542: stloc.s 41
+		IL_0544: ldloc.s 41
+		IL_0546: ldstr "add"
+		IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0550: stloc.s 41
+		IL_0552: ldloc.s 42
+		IL_0554: ldloc.s 41
+		IL_0556: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_055b: stloc.s 43
+		IL_055d: ldloc.s 43
+		IL_055f: box [System.Runtime]System.Boolean
+		IL_0564: stloc.s 44
+		IL_0566: ldloc.s 7
+		IL_0568: ldstr "get"
+		IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0572: stloc.s 41
+		IL_0574: ldloc.s 4
+		IL_0576: ldstr "prototype"
+		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0580: stloc.s 42
+		IL_0582: ldloc.s 42
+		IL_0584: ldstr "current"
+		IL_0589: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_058e: ldstr "get"
+		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0598: stloc.s 42
+		IL_059a: ldloc.s 41
+		IL_059c: ldloc.s 42
+		IL_059e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05a3: stloc.s 43
+		IL_05a5: ldloc.s 43
+		IL_05a7: box [System.Runtime]System.Boolean
+		IL_05ac: stloc.s 45
+		IL_05ae: ldloc.s 6
+		IL_05b0: ldstr "value"
+		IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ba: stloc.s 42
+		IL_05bc: ldloc.s 42
+		IL_05be: ldstr "prototype"
+		IL_05c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_05c8: box [System.Runtime]System.Boolean
+		IL_05cd: stloc.s 46
+		IL_05cf: ldloc.s 38
+		IL_05d1: ldc.i4.4
+		IL_05d2: newarr [System.Runtime]System.Object
+		IL_05d7: dup
+		IL_05d8: ldc.i4.0
+		IL_05d9: ldstr "descriptors"
+		IL_05de: stelem.ref
+		IL_05df: dup
+		IL_05e0: ldc.i4.1
+		IL_05e1: ldloc.s 44
+		IL_05e3: stelem.ref
+		IL_05e4: dup
+		IL_05e5: ldc.i4.2
+		IL_05e6: ldloc.s 45
+		IL_05e8: stelem.ref
+		IL_05e9: dup
+		IL_05ea: ldc.i4.3
+		IL_05eb: ldloc.s 46
+		IL_05ed: stelem.ref
+		IL_05ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_05f3: pop
+		IL_05f4: ldc.i4.0
+		IL_05f5: box [System.Runtime]System.Boolean
+		IL_05fa: stloc.s 9
 		.try
 		{
-			IL_0615: nop
-			IL_0616: ldstr "Reflect"
-			IL_061b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0625: stloc.s 42
-			IL_0627: ldloc.s 6
-			IL_0629: ldstr "value"
-			IL_062e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0633: stloc.s 41
-			IL_0635: ldc.i4.0
-			IL_0636: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_063b: stloc.s 47
-			IL_063d: ldloc.s 42
-			IL_063f: ldstr "construct"
-			IL_0644: ldloc.s 41
-			IL_0646: ldloc.s 47
-			IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_064d: pop
-			IL_064e: leave IL_06b2
+			IL_05fc: nop
+			IL_05fd: ldstr "Reflect"
+			IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0607: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_060c: stloc.s 42
+			IL_060e: ldloc.s 6
+			IL_0610: ldstr "value"
+			IL_0615: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_061a: stloc.s 41
+			IL_061c: ldc.i4.0
+			IL_061d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0622: stloc.s 47
+			IL_0624: ldloc.s 42
+			IL_0626: ldstr "construct"
+			IL_062b: ldloc.s 41
+			IL_062d: ldloc.s 47
+			IL_062f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0634: pop
+			IL_0635: leave IL_0699
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0653: stloc.s 10
-			IL_0655: ldloc.s 10
-			IL_0657: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_065c: dup
-			IL_065d: brtrue IL_0673
+			IL_063a: stloc.s 10
+			IL_063c: ldloc.s 10
+			IL_063e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0643: dup
+			IL_0644: brtrue IL_065a
 
-			IL_0662: pop
-			IL_0663: ldloc.s 10
-			IL_0665: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_066a: dup
-			IL_066b: brtrue IL_067f
+			IL_0649: pop
+			IL_064a: ldloc.s 10
+			IL_064c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0651: dup
+			IL_0652: brtrue IL_0666
 
-			IL_0670: pop
-			IL_0671: rethrow
+			IL_0657: pop
+			IL_0658: rethrow
 
-			IL_0673: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0678: stloc.s 11
-			IL_067a: br IL_0681
+			IL_065a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_065f: stloc.s 11
+			IL_0661: br IL_0668
 
-			IL_067f: stloc.s 11
+			IL_0666: stloc.s 11
 
-			IL_0681: ldloc.s 11
-			IL_0683: stloc.s 12
-			IL_0685: ldloc.s 12
-			IL_0687: stloc.s 41
-			IL_0689: ldstr "TypeError"
-			IL_068e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0693: stloc.s 42
-			IL_0695: ldloc.s 41
-			IL_0697: ldloc.s 42
-			IL_0699: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_069e: stloc.s 43
-			IL_06a0: ldloc.s 43
-			IL_06a2: box [System.Runtime]System.Boolean
-			IL_06a7: stloc.s 46
-			IL_06a9: ldloc.s 46
-			IL_06ab: stloc.s 9
-			IL_06ad: leave IL_06b2
+			IL_0668: ldloc.s 11
+			IL_066a: stloc.s 12
+			IL_066c: ldloc.s 12
+			IL_066e: stloc.s 41
+			IL_0670: ldstr "TypeError"
+			IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_067a: stloc.s 42
+			IL_067c: ldloc.s 41
+			IL_067e: ldloc.s 42
+			IL_0680: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0685: stloc.s 43
+			IL_0687: ldloc.s 43
+			IL_0689: box [System.Runtime]System.Boolean
+			IL_068e: stloc.s 46
+			IL_0690: ldloc.s 46
+			IL_0692: stloc.s 9
+			IL_0694: leave IL_0699
 		} // end handler
 
-		IL_06b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06b7: stloc.s 38
-		IL_06b9: ldloc.s 38
-		IL_06bb: ldstr "nonconstructor"
-		IL_06c0: ldloc.s 9
-		IL_06c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_06c7: pop
-		IL_06c8: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_06cd: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_06d2: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_06d7: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_06dc: stloc.s 36
-		IL_06de: ldloc.s 36
-		IL_06e0: ldstr "prototype"
-		IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06ea: stloc.s 42
-		IL_06ec: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_06f1: stloc.s 35
-		IL_06f3: ldloc.s 42
-		IL_06f5: ldstr "read"
-		IL_06fa: ldloc.s 36
-		IL_06fc: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read::.ctor(class [System.Runtime]System.Object)
-		IL_0701: ldc.i4.0
-		IL_0702: conv.r8
-		IL_0703: ldstr "read"
-		IL_0708: ldc.i4.1
-		IL_0709: ldc.i4.1
-		IL_070a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0, float64, string, bool, bool)
-		IL_070f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0)
-		IL_0714: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0)
-		IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_071e: pop
-		IL_071f: ldc.i4.1
-		IL_0720: newarr [System.Runtime]System.Object
-		IL_0725: dup
-		IL_0726: ldc.i4.0
-		IL_0727: ldloc.0
-		IL_0728: stelem.ref
-		IL_0729: stloc.s 35
-		IL_072b: ldloc.s 36
-		IL_072d: ldloc.s 35
-		IL_072f: ldc.r8 1
-		IL_0738: box [System.Runtime]System.Double
-		IL_073d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0742: stloc.s 42
-		IL_0744: ldloc.s 42
-		IL_0746: stloc.s 13
-		IL_0748: ldc.i4.1
-		IL_0749: newarr [System.Runtime]System.Object
-		IL_074e: dup
-		IL_074f: ldc.i4.0
-		IL_0750: ldloc.0
-		IL_0751: stelem.ref
-		IL_0752: stloc.s 35
-		IL_0754: ldloc.s 35
-		IL_0756: ldc.i4.1
-		IL_0757: newarr [System.Runtime]System.Object
-		IL_075c: dup
-		IL_075d: ldc.i4.0
-		IL_075e: ldc.r8 17
-		IL_0767: box [System.Runtime]System.Double
-		IL_076c: stelem.ref
-		IL_076d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0772: ldc.r8 17
-		IL_077b: box [System.Runtime]System.Double
-		IL_0780: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret::.ctor(object[], object)
-		IL_0785: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_078a: stloc.s 14
-		IL_078c: ldloc.s 14
-		IL_078e: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_0793: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0798: ldstr "prototype"
-		IL_079d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_07a2: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_07a7: ldloc.s 13
-		IL_07a9: ldstr "prototype"
-		IL_07ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07b3: stloc.s 42
-		IL_07b5: ldloc.s 42
-		IL_07b7: ldstr "read"
-		IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07c1: stloc.s 15
-		IL_07c3: ldc.i4.0
-		IL_07c4: box [System.Runtime]System.Boolean
-		IL_07c9: stloc.s 16
+		IL_0699: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_069e: stloc.s 38
+		IL_06a0: ldloc.s 38
+		IL_06a2: ldstr "nonconstructor"
+		IL_06a7: ldloc.s 9
+		IL_06a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_06ae: pop
+		IL_06af: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+		IL_06b4: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_06b9: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+		IL_06be: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_06c3: stloc.s 36
+		IL_06c5: ldloc.s 36
+		IL_06c7: ldstr "prototype"
+		IL_06cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06d1: stloc.s 42
+		IL_06d3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06d8: stloc.s 35
+		IL_06da: ldloc.s 42
+		IL_06dc: ldstr "read"
+		IL_06e1: ldloc.s 36
+		IL_06e3: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read::.ctor(class [System.Runtime]System.Object)
+		IL_06e8: ldc.i4.0
+		IL_06e9: conv.r8
+		IL_06ea: ldstr "read"
+		IL_06ef: ldc.i4.1
+		IL_06f0: ldc.i4.1
+		IL_06f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0, float64, string, bool, bool)
+		IL_06f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0)
+		IL_06fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0700: pop
+		IL_0701: ldc.i4.1
+		IL_0702: newarr [System.Runtime]System.Object
+		IL_0707: dup
+		IL_0708: ldc.i4.0
+		IL_0709: ldloc.0
+		IL_070a: stelem.ref
+		IL_070b: stloc.s 35
+		IL_070d: ldloc.s 36
+		IL_070f: ldloc.s 35
+		IL_0711: ldc.r8 1
+		IL_071a: box [System.Runtime]System.Double
+		IL_071f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0724: stloc.s 42
+		IL_0726: ldloc.s 42
+		IL_0728: stloc.s 13
+		IL_072a: ldc.i4.1
+		IL_072b: newarr [System.Runtime]System.Object
+		IL_0730: dup
+		IL_0731: ldc.i4.0
+		IL_0732: ldloc.0
+		IL_0733: stelem.ref
+		IL_0734: stloc.s 35
+		IL_0736: ldloc.s 35
+		IL_0738: ldc.i4.1
+		IL_0739: newarr [System.Runtime]System.Object
+		IL_073e: dup
+		IL_073f: ldc.i4.0
+		IL_0740: ldc.r8 17
+		IL_0749: box [System.Runtime]System.Double
+		IL_074e: stelem.ref
+		IL_074f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0754: ldc.r8 17
+		IL_075d: box [System.Runtime]System.Double
+		IL_0762: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret::.ctor(object[], object)
+		IL_0767: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_076c: stloc.s 14
+		IL_076e: ldloc.s 14
+		IL_0770: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+		IL_0775: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_077a: ldstr "prototype"
+		IL_077f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0784: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0789: ldloc.s 13
+		IL_078b: ldstr "prototype"
+		IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0795: stloc.s 42
+		IL_0797: ldloc.s 42
+		IL_0799: ldstr "read"
+		IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07a3: stloc.s 15
+		IL_07a5: ldc.i4.0
+		IL_07a6: box [System.Runtime]System.Boolean
+		IL_07ab: stloc.s 16
 		.try
 		{
-			IL_07cb: nop
-			IL_07cc: ldloc.s 15
-			IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07d3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_07d8: stloc.s 48
-			IL_07da: ldstr "call"
-			IL_07df: ldloc.s 48
-			IL_07e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_07e6: pop
-			IL_07e7: leave IL_084b
+			IL_07ad: nop
+			IL_07ae: ldloc.s 15
+			IL_07b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_07ba: stloc.s 48
+			IL_07bc: ldstr "call"
+			IL_07c1: ldloc.s 48
+			IL_07c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_07c8: pop
+			IL_07c9: leave IL_082d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_07ec: stloc.s 17
-			IL_07ee: ldloc.s 17
-			IL_07f0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_07f5: dup
-			IL_07f6: brtrue IL_080c
+			IL_07ce: stloc.s 17
+			IL_07d0: ldloc.s 17
+			IL_07d2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_07d7: dup
+			IL_07d8: brtrue IL_07ee
 
-			IL_07fb: pop
-			IL_07fc: ldloc.s 17
-			IL_07fe: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0803: dup
-			IL_0804: brtrue IL_0818
+			IL_07dd: pop
+			IL_07de: ldloc.s 17
+			IL_07e0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_07e5: dup
+			IL_07e6: brtrue IL_07fa
 
-			IL_0809: pop
-			IL_080a: rethrow
+			IL_07eb: pop
+			IL_07ec: rethrow
 
-			IL_080c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0811: stloc.s 18
-			IL_0813: br IL_081a
+			IL_07ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_07f3: stloc.s 18
+			IL_07f5: br IL_07fc
 
-			IL_0818: stloc.s 18
+			IL_07fa: stloc.s 18
 
-			IL_081a: ldloc.s 18
-			IL_081c: stloc.s 19
-			IL_081e: ldloc.s 19
-			IL_0820: stloc.s 42
-			IL_0822: ldstr "TypeError"
-			IL_0827: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_082c: stloc.s 41
-			IL_082e: ldloc.s 42
-			IL_0830: ldloc.s 41
-			IL_0832: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0837: stloc.s 43
-			IL_0839: ldloc.s 43
-			IL_083b: box [System.Runtime]System.Boolean
-			IL_0840: stloc.s 46
-			IL_0842: ldloc.s 46
-			IL_0844: stloc.s 16
-			IL_0846: leave IL_084b
+			IL_07fc: ldloc.s 18
+			IL_07fe: stloc.s 19
+			IL_0800: ldloc.s 19
+			IL_0802: stloc.s 42
+			IL_0804: ldstr "TypeError"
+			IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_080e: stloc.s 41
+			IL_0810: ldloc.s 42
+			IL_0812: ldloc.s 41
+			IL_0814: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0819: stloc.s 43
+			IL_081b: ldloc.s 43
+			IL_081d: box [System.Runtime]System.Boolean
+			IL_0822: stloc.s 46
+			IL_0824: ldloc.s 46
+			IL_0826: stloc.s 16
+			IL_0828: leave IL_082d
 		} // end handler
 
-		IL_084b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0850: stloc.s 38
-		IL_0852: ldloc.s 15
-		IL_0854: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0859: ldstr "call"
-		IL_085e: ldloc.s 14
-		IL_0860: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0865: stloc.s 41
-		IL_0867: ldloc.s 38
-		IL_0869: ldstr "private"
-		IL_086e: ldloc.s 41
-		IL_0870: ldloc.s 16
-		IL_0872: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0877: pop
-		IL_0878: nop
-		IL_0879: ldloc.1
-		IL_087a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_087f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0884: stloc.s 20
-		IL_0886: ldloc.1
-		IL_0887: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_088c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0891: stloc.s 21
-		IL_0893: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0898: stloc.s 38
-		IL_089a: ldloc.s 20
-		IL_089c: ldstr "prototype"
-		IL_08a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08a6: stloc.s 41
-		IL_08a8: ldloc.s 41
-		IL_08aa: ldstr "method"
-		IL_08af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08b4: stloc.s 41
-		IL_08b6: ldloc.s 21
-		IL_08b8: ldstr "prototype"
-		IL_08bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08c2: stloc.s 42
-		IL_08c4: ldloc.s 42
-		IL_08c6: ldstr "method"
-		IL_08cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08d0: stloc.s 42
-		IL_08d2: ldloc.s 41
-		IL_08d4: ldloc.s 42
-		IL_08d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_08db: stloc.s 43
-		IL_08dd: ldloc.s 43
-		IL_08df: box [System.Runtime]System.Boolean
-		IL_08e4: stloc.s 46
-		IL_08e6: ldloc.s 38
-		IL_08e8: ldstr "identity"
-		IL_08ed: ldloc.s 46
-		IL_08ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_08f4: pop
-		IL_08f5: nop
-		IL_08f6: ldloc.2
-		IL_08f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_08fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0901: stloc.s 22
-		IL_0903: ldloc.2
-		IL_0904: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0909: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_090e: stloc.s 23
-		IL_0910: ldloc.s 22
-		IL_0912: ldc.i4.1
-		IL_0913: newarr [System.Runtime]System.Object
-		IL_0918: dup
-		IL_0919: ldc.i4.0
-		IL_091a: ldc.r8 1
-		IL_0923: box [System.Runtime]System.Double
-		IL_0928: stelem.ref
-		IL_0929: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_092e: stloc.s 24
-		IL_0930: ldloc.s 23
-		IL_0932: ldc.i4.1
-		IL_0933: newarr [System.Runtime]System.Object
-		IL_0938: dup
-		IL_0939: ldc.i4.0
-		IL_093a: ldc.r8 2
-		IL_0943: box [System.Runtime]System.Double
-		IL_0948: stelem.ref
-		IL_0949: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_094e: stloc.s 25
-		IL_0950: ldc.i4.0
-		IL_0951: box [System.Runtime]System.Boolean
-		IL_0956: stloc.s 26
+		IL_082d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0832: stloc.s 38
+		IL_0834: ldloc.s 15
+		IL_0836: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_083b: ldstr "call"
+		IL_0840: ldloc.s 14
+		IL_0842: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0847: stloc.s 41
+		IL_0849: ldloc.s 38
+		IL_084b: ldstr "private"
+		IL_0850: ldloc.s 41
+		IL_0852: ldloc.s 16
+		IL_0854: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0859: pop
+		IL_085a: nop
+		IL_085b: ldloc.1
+		IL_085c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0861: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0866: stloc.s 20
+		IL_0868: ldloc.1
+		IL_0869: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_086e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0873: stloc.s 21
+		IL_0875: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_087a: stloc.s 38
+		IL_087c: ldloc.s 20
+		IL_087e: ldstr "prototype"
+		IL_0883: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0888: stloc.s 41
+		IL_088a: ldloc.s 41
+		IL_088c: ldstr "method"
+		IL_0891: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0896: stloc.s 41
+		IL_0898: ldloc.s 21
+		IL_089a: ldstr "prototype"
+		IL_089f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08a4: stloc.s 42
+		IL_08a6: ldloc.s 42
+		IL_08a8: ldstr "method"
+		IL_08ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08b2: stloc.s 42
+		IL_08b4: ldloc.s 41
+		IL_08b6: ldloc.s 42
+		IL_08b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_08bd: stloc.s 43
+		IL_08bf: ldloc.s 43
+		IL_08c1: box [System.Runtime]System.Boolean
+		IL_08c6: stloc.s 46
+		IL_08c8: ldloc.s 38
+		IL_08ca: ldstr "identity"
+		IL_08cf: ldloc.s 46
+		IL_08d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_08d6: pop
+		IL_08d7: nop
+		IL_08d8: ldloc.2
+		IL_08d9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_08de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_08e3: stloc.s 22
+		IL_08e5: ldloc.2
+		IL_08e6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_08eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_08f0: stloc.s 23
+		IL_08f2: ldloc.s 22
+		IL_08f4: ldc.i4.1
+		IL_08f5: newarr [System.Runtime]System.Object
+		IL_08fa: dup
+		IL_08fb: ldc.i4.0
+		IL_08fc: ldc.r8 1
+		IL_0905: box [System.Runtime]System.Double
+		IL_090a: stelem.ref
+		IL_090b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_0910: stloc.s 24
+		IL_0912: ldloc.s 23
+		IL_0914: ldc.i4.1
+		IL_0915: newarr [System.Runtime]System.Object
+		IL_091a: dup
+		IL_091b: ldc.i4.0
+		IL_091c: ldc.r8 2
+		IL_0925: box [System.Runtime]System.Double
+		IL_092a: stelem.ref
+		IL_092b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_0930: stloc.s 25
+		IL_0932: ldc.i4.0
+		IL_0933: box [System.Runtime]System.Boolean
+		IL_0938: stloc.s 26
 		.try
 		{
-			IL_0958: nop
-			IL_0959: ldloc.s 22
-			IL_095b: ldstr "prototype"
-			IL_0960: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0965: stloc.s 42
-			IL_0967: ldloc.s 42
-			IL_0969: ldstr "read"
-			IL_096e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0973: stloc.s 42
-			IL_0975: ldloc.s 42
-			IL_0977: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_097c: ldstr "call"
-			IL_0981: ldloc.s 25
-			IL_0983: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0988: pop
-			IL_0989: leave IL_09ed
+			IL_093a: nop
+			IL_093b: ldloc.s 22
+			IL_093d: ldstr "prototype"
+			IL_0942: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0947: stloc.s 42
+			IL_0949: ldloc.s 42
+			IL_094b: ldstr "read"
+			IL_0950: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0955: stloc.s 42
+			IL_0957: ldloc.s 42
+			IL_0959: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_095e: ldstr "call"
+			IL_0963: ldloc.s 25
+			IL_0965: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_096a: pop
+			IL_096b: leave IL_09cf
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_098e: stloc.s 27
-			IL_0990: ldloc.s 27
-			IL_0992: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0997: dup
-			IL_0998: brtrue IL_09ae
+			IL_0970: stloc.s 27
+			IL_0972: ldloc.s 27
+			IL_0974: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0979: dup
+			IL_097a: brtrue IL_0990
 
-			IL_099d: pop
-			IL_099e: ldloc.s 27
-			IL_09a0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_09a5: dup
-			IL_09a6: brtrue IL_09ba
+			IL_097f: pop
+			IL_0980: ldloc.s 27
+			IL_0982: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0987: dup
+			IL_0988: brtrue IL_099c
 
-			IL_09ab: pop
-			IL_09ac: rethrow
+			IL_098d: pop
+			IL_098e: rethrow
 
-			IL_09ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_09b3: stloc.s 28
-			IL_09b5: br IL_09bc
+			IL_0990: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0995: stloc.s 28
+			IL_0997: br IL_099e
 
-			IL_09ba: stloc.s 28
+			IL_099c: stloc.s 28
 
-			IL_09bc: ldloc.s 28
-			IL_09be: stloc.s 29
-			IL_09c0: ldloc.s 29
-			IL_09c2: stloc.s 42
-			IL_09c4: ldstr "TypeError"
-			IL_09c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09ce: stloc.s 41
-			IL_09d0: ldloc.s 42
-			IL_09d2: ldloc.s 41
-			IL_09d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_09d9: stloc.s 43
-			IL_09db: ldloc.s 43
-			IL_09dd: box [System.Runtime]System.Boolean
-			IL_09e2: stloc.s 46
-			IL_09e4: ldloc.s 46
-			IL_09e6: stloc.s 26
-			IL_09e8: leave IL_09ed
+			IL_099e: ldloc.s 28
+			IL_09a0: stloc.s 29
+			IL_09a2: ldloc.s 29
+			IL_09a4: stloc.s 42
+			IL_09a6: ldstr "TypeError"
+			IL_09ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09b0: stloc.s 41
+			IL_09b2: ldloc.s 42
+			IL_09b4: ldloc.s 41
+			IL_09b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_09bb: stloc.s 43
+			IL_09bd: ldloc.s 43
+			IL_09bf: box [System.Runtime]System.Boolean
+			IL_09c4: stloc.s 46
+			IL_09c6: ldloc.s 46
+			IL_09c8: stloc.s 26
+			IL_09ca: leave IL_09cf
 		} // end handler
 
-		IL_09ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_09f2: stloc.s 38
-		IL_09f4: ldloc.s 22
-		IL_09f6: ldstr "prototype"
-		IL_09fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a00: stloc.s 41
-		IL_0a02: ldloc.s 23
-		IL_0a04: ldstr "prototype"
-		IL_0a09: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a0e: stloc.s 42
-		IL_0a10: ldloc.s 41
-		IL_0a12: ldloc.s 42
-		IL_0a14: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0a19: stloc.s 43
-		IL_0a1b: ldloc.s 43
-		IL_0a1d: box [System.Runtime]System.Boolean
-		IL_0a22: stloc.s 46
-		IL_0a24: ldloc.s 22
-		IL_0a26: ldstr "prototype"
-		IL_0a2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a30: stloc.s 42
-		IL_0a32: ldloc.s 42
-		IL_0a34: ldstr "read"
-		IL_0a39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a3e: stloc.s 42
-		IL_0a40: ldloc.s 23
-		IL_0a42: ldstr "prototype"
-		IL_0a47: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a4c: stloc.s 41
-		IL_0a4e: ldloc.s 41
-		IL_0a50: ldstr "read"
-		IL_0a55: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a5a: stloc.s 41
-		IL_0a5c: ldloc.s 42
-		IL_0a5e: ldloc.s 41
-		IL_0a60: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0a65: stloc.s 43
-		IL_0a67: ldloc.s 43
-		IL_0a69: box [System.Runtime]System.Boolean
-		IL_0a6e: stloc.s 45
-		IL_0a70: ldloc.s 22
-		IL_0a72: ldstr "prototype"
-		IL_0a77: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a7c: stloc.s 41
-		IL_0a7e: ldloc.s 41
-		IL_0a80: ldstr "read"
-		IL_0a85: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a8a: stloc.s 41
-		IL_0a8c: ldloc.s 41
-		IL_0a8e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0a93: ldstr "call"
-		IL_0a98: ldloc.s 24
-		IL_0a9a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0a9f: stloc.s 41
-		IL_0aa1: ldloc.s 38
-		IL_0aa3: ldc.i4.5
-		IL_0aa4: newarr [System.Runtime]System.Object
-		IL_0aa9: dup
-		IL_0aaa: ldc.i4.0
-		IL_0aab: ldstr "privateIdentity"
-		IL_0ab0: stelem.ref
-		IL_0ab1: dup
-		IL_0ab2: ldc.i4.1
-		IL_0ab3: ldloc.s 46
-		IL_0ab5: stelem.ref
-		IL_0ab6: dup
-		IL_0ab7: ldc.i4.2
-		IL_0ab8: ldloc.s 45
-		IL_0aba: stelem.ref
-		IL_0abb: dup
-		IL_0abc: ldc.i4.3
-		IL_0abd: ldloc.s 41
-		IL_0abf: stelem.ref
-		IL_0ac0: dup
-		IL_0ac1: ldc.i4.4
-		IL_0ac2: ldloc.s 26
-		IL_0ac4: stelem.ref
-		IL_0ac5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0aca: pop
-		IL_0acb: ldc.i4.0
-		IL_0acc: box [System.Runtime]System.Boolean
-		IL_0ad1: stloc.s 30
+		IL_09cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_09d4: stloc.s 38
+		IL_09d6: ldloc.s 22
+		IL_09d8: ldstr "prototype"
+		IL_09dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09e2: stloc.s 41
+		IL_09e4: ldloc.s 23
+		IL_09e6: ldstr "prototype"
+		IL_09eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09f0: stloc.s 42
+		IL_09f2: ldloc.s 41
+		IL_09f4: ldloc.s 42
+		IL_09f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_09fb: stloc.s 43
+		IL_09fd: ldloc.s 43
+		IL_09ff: box [System.Runtime]System.Boolean
+		IL_0a04: stloc.s 46
+		IL_0a06: ldloc.s 22
+		IL_0a08: ldstr "prototype"
+		IL_0a0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a12: stloc.s 42
+		IL_0a14: ldloc.s 42
+		IL_0a16: ldstr "read"
+		IL_0a1b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a20: stloc.s 42
+		IL_0a22: ldloc.s 23
+		IL_0a24: ldstr "prototype"
+		IL_0a29: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a2e: stloc.s 41
+		IL_0a30: ldloc.s 41
+		IL_0a32: ldstr "read"
+		IL_0a37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a3c: stloc.s 41
+		IL_0a3e: ldloc.s 42
+		IL_0a40: ldloc.s 41
+		IL_0a42: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0a47: stloc.s 43
+		IL_0a49: ldloc.s 43
+		IL_0a4b: box [System.Runtime]System.Boolean
+		IL_0a50: stloc.s 45
+		IL_0a52: ldloc.s 22
+		IL_0a54: ldstr "prototype"
+		IL_0a59: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a5e: stloc.s 41
+		IL_0a60: ldloc.s 41
+		IL_0a62: ldstr "read"
+		IL_0a67: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a6c: stloc.s 41
+		IL_0a6e: ldloc.s 41
+		IL_0a70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0a75: ldstr "call"
+		IL_0a7a: ldloc.s 24
+		IL_0a7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0a81: stloc.s 41
+		IL_0a83: ldloc.s 38
+		IL_0a85: ldc.i4.5
+		IL_0a86: newarr [System.Runtime]System.Object
+		IL_0a8b: dup
+		IL_0a8c: ldc.i4.0
+		IL_0a8d: ldstr "privateIdentity"
+		IL_0a92: stelem.ref
+		IL_0a93: dup
+		IL_0a94: ldc.i4.1
+		IL_0a95: ldloc.s 46
+		IL_0a97: stelem.ref
+		IL_0a98: dup
+		IL_0a99: ldc.i4.2
+		IL_0a9a: ldloc.s 45
+		IL_0a9c: stelem.ref
+		IL_0a9d: dup
+		IL_0a9e: ldc.i4.3
+		IL_0a9f: ldloc.s 41
+		IL_0aa1: stelem.ref
+		IL_0aa2: dup
+		IL_0aa3: ldc.i4.4
+		IL_0aa4: ldloc.s 26
+		IL_0aa6: stelem.ref
+		IL_0aa7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0aac: pop
+		IL_0aad: ldc.i4.0
+		IL_0aae: box [System.Runtime]System.Boolean
+		IL_0ab3: stloc.s 30
 		.try
 		{
-			IL_0ad3: nop
-			IL_0ad4: ldloc.s 22
-			IL_0ad6: ldstr "readStatic"
-			IL_0adb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ae0: stloc.s 41
-			IL_0ae2: ldloc.s 41
-			IL_0ae4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0ae9: ldstr "call"
-			IL_0aee: ldloc.s 23
-			IL_0af0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0af5: pop
-			IL_0af6: leave IL_0b5a
+			IL_0ab5: nop
+			IL_0ab6: ldloc.s 22
+			IL_0ab8: ldstr "readStatic"
+			IL_0abd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ac2: stloc.s 41
+			IL_0ac4: ldloc.s 41
+			IL_0ac6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0acb: ldstr "call"
+			IL_0ad0: ldloc.s 23
+			IL_0ad2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0ad7: pop
+			IL_0ad8: leave IL_0b3c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0afb: stloc.s 31
-			IL_0afd: ldloc.s 31
-			IL_0aff: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0b04: dup
-			IL_0b05: brtrue IL_0b1b
+			IL_0add: stloc.s 31
+			IL_0adf: ldloc.s 31
+			IL_0ae1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0ae6: dup
+			IL_0ae7: brtrue IL_0afd
 
-			IL_0b0a: pop
-			IL_0b0b: ldloc.s 31
-			IL_0b0d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0b12: dup
-			IL_0b13: brtrue IL_0b27
+			IL_0aec: pop
+			IL_0aed: ldloc.s 31
+			IL_0aef: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0af4: dup
+			IL_0af5: brtrue IL_0b09
 
-			IL_0b18: pop
-			IL_0b19: rethrow
+			IL_0afa: pop
+			IL_0afb: rethrow
 
-			IL_0b1b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0b20: stloc.s 32
-			IL_0b22: br IL_0b29
+			IL_0afd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0b02: stloc.s 32
+			IL_0b04: br IL_0b0b
 
-			IL_0b27: stloc.s 32
+			IL_0b09: stloc.s 32
 
-			IL_0b29: ldloc.s 32
-			IL_0b2b: stloc.s 33
-			IL_0b2d: ldloc.s 33
-			IL_0b2f: stloc.s 41
-			IL_0b31: ldstr "TypeError"
-			IL_0b36: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b3b: stloc.s 42
-			IL_0b3d: ldloc.s 41
-			IL_0b3f: ldloc.s 42
-			IL_0b41: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0b46: stloc.s 43
-			IL_0b48: ldloc.s 43
-			IL_0b4a: box [System.Runtime]System.Boolean
-			IL_0b4f: stloc.s 45
-			IL_0b51: ldloc.s 45
-			IL_0b53: stloc.s 30
-			IL_0b55: leave IL_0b5a
+			IL_0b0b: ldloc.s 32
+			IL_0b0d: stloc.s 33
+			IL_0b0f: ldloc.s 33
+			IL_0b11: stloc.s 41
+			IL_0b13: ldstr "TypeError"
+			IL_0b18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b1d: stloc.s 42
+			IL_0b1f: ldloc.s 41
+			IL_0b21: ldloc.s 42
+			IL_0b23: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0b28: stloc.s 43
+			IL_0b2a: ldloc.s 43
+			IL_0b2c: box [System.Runtime]System.Boolean
+			IL_0b31: stloc.s 45
+			IL_0b33: ldloc.s 45
+			IL_0b35: stloc.s 30
+			IL_0b37: leave IL_0b3c
 		} // end handler
 
-		IL_0b5a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0b5f: stloc.s 38
-		IL_0b61: ldloc.s 22
-		IL_0b63: ldstr "readStatic"
-		IL_0b68: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b6d: stloc.s 42
-		IL_0b6f: ldloc.s 23
-		IL_0b71: ldstr "readStatic"
-		IL_0b76: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b7b: stloc.s 41
-		IL_0b7d: ldloc.s 42
-		IL_0b7f: ldloc.s 41
-		IL_0b81: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0b86: stloc.s 43
-		IL_0b88: ldloc.s 43
-		IL_0b8a: box [System.Runtime]System.Boolean
-		IL_0b8f: stloc.s 45
-		IL_0b91: ldloc.s 22
-		IL_0b93: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0b98: ldstr "readStatic"
-		IL_0b9d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0ba2: stloc.s 41
-		IL_0ba4: ldloc.s 38
-		IL_0ba6: ldc.i4.4
-		IL_0ba7: newarr [System.Runtime]System.Object
-		IL_0bac: dup
-		IL_0bad: ldc.i4.0
-		IL_0bae: ldstr "staticPrivateIdentity"
-		IL_0bb3: stelem.ref
-		IL_0bb4: dup
-		IL_0bb5: ldc.i4.1
-		IL_0bb6: ldloc.s 45
-		IL_0bb8: stelem.ref
-		IL_0bb9: dup
-		IL_0bba: ldc.i4.2
-		IL_0bbb: ldloc.s 41
-		IL_0bbd: stelem.ref
-		IL_0bbe: dup
-		IL_0bbf: ldc.i4.3
-		IL_0bc0: ldloc.s 30
-		IL_0bc2: stelem.ref
-		IL_0bc3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0bc8: pop
-		IL_0bc9: ldnull
-		IL_0bca: stloc.s 34
-		IL_0bcc: ret
+		IL_0b3c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0b41: stloc.s 38
+		IL_0b43: ldloc.s 22
+		IL_0b45: ldstr "readStatic"
+		IL_0b4a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b4f: stloc.s 42
+		IL_0b51: ldloc.s 23
+		IL_0b53: ldstr "readStatic"
+		IL_0b58: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b5d: stloc.s 41
+		IL_0b5f: ldloc.s 42
+		IL_0b61: ldloc.s 41
+		IL_0b63: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0b68: stloc.s 43
+		IL_0b6a: ldloc.s 43
+		IL_0b6c: box [System.Runtime]System.Boolean
+		IL_0b71: stloc.s 45
+		IL_0b73: ldloc.s 22
+		IL_0b75: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0b7a: ldstr "readStatic"
+		IL_0b7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0b84: stloc.s 41
+		IL_0b86: ldloc.s 38
+		IL_0b88: ldc.i4.4
+		IL_0b89: newarr [System.Runtime]System.Object
+		IL_0b8e: dup
+		IL_0b8f: ldc.i4.0
+		IL_0b90: ldstr "staticPrivateIdentity"
+		IL_0b95: stelem.ref
+		IL_0b96: dup
+		IL_0b97: ldc.i4.1
+		IL_0b98: ldloc.s 45
+		IL_0b9a: stelem.ref
+		IL_0b9b: dup
+		IL_0b9c: ldc.i4.2
+		IL_0b9d: ldloc.s 41
+		IL_0b9f: stelem.ref
+		IL_0ba0: dup
+		IL_0ba1: ldc.i4.3
+		IL_0ba2: ldloc.s 30
+		IL_0ba4: stelem.ref
+		IL_0ba5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0baa: pop
+		IL_0bab: ldnull
+		IL_0bac: stloc.s 34
+		IL_0bae: ret
 	} // end of method Classes_GeneratedMethodFunctionObjects::__js_module_init__
 
 } // end of class Modules.Classes_GeneratedMethodFunctionObjects

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
@@ -394,7 +394,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 335 (0x14f)
+			// Code size: 330 (0x14a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/Scope,
@@ -431,82 +431,81 @@
 			IL_0044: ldc.i4.1
 			IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0, float64, string, bool, bool)
 			IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0)
-			IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0)
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_0059: pop
-			IL_005a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_005f: stloc.s 4
-			IL_0061: ldloc.2
-			IL_0062: ldloc.s 4
-			IL_0064: ldc.r8 0.0
-			IL_006d: box [System.Runtime]System.Double
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_0077: stloc.3
-			IL_0078: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_007d: stloc.s 4
-			IL_007f: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
-			IL_0084: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0089: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
-			IL_008e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0093: stloc.2
-			IL_0094: ldloc.2
-			IL_0095: ldloc.s 4
-			IL_0097: ldc.r8 0.0
-			IL_00a0: box [System.Runtime]System.Double
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_00aa: stloc.s 5
-			IL_00ac: ldloc.3
-			IL_00ad: ldloc.s 5
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-			IL_00b4: stloc.s 5
-			IL_00b6: ldloc.s 5
-			IL_00b8: stloc.1
-			IL_00b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00be: stloc.s 6
-			IL_00c0: ldc.i4.0
-			IL_00c1: newarr [System.Runtime]System.Object
-			IL_00c6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_00cb: ldloc.1
-			IL_00cc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-			IL_00d1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-			IL_00d6: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::.ctor()
-			IL_00db: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-			IL_00e0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_00e5: dup
-			IL_00e6: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
-			IL_00eb: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00f0: ldstr "prototype"
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_00fa: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_00ff: stloc.s 5
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_010b: stloc.s 5
-			IL_010d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-			IL_0112: ldloc.s 5
-			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0119: stloc.s 5
-			IL_011b: ldloc.s 5
-			IL_011d: isinst Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
-			IL_0122: dup
-			IL_0123: brfalse IL_0134
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_0054: pop
+			IL_0055: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_005a: stloc.s 4
+			IL_005c: ldloc.2
+			IL_005d: ldloc.s 4
+			IL_005f: ldc.r8 0.0
+			IL_0068: box [System.Runtime]System.Double
+			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_0072: stloc.3
+			IL_0073: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0078: stloc.s 4
+			IL_007a: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
+			IL_007f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0084: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
+			IL_0089: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_008e: stloc.2
+			IL_008f: ldloc.2
+			IL_0090: ldloc.s 4
+			IL_0092: ldc.r8 0.0
+			IL_009b: box [System.Runtime]System.Double
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_00a5: stloc.s 5
+			IL_00a7: ldloc.3
+			IL_00a8: ldloc.s 5
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+			IL_00af: stloc.s 5
+			IL_00b1: ldloc.s 5
+			IL_00b3: stloc.1
+			IL_00b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00b9: stloc.s 6
+			IL_00bb: ldc.i4.0
+			IL_00bc: newarr [System.Runtime]System.Object
+			IL_00c1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_00c6: ldloc.1
+			IL_00c7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+			IL_00cc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+			IL_00d1: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::.ctor()
+			IL_00d6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+			IL_00db: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_00e0: dup
+			IL_00e1: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
+			IL_00e6: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_00eb: ldstr "prototype"
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_00f5: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_00fa: stloc.s 5
+			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0106: stloc.s 5
+			IL_0108: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+			IL_010d: ldloc.s 5
+			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0114: stloc.s 5
+			IL_0116: ldloc.s 5
+			IL_0118: isinst Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
+			IL_011d: dup
+			IL_011e: brfalse IL_012f
 
-			IL_0128: callvirt instance object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::n()
-			IL_012d: stloc.s 5
-			IL_012f: br IL_0143
+			IL_0123: callvirt instance object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::n()
+			IL_0128: stloc.s 5
+			IL_012a: br IL_013e
 
-			IL_0134: pop
-			IL_0135: ldloc.s 5
-			IL_0137: ldstr "n"
-			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0141: stloc.s 5
+			IL_012f: pop
+			IL_0130: ldloc.s 5
+			IL_0132: ldstr "n"
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_013c: stloc.s 5
 
-			IL_0143: ldloc.s 6
-			IL_0145: ldloc.s 5
-			IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_014c: pop
-			IL_014d: ldnull
-			IL_014e: ret
+			IL_013e: ldloc.s 6
+			IL_0140: ldloc.s 5
+			IL_0142: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0147: pop
+			IL_0148: ldnull
+			IL_0149: ret
 		} // end of method makeAndRun::__js_call__
 
 	} // end of class makeAndRun
@@ -767,7 +766,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 174 (0xae)
+		// Code size: 169 (0xa9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope,
@@ -817,30 +816,29 @@
 		IL_0064: ldc.i4.1
 		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0, float64, string, bool, bool)
 		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0)
-		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0)
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0079: pop
-		IL_007a: ldc.i4.1
-		IL_007b: newarr [System.Runtime]System.Object
-		IL_0080: dup
-		IL_0081: ldc.i4.0
-		IL_0082: ldloc.0
-		IL_0083: stelem.ref
-		IL_0084: stloc.3
-		IL_0085: ldloc.s 4
-		IL_0087: ldloc.3
-		IL_0088: ldc.r8 0.0
-		IL_0091: box [System.Runtime]System.Double
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_009b: stloc.s 5
-		IL_009d: ldloc.s 5
-		IL_009f: stloc.2
-		IL_00a0: nop
-		IL_00a1: ldloc.1
-		IL_00a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00ac: pop
-		IL_00ad: ret
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0074: pop
+		IL_0075: ldc.i4.1
+		IL_0076: newarr [System.Runtime]System.Object
+		IL_007b: dup
+		IL_007c: ldc.i4.0
+		IL_007d: ldloc.0
+		IL_007e: stelem.ref
+		IL_007f: stloc.3
+		IL_0080: ldloc.s 4
+		IL_0082: ldloc.3
+		IL_0083: ldc.r8 0.0
+		IL_008c: box [System.Runtime]System.Double
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0096: stloc.s 5
+		IL_0098: ldloc.s 5
+		IL_009a: stloc.2
+		IL_009b: nop
+		IL_009c: ldloc.1
+		IL_009d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00a7: pop
+		IL_00a8: ret
 	} // end of method Classes_Inheritance_NestedClassExtendsGlobal::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_NestedClassExtendsGlobal

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -659,7 +659,7 @@
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
 			// Header size: 12
-			// Code size: 451 (0x1c3)
+			// Code size: 441 (0x1b9)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope,
@@ -704,135 +704,133 @@
 			IL_004e: ldc.i4.1
 			IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0, float64, string, bool, bool)
 			IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0)
-			IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0)
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_0063: pop
-			IL_0064: ldc.i4.2
-			IL_0065: newarr [System.Runtime]System.Object
-			IL_006a: dup
-			IL_006b: ldc.i4.0
-			IL_006c: ldarg.0
-			IL_006d: stelem.ref
-			IL_006e: dup
-			IL_006f: ldc.i4.1
-			IL_0070: ldloc.0
-			IL_0071: stelem.ref
-			IL_0072: stloc.s 5
-			IL_0074: ldloc.3
-			IL_0075: ldloc.s 5
-			IL_0077: ldc.r8 0.0
-			IL_0080: box [System.Runtime]System.Double
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_008a: stloc.s 4
-			IL_008c: ldloc.s 4
-			IL_008e: stloc.1
-			IL_008f: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_0094: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0099: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_009e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00a3: stloc.3
-			IL_00a4: ldloc.3
-			IL_00a5: ldstr "prototype"
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00af: stloc.s 4
-			IL_00b1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_00b6: stloc.s 5
-			IL_00b8: ldloc.s 4
-			IL_00ba: ldstr "n"
-			IL_00bf: ldloc.s 4
-			IL_00c1: ldloc.s 5
-			IL_00c3: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n::.ctor(class [System.Runtime]System.Object, object[])
-			IL_00c8: ldc.i4.0
-			IL_00c9: conv.r8
-			IL_00ca: ldstr "n"
-			IL_00cf: ldc.i4.1
-			IL_00d0: ldc.i4.1
-			IL_00d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0, float64, string, bool, bool)
-			IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0)
-			IL_00db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0)
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-			IL_00e5: pop
-			IL_00e6: ldc.i4.2
-			IL_00e7: newarr [System.Runtime]System.Object
-			IL_00ec: dup
-			IL_00ed: ldc.i4.0
-			IL_00ee: ldarg.0
-			IL_00ef: stelem.ref
-			IL_00f0: dup
-			IL_00f1: ldc.i4.1
-			IL_00f2: ldloc.0
-			IL_00f3: stelem.ref
-			IL_00f4: stloc.s 5
-			IL_00f6: ldloc.3
-			IL_00f7: ldloc.s 5
-			IL_00f9: ldc.r8 0.0
-			IL_0102: box [System.Runtime]System.Double
-			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_005e: pop
+			IL_005f: ldc.i4.2
+			IL_0060: newarr [System.Runtime]System.Object
+			IL_0065: dup
+			IL_0066: ldc.i4.0
+			IL_0067: ldarg.0
+			IL_0068: stelem.ref
+			IL_0069: dup
+			IL_006a: ldc.i4.1
+			IL_006b: ldloc.0
+			IL_006c: stelem.ref
+			IL_006d: stloc.s 5
+			IL_006f: ldloc.3
+			IL_0070: ldloc.s 5
+			IL_0072: ldc.r8 0.0
+			IL_007b: box [System.Runtime]System.Double
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_0085: stloc.s 4
+			IL_0087: ldloc.s 4
+			IL_0089: stloc.1
+			IL_008a: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_008f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0094: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_0099: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_009e: stloc.3
+			IL_009f: ldloc.3
+			IL_00a0: ldstr "prototype"
+			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00aa: stloc.s 4
+			IL_00ac: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_00b1: stloc.s 5
+			IL_00b3: ldloc.s 4
+			IL_00b5: ldstr "n"
+			IL_00ba: ldloc.s 4
+			IL_00bc: ldloc.s 5
+			IL_00be: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n::.ctor(class [System.Runtime]System.Object, object[])
+			IL_00c3: ldc.i4.0
+			IL_00c4: conv.r8
+			IL_00c5: ldstr "n"
+			IL_00ca: ldc.i4.1
+			IL_00cb: ldc.i4.1
+			IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0, float64, string, bool, bool)
+			IL_00d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0)
+			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+			IL_00db: pop
+			IL_00dc: ldc.i4.2
+			IL_00dd: newarr [System.Runtime]System.Object
+			IL_00e2: dup
+			IL_00e3: ldc.i4.0
+			IL_00e4: ldarg.0
+			IL_00e5: stelem.ref
+			IL_00e6: dup
+			IL_00e7: ldc.i4.1
+			IL_00e8: ldloc.0
+			IL_00e9: stelem.ref
+			IL_00ea: stloc.s 5
+			IL_00ec: ldloc.3
+			IL_00ed: ldloc.s 5
+			IL_00ef: ldc.r8 0.0
+			IL_00f8: box [System.Runtime]System.Double
+			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_0102: stloc.s 4
+			IL_0104: ldloc.s 4
+			IL_0106: ldloc.1
+			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
 			IL_010c: stloc.s 4
 			IL_010e: ldloc.s 4
-			IL_0110: ldloc.1
-			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-			IL_0116: stloc.s 4
-			IL_0118: ldloc.s 4
-			IL_011a: stloc.2
-			IL_011b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0120: stloc.s 6
-			IL_0122: ldc.i4.2
-			IL_0123: newarr [System.Runtime]System.Object
-			IL_0128: dup
-			IL_0129: ldc.i4.0
-			IL_012a: ldarg.0
-			IL_012b: stelem.ref
-			IL_012c: dup
-			IL_012d: ldc.i4.1
-			IL_012e: ldloc.0
-			IL_012f: stelem.ref
-			IL_0130: stloc.s 5
-			IL_0132: ldloc.s 5
-			IL_0134: ldc.i4.0
-			IL_0135: newarr [System.Runtime]System.Object
-			IL_013a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_013f: ldloc.2
-			IL_0140: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-			IL_0145: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-			IL_014a: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
-			IL_014f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-			IL_0154: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_0159: dup
-			IL_015a: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_015f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0164: ldstr "prototype"
-			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_016e: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0173: stloc.s 4
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_017f: stloc.s 4
-			IL_0181: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-			IL_0186: ldloc.s 4
-			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018d: stloc.s 4
-			IL_018f: ldloc.s 4
-			IL_0191: isinst Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_0196: dup
-			IL_0197: brfalse IL_01a8
+			IL_0110: stloc.2
+			IL_0111: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0116: stloc.s 6
+			IL_0118: ldc.i4.2
+			IL_0119: newarr [System.Runtime]System.Object
+			IL_011e: dup
+			IL_011f: ldc.i4.0
+			IL_0120: ldarg.0
+			IL_0121: stelem.ref
+			IL_0122: dup
+			IL_0123: ldc.i4.1
+			IL_0124: ldloc.0
+			IL_0125: stelem.ref
+			IL_0126: stloc.s 5
+			IL_0128: ldloc.s 5
+			IL_012a: ldc.i4.0
+			IL_012b: newarr [System.Runtime]System.Object
+			IL_0130: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0135: ldloc.2
+			IL_0136: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+			IL_013b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+			IL_0140: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
+			IL_0145: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+			IL_014a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_014f: dup
+			IL_0150: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_0155: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_015a: ldstr "prototype"
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0164: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0169: stloc.s 4
+			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0175: stloc.s 4
+			IL_0177: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+			IL_017c: ldloc.s 4
+			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0183: stloc.s 4
+			IL_0185: ldloc.s 4
+			IL_0187: isinst Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_018c: dup
+			IL_018d: brfalse IL_019e
 
-			IL_019c: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
-			IL_01a1: stloc.s 4
-			IL_01a3: br IL_01b7
+			IL_0192: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
+			IL_0197: stloc.s 4
+			IL_0199: br IL_01ad
 
-			IL_01a8: pop
-			IL_01a9: ldloc.s 4
-			IL_01ab: ldstr "n"
-			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_01b5: stloc.s 4
+			IL_019e: pop
+			IL_019f: ldloc.s 4
+			IL_01a1: ldstr "n"
+			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_01ab: stloc.s 4
 
-			IL_01b7: ldloc.s 6
-			IL_01b9: ldloc.s 4
-			IL_01bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01c0: pop
-			IL_01c1: ldnull
-			IL_01c2: ret
+			IL_01ad: ldloc.s 6
+			IL_01af: ldloc.s 4
+			IL_01b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01b6: pop
+			IL_01b7: ldnull
+			IL_01b8: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperMethodCall.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperMethodCall.verified.txt
@@ -519,7 +519,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 384 (0x180)
+		// Code size: 374 (0x176)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_SuperMethodCall/Scope,
@@ -555,101 +555,99 @@
 		IL_0044: ldc.i4.1
 		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0, float64, string, bool, bool)
 		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0)
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0)
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0059: pop
-		IL_005a: ldc.i4.1
-		IL_005b: newarr [System.Runtime]System.Object
-		IL_0060: dup
-		IL_0061: ldc.i4.0
-		IL_0062: ldloc.0
-		IL_0063: stelem.ref
-		IL_0064: stloc.s 5
-		IL_0066: ldloc.3
-		IL_0067: ldloc.s 5
-		IL_0069: ldc.r8 0.0
-		IL_0072: box [System.Runtime]System.Double
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007c: stloc.s 4
-		IL_007e: ldloc.s 4
-		IL_0080: stloc.1
-		IL_0081: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
-		IL_0086: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_008b: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
-		IL_0090: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0095: stloc.3
-		IL_0096: ldloc.3
-		IL_0097: ldstr "prototype"
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a1: stloc.s 4
-		IL_00a3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00a8: stloc.s 5
-		IL_00aa: ldloc.s 4
-		IL_00ac: ldstr "m"
-		IL_00b1: ldloc.s 4
-		IL_00b3: ldloc.s 5
-		IL_00b5: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m::.ctor(class [System.Runtime]System.Object, object[])
-		IL_00ba: ldc.i4.0
-		IL_00bb: conv.r8
-		IL_00bc: ldstr "m"
-		IL_00c1: ldc.i4.1
-		IL_00c2: ldc.i4.1
-		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0, float64, string, bool, bool)
-		IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0)
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0)
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00d7: pop
-		IL_00d8: ldc.i4.1
-		IL_00d9: newarr [System.Runtime]System.Object
-		IL_00de: dup
-		IL_00df: ldc.i4.0
-		IL_00e0: ldloc.0
-		IL_00e1: stelem.ref
-		IL_00e2: stloc.s 5
-		IL_00e4: ldloc.3
-		IL_00e5: ldloc.s 5
-		IL_00e7: ldc.r8 0.0
-		IL_00f0: box [System.Runtime]System.Double
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0054: pop
+		IL_0055: ldc.i4.1
+		IL_0056: newarr [System.Runtime]System.Object
+		IL_005b: dup
+		IL_005c: ldc.i4.0
+		IL_005d: ldloc.0
+		IL_005e: stelem.ref
+		IL_005f: stloc.s 5
+		IL_0061: ldloc.3
+		IL_0062: ldloc.s 5
+		IL_0064: ldc.r8 0.0
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.s 4
+		IL_007b: stloc.1
+		IL_007c: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
+		IL_0081: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0086: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
+		IL_008b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0090: stloc.3
+		IL_0091: ldloc.3
+		IL_0092: ldstr "prototype"
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009c: stloc.s 4
+		IL_009e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a3: stloc.s 5
+		IL_00a5: ldloc.s 4
+		IL_00a7: ldstr "m"
+		IL_00ac: ldloc.s 4
+		IL_00ae: ldloc.s 5
+		IL_00b0: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m::.ctor(class [System.Runtime]System.Object, object[])
+		IL_00b5: ldc.i4.0
+		IL_00b6: conv.r8
+		IL_00b7: ldstr "m"
+		IL_00bc: ldc.i4.1
+		IL_00bd: ldc.i4.1
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0, float64, string, bool, bool)
+		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0)
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00cd: pop
+		IL_00ce: ldc.i4.1
+		IL_00cf: newarr [System.Runtime]System.Object
+		IL_00d4: dup
+		IL_00d5: ldc.i4.0
+		IL_00d6: ldloc.0
+		IL_00d7: stelem.ref
+		IL_00d8: stloc.s 5
+		IL_00da: ldloc.3
+		IL_00db: ldloc.s 5
+		IL_00dd: ldc.r8 0.0
+		IL_00e6: box [System.Runtime]System.Double
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00f0: stloc.s 4
+		IL_00f2: ldloc.s 4
+		IL_00f4: ldloc.1
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
 		IL_00fa: stloc.s 4
 		IL_00fc: ldloc.s 4
-		IL_00fe: ldloc.1
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0104: stloc.s 4
-		IL_0106: ldloc.s 4
-		IL_0108: stloc.2
-		IL_0109: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010e: stloc.s 6
-		IL_0110: ldc.i4.0
-		IL_0111: newarr [System.Runtime]System.Object
-		IL_0116: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_011b: ldloc.2
-		IL_011c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_0121: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0126: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D::.ctor()
-		IL_012b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_0130: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0135: dup
-		IL_0136: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
-		IL_013b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0140: ldstr "prototype"
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_014a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_014f: stloc.s 4
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_015b: stloc.s 4
-		IL_015d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_0162: ldloc.s 4
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0169: ldstr "m"
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0173: stloc.s 4
-		IL_0175: ldloc.s 6
-		IL_0177: ldloc.s 4
-		IL_0179: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017e: pop
-		IL_017f: ret
+		IL_00fe: stloc.2
+		IL_00ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0104: stloc.s 6
+		IL_0106: ldc.i4.0
+		IL_0107: newarr [System.Runtime]System.Object
+		IL_010c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0111: ldloc.2
+		IL_0112: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0117: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_011c: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D::.ctor()
+		IL_0121: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_0126: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_012b: dup
+		IL_012c: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
+		IL_0131: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0136: ldstr "prototype"
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0140: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0145: stloc.s 4
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0151: stloc.s 4
+		IL_0153: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_0158: ldloc.s 4
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015f: ldstr "m"
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0169: stloc.s 4
+		IL_016b: ldloc.s 6
+		IL_016d: ldloc.s 4
+		IL_016f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0174: pop
+		IL_0175: ret
 	} // end of method Classes_Inheritance_SuperMethodCall::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_SuperMethodCall

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
@@ -579,7 +579,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 609 (0x261)
+		// Code size: 589 (0x24d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Method_DefaultReturnUndefined/Scope,
@@ -625,183 +625,179 @@
 		IL_0046: ldc.i4.1
 		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0, float64, string, bool, bool)
 		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0)
-		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0)
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005b: pop
-		IL_005c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0061: stloc.s 12
-		IL_0063: ldloc.s 11
-		IL_0065: ldstr "returnsUndefined"
-		IL_006a: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::.ctor()
-		IL_006f: ldc.i4.0
-		IL_0070: conv.r8
-		IL_0071: ldstr "returnsUndefined"
-		IL_0076: ldc.i4.0
-		IL_0077: ldc.i4.1
-		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0, float64, string, bool, bool)
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0)
-		IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0)
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_008c: pop
-		IL_008d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0092: stloc.s 12
-		IL_0094: ldloc.s 11
-		IL_0096: ldstr "returnsValue"
-		IL_009b: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::.ctor()
-		IL_00a0: ldc.i4.0
-		IL_00a1: conv.r8
-		IL_00a2: ldstr "returnsValue"
-		IL_00a7: ldc.i4.1
-		IL_00a8: ldc.i4.1
-		IL_00a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0, float64, string, bool, bool)
-		IL_00ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0)
-		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0)
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00bd: pop
-		IL_00be: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00c3: stloc.s 12
-		IL_00c5: ldloc.s 11
-		IL_00c7: ldstr "returnsThis"
-		IL_00cc: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::.ctor()
-		IL_00d1: ldc.i4.0
-		IL_00d2: conv.r8
-		IL_00d3: ldstr "returnsThis"
-		IL_00d8: ldc.i4.1
-		IL_00d9: ldc.i4.1
-		IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0, float64, string, bool, bool)
-		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0)
-		IL_00e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0)
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00ee: pop
-		IL_00ef: ldc.i4.1
-		IL_00f0: newarr [System.Runtime]System.Object
-		IL_00f5: dup
-		IL_00f6: ldc.i4.0
-		IL_00f7: ldloc.0
-		IL_00f8: stelem.ref
-		IL_00f9: stloc.s 12
-		IL_00fb: ldloc.s 10
-		IL_00fd: ldloc.s 12
-		IL_00ff: ldc.r8 1
-		IL_0108: box [System.Runtime]System.Double
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0112: stloc.s 11
-		IL_0114: ldloc.s 11
-		IL_0116: stloc.1
-		IL_0117: ldc.i4.1
-		IL_0118: newarr [System.Runtime]System.Object
-		IL_011d: dup
-		IL_011e: ldc.i4.0
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0056: pop
+		IL_0057: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_005c: stloc.s 12
+		IL_005e: ldloc.s 11
+		IL_0060: ldstr "returnsUndefined"
+		IL_0065: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::.ctor()
+		IL_006a: ldc.i4.0
+		IL_006b: conv.r8
+		IL_006c: ldstr "returnsUndefined"
+		IL_0071: ldc.i4.0
+		IL_0072: ldc.i4.1
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0, float64, string, bool, bool)
+		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0)
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0082: pop
+		IL_0083: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0088: stloc.s 12
+		IL_008a: ldloc.s 11
+		IL_008c: ldstr "returnsValue"
+		IL_0091: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::.ctor()
+		IL_0096: ldc.i4.0
+		IL_0097: conv.r8
+		IL_0098: ldstr "returnsValue"
+		IL_009d: ldc.i4.1
+		IL_009e: ldc.i4.1
+		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0)
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00ae: pop
+		IL_00af: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00b4: stloc.s 12
+		IL_00b6: ldloc.s 11
+		IL_00b8: ldstr "returnsThis"
+		IL_00bd: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::.ctor()
+		IL_00c2: ldc.i4.0
+		IL_00c3: conv.r8
+		IL_00c4: ldstr "returnsThis"
+		IL_00c9: ldc.i4.1
+		IL_00ca: ldc.i4.1
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0, float64, string, bool, bool)
+		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0)
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00da: pop
+		IL_00db: ldc.i4.1
+		IL_00dc: newarr [System.Runtime]System.Object
+		IL_00e1: dup
+		IL_00e2: ldc.i4.0
+		IL_00e3: ldloc.0
+		IL_00e4: stelem.ref
+		IL_00e5: stloc.s 12
+		IL_00e7: ldloc.s 10
+		IL_00e9: ldloc.s 12
+		IL_00eb: ldc.r8 1
+		IL_00f4: box [System.Runtime]System.Double
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00fe: stloc.s 11
+		IL_0100: ldloc.s 11
+		IL_0102: stloc.1
+		IL_0103: ldc.i4.1
+		IL_0104: newarr [System.Runtime]System.Object
+		IL_0109: dup
+		IL_010a: ldc.i4.0
+		IL_010b: ldc.r8 10
+		IL_0114: box [System.Runtime]System.Double
+		IL_0119: stelem.ref
+		IL_011a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
 		IL_011f: ldc.r8 10
-		IL_0128: box [System.Runtime]System.Double
-		IL_012d: stelem.ref
-		IL_012e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0133: ldc.r8 10
-		IL_013c: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator::.ctor(float64)
-		IL_0141: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0146: stloc.2
-		IL_0147: ldloc.2
-		IL_0148: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
-		IL_014d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0152: ldstr "prototype"
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_015c: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0161: ldloc.2
-		IL_0162: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
-		IL_0167: stloc.s 13
-		IL_0169: ldloc.s 13
-		IL_016b: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::doNothing()
-		IL_0170: stloc.3
-		IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0176: stloc.s 14
-		IL_0178: ldloc.3
-		IL_0179: ldnull
-		IL_017a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_017f: stloc.s 15
-		IL_0181: ldloc.s 15
-		IL_0183: brfalse IL_0194
+		IL_0128: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator::.ctor(float64)
+		IL_012d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0132: stloc.2
+		IL_0133: ldloc.2
+		IL_0134: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
+		IL_0139: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_013e: ldstr "prototype"
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0148: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_014d: ldloc.2
+		IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
+		IL_0153: stloc.s 13
+		IL_0155: ldloc.s 13
+		IL_0157: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::doNothing()
+		IL_015c: stloc.3
+		IL_015d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0162: stloc.s 14
+		IL_0164: ldloc.3
+		IL_0165: ldnull
+		IL_0166: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_016b: stloc.s 15
+		IL_016d: ldloc.s 15
+		IL_016f: brfalse IL_0180
 
-		IL_0188: ldstr "undefined"
-		IL_018d: stloc.s 4
-		IL_018f: br IL_019b
+		IL_0174: ldstr "undefined"
+		IL_0179: stloc.s 4
+		IL_017b: br IL_0187
 
-		IL_0194: ldstr "not undefined"
-		IL_0199: stloc.s 4
+		IL_0180: ldstr "not undefined"
+		IL_0185: stloc.s 4
 
-		IL_019b: ldloc.s 14
-		IL_019d: ldloc.s 4
-		IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a4: pop
-		IL_01a5: ldloc.2
-		IL_01a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
-		IL_01ab: stloc.s 13
-		IL_01ad: ldloc.s 13
-		IL_01af: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsUndefined()
-		IL_01b4: stloc.s 5
-		IL_01b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01bb: stloc.s 14
-		IL_01bd: ldloc.s 5
-		IL_01bf: ldnull
-		IL_01c0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01c5: stloc.s 15
-		IL_01c7: ldloc.s 15
-		IL_01c9: brfalse IL_01da
+		IL_0187: ldloc.s 14
+		IL_0189: ldloc.s 4
+		IL_018b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0190: pop
+		IL_0191: ldloc.2
+		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
+		IL_0197: stloc.s 13
+		IL_0199: ldloc.s 13
+		IL_019b: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsUndefined()
+		IL_01a0: stloc.s 5
+		IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a7: stloc.s 14
+		IL_01a9: ldloc.s 5
+		IL_01ab: ldnull
+		IL_01ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01b1: stloc.s 15
+		IL_01b3: ldloc.s 15
+		IL_01b5: brfalse IL_01c6
 
-		IL_01ce: ldstr "undefined"
-		IL_01d3: stloc.s 6
-		IL_01d5: br IL_01e1
+		IL_01ba: ldstr "undefined"
+		IL_01bf: stloc.s 6
+		IL_01c1: br IL_01cd
 
-		IL_01da: ldstr "not undefined"
-		IL_01df: stloc.s 6
+		IL_01c6: ldstr "not undefined"
+		IL_01cb: stloc.s 6
 
-		IL_01e1: ldloc.s 14
-		IL_01e3: ldloc.s 6
-		IL_01e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ea: pop
-		IL_01eb: ldloc.2
-		IL_01ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
-		IL_01f1: stloc.s 13
-		IL_01f3: ldloc.s 13
-		IL_01f5: callvirt instance float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
-		IL_01fa: stloc.s 16
-		IL_01fc: ldloc.s 16
-		IL_01fe: box [System.Runtime]System.Double
-		IL_0203: stloc.s 7
-		IL_0205: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_020a: stloc.s 14
-		IL_020c: ldloc.s 14
-		IL_020e: ldloc.s 7
-		IL_0210: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0215: pop
-		IL_0216: ldloc.2
-		IL_0217: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
-		IL_021c: stloc.s 13
-		IL_021e: ldloc.s 13
-		IL_0220: callvirt instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
-		IL_0225: stloc.s 13
-		IL_0227: ldloc.s 13
-		IL_0229: stloc.s 8
-		IL_022b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0230: stloc.s 14
-		IL_0232: ldloc.s 8
-		IL_0234: ldloc.2
-		IL_0235: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_023a: stloc.s 15
-		IL_023c: ldloc.s 15
-		IL_023e: brfalse IL_024f
+		IL_01cd: ldloc.s 14
+		IL_01cf: ldloc.s 6
+		IL_01d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d6: pop
+		IL_01d7: ldloc.2
+		IL_01d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
+		IL_01dd: stloc.s 13
+		IL_01df: ldloc.s 13
+		IL_01e1: callvirt instance float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
+		IL_01e6: stloc.s 16
+		IL_01e8: ldloc.s 16
+		IL_01ea: box [System.Runtime]System.Double
+		IL_01ef: stloc.s 7
+		IL_01f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f6: stloc.s 14
+		IL_01f8: ldloc.s 14
+		IL_01fa: ldloc.s 7
+		IL_01fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0201: pop
+		IL_0202: ldloc.2
+		IL_0203: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_Method_DefaultReturnUndefined/Calculator>(!!0)
+		IL_0208: stloc.s 13
+		IL_020a: ldloc.s 13
+		IL_020c: callvirt instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
+		IL_0211: stloc.s 13
+		IL_0213: ldloc.s 13
+		IL_0215: stloc.s 8
+		IL_0217: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_021c: stloc.s 14
+		IL_021e: ldloc.s 8
+		IL_0220: ldloc.2
+		IL_0221: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0226: stloc.s 15
+		IL_0228: ldloc.s 15
+		IL_022a: brfalse IL_023b
 
-		IL_0243: ldstr "same instance"
-		IL_0248: stloc.s 9
-		IL_024a: br IL_0256
+		IL_022f: ldstr "same instance"
+		IL_0234: stloc.s 9
+		IL_0236: br IL_0242
 
-		IL_024f: ldstr "different"
-		IL_0254: stloc.s 9
+		IL_023b: ldstr "different"
+		IL_0240: stloc.s 9
 
-		IL_0256: ldloc.s 14
-		IL_0258: ldloc.s 9
-		IL_025a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_025f: pop
-		IL_0260: ret
+		IL_0242: ldloc.s 14
+		IL_0244: ldloc.s 9
+		IL_0246: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_024b: pop
+		IL_024c: ret
 	} // end of method Classes_Method_DefaultReturnUndefined::__js_module_init__
 
 } // end of class Modules.Classes_Method_DefaultReturnUndefined

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
@@ -508,7 +508,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 188 (0xbc)
+		// Code size: 178 (0xb2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_Class_Lib/Scope,
@@ -542,46 +542,44 @@
 		IL_0042: ldc.i4.1
 		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0, float64, string, bool, bool)
 		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0)
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0)
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0057: pop
-		IL_0058: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_005d: stloc.s 4
-		IL_005f: ldloc.3
-		IL_0060: ldstr "multiply"
-		IL_0065: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::.ctor()
-		IL_006a: ldc.i4.2
-		IL_006b: conv.r8
-		IL_006c: ldstr "multiply"
-		IL_0071: ldc.i4.0
-		IL_0072: ldc.i4.1
-		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0, float64, string, bool, bool)
-		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0)
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0)
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0087: pop
-		IL_0088: ldc.i4.1
-		IL_0089: newarr [System.Runtime]System.Object
-		IL_008e: dup
-		IL_008f: ldc.i4.0
-		IL_0090: ldloc.0
-		IL_0091: stelem.ref
-		IL_0092: stloc.s 4
-		IL_0094: ldloc.2
-		IL_0095: ldloc.s 4
-		IL_0097: ldc.r8 0.0
-		IL_00a0: box [System.Runtime]System.Double
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00aa: stloc.3
-		IL_00ab: ldloc.3
-		IL_00ac: stloc.1
-		IL_00ad: ldarg.2
-		IL_00ae: ldstr "exports"
-		IL_00b3: ldloc.1
-		IL_00b4: ldc.i4.1
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00ba: pop
-		IL_00bb: ret
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0052: pop
+		IL_0053: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0058: stloc.s 4
+		IL_005a: ldloc.3
+		IL_005b: ldstr "multiply"
+		IL_0060: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::.ctor()
+		IL_0065: ldc.i4.2
+		IL_0066: conv.r8
+		IL_0067: ldstr "multiply"
+		IL_006c: ldc.i4.0
+		IL_006d: ldc.i4.1
+		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0, float64, string, bool, bool)
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0)
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_007d: pop
+		IL_007e: ldc.i4.1
+		IL_007f: newarr [System.Runtime]System.Object
+		IL_0084: dup
+		IL_0085: ldc.i4.0
+		IL_0086: ldloc.0
+		IL_0087: stelem.ref
+		IL_0088: stloc.s 4
+		IL_008a: ldloc.2
+		IL_008b: ldloc.s 4
+		IL_008d: ldc.r8 0.0
+		IL_0096: box [System.Runtime]System.Double
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00a0: stloc.3
+		IL_00a1: ldloc.3
+		IL_00a2: stloc.1
+		IL_00a3: ldarg.2
+		IL_00a4: ldstr "exports"
+		IL_00a9: ldloc.1
+		IL_00aa: ldc.i4.1
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_00b0: pop
+		IL_00b1: ret
 	} // end of method CommonJS_Export_Class_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_Class_Lib

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
@@ -465,7 +465,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 140 (0x8c)
+		// Code size: 135 (0x87)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ClassWithConstructor_Lib/Scope,
@@ -499,31 +499,30 @@
 		IL_0042: ldc.i4.1
 		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0, float64, string, bool, bool)
 		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0)
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0)
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0057: pop
-		IL_0058: ldc.i4.1
-		IL_0059: newarr [System.Runtime]System.Object
-		IL_005e: dup
-		IL_005f: ldc.i4.0
-		IL_0060: ldloc.0
-		IL_0061: stelem.ref
-		IL_0062: stloc.s 4
-		IL_0064: ldloc.2
-		IL_0065: ldloc.s 4
-		IL_0067: ldc.r8 2
-		IL_0070: box [System.Runtime]System.Double
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007a: stloc.3
-		IL_007b: ldloc.3
-		IL_007c: stloc.1
-		IL_007d: ldarg.2
-		IL_007e: ldstr "exports"
-		IL_0083: ldloc.1
-		IL_0084: ldc.i4.1
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_008a: pop
-		IL_008b: ret
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0052: pop
+		IL_0053: ldc.i4.1
+		IL_0054: newarr [System.Runtime]System.Object
+		IL_0059: dup
+		IL_005a: ldc.i4.0
+		IL_005b: ldloc.0
+		IL_005c: stelem.ref
+		IL_005d: stloc.s 4
+		IL_005f: ldloc.2
+		IL_0060: ldloc.s 4
+		IL_0062: ldc.r8 2
+		IL_006b: box [System.Runtime]System.Double
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0075: stloc.3
+		IL_0076: ldloc.3
+		IL_0077: stloc.1
+		IL_0078: ldarg.2
+		IL_0079: ldstr "exports"
+		IL_007e: ldloc.1
+		IL_007f: ldc.i4.1
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0085: pop
+		IL_0086: ret
 	} // end of method CommonJS_Export_ClassWithConstructor_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_ClassWithConstructor_Lib

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ClassExpression_ExtendsArray.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ClassExpression_ExtendsArray.verified.txt
@@ -459,7 +459,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 199 (0xc7)
+		// Code size: 194 (0xc2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/Scope,
@@ -519,22 +519,21 @@
 		IL_008d: ldc.i4.1
 		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0, float64, string, bool, bool)
 		IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0)
-		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0)
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00a2: pop
-		IL_00a3: ldarg.2
-		IL_00a4: ldstr "exports"
-		IL_00a9: ldloc.s 4
-		IL_00ab: ldc.i4.1
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00b1: pop
-		IL_00b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b7: stloc.s 5
-		IL_00b9: ldloc.s 5
-		IL_00bb: ldstr "ok"
-		IL_00c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c5: pop
-		IL_00c6: ret
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_009d: pop
+		IL_009e: ldarg.2
+		IL_009f: ldstr "exports"
+		IL_00a4: ldloc.s 4
+		IL_00a6: ldc.i4.1
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_00ac: pop
+		IL_00ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b2: stloc.s 5
+		IL_00b4: ldloc.s 5
+		IL_00b6: ldstr "ok"
+		IL_00bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c0: pop
+		IL_00c1: ret
 	} // end of method CommonJS_Module_Exports_ClassExpression_ExtendsArray::__js_module_init__
 
 } // end of class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_BoundFunctionObject_UnifiedTargets.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_BoundFunctionObject_UnifiedTargets.verified.txt
@@ -785,7 +785,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1727 (0x6bf)
+		// Code size: 1718 (0x6b6)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Function_BoundFunctionObject_UnifiedTargets/Scope,
@@ -1086,321 +1086,318 @@
 		IL_0329: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject_FunctionExpression_0C6E34EF_L23C11>(!!0, float64, string, bool, bool)
 		IL_032e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject_FunctionExpression_0C6E34EF_L23C11>(!!0)
 		IL_0333: stloc.s 30
-		IL_0335: ldloc.s 30
-		IL_0337: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject_FunctionExpression_0C6E34EF_L23C11>(!!0)
-		IL_033c: stloc.s 30
-		IL_033e: ldloc.s 17
-		IL_0340: ldstr "method"
-		IL_0345: ldloc.s 30
-		IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_034c: pop
-		IL_034d: ldloc.s 17
-		IL_034f: stloc.s 4
-		IL_0351: ldloc.s 4
-		IL_0353: ldstr "method"
-		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_035d: stloc.s 23
-		IL_035f: ldloc.s 23
-		IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0366: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_036b: dup
-		IL_036c: ldstr "value"
-		IL_0371: ldc.r8 20
-		IL_037a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_037f: stloc.s 17
-		IL_0381: ldstr "bind"
-		IL_0386: ldloc.s 17
-		IL_0388: ldc.r8 2
-		IL_0391: box [System.Runtime]System.Double
-		IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_039b: stloc.s 5
-		IL_039d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03a2: stloc.s 18
-		IL_03a4: ldloc.s 5
-		IL_03a6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_03b0: stloc.s 23
-		IL_03b2: ldloc.s 5
-		IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03be: dup
-		IL_03bf: ldstr "value"
-		IL_03c4: ldc.r8 100
-		IL_03cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_03d2: stloc.s 17
-		IL_03d4: ldstr "call"
-		IL_03d9: ldloc.s 17
-		IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03e0: stloc.s 22
-		IL_03e2: ldloc.s 18
-		IL_03e4: ldstr "method"
-		IL_03e9: ldloc.s 23
-		IL_03eb: ldloc.s 22
-		IL_03ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_03f2: pop
-		IL_03f3: ldc.i4.1
-		IL_03f4: newarr [System.Runtime]System.Object
-		IL_03f9: dup
-		IL_03fa: ldc.i4.0
-		IL_03fb: ldloc.0
-		IL_03fc: stelem.ref
-		IL_03fd: stloc.s 16
-		IL_03ff: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject::.ctor()
-		IL_0404: ldc.i4.1
-		IL_0405: conv.r8
-		IL_0406: ldstr ""
-		IL_040b: ldc.i4.0
-		IL_040c: ldc.i4.0
-		IL_040d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0412: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0)
-		IL_0417: stloc.s 31
-		IL_0419: ldloc.s 31
-		IL_041b: ldstr "arrow"
-		IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0425: stloc.s 6
-		IL_0427: ldloc.s 6
-		IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_042e: ldstr "bind"
-		IL_0433: ldc.i4.0
-		IL_0434: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0439: ldc.r8 4
-		IL_0442: box [System.Runtime]System.Double
-		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_044c: stloc.s 7
-		IL_044e: ldc.i4.0
-		IL_044f: box [System.Runtime]System.Boolean
-		IL_0454: stloc.s 8
+		IL_0335: ldloc.s 17
+		IL_0337: ldstr "method"
+		IL_033c: ldloc.s 30
+		IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0343: pop
+		IL_0344: ldloc.s 17
+		IL_0346: stloc.s 4
+		IL_0348: ldloc.s 4
+		IL_034a: ldstr "method"
+		IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0354: stloc.s 23
+		IL_0356: ldloc.s 23
+		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_035d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0362: dup
+		IL_0363: ldstr "value"
+		IL_0368: ldc.r8 20
+		IL_0371: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0376: stloc.s 17
+		IL_0378: ldstr "bind"
+		IL_037d: ldloc.s 17
+		IL_037f: ldc.r8 2
+		IL_0388: box [System.Runtime]System.Double
+		IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0392: stloc.s 5
+		IL_0394: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0399: stloc.s 18
+		IL_039b: ldloc.s 5
+		IL_039d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_03a7: stloc.s 23
+		IL_03a9: ldloc.s 5
+		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03b5: dup
+		IL_03b6: ldstr "value"
+		IL_03bb: ldc.r8 100
+		IL_03c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_03c9: stloc.s 17
+		IL_03cb: ldstr "call"
+		IL_03d0: ldloc.s 17
+		IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03d7: stloc.s 22
+		IL_03d9: ldloc.s 18
+		IL_03db: ldstr "method"
+		IL_03e0: ldloc.s 23
+		IL_03e2: ldloc.s 22
+		IL_03e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_03e9: pop
+		IL_03ea: ldc.i4.1
+		IL_03eb: newarr [System.Runtime]System.Object
+		IL_03f0: dup
+		IL_03f1: ldc.i4.0
+		IL_03f2: ldloc.0
+		IL_03f3: stelem.ref
+		IL_03f4: stloc.s 16
+		IL_03f6: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject::.ctor()
+		IL_03fb: ldc.i4.1
+		IL_03fc: conv.r8
+		IL_03fd: ldstr ""
+		IL_0402: ldc.i4.0
+		IL_0403: ldc.i4.0
+		IL_0404: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0409: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0)
+		IL_040e: stloc.s 31
+		IL_0410: ldloc.s 31
+		IL_0412: ldstr "arrow"
+		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_041c: stloc.s 6
+		IL_041e: ldloc.s 6
+		IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0425: ldstr "bind"
+		IL_042a: ldc.i4.0
+		IL_042b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0430: ldc.r8 4
+		IL_0439: box [System.Runtime]System.Double
+		IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0443: stloc.s 7
+		IL_0445: ldc.i4.0
+		IL_0446: box [System.Runtime]System.Boolean
+		IL_044b: stloc.s 8
 		.try
 		{
-			IL_0456: nop
-			IL_0457: ldstr "Reflect"
-			IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0466: ldc.i4.0
-			IL_0467: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_046c: stloc.s 21
-			IL_046e: ldstr "construct"
-			IL_0473: ldloc.s 7
-			IL_0475: ldloc.s 21
-			IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_047c: pop
-			IL_047d: leave IL_04e1
+			IL_044d: nop
+			IL_044e: ldstr "Reflect"
+			IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_045d: ldc.i4.0
+			IL_045e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0463: stloc.s 21
+			IL_0465: ldstr "construct"
+			IL_046a: ldloc.s 7
+			IL_046c: ldloc.s 21
+			IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0473: pop
+			IL_0474: leave IL_04d8
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0482: stloc.s 9
-			IL_0484: ldloc.s 9
-			IL_0486: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_048b: dup
-			IL_048c: brtrue IL_04a2
+			IL_0479: stloc.s 9
+			IL_047b: ldloc.s 9
+			IL_047d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0482: dup
+			IL_0483: brtrue IL_0499
 
-			IL_0491: pop
-			IL_0492: ldloc.s 9
-			IL_0494: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0499: dup
-			IL_049a: brtrue IL_04ae
+			IL_0488: pop
+			IL_0489: ldloc.s 9
+			IL_048b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0490: dup
+			IL_0491: brtrue IL_04a5
 
-			IL_049f: pop
-			IL_04a0: rethrow
+			IL_0496: pop
+			IL_0497: rethrow
 
-			IL_04a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_04a7: stloc.s 10
-			IL_04a9: br IL_04b0
+			IL_0499: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_049e: stloc.s 10
+			IL_04a0: br IL_04a7
 
-			IL_04ae: stloc.s 10
+			IL_04a5: stloc.s 10
 
-			IL_04b0: ldloc.s 10
-			IL_04b2: stloc.s 11
-			IL_04b4: ldloc.s 11
-			IL_04b6: stloc.s 22
-			IL_04b8: ldstr "TypeError"
-			IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04c2: stloc.s 23
-			IL_04c4: ldloc.s 22
-			IL_04c6: ldloc.s 23
-			IL_04c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_04cd: stloc.s 28
-			IL_04cf: ldloc.s 28
-			IL_04d1: box [System.Runtime]System.Boolean
-			IL_04d6: stloc.s 29
-			IL_04d8: ldloc.s 29
-			IL_04da: stloc.s 8
-			IL_04dc: leave IL_04e1
+			IL_04a7: ldloc.s 10
+			IL_04a9: stloc.s 11
+			IL_04ab: ldloc.s 11
+			IL_04ad: stloc.s 22
+			IL_04af: ldstr "TypeError"
+			IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04b9: stloc.s 23
+			IL_04bb: ldloc.s 22
+			IL_04bd: ldloc.s 23
+			IL_04bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_04c4: stloc.s 28
+			IL_04c6: ldloc.s 28
+			IL_04c8: box [System.Runtime]System.Boolean
+			IL_04cd: stloc.s 29
+			IL_04cf: ldloc.s 29
+			IL_04d1: stloc.s 8
+			IL_04d3: leave IL_04d8
 		} // end handler
 
-		IL_04e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04e6: stloc.s 18
-		IL_04e8: ldloc.s 7
-		IL_04ea: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_04f4: stloc.s 23
-		IL_04f6: ldloc.s 18
-		IL_04f8: ldstr "arrow"
-		IL_04fd: ldloc.s 23
-		IL_04ff: ldloc.s 8
-		IL_0501: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0506: pop
-		IL_0507: ldc.i4.1
-		IL_0508: newarr [System.Runtime]System.Object
-		IL_050d: dup
-		IL_050e: ldc.i4.0
-		IL_050f: ldloc.0
-		IL_0510: stelem.ref
-		IL_0511: stloc.s 16
-		IL_0513: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
-		IL_0518: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_051d: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
-		IL_0522: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0527: stloc.s 32
-		IL_0529: ldloc.s 32
-		IL_052b: ldloc.s 16
-		IL_052d: ldc.r8 2
-		IL_0536: box [System.Runtime]System.Double
-		IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0540: stloc.s 23
-		IL_0542: ldloc.s 23
-		IL_0544: stloc.s 12
-		IL_0546: ldloc.s 12
-		IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_054d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0552: dup
-		IL_0553: ldstr "ignored"
-		IL_0558: ldc.i4.1
-		IL_0559: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_055e: stloc.s 17
-		IL_0560: ldstr "bind"
-		IL_0565: ldloc.s 17
-		IL_0567: ldc.r8 7
-		IL_0570: box [System.Runtime]System.Double
-		IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_057a: stloc.s 13
-		IL_057c: ldloc.s 13
-		IL_057e: ldc.i4.1
-		IL_057f: newarr [System.Runtime]System.Object
-		IL_0584: dup
-		IL_0585: ldc.i4.0
-		IL_0586: ldc.r8 8
-		IL_058f: box [System.Runtime]System.Double
-		IL_0594: stelem.ref
-		IL_0595: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_059a: stloc.s 14
-		IL_059c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05a1: stloc.s 18
-		IL_05a3: ldloc.s 14
-		IL_05a5: ldstr "total"
-		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05af: stloc.s 23
-		IL_05b1: ldloc.s 14
-		IL_05b3: ldstr "seenNewTarget"
-		IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05bd: stloc.s 22
-		IL_05bf: ldloc.s 22
-		IL_05c1: ldloc.s 12
-		IL_05c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_05c8: stloc.s 28
-		IL_05ca: ldloc.s 28
-		IL_05cc: box [System.Runtime]System.Boolean
-		IL_05d1: stloc.s 29
-		IL_05d3: ldloc.s 14
-		IL_05d5: ldloc.s 12
-		IL_05d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_05dc: stloc.s 28
-		IL_05de: ldloc.s 28
-		IL_05e0: box [System.Runtime]System.Boolean
-		IL_05e5: stloc.s 27
-		IL_05e7: ldloc.s 14
-		IL_05e9: ldloc.s 13
-		IL_05eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_05f0: stloc.s 28
-		IL_05f2: ldloc.s 28
-		IL_05f4: box [System.Runtime]System.Boolean
-		IL_05f9: stloc.s 26
-		IL_05fb: ldloc.s 13
-		IL_05fd: ldstr "name"
-		IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0607: stloc.s 22
-		IL_0609: ldloc.s 13
-		IL_060b: ldstr "length"
-		IL_0610: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0615: stloc.s 20
-		IL_0617: ldloc.s 13
-		IL_0619: ldstr "prototype"
-		IL_061e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0623: box [System.Runtime]System.Boolean
-		IL_0628: stloc.s 25
-		IL_062a: ldloc.s 18
-		IL_062c: ldc.i4.8
-		IL_062d: newarr [System.Runtime]System.Object
-		IL_0632: dup
-		IL_0633: ldc.i4.0
-		IL_0634: ldstr "class"
-		IL_0639: stelem.ref
-		IL_063a: dup
-		IL_063b: ldc.i4.1
-		IL_063c: ldloc.s 23
-		IL_063e: stelem.ref
-		IL_063f: dup
-		IL_0640: ldc.i4.2
-		IL_0641: ldloc.s 29
-		IL_0643: stelem.ref
-		IL_0644: dup
-		IL_0645: ldc.i4.3
-		IL_0646: ldloc.s 27
-		IL_0648: stelem.ref
-		IL_0649: dup
-		IL_064a: ldc.i4.4
-		IL_064b: ldloc.s 26
-		IL_064d: stelem.ref
-		IL_064e: dup
-		IL_064f: ldc.i4.5
-		IL_0650: ldloc.s 22
-		IL_0652: stelem.ref
-		IL_0653: dup
-		IL_0654: ldc.i4.6
-		IL_0655: ldloc.s 20
-		IL_0657: stelem.ref
-		IL_0658: dup
-		IL_0659: ldc.i4.7
-		IL_065a: ldloc.s 25
-		IL_065c: stelem.ref
-		IL_065d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0662: pop
-		IL_0663: ldc.i4.1
-		IL_0664: newarr [System.Runtime]System.Object
-		IL_0669: dup
-		IL_066a: ldc.i4.0
-		IL_066b: ldloc.0
-		IL_066c: stelem.ref
-		IL_066d: stloc.s 16
-		IL_066f: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject_FunctionExpression_E85FC2F7_L59C14::.ctor()
-		IL_0674: ldc.i4.0
-		IL_0675: conv.r8
-		IL_0676: ldstr ""
-		IL_067b: ldc.i4.0
-		IL_067c: ldc.i4.1
-		IL_067d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject_FunctionExpression_E85FC2F7_L59C14>(!!0, float64, string, bool, bool)
-		IL_0682: stloc.s 33
-		IL_0684: ldloc.2
-		IL_0685: ldstr "call"
-		IL_068a: ldloc.s 33
-		IL_068c: ldc.i4.1
-		IL_068d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0692: pop
-		IL_0693: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0698: stloc.s 18
-		IL_069a: ldloc.2
-		IL_069b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06a0: ldstr "call"
-		IL_06a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_06aa: stloc.s 20
-		IL_06ac: ldloc.s 18
-		IL_06ae: ldstr "override"
-		IL_06b3: ldloc.s 20
-		IL_06b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_06ba: pop
-		IL_06bb: ldnull
-		IL_06bc: stloc.s 15
-		IL_06be: ret
+		IL_04d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04dd: stloc.s 18
+		IL_04df: ldloc.s 7
+		IL_04e1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_04eb: stloc.s 23
+		IL_04ed: ldloc.s 18
+		IL_04ef: ldstr "arrow"
+		IL_04f4: ldloc.s 23
+		IL_04f6: ldloc.s 8
+		IL_04f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_04fd: pop
+		IL_04fe: ldc.i4.1
+		IL_04ff: newarr [System.Runtime]System.Object
+		IL_0504: dup
+		IL_0505: ldc.i4.0
+		IL_0506: ldloc.0
+		IL_0507: stelem.ref
+		IL_0508: stloc.s 16
+		IL_050a: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
+		IL_050f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0514: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
+		IL_0519: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_051e: stloc.s 32
+		IL_0520: ldloc.s 32
+		IL_0522: ldloc.s 16
+		IL_0524: ldc.r8 2
+		IL_052d: box [System.Runtime]System.Double
+		IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0537: stloc.s 23
+		IL_0539: ldloc.s 23
+		IL_053b: stloc.s 12
+		IL_053d: ldloc.s 12
+		IL_053f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0544: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0549: dup
+		IL_054a: ldstr "ignored"
+		IL_054f: ldc.i4.1
+		IL_0550: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0555: stloc.s 17
+		IL_0557: ldstr "bind"
+		IL_055c: ldloc.s 17
+		IL_055e: ldc.r8 7
+		IL_0567: box [System.Runtime]System.Double
+		IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0571: stloc.s 13
+		IL_0573: ldloc.s 13
+		IL_0575: ldc.i4.1
+		IL_0576: newarr [System.Runtime]System.Object
+		IL_057b: dup
+		IL_057c: ldc.i4.0
+		IL_057d: ldc.r8 8
+		IL_0586: box [System.Runtime]System.Double
+		IL_058b: stelem.ref
+		IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_0591: stloc.s 14
+		IL_0593: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0598: stloc.s 18
+		IL_059a: ldloc.s 14
+		IL_059c: ldstr "total"
+		IL_05a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05a6: stloc.s 23
+		IL_05a8: ldloc.s 14
+		IL_05aa: ldstr "seenNewTarget"
+		IL_05af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05b4: stloc.s 22
+		IL_05b6: ldloc.s 22
+		IL_05b8: ldloc.s 12
+		IL_05ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05bf: stloc.s 28
+		IL_05c1: ldloc.s 28
+		IL_05c3: box [System.Runtime]System.Boolean
+		IL_05c8: stloc.s 29
+		IL_05ca: ldloc.s 14
+		IL_05cc: ldloc.s 12
+		IL_05ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_05d3: stloc.s 28
+		IL_05d5: ldloc.s 28
+		IL_05d7: box [System.Runtime]System.Boolean
+		IL_05dc: stloc.s 27
+		IL_05de: ldloc.s 14
+		IL_05e0: ldloc.s 13
+		IL_05e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_05e7: stloc.s 28
+		IL_05e9: ldloc.s 28
+		IL_05eb: box [System.Runtime]System.Boolean
+		IL_05f0: stloc.s 26
+		IL_05f2: ldloc.s 13
+		IL_05f4: ldstr "name"
+		IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05fe: stloc.s 22
+		IL_0600: ldloc.s 13
+		IL_0602: ldstr "length"
+		IL_0607: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_060c: stloc.s 20
+		IL_060e: ldloc.s 13
+		IL_0610: ldstr "prototype"
+		IL_0615: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_061a: box [System.Runtime]System.Boolean
+		IL_061f: stloc.s 25
+		IL_0621: ldloc.s 18
+		IL_0623: ldc.i4.8
+		IL_0624: newarr [System.Runtime]System.Object
+		IL_0629: dup
+		IL_062a: ldc.i4.0
+		IL_062b: ldstr "class"
+		IL_0630: stelem.ref
+		IL_0631: dup
+		IL_0632: ldc.i4.1
+		IL_0633: ldloc.s 23
+		IL_0635: stelem.ref
+		IL_0636: dup
+		IL_0637: ldc.i4.2
+		IL_0638: ldloc.s 29
+		IL_063a: stelem.ref
+		IL_063b: dup
+		IL_063c: ldc.i4.3
+		IL_063d: ldloc.s 27
+		IL_063f: stelem.ref
+		IL_0640: dup
+		IL_0641: ldc.i4.4
+		IL_0642: ldloc.s 26
+		IL_0644: stelem.ref
+		IL_0645: dup
+		IL_0646: ldc.i4.5
+		IL_0647: ldloc.s 22
+		IL_0649: stelem.ref
+		IL_064a: dup
+		IL_064b: ldc.i4.6
+		IL_064c: ldloc.s 20
+		IL_064e: stelem.ref
+		IL_064f: dup
+		IL_0650: ldc.i4.7
+		IL_0651: ldloc.s 25
+		IL_0653: stelem.ref
+		IL_0654: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0659: pop
+		IL_065a: ldc.i4.1
+		IL_065b: newarr [System.Runtime]System.Object
+		IL_0660: dup
+		IL_0661: ldc.i4.0
+		IL_0662: ldloc.0
+		IL_0663: stelem.ref
+		IL_0664: stloc.s 16
+		IL_0666: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject_FunctionExpression_E85FC2F7_L59C14::.ctor()
+		IL_066b: ldc.i4.0
+		IL_066c: conv.r8
+		IL_066d: ldstr ""
+		IL_0672: ldc.i4.0
+		IL_0673: ldc.i4.1
+		IL_0674: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject_FunctionExpression_E85FC2F7_L59C14>(!!0, float64, string, bool, bool)
+		IL_0679: stloc.s 33
+		IL_067b: ldloc.2
+		IL_067c: ldstr "call"
+		IL_0681: ldloc.s 33
+		IL_0683: ldc.i4.1
+		IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0689: pop
+		IL_068a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_068f: stloc.s 18
+		IL_0691: ldloc.2
+		IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0697: ldstr "call"
+		IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_06a1: stloc.s 20
+		IL_06a3: ldloc.s 18
+		IL_06a5: ldstr "override"
+		IL_06aa: ldloc.s 20
+		IL_06ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_06b1: pop
+		IL_06b2: ldnull
+		IL_06b3: stloc.s 15
+		IL_06b5: ret
 	} // end of method Function_BoundFunctionObject_UnifiedTargets::__js_module_init__
 
 } // end of class Modules.Function_BoundFunctionObject_UnifiedTargets

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableReflection_ProxyIntegration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableReflection_ProxyIntegration.verified.txt
@@ -1729,7 +1729,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2994 (0xbb2)
+		// Code size: 2913 (0xb61)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallableReflection_ProxyIntegration/Scope,
@@ -1885,1035 +1885,1008 @@
 		IL_00e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject_FunctionExpression_B1EFE281_L10C8>(!!0, float64, string, bool, bool)
 		IL_00e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject_FunctionExpression_B1EFE281_L10C8>(!!0)
 		IL_00ee: stloc.s 38
-		IL_00f0: ldloc.s 38
-		IL_00f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject_FunctionExpression_B1EFE281_L10C8>(!!0)
-		IL_00f7: stloc.s 38
-		IL_00f9: ldloc.s 37
-		IL_00fb: ldstr "get"
-		IL_0100: ldloc.s 38
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0107: pop
-		IL_0108: ldc.i4.1
-		IL_0109: newarr [System.Runtime]System.Object
-		IL_010e: dup
-		IL_010f: ldc.i4.0
-		IL_0110: ldloc.0
-		IL_0111: stelem.ref
-		IL_0112: stloc.s 33
-		IL_0114: ldloc.s 33
-		IL_0116: ldc.i4.0
-		IL_0117: ldelem.ref
-		IL_0118: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_011d: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
-		IL_0122: ldc.i4.1
-		IL_0123: conv.r8
-		IL_0124: ldstr ""
-		IL_0129: ldc.i4.0
-		IL_012a: ldc.i4.1
-		IL_012b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8>(!!0, float64, string, bool, bool)
-		IL_0130: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8>(!!0)
-		IL_0135: stloc.s 39
-		IL_0137: ldloc.s 39
-		IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8>(!!0)
-		IL_013e: stloc.s 39
-		IL_0140: ldloc.s 37
-		IL_0142: ldstr "set"
-		IL_0147: ldloc.s 39
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_014e: pop
-		IL_014f: ldloc.s 37
-		IL_0151: ldstr "enumerable"
-		IL_0156: ldc.i4.1
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
-		IL_015c: pop
-		IL_015d: ldloc.s 37
-		IL_015f: ldstr "configurable"
-		IL_0164: ldc.i4.1
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
-		IL_016a: pop
-		IL_016b: ldloc.s 36
-		IL_016d: ldstr "accessor"
-		IL_0172: ldloc.s 37
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_0179: pop
-		IL_017a: ldloc.0
-		IL_017b: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0180: stloc.s 36
-		IL_0182: ldloc.s 36
-		IL_0184: ldstr "accessor"
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_018e: stloc.2
-		IL_018f: ldloc.0
-		IL_0190: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0195: stloc.s 36
-		IL_0197: ldloc.s 36
-		IL_0199: ldstr "accessor"
-		IL_019e: ldc.r8 8
-		IL_01a7: ldc.i4.1
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_01ad: pop
-		IL_01ae: ldloc.0
-		IL_01af: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_01b4: stloc.s 36
-		IL_01b6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01bb: stloc.s 37
-		IL_01bd: ldloc.s 37
-		IL_01bf: ldloc.s 36
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
-		IL_01c6: pop
-		IL_01c7: ldloc.s 37
-		IL_01c9: stloc.3
-		IL_01ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01cf: stloc.s 40
-		IL_01d1: ldloc.0
-		IL_01d2: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_01d7: stloc.s 36
-		IL_01d9: ldloc.s 36
-		IL_01db: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_01e0: stloc.s 41
-		IL_01e2: ldloc.2
-		IL_01e3: ldstr "get"
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ed: stloc.s 36
-		IL_01ef: ldloc.0
-		IL_01f0: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_01f5: stloc.s 42
-		IL_01f7: ldloc.s 42
-		IL_01f9: ldstr "accessor"
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0203: ldstr "get"
-		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_020d: stloc.s 42
-		IL_020f: ldloc.s 36
-		IL_0211: ldloc.s 42
-		IL_0213: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0218: stloc.s 43
-		IL_021a: ldloc.s 43
-		IL_021c: box [System.Runtime]System.Boolean
-		IL_0221: stloc.s 44
-		IL_0223: ldloc.2
-		IL_0224: ldstr "set"
-		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_022e: stloc.s 42
-		IL_0230: ldloc.0
-		IL_0231: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0236: stloc.s 36
-		IL_0238: ldloc.s 36
-		IL_023a: ldstr "accessor"
-		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0244: ldstr "set"
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_024e: stloc.s 36
-		IL_0250: ldloc.s 42
-		IL_0252: ldloc.s 36
-		IL_0254: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0259: stloc.s 43
-		IL_025b: ldloc.s 43
-		IL_025d: box [System.Runtime]System.Boolean
-		IL_0262: stloc.s 45
-		IL_0264: ldloc.0
-		IL_0265: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_026a: ldstr "accessor"
-		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0274: stloc.s 36
-		IL_0276: ldloc.3
-		IL_0277: ldstr "custom"
-		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0281: stloc.s 42
-		IL_0283: ldloc.3
-		IL_0284: ldstr "accessor"
-		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_028e: stloc.s 46
-		IL_0290: ldloc.s 40
-		IL_0292: ldc.i4.7
-		IL_0293: newarr [System.Runtime]System.Object
+		IL_00f0: ldloc.s 37
+		IL_00f2: ldstr "get"
+		IL_00f7: ldloc.s 38
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_00fe: pop
+		IL_00ff: ldc.i4.1
+		IL_0100: newarr [System.Runtime]System.Object
+		IL_0105: dup
+		IL_0106: ldc.i4.0
+		IL_0107: ldloc.0
+		IL_0108: stelem.ref
+		IL_0109: stloc.s 33
+		IL_010b: ldloc.s 33
+		IL_010d: ldc.i4.0
+		IL_010e: ldelem.ref
+		IL_010f: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
+		IL_0114: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_0119: ldc.i4.1
+		IL_011a: conv.r8
+		IL_011b: ldstr ""
+		IL_0120: ldc.i4.0
+		IL_0121: ldc.i4.1
+		IL_0122: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8>(!!0, float64, string, bool, bool)
+		IL_0127: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8>(!!0)
+		IL_012c: stloc.s 39
+		IL_012e: ldloc.s 37
+		IL_0130: ldstr "set"
+		IL_0135: ldloc.s 39
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_013c: pop
+		IL_013d: ldloc.s 37
+		IL_013f: ldstr "enumerable"
+		IL_0144: ldc.i4.1
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
+		IL_014a: pop
+		IL_014b: ldloc.s 37
+		IL_014d: ldstr "configurable"
+		IL_0152: ldc.i4.1
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
+		IL_0158: pop
+		IL_0159: ldloc.s 36
+		IL_015b: ldstr "accessor"
+		IL_0160: ldloc.s 37
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0167: pop
+		IL_0168: ldloc.0
+		IL_0169: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_016e: stloc.s 36
+		IL_0170: ldloc.s 36
+		IL_0172: ldstr "accessor"
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_017c: stloc.2
+		IL_017d: ldloc.0
+		IL_017e: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0183: stloc.s 36
+		IL_0185: ldloc.s 36
+		IL_0187: ldstr "accessor"
+		IL_018c: ldc.r8 8
+		IL_0195: ldc.i4.1
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_019b: pop
+		IL_019c: ldloc.0
+		IL_019d: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_01a2: stloc.s 36
+		IL_01a4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01a9: stloc.s 37
+		IL_01ab: ldloc.s 37
+		IL_01ad: ldloc.s 36
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
+		IL_01b4: pop
+		IL_01b5: ldloc.s 37
+		IL_01b7: stloc.3
+		IL_01b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01bd: stloc.s 40
+		IL_01bf: ldloc.0
+		IL_01c0: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_01c5: stloc.s 36
+		IL_01c7: ldloc.s 36
+		IL_01c9: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_01ce: stloc.s 41
+		IL_01d0: ldloc.2
+		IL_01d1: ldstr "get"
+		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01db: stloc.s 36
+		IL_01dd: ldloc.0
+		IL_01de: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_01e3: stloc.s 42
+		IL_01e5: ldloc.s 42
+		IL_01e7: ldstr "accessor"
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_01f1: ldstr "get"
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01fb: stloc.s 42
+		IL_01fd: ldloc.s 36
+		IL_01ff: ldloc.s 42
+		IL_0201: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0206: stloc.s 43
+		IL_0208: ldloc.s 43
+		IL_020a: box [System.Runtime]System.Boolean
+		IL_020f: stloc.s 44
+		IL_0211: ldloc.2
+		IL_0212: ldstr "set"
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_021c: stloc.s 42
+		IL_021e: ldloc.0
+		IL_021f: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0224: stloc.s 36
+		IL_0226: ldloc.s 36
+		IL_0228: ldstr "accessor"
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0232: ldstr "set"
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023c: stloc.s 36
+		IL_023e: ldloc.s 42
+		IL_0240: ldloc.s 36
+		IL_0242: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0247: stloc.s 43
+		IL_0249: ldloc.s 43
+		IL_024b: box [System.Runtime]System.Boolean
+		IL_0250: stloc.s 45
+		IL_0252: ldloc.0
+		IL_0253: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0258: ldstr "accessor"
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0262: stloc.s 36
+		IL_0264: ldloc.3
+		IL_0265: ldstr "custom"
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_026f: stloc.s 42
+		IL_0271: ldloc.3
+		IL_0272: ldstr "accessor"
+		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_027c: stloc.s 46
+		IL_027e: ldloc.s 40
+		IL_0280: ldc.i4.7
+		IL_0281: newarr [System.Runtime]System.Object
+		IL_0286: dup
+		IL_0287: ldc.i4.0
+		IL_0288: ldstr "reflection"
+		IL_028d: stelem.ref
+		IL_028e: dup
+		IL_028f: ldc.i4.1
+		IL_0290: ldloc.s 41
+		IL_0292: stelem.ref
+		IL_0293: dup
+		IL_0294: ldc.i4.2
+		IL_0295: ldloc.s 44
+		IL_0297: stelem.ref
 		IL_0298: dup
-		IL_0299: ldc.i4.0
-		IL_029a: ldstr "reflection"
-		IL_029f: stelem.ref
-		IL_02a0: dup
-		IL_02a1: ldc.i4.1
-		IL_02a2: ldloc.s 41
-		IL_02a4: stelem.ref
-		IL_02a5: dup
-		IL_02a6: ldc.i4.2
-		IL_02a7: ldloc.s 44
-		IL_02a9: stelem.ref
-		IL_02aa: dup
-		IL_02ab: ldc.i4.3
-		IL_02ac: ldloc.s 45
-		IL_02ae: stelem.ref
-		IL_02af: dup
-		IL_02b0: ldc.i4.4
-		IL_02b1: ldloc.s 36
-		IL_02b3: stelem.ref
-		IL_02b4: dup
-		IL_02b5: ldc.i4.5
-		IL_02b6: ldloc.s 42
-		IL_02b8: stelem.ref
-		IL_02b9: dup
-		IL_02ba: ldc.i4.6
-		IL_02bb: ldloc.s 46
-		IL_02bd: stelem.ref
-		IL_02be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_02c3: pop
-		IL_02c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02c9: stloc.s 40
-		IL_02cb: ldloc.0
-		IL_02cc: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_02d1: stloc.s 46
-		IL_02d3: ldloc.s 46
-		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_02da: stloc.s 46
-		IL_02dc: ldloc.s 46
-		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e3: ldstr "join"
-		IL_02e8: ldstr ","
-		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02f2: stloc.s 46
-		IL_02f4: ldloc.0
-		IL_02f5: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_02fa: stloc.s 42
-		IL_02fc: ldloc.s 42
-		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_0303: stloc.s 42
-		IL_0305: ldloc.s 42
-		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_030c: ldstr "includes"
-		IL_0311: ldstr "name"
-		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_031b: stloc.s 42
-		IL_031d: ldloc.0
-		IL_031e: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0323: stloc.s 36
-		IL_0325: ldloc.s 36
-		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_032c: stloc.s 36
-		IL_032e: ldloc.s 36
-		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0335: ldstr "includes"
-		IL_033a: ldstr "length"
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0344: stloc.s 36
-		IL_0346: ldloc.s 40
-		IL_0348: ldc.i4.4
-		IL_0349: newarr [System.Runtime]System.Object
+		IL_0299: ldc.i4.3
+		IL_029a: ldloc.s 45
+		IL_029c: stelem.ref
+		IL_029d: dup
+		IL_029e: ldc.i4.4
+		IL_029f: ldloc.s 36
+		IL_02a1: stelem.ref
+		IL_02a2: dup
+		IL_02a3: ldc.i4.5
+		IL_02a4: ldloc.s 42
+		IL_02a6: stelem.ref
+		IL_02a7: dup
+		IL_02a8: ldc.i4.6
+		IL_02a9: ldloc.s 46
+		IL_02ab: stelem.ref
+		IL_02ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_02b1: pop
+		IL_02b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02b7: stloc.s 40
+		IL_02b9: ldloc.0
+		IL_02ba: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_02bf: stloc.s 46
+		IL_02c1: ldloc.s 46
+		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_02c8: stloc.s 46
+		IL_02ca: ldloc.s 46
+		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d1: ldstr "join"
+		IL_02d6: ldstr ","
+		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02e0: stloc.s 46
+		IL_02e2: ldloc.0
+		IL_02e3: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_02e8: stloc.s 42
+		IL_02ea: ldloc.s 42
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_02f1: stloc.s 42
+		IL_02f3: ldloc.s 42
+		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fa: ldstr "includes"
+		IL_02ff: ldstr "name"
+		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0309: stloc.s 42
+		IL_030b: ldloc.0
+		IL_030c: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0311: stloc.s 36
+		IL_0313: ldloc.s 36
+		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_031a: stloc.s 36
+		IL_031c: ldloc.s 36
+		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0323: ldstr "includes"
+		IL_0328: ldstr "length"
+		IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0332: stloc.s 36
+		IL_0334: ldloc.s 40
+		IL_0336: ldc.i4.4
+		IL_0337: newarr [System.Runtime]System.Object
+		IL_033c: dup
+		IL_033d: ldc.i4.0
+		IL_033e: ldstr "keys"
+		IL_0343: stelem.ref
+		IL_0344: dup
+		IL_0345: ldc.i4.1
+		IL_0346: ldloc.s 46
+		IL_0348: stelem.ref
+		IL_0349: dup
+		IL_034a: ldc.i4.2
+		IL_034b: ldloc.s 42
+		IL_034d: stelem.ref
 		IL_034e: dup
-		IL_034f: ldc.i4.0
-		IL_0350: ldstr "keys"
-		IL_0355: stelem.ref
-		IL_0356: dup
-		IL_0357: ldc.i4.1
-		IL_0358: ldloc.s 46
-		IL_035a: stelem.ref
-		IL_035b: dup
-		IL_035c: ldc.i4.2
-		IL_035d: ldloc.s 42
-		IL_035f: stelem.ref
-		IL_0360: dup
-		IL_0361: ldc.i4.3
-		IL_0362: ldloc.s 36
-		IL_0364: stelem.ref
-		IL_0365: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_036a: pop
-		IL_036b: ldloc.0
-		IL_036c: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0371: stloc.s 36
-		IL_0373: ldloc.s 36
-		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_037a: pop
-		IL_037b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0380: stloc.s 40
-		IL_0382: ldloc.0
-		IL_0383: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0388: stloc.s 36
-		IL_038a: ldloc.s 36
-		IL_038c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0391: box [System.Runtime]System.Boolean
-		IL_0396: stloc.s 45
-		IL_0398: ldloc.2
-		IL_0399: ldstr "get"
-		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03a3: stloc.s 36
-		IL_03a5: ldloc.s 36
-		IL_03a7: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_03ac: box [System.Runtime]System.Boolean
-		IL_03b1: stloc.s 44
-		IL_03b3: ldloc.s 40
-		IL_03b5: ldstr "integrity"
-		IL_03ba: ldloc.s 45
-		IL_03bc: ldloc.s 44
-		IL_03be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_03c3: pop
-		IL_03c4: ldloc.2
-		IL_03c5: ldstr "get"
-		IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03cf: stloc.s 36
-		IL_03d1: ldloc.s 36
-		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
-		IL_03d8: pop
-		IL_03d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03de: stloc.s 40
-		IL_03e0: ldloc.2
-		IL_03e1: ldstr "get"
-		IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03eb: stloc.s 36
-		IL_03ed: ldloc.s 36
-		IL_03ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
-		IL_03f4: box [System.Runtime]System.Boolean
-		IL_03f9: stloc.s 44
-		IL_03fb: ldloc.s 40
-		IL_03fd: ldstr "frozenFunction"
-		IL_0402: ldloc.s 44
-		IL_0404: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0409: pop
-		IL_040a: nop
-		IL_040b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0410: dup
-		IL_0411: ldstr "marker"
-		IL_0416: ldstr "custom-function-prototype"
-		IL_041b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0420: stloc.s 4
-		IL_0422: ldloc.1
-		IL_0423: ldloc.s 4
-		IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_042a: pop
-		IL_042b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0430: stloc.s 40
-		IL_0432: ldloc.1
-		IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0438: stloc.s 36
-		IL_043a: ldloc.s 36
-		IL_043c: ldloc.s 4
-		IL_043e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0443: stloc.s 43
-		IL_0445: ldloc.s 43
-		IL_0447: box [System.Runtime]System.Boolean
-		IL_044c: stloc.s 44
-		IL_044e: ldloc.1
-		IL_044f: ldstr "marker"
-		IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0459: stloc.s 36
-		IL_045b: ldloc.s 40
-		IL_045d: ldstr "prototypeMutation"
-		IL_0462: ldloc.s 44
-		IL_0464: ldloc.s 36
-		IL_0466: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_046b: pop
-		IL_046c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0471: stloc.s 40
-		IL_0473: ldloc.0
-		IL_0474: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0479: stloc.s 36
-		IL_047b: ldloc.s 36
-		IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0482: stloc.s 36
-		IL_0484: ldloc.s 36
-		IL_0486: ldnull
-		IL_0487: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_048c: stloc.s 43
-		IL_048e: ldloc.s 43
-		IL_0490: box [System.Runtime]System.Boolean
-		IL_0495: stloc.s 44
-		IL_0497: ldloc.0
-		IL_0498: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_049d: stloc.s 36
-		IL_049f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04a4: dup
-		IL_04a5: ldstr "target"
+		IL_034f: ldc.i4.3
+		IL_0350: ldloc.s 36
+		IL_0352: stelem.ref
+		IL_0353: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0358: pop
+		IL_0359: ldloc.0
+		IL_035a: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_035f: stloc.s 36
+		IL_0361: ldloc.s 36
+		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_0368: pop
+		IL_0369: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_036e: stloc.s 40
+		IL_0370: ldloc.0
+		IL_0371: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0376: stloc.s 36
+		IL_0378: ldloc.s 36
+		IL_037a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_037f: box [System.Runtime]System.Boolean
+		IL_0384: stloc.s 45
+		IL_0386: ldloc.2
+		IL_0387: ldstr "get"
+		IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0391: stloc.s 36
+		IL_0393: ldloc.s 36
+		IL_0395: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_039a: box [System.Runtime]System.Boolean
+		IL_039f: stloc.s 44
+		IL_03a1: ldloc.s 40
+		IL_03a3: ldstr "integrity"
+		IL_03a8: ldloc.s 45
+		IL_03aa: ldloc.s 44
+		IL_03ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_03b1: pop
+		IL_03b2: ldloc.2
+		IL_03b3: ldstr "get"
+		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03bd: stloc.s 36
+		IL_03bf: ldloc.s 36
+		IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_03c6: pop
+		IL_03c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03cc: stloc.s 40
+		IL_03ce: ldloc.2
+		IL_03cf: ldstr "get"
+		IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03d9: stloc.s 36
+		IL_03db: ldloc.s 36
+		IL_03dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
+		IL_03e2: box [System.Runtime]System.Boolean
+		IL_03e7: stloc.s 44
+		IL_03e9: ldloc.s 40
+		IL_03eb: ldstr "frozenFunction"
+		IL_03f0: ldloc.s 44
+		IL_03f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03f7: pop
+		IL_03f8: nop
+		IL_03f9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03fe: dup
+		IL_03ff: ldstr "marker"
+		IL_0404: ldstr "custom-function-prototype"
+		IL_0409: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_040e: stloc.s 4
+		IL_0410: ldloc.1
+		IL_0411: ldloc.s 4
+		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_0418: pop
+		IL_0419: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_041e: stloc.s 40
+		IL_0420: ldloc.1
+		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0426: stloc.s 36
+		IL_0428: ldloc.s 36
+		IL_042a: ldloc.s 4
+		IL_042c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0431: stloc.s 43
+		IL_0433: ldloc.s 43
+		IL_0435: box [System.Runtime]System.Boolean
+		IL_043a: stloc.s 44
+		IL_043c: ldloc.1
+		IL_043d: ldstr "marker"
+		IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0447: stloc.s 36
+		IL_0449: ldloc.s 40
+		IL_044b: ldstr "prototypeMutation"
+		IL_0450: ldloc.s 44
+		IL_0452: ldloc.s 36
+		IL_0454: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0459: pop
+		IL_045a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_045f: stloc.s 40
+		IL_0461: ldloc.0
+		IL_0462: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0467: stloc.s 36
+		IL_0469: ldloc.s 36
+		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0470: stloc.s 36
+		IL_0472: ldloc.s 36
+		IL_0474: ldnull
+		IL_0475: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_047a: stloc.s 43
+		IL_047c: ldloc.s 43
+		IL_047e: box [System.Runtime]System.Boolean
+		IL_0483: stloc.s 44
+		IL_0485: ldloc.0
+		IL_0486: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_048b: stloc.s 36
+		IL_048d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0492: dup
+		IL_0493: ldstr "target"
+		IL_0498: ldloc.s 36
+		IL_049a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_049f: stloc.s 37
+		IL_04a1: ldloc.s 37
+		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_04a8: stloc.s 36
 		IL_04aa: ldloc.s 36
-		IL_04ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_04b1: stloc.s 37
-		IL_04b3: ldloc.s 37
-		IL_04b5: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_04ba: stloc.s 36
-		IL_04bc: ldloc.s 36
-		IL_04be: ldstr "{}"
-		IL_04c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04c8: stloc.s 43
-		IL_04ca: ldloc.s 43
-		IL_04cc: box [System.Runtime]System.Boolean
-		IL_04d1: stloc.s 45
-		IL_04d3: ldloc.s 40
-		IL_04d5: ldstr "json"
-		IL_04da: ldloc.s 44
-		IL_04dc: ldloc.s 45
-		IL_04de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_04e3: pop
-		IL_04e4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04e9: stloc.s 37
-		IL_04eb: ldc.i4.1
-		IL_04ec: newarr [System.Runtime]System.Object
-		IL_04f1: dup
-		IL_04f2: ldc.i4.0
-		IL_04f3: ldloc.0
-		IL_04f4: stelem.ref
-		IL_04f5: stloc.s 33
-		IL_04f7: ldloc.s 33
-		IL_04f9: ldc.i4.0
-		IL_04fa: ldelem.ref
-		IL_04fb: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_0500: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
-		IL_0505: ldc.i4.3
-		IL_0506: conv.r8
-		IL_0507: ldstr ""
-		IL_050c: ldc.i4.1
-		IL_050d: ldc.i4.1
-		IL_050e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10>(!!0, float64, string, bool, bool)
-		IL_0513: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10>(!!0)
-		IL_0518: stloc.s 47
-		IL_051a: ldloc.s 47
-		IL_051c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10>(!!0)
-		IL_0521: stloc.s 47
-		IL_0523: ldloc.s 37
-		IL_0525: ldstr "apply"
-		IL_052a: ldloc.s 47
-		IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0531: pop
-		IL_0532: ldloc.0
-		IL_0533: ldloc.s 37
-		IL_0535: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
-		IL_053a: ldloc.0
-		IL_053b: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0540: stloc.s 36
-		IL_0542: ldloc.0
-		IL_0543: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
-		IL_0548: ldstr "Cannot access 'applyHandler' before initialization"
-		IL_054d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0552: stloc.s 42
-		IL_0554: ldloc.s 36
-		IL_0556: ldloc.s 42
-		IL_0558: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_055d: stloc.s 5
-		IL_055f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0564: dup
-		IL_0565: ldstr "base"
-		IL_056a: ldc.r8 10
-		IL_0573: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0578: dup
-		IL_0579: ldstr "method"
-		IL_057e: ldloc.s 5
-		IL_0580: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0585: stloc.s 6
-		IL_0587: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_058c: stloc.s 40
-		IL_058e: ldloc.s 5
-		IL_0590: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0595: stloc.s 41
-		IL_0597: ldloc.s 6
-		IL_0599: ldstr "method"
-		IL_059e: ldc.r8 5
-		IL_05a7: box [System.Runtime]System.Double
-		IL_05ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05b1: stloc.s 42
-		IL_05b3: ldloc.0
-		IL_05b4: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_05b9: stloc.s 36
-		IL_05bb: ldloc.s 5
-		IL_05bd: ldloc.s 36
-		IL_05bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_05c4: stloc.s 43
-		IL_05c6: ldloc.s 43
-		IL_05c8: box [System.Runtime]System.Boolean
-		IL_05cd: stloc.s 45
-		IL_05cf: ldloc.s 40
-		IL_05d1: ldc.i4.4
-		IL_05d2: newarr [System.Runtime]System.Object
-		IL_05d7: dup
-		IL_05d8: ldc.i4.0
-		IL_05d9: ldstr "apply"
-		IL_05de: stelem.ref
-		IL_05df: dup
-		IL_05e0: ldc.i4.1
-		IL_05e1: ldloc.s 41
-		IL_05e3: stelem.ref
-		IL_05e4: dup
-		IL_05e5: ldc.i4.2
-		IL_05e6: ldloc.s 42
-		IL_05e8: stelem.ref
-		IL_05e9: dup
-		IL_05ea: ldc.i4.3
-		IL_05eb: ldloc.s 45
-		IL_05ed: stelem.ref
-		IL_05ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_05f3: pop
-		IL_05f4: ldloc.0
-		IL_05f5: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_05fa: stloc.s 42
-		IL_05fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0601: stloc.s 37
-		IL_0603: ldloc.s 42
-		IL_0605: ldloc.s 37
-		IL_0607: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_060c: stloc.s 7
-		IL_060e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0613: stloc.s 40
-		IL_0615: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_061a: dup
-		IL_061b: ldstr "base"
-		IL_0620: ldc.r8 20
-		IL_0629: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_062e: stloc.s 37
-		IL_0630: ldloc.s 7
-		IL_0632: ldstr "call"
-		IL_0637: ldloc.s 37
-		IL_0639: ldc.r8 2
-		IL_0642: box [System.Runtime]System.Double
-		IL_0647: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_064c: stloc.s 42
-		IL_064e: ldloc.s 40
-		IL_0650: ldstr "fallback"
-		IL_0655: ldloc.s 42
-		IL_0657: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_065c: pop
-		IL_065d: nop
-		IL_065e: ldloc.0
-		IL_065f: ldnull
-		IL_0660: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_0665: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_066a: stloc.s 37
-		IL_066c: ldc.i4.1
-		IL_066d: newarr [System.Runtime]System.Object
-		IL_0672: dup
-		IL_0673: ldc.i4.0
-		IL_0674: ldloc.0
-		IL_0675: stelem.ref
-		IL_0676: stloc.s 33
-		IL_0678: ldloc.s 33
-		IL_067a: ldc.i4.0
-		IL_067b: ldelem.ref
-		IL_067c: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_0681: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
-		IL_0686: ldc.i4.3
-		IL_0687: conv.r8
-		IL_0688: ldstr ""
-		IL_068d: ldc.i4.0
-		IL_068e: ldc.i4.1
-		IL_068f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14>(!!0, float64, string, bool, bool)
-		IL_0694: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14>(!!0)
-		IL_0699: stloc.s 48
-		IL_069b: ldloc.s 48
-		IL_069d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14>(!!0)
-		IL_06a2: stloc.s 48
-		IL_06a4: ldloc.s 37
-		IL_06a6: ldstr "construct"
-		IL_06ab: ldloc.s 48
-		IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_06b2: pop
-		IL_06b3: ldloc.s 37
-		IL_06b5: stloc.s 8
-		IL_06b7: ldloc.0
-		IL_06b8: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
-		IL_06bd: stloc.s 42
-		IL_06bf: ldloc.s 42
-		IL_06c1: ldloc.s 8
-		IL_06c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_06c8: stloc.s 49
-		IL_06ca: ldloc.0
-		IL_06cb: ldloc.s 49
-		IL_06cd: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_06d2: ldloc.0
-		IL_06d3: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_06d8: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
-		IL_06dd: stloc.s 49
-		IL_06df: ldloc.s 49
-		IL_06e1: ldc.i4.1
-		IL_06e2: newarr [System.Runtime]System.Object
-		IL_06e7: dup
-		IL_06e8: ldc.i4.0
-		IL_06e9: ldc.r8 12
-		IL_06f2: box [System.Runtime]System.Double
-		IL_06f7: stelem.ref
-		IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_06fd: stloc.s 9
-		IL_06ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0704: stloc.s 40
-		IL_0706: ldloc.0
-		IL_0707: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_070c: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
-		IL_0711: stloc.s 49
-		IL_0713: ldloc.s 49
-		IL_0715: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_071a: stloc.s 41
-		IL_071c: ldloc.s 9
-		IL_071e: ldstr "targetMatches"
-		IL_0723: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0728: stloc.s 42
-		IL_072a: ldloc.s 9
-		IL_072c: ldstr "argument"
-		IL_0731: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0736: stloc.s 36
-		IL_0738: ldloc.s 9
-		IL_073a: ldstr "newTargetMatches"
-		IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0744: stloc.s 46
-		IL_0746: ldloc.s 40
-		IL_0748: ldc.i4.5
-		IL_0749: newarr [System.Runtime]System.Object
-		IL_074e: dup
-		IL_074f: ldc.i4.0
-		IL_0750: ldstr "construct"
-		IL_0755: stelem.ref
-		IL_0756: dup
-		IL_0757: ldc.i4.1
-		IL_0758: ldloc.s 41
-		IL_075a: stelem.ref
-		IL_075b: dup
-		IL_075c: ldc.i4.2
-		IL_075d: ldloc.s 42
-		IL_075f: stelem.ref
-		IL_0760: dup
-		IL_0761: ldc.i4.3
-		IL_0762: ldloc.s 36
+		IL_04ac: ldstr "{}"
+		IL_04b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04b6: stloc.s 43
+		IL_04b8: ldloc.s 43
+		IL_04ba: box [System.Runtime]System.Boolean
+		IL_04bf: stloc.s 45
+		IL_04c1: ldloc.s 40
+		IL_04c3: ldstr "json"
+		IL_04c8: ldloc.s 44
+		IL_04ca: ldloc.s 45
+		IL_04cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_04d1: pop
+		IL_04d2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04d7: stloc.s 37
+		IL_04d9: ldc.i4.1
+		IL_04da: newarr [System.Runtime]System.Object
+		IL_04df: dup
+		IL_04e0: ldc.i4.0
+		IL_04e1: ldloc.0
+		IL_04e2: stelem.ref
+		IL_04e3: stloc.s 33
+		IL_04e5: ldloc.s 33
+		IL_04e7: ldc.i4.0
+		IL_04e8: ldelem.ref
+		IL_04e9: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
+		IL_04ee: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_04f3: ldc.i4.3
+		IL_04f4: conv.r8
+		IL_04f5: ldstr ""
+		IL_04fa: ldc.i4.1
+		IL_04fb: ldc.i4.1
+		IL_04fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10>(!!0, float64, string, bool, bool)
+		IL_0501: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10>(!!0)
+		IL_0506: stloc.s 47
+		IL_0508: ldloc.s 37
+		IL_050a: ldstr "apply"
+		IL_050f: ldloc.s 47
+		IL_0511: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0516: pop
+		IL_0517: ldloc.0
+		IL_0518: ldloc.s 37
+		IL_051a: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
+		IL_051f: ldloc.0
+		IL_0520: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0525: stloc.s 36
+		IL_0527: ldloc.0
+		IL_0528: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
+		IL_052d: ldstr "Cannot access 'applyHandler' before initialization"
+		IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0537: stloc.s 42
+		IL_0539: ldloc.s 36
+		IL_053b: ldloc.s 42
+		IL_053d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0542: stloc.s 5
+		IL_0544: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0549: dup
+		IL_054a: ldstr "base"
+		IL_054f: ldc.r8 10
+		IL_0558: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_055d: dup
+		IL_055e: ldstr "method"
+		IL_0563: ldloc.s 5
+		IL_0565: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_056a: stloc.s 6
+		IL_056c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0571: stloc.s 40
+		IL_0573: ldloc.s 5
+		IL_0575: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_057a: stloc.s 41
+		IL_057c: ldloc.s 6
+		IL_057e: ldstr "method"
+		IL_0583: ldc.r8 5
+		IL_058c: box [System.Runtime]System.Double
+		IL_0591: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0596: stloc.s 42
+		IL_0598: ldloc.0
+		IL_0599: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_059e: stloc.s 36
+		IL_05a0: ldloc.s 5
+		IL_05a2: ldloc.s 36
+		IL_05a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_05a9: stloc.s 43
+		IL_05ab: ldloc.s 43
+		IL_05ad: box [System.Runtime]System.Boolean
+		IL_05b2: stloc.s 45
+		IL_05b4: ldloc.s 40
+		IL_05b6: ldc.i4.4
+		IL_05b7: newarr [System.Runtime]System.Object
+		IL_05bc: dup
+		IL_05bd: ldc.i4.0
+		IL_05be: ldstr "apply"
+		IL_05c3: stelem.ref
+		IL_05c4: dup
+		IL_05c5: ldc.i4.1
+		IL_05c6: ldloc.s 41
+		IL_05c8: stelem.ref
+		IL_05c9: dup
+		IL_05ca: ldc.i4.2
+		IL_05cb: ldloc.s 42
+		IL_05cd: stelem.ref
+		IL_05ce: dup
+		IL_05cf: ldc.i4.3
+		IL_05d0: ldloc.s 45
+		IL_05d2: stelem.ref
+		IL_05d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_05d8: pop
+		IL_05d9: ldloc.0
+		IL_05da: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_05df: stloc.s 42
+		IL_05e1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_05e6: stloc.s 37
+		IL_05e8: ldloc.s 42
+		IL_05ea: ldloc.s 37
+		IL_05ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_05f1: stloc.s 7
+		IL_05f3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05f8: stloc.s 40
+		IL_05fa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_05ff: dup
+		IL_0600: ldstr "base"
+		IL_0605: ldc.r8 20
+		IL_060e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0613: stloc.s 37
+		IL_0615: ldloc.s 7
+		IL_0617: ldstr "call"
+		IL_061c: ldloc.s 37
+		IL_061e: ldc.r8 2
+		IL_0627: box [System.Runtime]System.Double
+		IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0631: stloc.s 42
+		IL_0633: ldloc.s 40
+		IL_0635: ldstr "fallback"
+		IL_063a: ldloc.s 42
+		IL_063c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0641: pop
+		IL_0642: nop
+		IL_0643: ldloc.0
+		IL_0644: ldnull
+		IL_0645: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_064a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_064f: stloc.s 37
+		IL_0651: ldc.i4.1
+		IL_0652: newarr [System.Runtime]System.Object
+		IL_0657: dup
+		IL_0658: ldc.i4.0
+		IL_0659: ldloc.0
+		IL_065a: stelem.ref
+		IL_065b: stloc.s 33
+		IL_065d: ldloc.s 33
+		IL_065f: ldc.i4.0
+		IL_0660: ldelem.ref
+		IL_0661: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
+		IL_0666: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_066b: ldc.i4.3
+		IL_066c: conv.r8
+		IL_066d: ldstr ""
+		IL_0672: ldc.i4.0
+		IL_0673: ldc.i4.1
+		IL_0674: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14>(!!0, float64, string, bool, bool)
+		IL_0679: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14>(!!0)
+		IL_067e: stloc.s 48
+		IL_0680: ldloc.s 37
+		IL_0682: ldstr "construct"
+		IL_0687: ldloc.s 48
+		IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_068e: pop
+		IL_068f: ldloc.s 37
+		IL_0691: stloc.s 8
+		IL_0693: ldloc.0
+		IL_0694: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
+		IL_0699: stloc.s 42
+		IL_069b: ldloc.s 42
+		IL_069d: ldloc.s 8
+		IL_069f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_06a4: stloc.s 49
+		IL_06a6: ldloc.0
+		IL_06a7: ldloc.s 49
+		IL_06a9: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_06ae: ldloc.0
+		IL_06af: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_06b4: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
+		IL_06b9: stloc.s 49
+		IL_06bb: ldloc.s 49
+		IL_06bd: ldc.i4.1
+		IL_06be: newarr [System.Runtime]System.Object
+		IL_06c3: dup
+		IL_06c4: ldc.i4.0
+		IL_06c5: ldc.r8 12
+		IL_06ce: box [System.Runtime]System.Double
+		IL_06d3: stelem.ref
+		IL_06d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_06d9: stloc.s 9
+		IL_06db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06e0: stloc.s 40
+		IL_06e2: ldloc.0
+		IL_06e3: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_06e8: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
+		IL_06ed: stloc.s 49
+		IL_06ef: ldloc.s 49
+		IL_06f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_06f6: stloc.s 41
+		IL_06f8: ldloc.s 9
+		IL_06fa: ldstr "targetMatches"
+		IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0704: stloc.s 42
+		IL_0706: ldloc.s 9
+		IL_0708: ldstr "argument"
+		IL_070d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0712: stloc.s 36
+		IL_0714: ldloc.s 9
+		IL_0716: ldstr "newTargetMatches"
+		IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0720: stloc.s 46
+		IL_0722: ldloc.s 40
+		IL_0724: ldc.i4.5
+		IL_0725: newarr [System.Runtime]System.Object
+		IL_072a: dup
+		IL_072b: ldc.i4.0
+		IL_072c: ldstr "construct"
+		IL_0731: stelem.ref
+		IL_0732: dup
+		IL_0733: ldc.i4.1
+		IL_0734: ldloc.s 41
+		IL_0736: stelem.ref
+		IL_0737: dup
+		IL_0738: ldc.i4.2
+		IL_0739: ldloc.s 42
+		IL_073b: stelem.ref
+		IL_073c: dup
+		IL_073d: ldc.i4.3
+		IL_073e: ldloc.s 36
+		IL_0740: stelem.ref
+		IL_0741: dup
+		IL_0742: ldc.i4.4
+		IL_0743: ldloc.s 46
+		IL_0745: stelem.ref
+		IL_0746: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_074b: pop
+		IL_074c: ldloc.0
+		IL_074d: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
+		IL_0752: stloc.s 46
+		IL_0754: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0759: stloc.s 37
+		IL_075b: ldc.i4.1
+		IL_075c: newarr [System.Runtime]System.Object
+		IL_0761: dup
+		IL_0762: ldc.i4.0
+		IL_0763: ldloc.0
 		IL_0764: stelem.ref
-		IL_0765: dup
-		IL_0766: ldc.i4.4
-		IL_0767: ldloc.s 46
-		IL_0769: stelem.ref
-		IL_076a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_076f: pop
-		IL_0770: ldloc.0
-		IL_0771: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
-		IL_0776: stloc.s 46
-		IL_0778: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_077d: stloc.s 37
-		IL_077f: ldc.i4.1
-		IL_0780: newarr [System.Runtime]System.Object
-		IL_0785: dup
-		IL_0786: ldc.i4.0
-		IL_0787: ldloc.0
-		IL_0788: stelem.ref
-		IL_0789: stloc.s 33
-		IL_078b: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject_FunctionExpression_F84AC1B6_L98C14::.ctor()
-		IL_0790: ldc.i4.0
-		IL_0791: conv.r8
-		IL_0792: ldstr ""
-		IL_0797: ldc.i4.0
-		IL_0798: ldc.i4.1
-		IL_0799: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject_FunctionExpression_F84AC1B6_L98C14>(!!0, float64, string, bool, bool)
-		IL_079e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject_FunctionExpression_F84AC1B6_L98C14>(!!0)
-		IL_07a3: stloc.s 50
-		IL_07a5: ldloc.s 50
-		IL_07a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject_FunctionExpression_F84AC1B6_L98C14>(!!0)
-		IL_07ac: stloc.s 50
-		IL_07ae: ldloc.s 37
-		IL_07b0: ldstr "construct"
-		IL_07b5: ldloc.s 50
-		IL_07b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_07bc: pop
-		IL_07bd: ldloc.s 46
-		IL_07bf: ldloc.s 37
-		IL_07c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_07c6: stloc.s 10
-		IL_07c8: ldc.i4.0
-		IL_07c9: box [System.Runtime]System.Boolean
-		IL_07ce: stloc.s 11
+		IL_0765: stloc.s 33
+		IL_0767: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject_FunctionExpression_F84AC1B6_L98C14::.ctor()
+		IL_076c: ldc.i4.0
+		IL_076d: conv.r8
+		IL_076e: ldstr ""
+		IL_0773: ldc.i4.0
+		IL_0774: ldc.i4.1
+		IL_0775: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject_FunctionExpression_F84AC1B6_L98C14>(!!0, float64, string, bool, bool)
+		IL_077a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject_FunctionExpression_F84AC1B6_L98C14>(!!0)
+		IL_077f: stloc.s 50
+		IL_0781: ldloc.s 37
+		IL_0783: ldstr "construct"
+		IL_0788: ldloc.s 50
+		IL_078a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_078f: pop
+		IL_0790: ldloc.s 46
+		IL_0792: ldloc.s 37
+		IL_0794: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0799: stloc.s 10
+		IL_079b: ldc.i4.0
+		IL_079c: box [System.Runtime]System.Boolean
+		IL_07a1: stloc.s 11
 		.try
 		{
-			IL_07d0: nop
-			IL_07d1: ldloc.s 10
-			IL_07d3: ldc.i4.0
-			IL_07d4: newarr [System.Runtime]System.Object
-			IL_07d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-			IL_07de: pop
-			IL_07df: leave IL_0843
+			IL_07a3: nop
+			IL_07a4: ldloc.s 10
+			IL_07a6: ldc.i4.0
+			IL_07a7: newarr [System.Runtime]System.Object
+			IL_07ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+			IL_07b1: pop
+			IL_07b2: leave IL_0816
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_07e4: stloc.s 12
-			IL_07e6: ldloc.s 12
-			IL_07e8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_07ed: dup
-			IL_07ee: brtrue IL_0804
+			IL_07b7: stloc.s 12
+			IL_07b9: ldloc.s 12
+			IL_07bb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_07c0: dup
+			IL_07c1: brtrue IL_07d7
 
-			IL_07f3: pop
-			IL_07f4: ldloc.s 12
-			IL_07f6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_07fb: dup
-			IL_07fc: brtrue IL_0810
+			IL_07c6: pop
+			IL_07c7: ldloc.s 12
+			IL_07c9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_07ce: dup
+			IL_07cf: brtrue IL_07e3
 
-			IL_0801: pop
-			IL_0802: rethrow
+			IL_07d4: pop
+			IL_07d5: rethrow
 
-			IL_0804: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0809: stloc.s 13
-			IL_080b: br IL_0812
+			IL_07d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_07dc: stloc.s 13
+			IL_07de: br IL_07e5
 
-			IL_0810: stloc.s 13
+			IL_07e3: stloc.s 13
 
-			IL_0812: ldloc.s 13
-			IL_0814: stloc.s 14
-			IL_0816: ldloc.s 14
-			IL_0818: stloc.s 46
-			IL_081a: ldstr "TypeError"
-			IL_081f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0824: stloc.s 36
-			IL_0826: ldloc.s 46
-			IL_0828: ldloc.s 36
-			IL_082a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_082f: stloc.s 43
-			IL_0831: ldloc.s 43
-			IL_0833: box [System.Runtime]System.Boolean
-			IL_0838: stloc.s 45
-			IL_083a: ldloc.s 45
-			IL_083c: stloc.s 11
-			IL_083e: leave IL_0843
+			IL_07e5: ldloc.s 13
+			IL_07e7: stloc.s 14
+			IL_07e9: ldloc.s 14
+			IL_07eb: stloc.s 46
+			IL_07ed: ldstr "TypeError"
+			IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07f7: stloc.s 36
+			IL_07f9: ldloc.s 46
+			IL_07fb: ldloc.s 36
+			IL_07fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0802: stloc.s 43
+			IL_0804: ldloc.s 43
+			IL_0806: box [System.Runtime]System.Boolean
+			IL_080b: stloc.s 45
+			IL_080d: ldloc.s 45
+			IL_080f: stloc.s 11
+			IL_0811: leave IL_0816
 		} // end handler
 
-		IL_0843: ldloc.0
-		IL_0844: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0849: stloc.s 36
-		IL_084b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0850: dup
-		IL_0851: ldstr "apply"
-		IL_0856: ldc.r8 1
-		IL_085f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0864: stloc.s 37
-		IL_0866: ldloc.s 36
-		IL_0868: ldloc.s 37
-		IL_086a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_086f: stloc.s 15
-		IL_0871: ldc.i4.0
-		IL_0872: box [System.Runtime]System.Boolean
-		IL_0877: stloc.s 16
+		IL_0816: ldloc.0
+		IL_0817: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_081c: stloc.s 36
+		IL_081e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0823: dup
+		IL_0824: ldstr "apply"
+		IL_0829: ldc.r8 1
+		IL_0832: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0837: stloc.s 37
+		IL_0839: ldloc.s 36
+		IL_083b: ldloc.s 37
+		IL_083d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0842: stloc.s 15
+		IL_0844: ldc.i4.0
+		IL_0845: box [System.Runtime]System.Boolean
+		IL_084a: stloc.s 16
 		.try
 		{
-			IL_0879: nop
-			IL_087a: ldloc.s 15
-			IL_087c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0881: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0886: pop
-			IL_0887: leave IL_08eb
+			IL_084c: nop
+			IL_084d: ldloc.s 15
+			IL_084f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0854: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0859: pop
+			IL_085a: leave IL_08be
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_088c: stloc.s 17
-			IL_088e: ldloc.s 17
-			IL_0890: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0895: dup
-			IL_0896: brtrue IL_08ac
+			IL_085f: stloc.s 17
+			IL_0861: ldloc.s 17
+			IL_0863: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0868: dup
+			IL_0869: brtrue IL_087f
 
-			IL_089b: pop
-			IL_089c: ldloc.s 17
-			IL_089e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_08a3: dup
-			IL_08a4: brtrue IL_08b8
+			IL_086e: pop
+			IL_086f: ldloc.s 17
+			IL_0871: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0876: dup
+			IL_0877: brtrue IL_088b
 
-			IL_08a9: pop
-			IL_08aa: rethrow
+			IL_087c: pop
+			IL_087d: rethrow
 
-			IL_08ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_08b1: stloc.s 18
-			IL_08b3: br IL_08ba
+			IL_087f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0884: stloc.s 18
+			IL_0886: br IL_088d
 
-			IL_08b8: stloc.s 18
+			IL_088b: stloc.s 18
 
-			IL_08ba: ldloc.s 18
-			IL_08bc: stloc.s 19
-			IL_08be: ldloc.s 19
-			IL_08c0: stloc.s 36
-			IL_08c2: ldstr "TypeError"
-			IL_08c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_08cc: stloc.s 46
-			IL_08ce: ldloc.s 36
-			IL_08d0: ldloc.s 46
-			IL_08d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_08d7: stloc.s 43
-			IL_08d9: ldloc.s 43
-			IL_08db: box [System.Runtime]System.Boolean
-			IL_08e0: stloc.s 45
-			IL_08e2: ldloc.s 45
-			IL_08e4: stloc.s 16
-			IL_08e6: leave IL_08eb
+			IL_088d: ldloc.s 18
+			IL_088f: stloc.s 19
+			IL_0891: ldloc.s 19
+			IL_0893: stloc.s 36
+			IL_0895: ldstr "TypeError"
+			IL_089a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_089f: stloc.s 46
+			IL_08a1: ldloc.s 36
+			IL_08a3: ldloc.s 46
+			IL_08a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_08aa: stloc.s 43
+			IL_08ac: ldloc.s 43
+			IL_08ae: box [System.Runtime]System.Boolean
+			IL_08b3: stloc.s 45
+			IL_08b5: ldloc.s 45
+			IL_08b7: stloc.s 16
+			IL_08b9: leave IL_08be
 		} // end handler
 
-		IL_08eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08f0: stloc.s 40
-		IL_08f2: ldloc.s 40
-		IL_08f4: ldstr "invalidTraps"
-		IL_08f9: ldloc.s 11
-		IL_08fb: ldloc.s 16
-		IL_08fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0902: pop
-		IL_0903: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0908: stloc.s 20
-		IL_090a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_090f: stloc.s 37
-		IL_0911: ldc.i4.1
-		IL_0912: newarr [System.Runtime]System.Object
-		IL_0917: dup
-		IL_0918: ldc.i4.0
-		IL_0919: ldloc.0
-		IL_091a: stelem.ref
-		IL_091b: stloc.s 33
-		IL_091d: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject_FunctionExpression_A54C4041_L120C17::.ctor()
-		IL_0922: ldc.i4.1
-		IL_0923: conv.r8
-		IL_0924: ldstr ""
-		IL_0929: ldc.i4.0
+		IL_08be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08c3: stloc.s 40
+		IL_08c5: ldloc.s 40
+		IL_08c7: ldstr "invalidTraps"
+		IL_08cc: ldloc.s 11
+		IL_08ce: ldloc.s 16
+		IL_08d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_08d5: pop
+		IL_08d6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_08db: stloc.s 20
+		IL_08dd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_08e2: stloc.s 37
+		IL_08e4: ldc.i4.1
+		IL_08e5: newarr [System.Runtime]System.Object
+		IL_08ea: dup
+		IL_08eb: ldc.i4.0
+		IL_08ec: ldloc.0
+		IL_08ed: stelem.ref
+		IL_08ee: stloc.s 33
+		IL_08f0: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject_FunctionExpression_A54C4041_L120C17::.ctor()
+		IL_08f5: ldc.i4.1
+		IL_08f6: conv.r8
+		IL_08f7: ldstr ""
+		IL_08fc: ldc.i4.0
+		IL_08fd: ldc.i4.1
+		IL_08fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject_FunctionExpression_A54C4041_L120C17>(!!0, float64, string, bool, bool)
+		IL_0903: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject_FunctionExpression_A54C4041_L120C17>(!!0)
+		IL_0908: stloc.s 51
+		IL_090a: ldloc.s 37
+		IL_090c: ldstr "isExtensible"
+		IL_0911: ldloc.s 51
+		IL_0913: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0918: pop
+		IL_0919: ldc.i4.1
+		IL_091a: newarr [System.Runtime]System.Object
+		IL_091f: dup
+		IL_0920: ldc.i4.0
+		IL_0921: ldloc.0
+		IL_0922: stelem.ref
+		IL_0923: stloc.s 33
+		IL_0925: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject_FunctionExpression_0158934E_L123C22::.ctor()
 		IL_092a: ldc.i4.1
-		IL_092b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject_FunctionExpression_A54C4041_L120C17>(!!0, float64, string, bool, bool)
-		IL_0930: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject_FunctionExpression_A54C4041_L120C17>(!!0)
-		IL_0935: stloc.s 51
-		IL_0937: ldloc.s 51
-		IL_0939: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject_FunctionExpression_A54C4041_L120C17>(!!0)
-		IL_093e: stloc.s 51
-		IL_0940: ldloc.s 37
-		IL_0942: ldstr "isExtensible"
-		IL_0947: ldloc.s 51
-		IL_0949: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_094e: pop
-		IL_094f: ldc.i4.1
-		IL_0950: newarr [System.Runtime]System.Object
-		IL_0955: dup
-		IL_0956: ldc.i4.0
-		IL_0957: ldloc.0
-		IL_0958: stelem.ref
-		IL_0959: stloc.s 33
-		IL_095b: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject_FunctionExpression_0158934E_L123C22::.ctor()
-		IL_0960: ldc.i4.1
-		IL_0961: conv.r8
-		IL_0962: ldstr ""
-		IL_0967: ldc.i4.0
-		IL_0968: ldc.i4.1
-		IL_0969: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject_FunctionExpression_0158934E_L123C22>(!!0, float64, string, bool, bool)
-		IL_096e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject_FunctionExpression_0158934E_L123C22>(!!0)
-		IL_0973: stloc.s 52
-		IL_0975: ldloc.s 52
-		IL_0977: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject_FunctionExpression_0158934E_L123C22>(!!0)
-		IL_097c: stloc.s 52
-		IL_097e: ldloc.s 37
-		IL_0980: ldstr "preventExtensions"
-		IL_0985: ldloc.s 52
-		IL_0987: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_098c: pop
-		IL_098d: ldloc.s 37
-		IL_098f: stloc.s 21
-		IL_0991: ldloc.s 20
-		IL_0993: ldloc.s 21
-		IL_0995: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_099a: stloc.s 22
-		IL_099c: ldloc.s 22
-		IL_099e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_09a3: stloc.s 23
-		IL_09a5: ldloc.s 22
-		IL_09a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_09ac: pop
-		IL_09ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_09b2: stloc.s 40
-		IL_09b4: ldloc.s 23
-		IL_09b6: box [System.Runtime]System.Boolean
-		IL_09bb: stloc.s 45
-		IL_09bd: ldloc.s 22
-		IL_09bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_09c4: box [System.Runtime]System.Boolean
-		IL_09c9: stloc.s 44
-		IL_09cb: ldloc.s 20
-		IL_09cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_09d2: box [System.Runtime]System.Boolean
-		IL_09d7: stloc.s 53
-		IL_09d9: ldloc.s 40
-		IL_09db: ldc.i4.4
-		IL_09dc: newarr [System.Runtime]System.Object
-		IL_09e1: dup
-		IL_09e2: ldc.i4.0
-		IL_09e3: ldstr "proxyIntegrity"
-		IL_09e8: stelem.ref
-		IL_09e9: dup
-		IL_09ea: ldc.i4.1
-		IL_09eb: ldloc.s 45
-		IL_09ed: stelem.ref
-		IL_09ee: dup
-		IL_09ef: ldc.i4.2
-		IL_09f0: ldloc.s 44
-		IL_09f2: stelem.ref
-		IL_09f3: dup
-		IL_09f4: ldc.i4.3
-		IL_09f5: ldloc.s 53
-		IL_09f7: stelem.ref
-		IL_09f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_09fd: pop
-		IL_09fe: ldc.i4.0
-		IL_09ff: box [System.Runtime]System.Boolean
-		IL_0a04: stloc.s 24
+		IL_092b: conv.r8
+		IL_092c: ldstr ""
+		IL_0931: ldc.i4.0
+		IL_0932: ldc.i4.1
+		IL_0933: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject_FunctionExpression_0158934E_L123C22>(!!0, float64, string, bool, bool)
+		IL_0938: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject_FunctionExpression_0158934E_L123C22>(!!0)
+		IL_093d: stloc.s 52
+		IL_093f: ldloc.s 37
+		IL_0941: ldstr "preventExtensions"
+		IL_0946: ldloc.s 52
+		IL_0948: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_094d: pop
+		IL_094e: ldloc.s 37
+		IL_0950: stloc.s 21
+		IL_0952: ldloc.s 20
+		IL_0954: ldloc.s 21
+		IL_0956: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_095b: stloc.s 22
+		IL_095d: ldloc.s 22
+		IL_095f: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_0964: stloc.s 23
+		IL_0966: ldloc.s 22
+		IL_0968: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_096d: pop
+		IL_096e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0973: stloc.s 40
+		IL_0975: ldloc.s 23
+		IL_0977: box [System.Runtime]System.Boolean
+		IL_097c: stloc.s 45
+		IL_097e: ldloc.s 22
+		IL_0980: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_0985: box [System.Runtime]System.Boolean
+		IL_098a: stloc.s 44
+		IL_098c: ldloc.s 20
+		IL_098e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_0993: box [System.Runtime]System.Boolean
+		IL_0998: stloc.s 53
+		IL_099a: ldloc.s 40
+		IL_099c: ldc.i4.4
+		IL_099d: newarr [System.Runtime]System.Object
+		IL_09a2: dup
+		IL_09a3: ldc.i4.0
+		IL_09a4: ldstr "proxyIntegrity"
+		IL_09a9: stelem.ref
+		IL_09aa: dup
+		IL_09ab: ldc.i4.1
+		IL_09ac: ldloc.s 45
+		IL_09ae: stelem.ref
+		IL_09af: dup
+		IL_09b0: ldc.i4.2
+		IL_09b1: ldloc.s 44
+		IL_09b3: stelem.ref
+		IL_09b4: dup
+		IL_09b5: ldc.i4.3
+		IL_09b6: ldloc.s 53
+		IL_09b8: stelem.ref
+		IL_09b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_09be: pop
+		IL_09bf: ldc.i4.0
+		IL_09c0: box [System.Runtime]System.Boolean
+		IL_09c5: stloc.s 24
 		.try
 		{
-			IL_0a06: nop
-			IL_0a07: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0a0c: stloc.s 37
-			IL_0a0e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0a13: stloc.s 54
-			IL_0a15: ldc.i4.1
-			IL_0a16: newarr [System.Runtime]System.Object
-			IL_0a1b: dup
-			IL_0a1c: ldc.i4.0
-			IL_0a1d: ldloc.0
-			IL_0a1e: stelem.ref
-			IL_0a1f: stloc.s 33
-			IL_0a21: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject_FunctionExpression_456E4DC3_L139C53::.ctor()
-			IL_0a26: ldc.i4.0
-			IL_0a27: conv.r8
-			IL_0a28: ldstr ""
-			IL_0a2d: ldc.i4.0
-			IL_0a2e: ldc.i4.1
-			IL_0a2f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject_FunctionExpression_456E4DC3_L139C53>(!!0, float64, string, bool, bool)
-			IL_0a34: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject_FunctionExpression_456E4DC3_L139C53>(!!0)
-			IL_0a39: stloc.s 55
-			IL_0a3b: ldloc.s 55
-			IL_0a3d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject_FunctionExpression_456E4DC3_L139C53>(!!0)
-			IL_0a42: stloc.s 55
-			IL_0a44: ldloc.s 54
-			IL_0a46: ldstr "isExtensible"
-			IL_0a4b: ldloc.s 55
-			IL_0a4d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0a52: pop
-			IL_0a53: ldloc.s 37
-			IL_0a55: ldloc.s 54
-			IL_0a57: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-			IL_0a5c: stloc.s 49
-			IL_0a5e: ldloc.s 49
-			IL_0a60: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-			IL_0a65: pop
-			IL_0a66: leave IL_0aca
+			IL_09c7: nop
+			IL_09c8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_09cd: stloc.s 37
+			IL_09cf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_09d4: stloc.s 54
+			IL_09d6: ldc.i4.1
+			IL_09d7: newarr [System.Runtime]System.Object
+			IL_09dc: dup
+			IL_09dd: ldc.i4.0
+			IL_09de: ldloc.0
+			IL_09df: stelem.ref
+			IL_09e0: stloc.s 33
+			IL_09e2: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject_FunctionExpression_456E4DC3_L139C53::.ctor()
+			IL_09e7: ldc.i4.0
+			IL_09e8: conv.r8
+			IL_09e9: ldstr ""
+			IL_09ee: ldc.i4.0
+			IL_09ef: ldc.i4.1
+			IL_09f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject_FunctionExpression_456E4DC3_L139C53>(!!0, float64, string, bool, bool)
+			IL_09f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject_FunctionExpression_456E4DC3_L139C53>(!!0)
+			IL_09fa: stloc.s 55
+			IL_09fc: ldloc.s 54
+			IL_09fe: ldstr "isExtensible"
+			IL_0a03: ldloc.s 55
+			IL_0a05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0a0a: pop
+			IL_0a0b: ldloc.s 37
+			IL_0a0d: ldloc.s 54
+			IL_0a0f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+			IL_0a14: stloc.s 49
+			IL_0a16: ldloc.s 49
+			IL_0a18: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+			IL_0a1d: pop
+			IL_0a1e: leave IL_0a82
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0a6b: stloc.s 25
-			IL_0a6d: ldloc.s 25
-			IL_0a6f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0a74: dup
-			IL_0a75: brtrue IL_0a8b
+			IL_0a23: stloc.s 25
+			IL_0a25: ldloc.s 25
+			IL_0a27: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0a2c: dup
+			IL_0a2d: brtrue IL_0a43
 
-			IL_0a7a: pop
-			IL_0a7b: ldloc.s 25
-			IL_0a7d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0a82: dup
-			IL_0a83: brtrue IL_0a97
+			IL_0a32: pop
+			IL_0a33: ldloc.s 25
+			IL_0a35: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0a3a: dup
+			IL_0a3b: brtrue IL_0a4f
 
-			IL_0a88: pop
-			IL_0a89: rethrow
+			IL_0a40: pop
+			IL_0a41: rethrow
 
-			IL_0a8b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0a90: stloc.s 26
-			IL_0a92: br IL_0a99
+			IL_0a43: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0a48: stloc.s 26
+			IL_0a4a: br IL_0a51
 
-			IL_0a97: stloc.s 26
+			IL_0a4f: stloc.s 26
 
-			IL_0a99: ldloc.s 26
-			IL_0a9b: stloc.s 27
-			IL_0a9d: ldloc.s 27
-			IL_0a9f: stloc.s 46
-			IL_0aa1: ldstr "TypeError"
-			IL_0aa6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0aab: stloc.s 36
-			IL_0aad: ldloc.s 46
-			IL_0aaf: ldloc.s 36
-			IL_0ab1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0ab6: stloc.s 43
-			IL_0ab8: ldloc.s 43
-			IL_0aba: box [System.Runtime]System.Boolean
-			IL_0abf: stloc.s 53
-			IL_0ac1: ldloc.s 53
-			IL_0ac3: stloc.s 24
-			IL_0ac5: leave IL_0aca
+			IL_0a51: ldloc.s 26
+			IL_0a53: stloc.s 27
+			IL_0a55: ldloc.s 27
+			IL_0a57: stloc.s 46
+			IL_0a59: ldstr "TypeError"
+			IL_0a5e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a63: stloc.s 36
+			IL_0a65: ldloc.s 46
+			IL_0a67: ldloc.s 36
+			IL_0a69: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0a6e: stloc.s 43
+			IL_0a70: ldloc.s 43
+			IL_0a72: box [System.Runtime]System.Boolean
+			IL_0a77: stloc.s 53
+			IL_0a79: ldloc.s 53
+			IL_0a7b: stloc.s 24
+			IL_0a7d: leave IL_0a82
 		} // end handler
 
-		IL_0aca: ldc.i4.0
-		IL_0acb: box [System.Runtime]System.Boolean
-		IL_0ad0: stloc.s 28
+		IL_0a82: ldc.i4.0
+		IL_0a83: box [System.Runtime]System.Boolean
+		IL_0a88: stloc.s 28
 		.try
 		{
-			IL_0ad2: nop
-			IL_0ad3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0ad8: stloc.s 54
-			IL_0ada: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0adf: stloc.s 37
-			IL_0ae1: ldc.i4.1
-			IL_0ae2: newarr [System.Runtime]System.Object
-			IL_0ae7: dup
-			IL_0ae8: ldc.i4.0
-			IL_0ae9: ldloc.0
-			IL_0aea: stelem.ref
-			IL_0aeb: stloc.s 33
-			IL_0aed: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject_FunctionExpression_F90B20CC_L145C63::.ctor()
-			IL_0af2: ldc.i4.0
-			IL_0af3: conv.r8
-			IL_0af4: ldstr ""
-			IL_0af9: ldc.i4.0
-			IL_0afa: ldc.i4.1
-			IL_0afb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject_FunctionExpression_F90B20CC_L145C63>(!!0, float64, string, bool, bool)
-			IL_0b00: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject_FunctionExpression_F90B20CC_L145C63>(!!0)
-			IL_0b05: stloc.s 56
-			IL_0b07: ldloc.s 56
-			IL_0b09: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject_FunctionExpression_F90B20CC_L145C63>(!!0)
-			IL_0b0e: stloc.s 56
-			IL_0b10: ldloc.s 37
-			IL_0b12: ldstr "preventExtensions"
-			IL_0b17: ldloc.s 56
-			IL_0b19: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0b1e: pop
-			IL_0b1f: ldloc.s 54
-			IL_0b21: ldloc.s 37
-			IL_0b23: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-			IL_0b28: stloc.s 49
-			IL_0b2a: ldloc.s 49
-			IL_0b2c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-			IL_0b31: pop
-			IL_0b32: leave IL_0b96
+			IL_0a8a: nop
+			IL_0a8b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0a90: stloc.s 54
+			IL_0a92: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0a97: stloc.s 37
+			IL_0a99: ldc.i4.1
+			IL_0a9a: newarr [System.Runtime]System.Object
+			IL_0a9f: dup
+			IL_0aa0: ldc.i4.0
+			IL_0aa1: ldloc.0
+			IL_0aa2: stelem.ref
+			IL_0aa3: stloc.s 33
+			IL_0aa5: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject_FunctionExpression_F90B20CC_L145C63::.ctor()
+			IL_0aaa: ldc.i4.0
+			IL_0aab: conv.r8
+			IL_0aac: ldstr ""
+			IL_0ab1: ldc.i4.0
+			IL_0ab2: ldc.i4.1
+			IL_0ab3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject_FunctionExpression_F90B20CC_L145C63>(!!0, float64, string, bool, bool)
+			IL_0ab8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject_FunctionExpression_F90B20CC_L145C63>(!!0)
+			IL_0abd: stloc.s 56
+			IL_0abf: ldloc.s 37
+			IL_0ac1: ldstr "preventExtensions"
+			IL_0ac6: ldloc.s 56
+			IL_0ac8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0acd: pop
+			IL_0ace: ldloc.s 54
+			IL_0ad0: ldloc.s 37
+			IL_0ad2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+			IL_0ad7: stloc.s 49
+			IL_0ad9: ldloc.s 49
+			IL_0adb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+			IL_0ae0: pop
+			IL_0ae1: leave IL_0b45
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0b37: stloc.s 29
-			IL_0b39: ldloc.s 29
-			IL_0b3b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0b40: dup
-			IL_0b41: brtrue IL_0b57
+			IL_0ae6: stloc.s 29
+			IL_0ae8: ldloc.s 29
+			IL_0aea: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0aef: dup
+			IL_0af0: brtrue IL_0b06
 
-			IL_0b46: pop
-			IL_0b47: ldloc.s 29
-			IL_0b49: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0b4e: dup
-			IL_0b4f: brtrue IL_0b63
+			IL_0af5: pop
+			IL_0af6: ldloc.s 29
+			IL_0af8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0afd: dup
+			IL_0afe: brtrue IL_0b12
 
-			IL_0b54: pop
-			IL_0b55: rethrow
+			IL_0b03: pop
+			IL_0b04: rethrow
 
-			IL_0b57: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0b5c: stloc.s 30
-			IL_0b5e: br IL_0b65
+			IL_0b06: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0b0b: stloc.s 30
+			IL_0b0d: br IL_0b14
 
-			IL_0b63: stloc.s 30
+			IL_0b12: stloc.s 30
 
-			IL_0b65: ldloc.s 30
-			IL_0b67: stloc.s 31
-			IL_0b69: ldloc.s 31
-			IL_0b6b: stloc.s 36
-			IL_0b6d: ldstr "TypeError"
-			IL_0b72: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b77: stloc.s 46
-			IL_0b79: ldloc.s 36
-			IL_0b7b: ldloc.s 46
-			IL_0b7d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0b82: stloc.s 43
-			IL_0b84: ldloc.s 43
-			IL_0b86: box [System.Runtime]System.Boolean
-			IL_0b8b: stloc.s 53
-			IL_0b8d: ldloc.s 53
-			IL_0b8f: stloc.s 28
-			IL_0b91: leave IL_0b96
+			IL_0b14: ldloc.s 30
+			IL_0b16: stloc.s 31
+			IL_0b18: ldloc.s 31
+			IL_0b1a: stloc.s 36
+			IL_0b1c: ldstr "TypeError"
+			IL_0b21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b26: stloc.s 46
+			IL_0b28: ldloc.s 36
+			IL_0b2a: ldloc.s 46
+			IL_0b2c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0b31: stloc.s 43
+			IL_0b33: ldloc.s 43
+			IL_0b35: box [System.Runtime]System.Boolean
+			IL_0b3a: stloc.s 53
+			IL_0b3c: ldloc.s 53
+			IL_0b3e: stloc.s 28
+			IL_0b40: leave IL_0b45
 		} // end handler
 
-		IL_0b96: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0b9b: stloc.s 40
-		IL_0b9d: ldloc.s 40
-		IL_0b9f: ldstr "proxyIntegrityInvariants"
-		IL_0ba4: ldloc.s 24
-		IL_0ba6: ldloc.s 28
-		IL_0ba8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0bad: pop
-		IL_0bae: ldnull
-		IL_0baf: stloc.s 32
-		IL_0bb1: ret
+		IL_0b45: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0b4a: stloc.s 40
+		IL_0b4c: ldloc.s 40
+		IL_0b4e: ldstr "proxyIntegrityInvariants"
+		IL_0b53: ldloc.s 24
+		IL_0b55: ldloc.s 28
+		IL_0b57: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0b5c: pop
+		IL_0b5d: ldnull
+		IL_0b5e: stloc.s 32
+		IL_0b60: ret
 	} // end of method Function_CallableReflection_ProxyIntegration::__js_module_init__
 
 } // end of class Modules.Function_CallableReflection_ProxyIntegration

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -1689,7 +1689,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1871 (0x74f)
+		// Code size: 1866 (0x74a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ConstructedInstance_ObjectSemantics/Scope,
@@ -2316,52 +2316,51 @@
 		IL_06bc: ldc.i4.1
 		IL_06bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0, float64, string, bool, bool)
 		IL_06c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0)
-		IL_06c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0)
-		IL_06cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_06d1: pop
-		IL_06d2: ldc.i4.1
-		IL_06d3: newarr [System.Runtime]System.Object
-		IL_06d8: dup
-		IL_06d9: ldc.i4.0
-		IL_06da: ldloc.0
-		IL_06db: stelem.ref
-		IL_06dc: stloc.s 16
-		IL_06de: ldloc.s 25
-		IL_06e0: ldloc.s 16
-		IL_06e2: ldc.r8 0.0
-		IL_06eb: box [System.Runtime]System.Double
-		IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_06f5: stloc.s 23
-		IL_06f7: ldloc.s 23
-		IL_06f9: stloc.s 15
-		IL_06fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0700: stloc.s 19
-		IL_0702: ldloc.1
-		IL_0703: ldc.i4.2
-		IL_0704: newarr [System.Runtime]System.Object
-		IL_0709: dup
-		IL_070a: ldc.i4.0
-		IL_070b: ldc.r8 6
-		IL_0714: box [System.Runtime]System.Double
-		IL_0719: stelem.ref
-		IL_071a: dup
-		IL_071b: ldc.i4.1
-		IL_071c: ldc.r8 1
-		IL_0725: box [System.Runtime]System.Double
-		IL_072a: stelem.ref
-		IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_0730: stloc.s 23
-		IL_0732: ldloc.s 15
-		IL_0734: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_0739: stloc.s 24
-		IL_073b: ldloc.s 23
-		IL_073d: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
-		IL_0742: stloc.s 23
-		IL_0744: ldloc.s 19
-		IL_0746: ldloc.s 23
-		IL_0748: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_074d: pop
-		IL_074e: ret
+		IL_06c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_06cc: pop
+		IL_06cd: ldc.i4.1
+		IL_06ce: newarr [System.Runtime]System.Object
+		IL_06d3: dup
+		IL_06d4: ldc.i4.0
+		IL_06d5: ldloc.0
+		IL_06d6: stelem.ref
+		IL_06d7: stloc.s 16
+		IL_06d9: ldloc.s 25
+		IL_06db: ldloc.s 16
+		IL_06dd: ldc.r8 0.0
+		IL_06e6: box [System.Runtime]System.Double
+		IL_06eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_06f0: stloc.s 23
+		IL_06f2: ldloc.s 23
+		IL_06f4: stloc.s 15
+		IL_06f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06fb: stloc.s 19
+		IL_06fd: ldloc.1
+		IL_06fe: ldc.i4.2
+		IL_06ff: newarr [System.Runtime]System.Object
+		IL_0704: dup
+		IL_0705: ldc.i4.0
+		IL_0706: ldc.r8 6
+		IL_070f: box [System.Runtime]System.Double
+		IL_0714: stelem.ref
+		IL_0715: dup
+		IL_0716: ldc.i4.1
+		IL_0717: ldc.r8 1
+		IL_0720: box [System.Runtime]System.Double
+		IL_0725: stelem.ref
+		IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_072b: stloc.s 23
+		IL_072d: ldloc.s 15
+		IL_072f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_0734: stloc.s 24
+		IL_0736: ldloc.s 23
+		IL_0738: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
+		IL_073d: stloc.s 23
+		IL_073f: ldloc.s 19
+		IL_0741: ldloc.s 23
+		IL_0743: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0748: pop
+		IL_0749: ret
 	} // end of method Function_ConstructedInstance_ObjectSemantics::__js_module_init__
 
 } // end of class Modules.Function_ConstructedInstance_ObjectSemantics

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GeneratedConstruction_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GeneratedConstruction_Semantics.verified.txt
@@ -1399,7 +1399,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2235 (0x8bb)
+		// Code size: 2226 (0x8b2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GeneratedConstruction_Semantics/Scope,
@@ -2153,154 +2153,151 @@
 		IL_073f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_2A9B4B11_L96C24>(!!0, float64, string, bool, bool)
 		IL_0744: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_2A9B4B11_L96C24>(!!0)
 		IL_0749: stloc.s 42
-		IL_074b: ldloc.s 42
-		IL_074d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_2A9B4B11_L96C24>(!!0)
-		IL_0752: stloc.s 42
-		IL_0754: ldloc.s 37
-		IL_0756: ldstr "method"
-		IL_075b: ldloc.s 42
-		IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0762: pop
-		IL_0763: ldloc.s 37
-		IL_0765: stloc.s 18
-		IL_0767: ldc.i4.0
-		IL_0768: box [System.Runtime]System.Boolean
-		IL_076d: stloc.s 19
-		IL_076f: ldc.i4.0
-		IL_0770: box [System.Runtime]System.Boolean
-		IL_0775: stloc.s 20
+		IL_074b: ldloc.s 37
+		IL_074d: ldstr "method"
+		IL_0752: ldloc.s 42
+		IL_0754: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0759: pop
+		IL_075a: ldloc.s 37
+		IL_075c: stloc.s 18
+		IL_075e: ldc.i4.0
+		IL_075f: box [System.Runtime]System.Boolean
+		IL_0764: stloc.s 19
+		IL_0766: ldc.i4.0
+		IL_0767: box [System.Runtime]System.Boolean
+		IL_076c: stloc.s 20
 		.try
 		{
-			IL_0777: nop
-			IL_0778: ldstr "Reflect"
-			IL_077d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0782: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0787: ldc.i4.0
-			IL_0788: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_078d: stloc.s 43
-			IL_078f: ldstr "construct"
-			IL_0794: ldloc.s 17
-			IL_0796: ldloc.s 43
-			IL_0798: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_079d: pop
-			IL_079e: leave IL_0802
+			IL_076e: nop
+			IL_076f: ldstr "Reflect"
+			IL_0774: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_077e: ldc.i4.0
+			IL_077f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0784: stloc.s 43
+			IL_0786: ldstr "construct"
+			IL_078b: ldloc.s 17
+			IL_078d: ldloc.s 43
+			IL_078f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0794: pop
+			IL_0795: leave IL_07f9
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_07a3: stloc.s 21
-			IL_07a5: ldloc.s 21
-			IL_07a7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_07ac: dup
-			IL_07ad: brtrue IL_07c3
+			IL_079a: stloc.s 21
+			IL_079c: ldloc.s 21
+			IL_079e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_07a3: dup
+			IL_07a4: brtrue IL_07ba
 
-			IL_07b2: pop
-			IL_07b3: ldloc.s 21
-			IL_07b5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_07ba: dup
-			IL_07bb: brtrue IL_07cf
+			IL_07a9: pop
+			IL_07aa: ldloc.s 21
+			IL_07ac: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_07b1: dup
+			IL_07b2: brtrue IL_07c6
 
-			IL_07c0: pop
-			IL_07c1: rethrow
+			IL_07b7: pop
+			IL_07b8: rethrow
 
-			IL_07c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_07c8: stloc.s 22
-			IL_07ca: br IL_07d1
+			IL_07ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_07bf: stloc.s 22
+			IL_07c1: br IL_07c8
 
-			IL_07cf: stloc.s 22
+			IL_07c6: stloc.s 22
 
-			IL_07d1: ldloc.s 22
-			IL_07d3: stloc.s 23
-			IL_07d5: ldloc.s 23
-			IL_07d7: stloc.s 32
-			IL_07d9: ldstr "TypeError"
-			IL_07de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07e3: stloc.s 31
-			IL_07e5: ldloc.s 32
-			IL_07e7: ldloc.s 31
-			IL_07e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_07ee: stloc.s 33
-			IL_07f0: ldloc.s 33
-			IL_07f2: box [System.Runtime]System.Boolean
-			IL_07f7: stloc.s 34
-			IL_07f9: ldloc.s 34
-			IL_07fb: stloc.s 19
-			IL_07fd: leave IL_0802
+			IL_07c8: ldloc.s 22
+			IL_07ca: stloc.s 23
+			IL_07cc: ldloc.s 23
+			IL_07ce: stloc.s 32
+			IL_07d0: ldstr "TypeError"
+			IL_07d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07da: stloc.s 31
+			IL_07dc: ldloc.s 32
+			IL_07de: ldloc.s 31
+			IL_07e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_07e5: stloc.s 33
+			IL_07e7: ldloc.s 33
+			IL_07e9: box [System.Runtime]System.Boolean
+			IL_07ee: stloc.s 34
+			IL_07f0: ldloc.s 34
+			IL_07f2: stloc.s 19
+			IL_07f4: leave IL_07f9
 		} // end handler
 		.try
 		{
-			IL_0802: nop
-			IL_0803: ldstr "Reflect"
-			IL_0808: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_080d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0812: stloc.s 31
-			IL_0814: ldloc.s 18
-			IL_0816: ldstr "method"
-			IL_081b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0820: stloc.s 32
-			IL_0822: ldc.i4.0
-			IL_0823: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0828: stloc.s 43
-			IL_082a: ldloc.s 31
-			IL_082c: ldstr "construct"
-			IL_0831: ldloc.s 32
-			IL_0833: ldloc.s 43
-			IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_083a: pop
-			IL_083b: leave IL_089f
+			IL_07f9: nop
+			IL_07fa: ldstr "Reflect"
+			IL_07ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0804: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0809: stloc.s 31
+			IL_080b: ldloc.s 18
+			IL_080d: ldstr "method"
+			IL_0812: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0817: stloc.s 32
+			IL_0819: ldc.i4.0
+			IL_081a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_081f: stloc.s 43
+			IL_0821: ldloc.s 31
+			IL_0823: ldstr "construct"
+			IL_0828: ldloc.s 32
+			IL_082a: ldloc.s 43
+			IL_082c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0831: pop
+			IL_0832: leave IL_0896
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0840: stloc.s 24
-			IL_0842: ldloc.s 24
-			IL_0844: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0849: dup
-			IL_084a: brtrue IL_0860
+			IL_0837: stloc.s 24
+			IL_0839: ldloc.s 24
+			IL_083b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0840: dup
+			IL_0841: brtrue IL_0857
 
-			IL_084f: pop
-			IL_0850: ldloc.s 24
-			IL_0852: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0857: dup
-			IL_0858: brtrue IL_086c
+			IL_0846: pop
+			IL_0847: ldloc.s 24
+			IL_0849: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_084e: dup
+			IL_084f: brtrue IL_0863
 
-			IL_085d: pop
-			IL_085e: rethrow
+			IL_0854: pop
+			IL_0855: rethrow
 
-			IL_0860: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0865: stloc.s 25
-			IL_0867: br IL_086e
+			IL_0857: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_085c: stloc.s 25
+			IL_085e: br IL_0865
 
-			IL_086c: stloc.s 25
+			IL_0863: stloc.s 25
 
-			IL_086e: ldloc.s 25
-			IL_0870: stloc.s 26
-			IL_0872: ldloc.s 26
-			IL_0874: stloc.s 32
-			IL_0876: ldstr "TypeError"
-			IL_087b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0880: stloc.s 31
-			IL_0882: ldloc.s 32
-			IL_0884: ldloc.s 31
-			IL_0886: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_088b: stloc.s 33
-			IL_088d: ldloc.s 33
-			IL_088f: box [System.Runtime]System.Boolean
-			IL_0894: stloc.s 34
-			IL_0896: ldloc.s 34
-			IL_0898: stloc.s 20
-			IL_089a: leave IL_089f
+			IL_0865: ldloc.s 25
+			IL_0867: stloc.s 26
+			IL_0869: ldloc.s 26
+			IL_086b: stloc.s 32
+			IL_086d: ldstr "TypeError"
+			IL_0872: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0877: stloc.s 31
+			IL_0879: ldloc.s 32
+			IL_087b: ldloc.s 31
+			IL_087d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0882: stloc.s 33
+			IL_0884: ldloc.s 33
+			IL_0886: box [System.Runtime]System.Boolean
+			IL_088b: stloc.s 34
+			IL_088d: ldloc.s 34
+			IL_088f: stloc.s 20
+			IL_0891: leave IL_0896
 		} // end handler
 
-		IL_089f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08a4: stloc.s 30
-		IL_08a6: ldloc.s 30
-		IL_08a8: ldstr "nonconstructors"
-		IL_08ad: ldloc.s 19
-		IL_08af: ldloc.s 20
-		IL_08b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_08b6: pop
-		IL_08b7: ldnull
-		IL_08b8: stloc.s 27
-		IL_08ba: ret
+		IL_0896: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_089b: stloc.s 30
+		IL_089d: ldloc.s 30
+		IL_089f: ldstr "nonconstructors"
+		IL_08a4: ldloc.s 19
+		IL_08a6: ldloc.s 20
+		IL_08a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_08ad: pop
+		IL_08ae: ldnull
+		IL_08af: stloc.s 27
+		IL_08b1: ret
 	} // end of method Function_GeneratedConstruction_Semantics::__js_module_init__
 
 } // end of class Modules.Function_GeneratedConstruction_Semantics

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
@@ -4186,7 +4186,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1696 (0x6a0)
+		// Code size: 1651 (0x673)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerCallResults/Scope,
@@ -4521,312 +4521,303 @@
 		IL_02b1: ldc.i4.1
 		IL_02b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0, float64, string, bool, bool)
 		IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0)
-		IL_02bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0)
-		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02c6: pop
-		IL_02c7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02cc: stloc.s 14
-		IL_02ce: ldloc.s 18
-		IL_02d0: ldstr "getValue"
-		IL_02d5: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue::.ctor()
-		IL_02da: ldc.i4.0
-		IL_02db: conv.r8
-		IL_02dc: ldstr "getValue"
-		IL_02e1: ldc.i4.1
-		IL_02e2: ldc.i4.1
-		IL_02e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0, float64, string, bool, bool)
-		IL_02e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0)
-		IL_02ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0)
-		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02f7: pop
-		IL_02f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02fd: stloc.s 14
-		IL_02ff: ldloc.s 18
-		IL_0301: ldstr "chain"
-		IL_0306: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain::.ctor()
-		IL_030b: ldc.i4.0
-		IL_030c: conv.r8
-		IL_030d: ldstr "chain"
-		IL_0312: ldc.i4.1
-		IL_0313: ldc.i4.1
-		IL_0314: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0, float64, string, bool, bool)
-		IL_0319: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0)
-		IL_031e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0)
-		IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0328: pop
-		IL_0329: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_032e: stloc.s 14
-		IL_0330: ldloc.s 18
-		IL_0332: ldstr "addOnce"
-		IL_0337: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::.ctor()
-		IL_033c: ldc.i4.0
-		IL_033d: conv.r8
-		IL_033e: ldstr "addOnce"
-		IL_0343: ldc.i4.1
-		IL_0344: ldc.i4.1
-		IL_0345: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0, float64, string, bool, bool)
-		IL_034a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0)
-		IL_034f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0)
-		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0359: pop
-		IL_035a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_035f: stloc.s 14
-		IL_0361: ldloc.s 18
-		IL_0363: ldstr "next"
-		IL_0368: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next::.ctor()
-		IL_036d: ldc.i4.0
-		IL_036e: conv.r8
-		IL_036f: ldstr "next"
-		IL_0374: ldc.i4.1
-		IL_0375: ldc.i4.1
-		IL_0376: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0, float64, string, bool, bool)
-		IL_037b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0)
-		IL_0380: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0)
-		IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_038a: pop
-		IL_038b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0390: stloc.s 14
-		IL_0392: ldloc.s 18
-		IL_0394: ldstr "maxNext"
-		IL_0399: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext::.ctor()
-		IL_039e: ldc.i4.0
-		IL_039f: conv.r8
-		IL_03a0: ldstr "maxNext"
-		IL_03a5: ldc.i4.1
-		IL_03a6: ldc.i4.1
-		IL_03a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0, float64, string, bool, bool)
-		IL_03ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0)
-		IL_03b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0)
-		IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_03bb: pop
-		IL_03bc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03c1: stloc.s 14
-		IL_03c3: ldloc.s 18
-		IL_03c5: ldstr "sum"
-		IL_03ca: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum::.ctor()
-		IL_03cf: ldc.i4.s 9
-		IL_03d1: conv.r8
-		IL_03d2: ldstr "sum"
-		IL_03d7: ldc.i4.0
-		IL_03d8: ldc.i4.1
-		IL_03d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0, float64, string, bool, bool)
-		IL_03de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0)
-		IL_03e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0)
-		IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_03ed: pop
-		IL_03ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03f3: stloc.s 14
-		IL_03f5: ldloc.s 18
-		IL_03f7: ldstr "maxSum"
-		IL_03fc: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::.ctor()
-		IL_0401: ldc.i4.0
-		IL_0402: conv.r8
-		IL_0403: ldstr "maxSum"
-		IL_0408: ldc.i4.1
-		IL_0409: ldc.i4.1
-		IL_040a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0, float64, string, bool, bool)
-		IL_040f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0)
-		IL_0414: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0)
-		IL_0419: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_041e: pop
-		IL_041f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0424: stloc.s 14
-		IL_0426: ldloc.s 18
-		IL_0428: ldstr "maxSumWithFloor"
-		IL_042d: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::.ctor()
-		IL_0432: ldc.i4.0
-		IL_0433: conv.r8
-		IL_0434: ldstr "maxSumWithFloor"
-		IL_0439: ldc.i4.1
-		IL_043a: ldc.i4.1
-		IL_043b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0, float64, string, bool, bool)
-		IL_0440: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0)
-		IL_0445: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0)
-		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_044f: pop
-		IL_0450: ldc.i4.1
-		IL_0451: newarr [System.Runtime]System.Object
-		IL_0456: dup
-		IL_0457: ldc.i4.0
-		IL_0458: ldloc.0
-		IL_0459: stelem.ref
-		IL_045a: stloc.s 14
-		IL_045c: ldloc.s 17
-		IL_045e: ldloc.s 14
-		IL_0460: ldc.r8 1
-		IL_0469: box [System.Runtime]System.Double
-		IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0473: stloc.s 18
-		IL_0475: ldloc.0
-		IL_0476: ldloc.s 18
-		IL_0478: stfld object Modules.Function_SchedulerCallResults/Scope::Counter
-		IL_047d: nop
-		IL_047e: nop
-		IL_047f: nop
-		IL_0480: nop
-		IL_0481: nop
-		IL_0482: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0487: stloc.s 19
-		IL_0489: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_048e: stloc.s 14
-		IL_0490: ldloc.1
-		IL_0491: ldloc.s 14
-		IL_0493: ldc.r8 9
-		IL_049c: box [System.Runtime]System.Double
-		IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_04a6: stloc.s 18
-		IL_04a8: ldloc.s 19
-		IL_04aa: ldloc.s 18
-		IL_04ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04b1: pop
-		IL_04b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04b7: stloc.s 19
-		IL_04b9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04be: stloc.s 14
-		IL_04c0: ldc.r8 2.7
-		IL_04c9: neg
-		IL_04ca: stloc.s 20
-		IL_04cc: ldloc.s 20
-		IL_04ce: box [System.Runtime]System.Double
-		IL_04d3: stloc.s 21
-		IL_04d5: ldloc.2
-		IL_04d6: ldloc.s 14
-		IL_04d8: ldloc.s 21
-		IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_04df: stloc.s 18
-		IL_04e1: ldloc.s 19
-		IL_04e3: ldloc.s 18
-		IL_04e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04ea: pop
-		IL_04eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04f0: stloc.s 19
-		IL_04f2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04f7: stloc.s 14
-		IL_04f9: ldloc.3
-		IL_04fa: ldloc.s 14
-		IL_04fc: ldc.r8 1.2
-		IL_0505: box [System.Runtime]System.Double
-		IL_050a: ldc.r8 1.1
-		IL_0513: box [System.Runtime]System.Double
-		IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_051d: stloc.s 18
-		IL_051f: ldloc.s 19
-		IL_0521: ldloc.s 18
-		IL_0523: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0528: pop
-		IL_0529: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_052e: stloc.s 19
-		IL_0530: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0535: stloc.s 14
-		IL_0537: ldloc.s 4
-		IL_0539: ldloc.s 14
-		IL_053b: ldc.r8 9
-		IL_0544: box [System.Runtime]System.Double
-		IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_054e: stloc.s 18
-		IL_0550: ldloc.s 19
-		IL_0552: ldloc.s 18
-		IL_0554: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0559: pop
-		IL_055a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_055f: stloc.s 19
-		IL_0561: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0566: stloc.s 14
-		IL_0568: ldloc.s 5
-		IL_056a: ldloc.s 14
-		IL_056c: ldc.r8 2
-		IL_0575: box [System.Runtime]System.Double
-		IL_057a: ldc.r8 3
-		IL_0583: box [System.Runtime]System.Double
-		IL_0588: ldc.r8 2
-		IL_0591: box [System.Runtime]System.Double
-		IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_059b: stloc.s 18
-		IL_059d: ldloc.s 19
-		IL_059f: ldloc.s 18
-		IL_05a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05a6: pop
-		IL_05a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05ac: stloc.s 19
-		IL_05ae: ldloc.s 6
-		IL_05b0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_05ba: stloc.s 18
-		IL_05bc: ldloc.s 19
-		IL_05be: ldloc.s 18
-		IL_05c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05c5: pop
-		IL_05c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05cb: stloc.s 19
-		IL_05cd: ldloc.s 7
-		IL_05cf: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_05d9: stloc.s 18
-		IL_05db: ldloc.s 19
-		IL_05dd: ldloc.s 18
-		IL_05df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05e4: pop
-		IL_05e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05ea: stloc.s 19
-		IL_05ec: ldloc.s 8
-		IL_05ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_05f8: stloc.s 18
-		IL_05fa: ldloc.s 19
-		IL_05fc: ldloc.s 18
-		IL_05fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0603: pop
-		IL_0604: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0609: stloc.s 19
-		IL_060b: ldloc.s 9
-		IL_060d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0617: stloc.s 18
-		IL_0619: ldloc.s 19
-		IL_061b: ldloc.s 18
-		IL_061d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0622: pop
-		IL_0623: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0628: stloc.s 19
-		IL_062a: ldloc.s 10
-		IL_062c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0636: stloc.s 18
-		IL_0638: ldloc.s 19
-		IL_063a: ldloc.s 18
-		IL_063c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0641: pop
-		IL_0642: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0647: stloc.s 19
-		IL_0649: ldloc.s 11
-		IL_064b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0650: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0655: stloc.s 18
-		IL_0657: ldloc.s 19
-		IL_0659: ldloc.s 18
-		IL_065b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0660: pop
-		IL_0661: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0666: stloc.s 19
-		IL_0668: ldloc.s 12
-		IL_066a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_066f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0674: stloc.s 18
-		IL_0676: ldloc.s 19
-		IL_0678: ldloc.s 18
-		IL_067a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_067f: pop
-		IL_0680: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0685: stloc.s 19
-		IL_0687: ldloc.s 13
-		IL_0689: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_068e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0693: stloc.s 18
-		IL_0695: ldloc.s 19
-		IL_0697: ldloc.s 18
-		IL_0699: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_069e: pop
-		IL_069f: ret
+		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02c1: pop
+		IL_02c2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02c7: stloc.s 14
+		IL_02c9: ldloc.s 18
+		IL_02cb: ldstr "getValue"
+		IL_02d0: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue::.ctor()
+		IL_02d5: ldc.i4.0
+		IL_02d6: conv.r8
+		IL_02d7: ldstr "getValue"
+		IL_02dc: ldc.i4.1
+		IL_02dd: ldc.i4.1
+		IL_02de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0, float64, string, bool, bool)
+		IL_02e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0)
+		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02ed: pop
+		IL_02ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02f3: stloc.s 14
+		IL_02f5: ldloc.s 18
+		IL_02f7: ldstr "chain"
+		IL_02fc: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain::.ctor()
+		IL_0301: ldc.i4.0
+		IL_0302: conv.r8
+		IL_0303: ldstr "chain"
+		IL_0308: ldc.i4.1
+		IL_0309: ldc.i4.1
+		IL_030a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0, float64, string, bool, bool)
+		IL_030f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0)
+		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0319: pop
+		IL_031a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_031f: stloc.s 14
+		IL_0321: ldloc.s 18
+		IL_0323: ldstr "addOnce"
+		IL_0328: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::.ctor()
+		IL_032d: ldc.i4.0
+		IL_032e: conv.r8
+		IL_032f: ldstr "addOnce"
+		IL_0334: ldc.i4.1
+		IL_0335: ldc.i4.1
+		IL_0336: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0, float64, string, bool, bool)
+		IL_033b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0)
+		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0345: pop
+		IL_0346: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_034b: stloc.s 14
+		IL_034d: ldloc.s 18
+		IL_034f: ldstr "next"
+		IL_0354: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next::.ctor()
+		IL_0359: ldc.i4.0
+		IL_035a: conv.r8
+		IL_035b: ldstr "next"
+		IL_0360: ldc.i4.1
+		IL_0361: ldc.i4.1
+		IL_0362: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0, float64, string, bool, bool)
+		IL_0367: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0)
+		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0371: pop
+		IL_0372: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0377: stloc.s 14
+		IL_0379: ldloc.s 18
+		IL_037b: ldstr "maxNext"
+		IL_0380: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext::.ctor()
+		IL_0385: ldc.i4.0
+		IL_0386: conv.r8
+		IL_0387: ldstr "maxNext"
+		IL_038c: ldc.i4.1
+		IL_038d: ldc.i4.1
+		IL_038e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0, float64, string, bool, bool)
+		IL_0393: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0)
+		IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_039d: pop
+		IL_039e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03a3: stloc.s 14
+		IL_03a5: ldloc.s 18
+		IL_03a7: ldstr "sum"
+		IL_03ac: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum::.ctor()
+		IL_03b1: ldc.i4.s 9
+		IL_03b3: conv.r8
+		IL_03b4: ldstr "sum"
+		IL_03b9: ldc.i4.0
+		IL_03ba: ldc.i4.1
+		IL_03bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0, float64, string, bool, bool)
+		IL_03c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0)
+		IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_03ca: pop
+		IL_03cb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03d0: stloc.s 14
+		IL_03d2: ldloc.s 18
+		IL_03d4: ldstr "maxSum"
+		IL_03d9: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::.ctor()
+		IL_03de: ldc.i4.0
+		IL_03df: conv.r8
+		IL_03e0: ldstr "maxSum"
+		IL_03e5: ldc.i4.1
+		IL_03e6: ldc.i4.1
+		IL_03e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0, float64, string, bool, bool)
+		IL_03ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0)
+		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_03f6: pop
+		IL_03f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03fc: stloc.s 14
+		IL_03fe: ldloc.s 18
+		IL_0400: ldstr "maxSumWithFloor"
+		IL_0405: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::.ctor()
+		IL_040a: ldc.i4.0
+		IL_040b: conv.r8
+		IL_040c: ldstr "maxSumWithFloor"
+		IL_0411: ldc.i4.1
+		IL_0412: ldc.i4.1
+		IL_0413: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0, float64, string, bool, bool)
+		IL_0418: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0)
+		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0422: pop
+		IL_0423: ldc.i4.1
+		IL_0424: newarr [System.Runtime]System.Object
+		IL_0429: dup
+		IL_042a: ldc.i4.0
+		IL_042b: ldloc.0
+		IL_042c: stelem.ref
+		IL_042d: stloc.s 14
+		IL_042f: ldloc.s 17
+		IL_0431: ldloc.s 14
+		IL_0433: ldc.r8 1
+		IL_043c: box [System.Runtime]System.Double
+		IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0446: stloc.s 18
+		IL_0448: ldloc.0
+		IL_0449: ldloc.s 18
+		IL_044b: stfld object Modules.Function_SchedulerCallResults/Scope::Counter
+		IL_0450: nop
+		IL_0451: nop
+		IL_0452: nop
+		IL_0453: nop
+		IL_0454: nop
+		IL_0455: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_045a: stloc.s 19
+		IL_045c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0461: stloc.s 14
+		IL_0463: ldloc.1
+		IL_0464: ldloc.s 14
+		IL_0466: ldc.r8 9
+		IL_046f: box [System.Runtime]System.Double
+		IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0479: stloc.s 18
+		IL_047b: ldloc.s 19
+		IL_047d: ldloc.s 18
+		IL_047f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0484: pop
+		IL_0485: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_048a: stloc.s 19
+		IL_048c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0491: stloc.s 14
+		IL_0493: ldc.r8 2.7
+		IL_049c: neg
+		IL_049d: stloc.s 20
+		IL_049f: ldloc.s 20
+		IL_04a1: box [System.Runtime]System.Double
+		IL_04a6: stloc.s 21
+		IL_04a8: ldloc.2
+		IL_04a9: ldloc.s 14
+		IL_04ab: ldloc.s 21
+		IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_04b2: stloc.s 18
+		IL_04b4: ldloc.s 19
+		IL_04b6: ldloc.s 18
+		IL_04b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04bd: pop
+		IL_04be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04c3: stloc.s 19
+		IL_04c5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04ca: stloc.s 14
+		IL_04cc: ldloc.3
+		IL_04cd: ldloc.s 14
+		IL_04cf: ldc.r8 1.2
+		IL_04d8: box [System.Runtime]System.Double
+		IL_04dd: ldc.r8 1.1
+		IL_04e6: box [System.Runtime]System.Double
+		IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_04f0: stloc.s 18
+		IL_04f2: ldloc.s 19
+		IL_04f4: ldloc.s 18
+		IL_04f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04fb: pop
+		IL_04fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0501: stloc.s 19
+		IL_0503: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0508: stloc.s 14
+		IL_050a: ldloc.s 4
+		IL_050c: ldloc.s 14
+		IL_050e: ldc.r8 9
+		IL_0517: box [System.Runtime]System.Double
+		IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0521: stloc.s 18
+		IL_0523: ldloc.s 19
+		IL_0525: ldloc.s 18
+		IL_0527: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_052c: pop
+		IL_052d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0532: stloc.s 19
+		IL_0534: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0539: stloc.s 14
+		IL_053b: ldloc.s 5
+		IL_053d: ldloc.s 14
+		IL_053f: ldc.r8 2
+		IL_0548: box [System.Runtime]System.Double
+		IL_054d: ldc.r8 3
+		IL_0556: box [System.Runtime]System.Double
+		IL_055b: ldc.r8 2
+		IL_0564: box [System.Runtime]System.Double
+		IL_0569: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_056e: stloc.s 18
+		IL_0570: ldloc.s 19
+		IL_0572: ldloc.s 18
+		IL_0574: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0579: pop
+		IL_057a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_057f: stloc.s 19
+		IL_0581: ldloc.s 6
+		IL_0583: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0588: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_058d: stloc.s 18
+		IL_058f: ldloc.s 19
+		IL_0591: ldloc.s 18
+		IL_0593: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0598: pop
+		IL_0599: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_059e: stloc.s 19
+		IL_05a0: ldloc.s 7
+		IL_05a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_05ac: stloc.s 18
+		IL_05ae: ldloc.s 19
+		IL_05b0: ldloc.s 18
+		IL_05b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05b7: pop
+		IL_05b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05bd: stloc.s 19
+		IL_05bf: ldloc.s 8
+		IL_05c1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_05cb: stloc.s 18
+		IL_05cd: ldloc.s 19
+		IL_05cf: ldloc.s 18
+		IL_05d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05d6: pop
+		IL_05d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05dc: stloc.s 19
+		IL_05de: ldloc.s 9
+		IL_05e0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_05ea: stloc.s 18
+		IL_05ec: ldloc.s 19
+		IL_05ee: ldloc.s 18
+		IL_05f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05f5: pop
+		IL_05f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05fb: stloc.s 19
+		IL_05fd: ldloc.s 10
+		IL_05ff: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0609: stloc.s 18
+		IL_060b: ldloc.s 19
+		IL_060d: ldloc.s 18
+		IL_060f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0614: pop
+		IL_0615: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_061a: stloc.s 19
+		IL_061c: ldloc.s 11
+		IL_061e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0623: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0628: stloc.s 18
+		IL_062a: ldloc.s 19
+		IL_062c: ldloc.s 18
+		IL_062e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0633: pop
+		IL_0634: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0639: stloc.s 19
+		IL_063b: ldloc.s 12
+		IL_063d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0647: stloc.s 18
+		IL_0649: ldloc.s 19
+		IL_064b: ldloc.s 18
+		IL_064d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0652: pop
+		IL_0653: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0658: stloc.s 19
+		IL_065a: ldloc.s 13
+		IL_065c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0666: stloc.s 18
+		IL_0668: ldloc.s 19
+		IL_066a: ldloc.s 18
+		IL_066c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0671: pop
+		IL_0672: ret
 	} // end of method Function_SchedulerCallResults::__js_module_init__
 
 } // end of class Modules.Function_SchedulerCallResults

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
@@ -1151,8 +1151,8 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 996 (0x3e4)
-		.maxstack 13
+		// Code size: 978 (0x3d2)
+		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerConversionsStableLoads/Scope,
 			[1] class Modules.Function_SchedulerConversionsStableLoads/concat/FunctionObject_FunctionDeclaration_769438BB_concat,
@@ -1307,243 +1307,237 @@
 		IL_0113: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10>(!!0)
 		IL_0118: stloc.s 15
 		IL_011a: ldloc.s 15
-		IL_011c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10>(!!0)
-		IL_0121: stloc.s 15
-		IL_0123: ldloc.s 15
-		IL_0125: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10>(!!0)
-		IL_012a: stloc.s 15
-		IL_012c: ldloc.s 15
-		IL_012e: ldstr "x"
-		IL_0133: ldstr "get"
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_013d: stloc.s 16
-		IL_013f: ldloc.s 14
-		IL_0141: ldstr "x"
-		IL_0146: ldloc.s 16
-		IL_0148: ldnull
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_014e: pop
-		IL_014f: ldloc.s 14
-		IL_0151: stloc.s 7
-		IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0158: stloc.s 17
-		IL_015a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_015f: stloc.s 13
-		IL_0161: ldloc.1
-		IL_0162: ldloc.s 13
-		IL_0164: ldc.r8 3
-		IL_016d: box [System.Runtime]System.Double
-		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0177: stloc.s 16
-		IL_0179: ldloc.s 17
-		IL_017b: ldloc.s 16
-		IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0182: pop
-		IL_0183: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0188: stloc.s 17
-		IL_018a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_018f: stloc.s 13
-		IL_0191: ldloc.2
-		IL_0192: ldloc.s 13
-		IL_0194: ldstr "abc"
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_019e: stloc.s 16
-		IL_01a0: ldloc.s 17
-		IL_01a2: ldloc.s 16
-		IL_01a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a9: pop
-		IL_01aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01af: stloc.s 17
-		IL_01b1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01b6: stloc.s 13
-		IL_01b8: ldc.i4.3
-		IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01be: dup
-		IL_01bf: ldc.r8 1
-		IL_01c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01cd: dup
-		IL_01ce: ldc.r8 2
-		IL_01d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01dc: dup
-		IL_01dd: ldc.r8 3
-		IL_01e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01eb: stloc.s 18
-		IL_01ed: ldloc.3
-		IL_01ee: ldloc.s 13
-		IL_01f0: ldloc.s 18
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01f7: stloc.s 16
-		IL_01f9: ldloc.s 17
-		IL_01fb: ldloc.s 16
-		IL_01fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0202: pop
-		IL_0203: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0208: stloc.s 17
-		IL_020a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_020f: stloc.s 13
-		IL_0211: ldc.i4.1
-		IL_0212: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0217: dup
-		IL_0218: ldc.r8 4
-		IL_0221: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0226: stloc.s 18
-		IL_0228: ldloc.s 4
-		IL_022a: ldloc.s 13
-		IL_022c: ldloc.s 18
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0233: stloc.s 16
-		IL_0235: ldloc.s 17
-		IL_0237: ldloc.s 16
-		IL_0239: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_023e: pop
-		IL_023f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0244: stloc.s 17
-		IL_0246: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_024b: stloc.s 13
-		IL_024d: ldc.i4.2
-		IL_024e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0253: dup
-		IL_0254: ldc.r8 5
-		IL_025d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0262: dup
-		IL_0263: ldc.r8 6
-		IL_026c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0271: stloc.s 18
-		IL_0273: ldloc.s 18
-		IL_0275: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_027a: stloc.s 19
-		IL_027c: ldloc.s 5
-		IL_027e: ldloc.s 13
-		IL_0280: ldloc.s 19
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0287: stloc.s 16
-		IL_0289: ldloc.s 17
-		IL_028b: ldloc.s 16
-		IL_028d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0292: pop
-		IL_0293: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0298: stloc.s 17
-		IL_029a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_029f: stloc.s 13
-		IL_02a1: ldloc.s 6
-		IL_02a3: ldloc.s 13
-		IL_02a5: ldc.r8 3
-		IL_02ae: box [System.Runtime]System.Double
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_02b8: stloc.s 16
-		IL_02ba: ldloc.s 16
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c1: ldstr "join"
-		IL_02c6: ldstr ","
-		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d0: stloc.s 16
-		IL_02d2: ldloc.s 17
-		IL_02d4: ldloc.s 16
-		IL_02d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02db: pop
-		IL_02dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02e1: stloc.s 17
-		IL_02e3: ldloc.s 7
-		IL_02e5: ldstr "x"
-		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ef: stloc.s 16
-		IL_02f1: ldloc.s 7
-		IL_02f3: ldstr "x"
-		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02fd: stloc.s 20
-		IL_02ff: ldloc.s 16
-		IL_0301: ldloc.s 20
-		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0308: stloc.s 21
-		IL_030a: ldloc.0
-		IL_030b: ldfld object Modules.Function_SchedulerConversionsStableLoads/Scope::getterCount
-		IL_0310: stloc.s 20
-		IL_0312: ldloc.s 17
-		IL_0314: ldloc.s 21
-		IL_0316: ldloc.s 20
-		IL_0318: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_031d: pop
+		IL_011c: ldstr "x"
+		IL_0121: ldstr "get"
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_012b: stloc.s 16
+		IL_012d: ldloc.s 14
+		IL_012f: ldstr "x"
+		IL_0134: ldloc.s 16
+		IL_0136: ldnull
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_013c: pop
+		IL_013d: ldloc.s 14
+		IL_013f: stloc.s 7
+		IL_0141: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0146: stloc.s 17
+		IL_0148: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_014d: stloc.s 13
+		IL_014f: ldloc.1
+		IL_0150: ldloc.s 13
+		IL_0152: ldc.r8 3
+		IL_015b: box [System.Runtime]System.Double
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0165: stloc.s 16
+		IL_0167: ldloc.s 17
+		IL_0169: ldloc.s 16
+		IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0170: pop
+		IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0176: stloc.s 17
+		IL_0178: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_017d: stloc.s 13
+		IL_017f: ldloc.2
+		IL_0180: ldloc.s 13
+		IL_0182: ldstr "abc"
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_018c: stloc.s 16
+		IL_018e: ldloc.s 17
+		IL_0190: ldloc.s 16
+		IL_0192: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0197: pop
+		IL_0198: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019d: stloc.s 17
+		IL_019f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01a4: stloc.s 13
+		IL_01a6: ldc.i4.3
+		IL_01a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01ac: dup
+		IL_01ad: ldc.r8 1
+		IL_01b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01bb: dup
+		IL_01bc: ldc.r8 2
+		IL_01c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01ca: dup
+		IL_01cb: ldc.r8 3
+		IL_01d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01d9: stloc.s 18
+		IL_01db: ldloc.3
+		IL_01dc: ldloc.s 13
+		IL_01de: ldloc.s 18
+		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_01e5: stloc.s 16
+		IL_01e7: ldloc.s 17
+		IL_01e9: ldloc.s 16
+		IL_01eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01f0: pop
+		IL_01f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f6: stloc.s 17
+		IL_01f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01fd: stloc.s 13
+		IL_01ff: ldc.i4.1
+		IL_0200: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0205: dup
+		IL_0206: ldc.r8 4
+		IL_020f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0214: stloc.s 18
+		IL_0216: ldloc.s 4
+		IL_0218: ldloc.s 13
+		IL_021a: ldloc.s 18
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0221: stloc.s 16
+		IL_0223: ldloc.s 17
+		IL_0225: ldloc.s 16
+		IL_0227: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_022c: pop
+		IL_022d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0232: stloc.s 17
+		IL_0234: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0239: stloc.s 13
+		IL_023b: ldc.i4.2
+		IL_023c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0241: dup
+		IL_0242: ldc.r8 5
+		IL_024b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0250: dup
+		IL_0251: ldc.r8 6
+		IL_025a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_025f: stloc.s 18
+		IL_0261: ldloc.s 18
+		IL_0263: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_0268: stloc.s 19
+		IL_026a: ldloc.s 5
+		IL_026c: ldloc.s 13
+		IL_026e: ldloc.s 19
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0275: stloc.s 16
+		IL_0277: ldloc.s 17
+		IL_0279: ldloc.s 16
+		IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0280: pop
+		IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0286: stloc.s 17
+		IL_0288: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_028d: stloc.s 13
+		IL_028f: ldloc.s 6
+		IL_0291: ldloc.s 13
+		IL_0293: ldc.r8 3
+		IL_029c: box [System.Runtime]System.Double
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_02a6: stloc.s 16
+		IL_02a8: ldloc.s 16
+		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02af: ldstr "join"
+		IL_02b4: ldstr ","
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02be: stloc.s 16
+		IL_02c0: ldloc.s 17
+		IL_02c2: ldloc.s 16
+		IL_02c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c9: pop
+		IL_02ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02cf: stloc.s 17
+		IL_02d1: ldloc.s 7
+		IL_02d3: ldstr "x"
+		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02dd: stloc.s 16
+		IL_02df: ldloc.s 7
+		IL_02e1: ldstr "x"
+		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02eb: stloc.s 20
+		IL_02ed: ldloc.s 16
+		IL_02ef: ldloc.s 20
+		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02f6: stloc.s 21
+		IL_02f8: ldloc.0
+		IL_02f9: ldfld object Modules.Function_SchedulerConversionsStableLoads/Scope::getterCount
+		IL_02fe: stloc.s 20
+		IL_0300: ldloc.s 17
+		IL_0302: ldloc.s 21
+		IL_0304: ldloc.s 20
+		IL_0306: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_030b: pop
 		.try
 		{
-			IL_031e: nop
-			IL_031f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0324: stloc.s 17
-			IL_0326: ldstr "Cannot access 'tdzValue' before initialization"
-			IL_032b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_0330: stloc.s 22
-			IL_0332: ldloc.s 22
-			IL_0334: isinst [System.Runtime]System.Exception
-			IL_0339: dup
-			IL_033a: brtrue IL_0348
+			IL_030c: nop
+			IL_030d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0312: stloc.s 17
+			IL_0314: ldstr "Cannot access 'tdzValue' before initialization"
+			IL_0319: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_031e: stloc.s 22
+			IL_0320: ldloc.s 22
+			IL_0322: isinst [System.Runtime]System.Exception
+			IL_0327: dup
+			IL_0328: brtrue IL_0336
 
-			IL_033f: pop
-			IL_0340: ldloc.s 22
-			IL_0342: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0347: throw
+			IL_032d: pop
+			IL_032e: ldloc.s 22
+			IL_0330: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0335: throw
 
-			IL_0348: throw
+			IL_0336: throw
 
-			IL_0349: ldnull
-			IL_034a: ldc.r8 1
-			IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0358: stloc.s 21
-			IL_035a: ldloc.s 17
-			IL_035c: ldloc.s 21
-			IL_035e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0363: pop
-			IL_0364: leave IL_03d5
+			IL_0337: ldnull
+			IL_0338: ldc.r8 1
+			IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0346: stloc.s 21
+			IL_0348: ldloc.s 17
+			IL_034a: ldloc.s 21
+			IL_034c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0351: pop
+			IL_0352: leave IL_03c3
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0369: stloc.s 8
-			IL_036b: ldloc.s 8
-			IL_036d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0372: dup
-			IL_0373: brtrue IL_0389
+			IL_0357: stloc.s 8
+			IL_0359: ldloc.s 8
+			IL_035b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0360: dup
+			IL_0361: brtrue IL_0377
 
-			IL_0378: pop
-			IL_0379: ldloc.s 8
-			IL_037b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0380: dup
-			IL_0381: brtrue IL_0395
+			IL_0366: pop
+			IL_0367: ldloc.s 8
+			IL_0369: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_036e: dup
+			IL_036f: brtrue IL_0383
 
-			IL_0386: pop
-			IL_0387: rethrow
+			IL_0374: pop
+			IL_0375: rethrow
 
-			IL_0389: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_038e: stloc.s 9
-			IL_0390: br IL_0397
+			IL_0377: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_037c: stloc.s 9
+			IL_037e: br IL_0385
 
-			IL_0395: stloc.s 9
+			IL_0383: stloc.s 9
 
-			IL_0397: ldloc.s 9
-			IL_0399: stloc.s 10
-			IL_039b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03a0: stloc.s 17
-			IL_03a2: ldloc.s 10
-			IL_03a4: stloc.s 20
-			IL_03a6: ldstr "ReferenceError"
-			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03b0: stloc.s 16
-			IL_03b2: ldloc.s 20
-			IL_03b4: ldloc.s 16
-			IL_03b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_03bb: stloc.s 23
-			IL_03bd: ldloc.s 23
-			IL_03bf: box [System.Runtime]System.Boolean
-			IL_03c4: stloc.s 24
-			IL_03c6: ldloc.s 17
-			IL_03c8: ldloc.s 24
-			IL_03ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03cf: pop
-			IL_03d0: leave IL_03d5
+			IL_0385: ldloc.s 9
+			IL_0387: stloc.s 10
+			IL_0389: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_038e: stloc.s 17
+			IL_0390: ldloc.s 10
+			IL_0392: stloc.s 20
+			IL_0394: ldstr "ReferenceError"
+			IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_039e: stloc.s 16
+			IL_03a0: ldloc.s 20
+			IL_03a2: ldloc.s 16
+			IL_03a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_03a9: stloc.s 23
+			IL_03ab: ldloc.s 23
+			IL_03ad: box [System.Runtime]System.Boolean
+			IL_03b2: stloc.s 24
+			IL_03b4: ldloc.s 17
+			IL_03b6: ldloc.s 24
+			IL_03b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03bd: pop
+			IL_03be: leave IL_03c3
 		} // end handler
 
-		IL_03d5: ldc.r8 2
-		IL_03de: stloc.s 11
-		IL_03e0: ldnull
-		IL_03e1: stloc.s 12
-		IL_03e3: ret
+		IL_03c3: ldc.r8 2
+		IL_03cc: stloc.s 11
+		IL_03ce: ldnull
+		IL_03cf: stloc.s 12
+		IL_03d1: ret
 	} // end of method Function_SchedulerConversionsStableLoads::__js_module_init__
 
 } // end of class Modules.Function_SchedulerConversionsStableLoads

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerGeneralRegions.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerGeneralRegions.verified.txt
@@ -1367,8 +1367,8 @@
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 337 (0x151)
-			.maxstack 13
+			// Code size: 309 (0x135)
+			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_SchedulerGeneralRegions/getter/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -1419,93 +1419,85 @@
 			IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14>(!!0)
 			IL_0057: stloc.s 5
 			IL_0059: ldloc.s 5
-			IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14>(!!0)
-			IL_0060: stloc.s 5
-			IL_0062: ldloc.s 5
-			IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14>(!!0)
-			IL_0069: stloc.s 5
-			IL_006b: ldloc.s 5
+			IL_005b: ldstr "x"
+			IL_0060: ldstr "get"
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+			IL_006a: stloc.s 6
+			IL_006c: ldloc.3
 			IL_006d: ldstr "x"
-			IL_0072: ldstr "get"
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-			IL_007c: stloc.s 6
-			IL_007e: ldloc.3
-			IL_007f: ldstr "x"
-			IL_0084: ldloc.s 6
-			IL_0086: ldnull
-			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-			IL_008c: pop
-			IL_008d: ldc.i4.2
-			IL_008e: newarr [System.Runtime]System.Object
-			IL_0093: dup
+			IL_0072: ldloc.s 6
+			IL_0074: ldnull
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+			IL_007a: pop
+			IL_007b: ldc.i4.2
+			IL_007c: newarr [System.Runtime]System.Object
+			IL_0081: dup
+			IL_0082: ldc.i4.0
+			IL_0083: ldarg.0
+			IL_0084: stelem.ref
+			IL_0085: dup
+			IL_0086: ldc.i4.1
+			IL_0087: ldloc.0
+			IL_0088: stelem.ref
+			IL_0089: stloc.s 4
+			IL_008b: ldloc.3
+			IL_008c: ldstr "x"
+			IL_0091: ldnull
+			IL_0092: ldloc.s 4
 			IL_0094: ldc.i4.0
-			IL_0095: ldarg.0
-			IL_0096: stelem.ref
-			IL_0097: dup
-			IL_0098: ldc.i4.1
-			IL_0099: ldloc.0
-			IL_009a: stelem.ref
-			IL_009b: stloc.s 4
-			IL_009d: ldloc.3
-			IL_009e: ldstr "x"
-			IL_00a3: ldnull
-			IL_00a4: ldloc.s 4
-			IL_00a6: ldc.i4.0
-			IL_00a7: ldelem.ref
-			IL_00a8: castclass Modules.Function_SchedulerGeneralRegions/Scope
-			IL_00ad: ldloc.s 4
-			IL_00af: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope, object[])
-			IL_00b4: ldc.i4.1
-			IL_00b5: conv.r8
-			IL_00b6: ldstr ""
-			IL_00bb: ldc.i4.1
-			IL_00bc: ldc.i4.1
-			IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0, float64, string, bool, bool)
-			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0)
-			IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0)
-			IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0)
-			IL_00d1: ldstr "x"
-			IL_00d6: ldstr "set"
-			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-			IL_00e5: pop
-			IL_00e6: ldloc.3
-			IL_00e7: stloc.1
-			IL_00e8: ldloc.1
-			IL_00e9: ldstr "x"
-			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f3: stloc.s 6
-			IL_00f5: ldloc.1
-			IL_00f6: ldstr "x"
-			IL_00fb: ldc.r8 2
-			IL_0104: ldc.i4.1
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_010a: stloc.s 7
-			IL_010c: ldloc.s 6
-			IL_010e: ldloc.s 7
-			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0115: stloc.s 8
-			IL_0117: ldloc.1
-			IL_0118: ldstr "x"
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0122: stloc.s 7
-			IL_0124: ldloc.s 8
-			IL_0126: ldloc.s 7
-			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_012d: stloc.2
-			IL_012e: ldloc.2
-			IL_012f: ldstr ","
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0139: stloc.s 8
-			IL_013b: ldarg.0
-			IL_013c: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::order
-			IL_0141: stloc.s 7
-			IL_0143: ldloc.s 8
-			IL_0145: ldloc.s 7
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_014c: stloc.s 8
-			IL_014e: ldloc.s 8
-			IL_0150: ret
+			IL_0095: ldelem.ref
+			IL_0096: castclass Modules.Function_SchedulerGeneralRegions/Scope
+			IL_009b: ldloc.s 4
+			IL_009d: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope, object[])
+			IL_00a2: ldc.i4.1
+			IL_00a3: conv.r8
+			IL_00a4: ldstr ""
+			IL_00a9: ldc.i4.1
+			IL_00aa: ldc.i4.1
+			IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0, float64, string, bool, bool)
+			IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0)
+			IL_00b5: ldstr "x"
+			IL_00ba: ldstr "set"
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+			IL_00c9: pop
+			IL_00ca: ldloc.3
+			IL_00cb: stloc.1
+			IL_00cc: ldloc.1
+			IL_00cd: ldstr "x"
+			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d7: stloc.s 6
+			IL_00d9: ldloc.1
+			IL_00da: ldstr "x"
+			IL_00df: ldc.r8 2
+			IL_00e8: ldc.i4.1
+			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_00ee: stloc.s 7
+			IL_00f0: ldloc.s 6
+			IL_00f2: ldloc.s 7
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00f9: stloc.s 8
+			IL_00fb: ldloc.1
+			IL_00fc: ldstr "x"
+			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0106: stloc.s 7
+			IL_0108: ldloc.s 8
+			IL_010a: ldloc.s 7
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0111: stloc.2
+			IL_0112: ldloc.2
+			IL_0113: ldstr ","
+			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_011d: stloc.s 8
+			IL_011f: ldarg.0
+			IL_0120: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::order
+			IL_0125: stloc.s 7
+			IL_0127: ldloc.s 8
+			IL_0129: ldloc.s 7
+			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0130: stloc.s 8
+			IL_0132: ldloc.s 8
+			IL_0134: ret
 		} // end of method getter::__js_call__
 
 	} // end of class getter

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
@@ -2448,7 +2448,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1322 (0x52a)
+		// Code size: 1317 (0x525)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerLiteralArguments/Scope,
@@ -2715,229 +2715,228 @@
 		IL_0214: ldc.i4.1
 		IL_0215: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22>(!!0, float64, string, bool, bool)
 		IL_021a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22>(!!0)
-		IL_021f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22>(!!0)
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_0229: pop
-		IL_022a: ldloc.0
-		IL_022b: ldloc.s 16
-		IL_022d: stfld object Modules.Function_SchedulerLiteralArguments/Scope::spread
-		IL_0232: nop
-		IL_0233: nop
-		IL_0234: nop
-		IL_0235: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_023a: stloc.s 17
-		IL_023c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0241: stloc.s 12
-		IL_0243: ldloc.1
-		IL_0244: ldloc.s 12
-		IL_0246: ldc.r8 2
-		IL_024f: box [System.Runtime]System.Double
-		IL_0254: ldc.r8 4
-		IL_025d: box [System.Runtime]System.Double
-		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0267: stloc.s 15
-		IL_0269: ldloc.s 17
-		IL_026b: ldloc.s 15
-		IL_026d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0272: pop
-		IL_0273: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0278: stloc.s 17
-		IL_027a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_027f: stloc.s 12
-		IL_0281: ldloc.2
-		IL_0282: ldloc.s 12
-		IL_0284: ldc.r8 2
-		IL_028d: box [System.Runtime]System.Double
-		IL_0292: ldc.r8 4
-		IL_029b: box [System.Runtime]System.Double
-		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02a5: stloc.s 15
-		IL_02a7: ldloc.s 15
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ae: ldstr "join"
-		IL_02b3: ldstr ","
-		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02bd: stloc.s 15
-		IL_02bf: ldloc.s 17
-		IL_02c1: ldloc.s 15
-		IL_02c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c8: pop
-		IL_02c9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02ce: stloc.s 12
-		IL_02d0: ldloc.3
-		IL_02d1: ldloc.s 12
-		IL_02d3: ldc.r8 2
-		IL_02dc: box [System.Runtime]System.Double
-		IL_02e1: ldc.r8 4
-		IL_02ea: box [System.Runtime]System.Double
-		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02f4: stloc.s 10
-		IL_02f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02fb: stloc.s 17
-		IL_02fd: ldloc.s 10
-		IL_02ff: ldstr "x"
-		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0309: stloc.s 15
-		IL_030b: ldloc.s 15
-		IL_030d: ldstr ","
-		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0317: stloc.s 18
-		IL_0319: ldloc.s 10
-		IL_031b: ldstr "y"
-		IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0325: stloc.s 15
-		IL_0327: ldloc.s 18
-		IL_0329: ldloc.s 15
-		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0330: stloc.s 18
-		IL_0332: ldloc.s 17
-		IL_0334: ldloc.s 18
-		IL_0336: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_033b: pop
-		IL_033c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0341: stloc.s 12
-		IL_0343: ldloc.s 4
-		IL_0345: ldloc.s 12
-		IL_0347: ldc.r8 2
-		IL_0350: box [System.Runtime]System.Double
-		IL_0355: ldc.r8 4
-		IL_035e: box [System.Runtime]System.Double
-		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0368: stloc.s 11
-		IL_036a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_036f: stloc.s 17
-		IL_0371: ldloc.s 11
-		IL_0373: ldc.r8 0.0
-		IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0381: stloc.s 15
-		IL_0383: ldloc.s 15
-		IL_0385: ldc.r8 0.0
-		IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0393: stloc.s 15
-		IL_0395: ldloc.s 15
-		IL_0397: ldstr ","
-		IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_03a1: stloc.s 18
-		IL_03a3: ldloc.s 11
-		IL_03a5: ldc.r8 1
-		IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03b3: stloc.s 15
-		IL_03b5: ldloc.s 15
-		IL_03b7: ldstr "y"
-		IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03c1: stloc.s 15
-		IL_03c3: ldloc.s 18
-		IL_03c5: ldloc.s 15
-		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_03cc: stloc.s 18
-		IL_03ce: ldloc.s 17
-		IL_03d0: ldloc.s 18
-		IL_03d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03d7: pop
-		IL_03d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03dd: stloc.s 17
-		IL_03df: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03e4: stloc.s 12
-		IL_03e6: ldloc.s 5
-		IL_03e8: ldloc.s 12
-		IL_03ea: ldc.i4.s 9
-		IL_03ec: newarr [System.Runtime]System.Object
-		IL_03f1: dup
-		IL_03f2: ldc.i4.0
-		IL_03f3: ldc.r8 1
-		IL_03fc: box [System.Runtime]System.Double
-		IL_0401: stelem.ref
-		IL_0402: dup
-		IL_0403: ldc.i4.1
-		IL_0404: ldc.r8 2
-		IL_040d: box [System.Runtime]System.Double
-		IL_0412: stelem.ref
-		IL_0413: dup
-		IL_0414: ldc.i4.2
-		IL_0415: ldc.r8 3
-		IL_041e: box [System.Runtime]System.Double
-		IL_0423: stelem.ref
-		IL_0424: dup
-		IL_0425: ldc.i4.3
-		IL_0426: ldc.r8 4
-		IL_042f: box [System.Runtime]System.Double
-		IL_0434: stelem.ref
-		IL_0435: dup
-		IL_0436: ldc.i4.4
-		IL_0437: ldc.r8 5
-		IL_0440: box [System.Runtime]System.Double
-		IL_0445: stelem.ref
-		IL_0446: dup
-		IL_0447: ldc.i4.5
-		IL_0448: ldc.r8 6
-		IL_0451: box [System.Runtime]System.Double
-		IL_0456: stelem.ref
-		IL_0457: dup
-		IL_0458: ldc.i4.6
-		IL_0459: ldc.r8 7
-		IL_0462: box [System.Runtime]System.Double
-		IL_0467: stelem.ref
-		IL_0468: dup
-		IL_0469: ldc.i4.7
-		IL_046a: ldc.r8 8
-		IL_0473: box [System.Runtime]System.Double
-		IL_0478: stelem.ref
-		IL_0479: dup
-		IL_047a: ldc.i4.8
-		IL_047b: ldc.r8 9
-		IL_0484: box [System.Runtime]System.Double
-		IL_0489: stelem.ref
-		IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_048f: stloc.s 15
-		IL_0491: ldloc.s 15
-		IL_0493: ldc.r8 0.0
-		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_04a1: stloc.s 15
-		IL_04a3: ldloc.s 17
-		IL_04a5: ldloc.s 15
-		IL_04a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04ac: pop
-		IL_04ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04b2: stloc.s 17
-		IL_04b4: ldloc.s 6
-		IL_04b6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_04c0: stloc.s 15
-		IL_04c2: ldloc.s 17
-		IL_04c4: ldloc.s 15
-		IL_04c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04cb: pop
-		IL_04cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04d1: stloc.s 17
-		IL_04d3: ldloc.s 7
-		IL_04d5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_04df: stloc.s 15
-		IL_04e1: ldloc.s 17
-		IL_04e3: ldloc.s 15
-		IL_04e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04ea: pop
-		IL_04eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04f0: stloc.s 17
-		IL_04f2: ldloc.s 8
-		IL_04f4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_04fe: stloc.s 15
-		IL_0500: ldloc.s 17
-		IL_0502: ldloc.s 15
-		IL_0504: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0509: pop
-		IL_050a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_050f: stloc.s 17
-		IL_0511: ldloc.s 9
-		IL_0513: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_051d: stloc.s 15
-		IL_051f: ldloc.s 17
-		IL_0521: ldloc.s 15
-		IL_0523: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0528: pop
-		IL_0529: ret
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0224: pop
+		IL_0225: ldloc.0
+		IL_0226: ldloc.s 16
+		IL_0228: stfld object Modules.Function_SchedulerLiteralArguments/Scope::spread
+		IL_022d: nop
+		IL_022e: nop
+		IL_022f: nop
+		IL_0230: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0235: stloc.s 17
+		IL_0237: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_023c: stloc.s 12
+		IL_023e: ldloc.1
+		IL_023f: ldloc.s 12
+		IL_0241: ldc.r8 2
+		IL_024a: box [System.Runtime]System.Double
+		IL_024f: ldc.r8 4
+		IL_0258: box [System.Runtime]System.Double
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0262: stloc.s 15
+		IL_0264: ldloc.s 17
+		IL_0266: ldloc.s 15
+		IL_0268: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_026d: pop
+		IL_026e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0273: stloc.s 17
+		IL_0275: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_027a: stloc.s 12
+		IL_027c: ldloc.2
+		IL_027d: ldloc.s 12
+		IL_027f: ldc.r8 2
+		IL_0288: box [System.Runtime]System.Double
+		IL_028d: ldc.r8 4
+		IL_0296: box [System.Runtime]System.Double
+		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02a0: stloc.s 15
+		IL_02a2: ldloc.s 15
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a9: ldstr "join"
+		IL_02ae: ldstr ","
+		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b8: stloc.s 15
+		IL_02ba: ldloc.s 17
+		IL_02bc: ldloc.s 15
+		IL_02be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c3: pop
+		IL_02c4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02c9: stloc.s 12
+		IL_02cb: ldloc.3
+		IL_02cc: ldloc.s 12
+		IL_02ce: ldc.r8 2
+		IL_02d7: box [System.Runtime]System.Double
+		IL_02dc: ldc.r8 4
+		IL_02e5: box [System.Runtime]System.Double
+		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02ef: stloc.s 10
+		IL_02f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02f6: stloc.s 17
+		IL_02f8: ldloc.s 10
+		IL_02fa: ldstr "x"
+		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0304: stloc.s 15
+		IL_0306: ldloc.s 15
+		IL_0308: ldstr ","
+		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0312: stloc.s 18
+		IL_0314: ldloc.s 10
+		IL_0316: ldstr "y"
+		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0320: stloc.s 15
+		IL_0322: ldloc.s 18
+		IL_0324: ldloc.s 15
+		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_032b: stloc.s 18
+		IL_032d: ldloc.s 17
+		IL_032f: ldloc.s 18
+		IL_0331: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0336: pop
+		IL_0337: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_033c: stloc.s 12
+		IL_033e: ldloc.s 4
+		IL_0340: ldloc.s 12
+		IL_0342: ldc.r8 2
+		IL_034b: box [System.Runtime]System.Double
+		IL_0350: ldc.r8 4
+		IL_0359: box [System.Runtime]System.Double
+		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0363: stloc.s 11
+		IL_0365: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_036a: stloc.s 17
+		IL_036c: ldloc.s 11
+		IL_036e: ldc.r8 0.0
+		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_037c: stloc.s 15
+		IL_037e: ldloc.s 15
+		IL_0380: ldc.r8 0.0
+		IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_038e: stloc.s 15
+		IL_0390: ldloc.s 15
+		IL_0392: ldstr ","
+		IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_039c: stloc.s 18
+		IL_039e: ldloc.s 11
+		IL_03a0: ldc.r8 1
+		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_03ae: stloc.s 15
+		IL_03b0: ldloc.s 15
+		IL_03b2: ldstr "y"
+		IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03bc: stloc.s 15
+		IL_03be: ldloc.s 18
+		IL_03c0: ldloc.s 15
+		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03c7: stloc.s 18
+		IL_03c9: ldloc.s 17
+		IL_03cb: ldloc.s 18
+		IL_03cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03d2: pop
+		IL_03d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03d8: stloc.s 17
+		IL_03da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03df: stloc.s 12
+		IL_03e1: ldloc.s 5
+		IL_03e3: ldloc.s 12
+		IL_03e5: ldc.i4.s 9
+		IL_03e7: newarr [System.Runtime]System.Object
+		IL_03ec: dup
+		IL_03ed: ldc.i4.0
+		IL_03ee: ldc.r8 1
+		IL_03f7: box [System.Runtime]System.Double
+		IL_03fc: stelem.ref
+		IL_03fd: dup
+		IL_03fe: ldc.i4.1
+		IL_03ff: ldc.r8 2
+		IL_0408: box [System.Runtime]System.Double
+		IL_040d: stelem.ref
+		IL_040e: dup
+		IL_040f: ldc.i4.2
+		IL_0410: ldc.r8 3
+		IL_0419: box [System.Runtime]System.Double
+		IL_041e: stelem.ref
+		IL_041f: dup
+		IL_0420: ldc.i4.3
+		IL_0421: ldc.r8 4
+		IL_042a: box [System.Runtime]System.Double
+		IL_042f: stelem.ref
+		IL_0430: dup
+		IL_0431: ldc.i4.4
+		IL_0432: ldc.r8 5
+		IL_043b: box [System.Runtime]System.Double
+		IL_0440: stelem.ref
+		IL_0441: dup
+		IL_0442: ldc.i4.5
+		IL_0443: ldc.r8 6
+		IL_044c: box [System.Runtime]System.Double
+		IL_0451: stelem.ref
+		IL_0452: dup
+		IL_0453: ldc.i4.6
+		IL_0454: ldc.r8 7
+		IL_045d: box [System.Runtime]System.Double
+		IL_0462: stelem.ref
+		IL_0463: dup
+		IL_0464: ldc.i4.7
+		IL_0465: ldc.r8 8
+		IL_046e: box [System.Runtime]System.Double
+		IL_0473: stelem.ref
+		IL_0474: dup
+		IL_0475: ldc.i4.8
+		IL_0476: ldc.r8 9
+		IL_047f: box [System.Runtime]System.Double
+		IL_0484: stelem.ref
+		IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_048a: stloc.s 15
+		IL_048c: ldloc.s 15
+		IL_048e: ldc.r8 0.0
+		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_049c: stloc.s 15
+		IL_049e: ldloc.s 17
+		IL_04a0: ldloc.s 15
+		IL_04a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04a7: pop
+		IL_04a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04ad: stloc.s 17
+		IL_04af: ldloc.s 6
+		IL_04b1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_04bb: stloc.s 15
+		IL_04bd: ldloc.s 17
+		IL_04bf: ldloc.s 15
+		IL_04c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04c6: pop
+		IL_04c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04cc: stloc.s 17
+		IL_04ce: ldloc.s 7
+		IL_04d0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_04da: stloc.s 15
+		IL_04dc: ldloc.s 17
+		IL_04de: ldloc.s 15
+		IL_04e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04e5: pop
+		IL_04e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04eb: stloc.s 17
+		IL_04ed: ldloc.s 8
+		IL_04ef: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_04f9: stloc.s 15
+		IL_04fb: ldloc.s 17
+		IL_04fd: ldloc.s 15
+		IL_04ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0504: pop
+		IL_0505: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_050a: stloc.s 17
+		IL_050c: ldloc.s 9
+		IL_050e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0518: stloc.s 15
+		IL_051a: ldloc.s 17
+		IL_051c: ldloc.s 15
+		IL_051e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0523: pop
+		IL_0524: ret
 	} // end of method Function_SchedulerLiteralArguments::__js_module_init__
 
 } // end of class Modules.Function_SchedulerLiteralArguments

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_GeneratedFunctionObject_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_GeneratedFunctionObject_Semantics.verified.txt
@@ -3355,7 +3355,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 3244 (0xcac)
+		// Code size: 3234 (0xca2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_GeneratedFunctionObject_Semantics/Scope,
@@ -4000,513 +4000,511 @@
 		IL_0678: ldc.i4.1
 		IL_0679: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_B1A67D8B_GeneratorClass_callRun>(!!0, float64, string, bool, bool)
 		IL_067e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_B1A67D8B_GeneratorClass_callRun>(!!0)
-		IL_0683: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_B1A67D8B_GeneratorClass_callRun>(!!0)
-		IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_068d: pop
-		IL_068e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0693: stloc.s 29
-		IL_0695: ldloc.s 44
-		IL_0697: ldstr "twice"
-		IL_069c: ldloc.s 29
-		IL_069e: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice::.ctor(object[])
-		IL_06a3: ldc.i4.1
-		IL_06a4: conv.r8
-		IL_06a5: ldstr "twice"
-		IL_06aa: ldc.i4.1
-		IL_06ab: ldc.i4.1
-		IL_06ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice>(!!0, float64, string, bool, bool)
-		IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_06b6: castclass Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice
-		IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_06c0: pop
-		IL_06c1: ldc.i4.1
-		IL_06c2: newarr [System.Runtime]System.Object
-		IL_06c7: dup
-		IL_06c8: ldc.i4.0
-		IL_06c9: ldloc.0
-		IL_06ca: stelem.ref
-		IL_06cb: stloc.s 29
-		IL_06cd: ldloc.s 44
-		IL_06cf: ldloc.s 29
-		IL_06d1: ldc.r8 1
-		IL_06da: box [System.Runtime]System.Double
-		IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_06e4: stloc.s 35
-		IL_06e6: ldloc.s 35
-		IL_06e8: stloc.s 17
-		IL_06ea: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
-		IL_06ef: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_06f4: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
-		IL_06f9: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_06fe: stloc.s 44
-		IL_0700: ldloc.s 44
-		IL_0702: ldstr "prototype"
-		IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_070c: stloc.s 35
-		IL_070e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0713: stloc.s 29
-		IL_0715: ldloc.s 35
-		IL_0717: ldstr "callSuper"
-		IL_071c: ldloc.s 35
-		IL_071e: ldloc.s 29
-		IL_0720: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::.ctor(class [System.Runtime]System.Object, object[])
-		IL_0725: ldc.i4.1
-		IL_0726: conv.r8
-		IL_0727: ldstr "callSuper"
-		IL_072c: ldc.i4.1
-		IL_072d: ldc.i4.1
-		IL_072e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper>(!!0, float64, string, bool, bool)
-		IL_0733: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper>(!!0)
-		IL_0738: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper>(!!0)
-		IL_073d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0742: pop
-		IL_0743: ldc.i4.1
-		IL_0744: newarr [System.Runtime]System.Object
-		IL_0749: dup
-		IL_074a: ldc.i4.0
-		IL_074b: ldloc.0
-		IL_074c: stelem.ref
-		IL_074d: stloc.s 29
-		IL_074f: ldloc.s 44
-		IL_0751: ldloc.s 29
-		IL_0753: ldc.r8 0.0
-		IL_075c: box [System.Runtime]System.Double
-		IL_0761: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0766: stloc.s 35
-		IL_0768: ldloc.s 35
-		IL_076a: ldloc.s 17
-		IL_076c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0771: stloc.s 35
-		IL_0773: ldloc.s 35
-		IL_0775: stloc.s 18
-		IL_0777: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_077c: stloc.s 31
-		IL_077e: ldloc.s 16
-		IL_0780: isinst Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
-		IL_0785: dup
-		IL_0786: brfalse IL_07b0
+		IL_0683: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0688: pop
+		IL_0689: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_068e: stloc.s 29
+		IL_0690: ldloc.s 44
+		IL_0692: ldstr "twice"
+		IL_0697: ldloc.s 29
+		IL_0699: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice::.ctor(object[])
+		IL_069e: ldc.i4.1
+		IL_069f: conv.r8
+		IL_06a0: ldstr "twice"
+		IL_06a5: ldc.i4.1
+		IL_06a6: ldc.i4.1
+		IL_06a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice>(!!0, float64, string, bool, bool)
+		IL_06ac: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
+		IL_06b1: castclass Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice
+		IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_06bb: pop
+		IL_06bc: ldc.i4.1
+		IL_06bd: newarr [System.Runtime]System.Object
+		IL_06c2: dup
+		IL_06c3: ldc.i4.0
+		IL_06c4: ldloc.0
+		IL_06c5: stelem.ref
+		IL_06c6: stloc.s 29
+		IL_06c8: ldloc.s 44
+		IL_06ca: ldloc.s 29
+		IL_06cc: ldc.r8 1
+		IL_06d5: box [System.Runtime]System.Double
+		IL_06da: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_06df: stloc.s 35
+		IL_06e1: ldloc.s 35
+		IL_06e3: stloc.s 17
+		IL_06e5: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
+		IL_06ea: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_06ef: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
+		IL_06f4: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_06f9: stloc.s 44
+		IL_06fb: ldloc.s 44
+		IL_06fd: ldstr "prototype"
+		IL_0702: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0707: stloc.s 35
+		IL_0709: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_070e: stloc.s 29
+		IL_0710: ldloc.s 35
+		IL_0712: ldstr "callSuper"
+		IL_0717: ldloc.s 35
+		IL_0719: ldloc.s 29
+		IL_071b: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::.ctor(class [System.Runtime]System.Object, object[])
+		IL_0720: ldc.i4.1
+		IL_0721: conv.r8
+		IL_0722: ldstr "callSuper"
+		IL_0727: ldc.i4.1
+		IL_0728: ldc.i4.1
+		IL_0729: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper>(!!0, float64, string, bool, bool)
+		IL_072e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper>(!!0)
+		IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0738: pop
+		IL_0739: ldc.i4.1
+		IL_073a: newarr [System.Runtime]System.Object
+		IL_073f: dup
+		IL_0740: ldc.i4.0
+		IL_0741: ldloc.0
+		IL_0742: stelem.ref
+		IL_0743: stloc.s 29
+		IL_0745: ldloc.s 44
+		IL_0747: ldloc.s 29
+		IL_0749: ldc.r8 0.0
+		IL_0752: box [System.Runtime]System.Double
+		IL_0757: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_075c: stloc.s 35
+		IL_075e: ldloc.s 35
+		IL_0760: ldloc.s 17
+		IL_0762: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_0767: stloc.s 35
+		IL_0769: ldloc.s 35
+		IL_076b: stloc.s 18
+		IL_076d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0772: stloc.s 31
+		IL_0774: ldloc.s 16
+		IL_0776: isinst Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
+		IL_077b: dup
+		IL_077c: brfalse IL_07a6
 
-		IL_078b: ldc.i4.1
-		IL_078c: newarr [System.Runtime]System.Object
-		IL_0791: dup
-		IL_0792: ldc.i4.0
-		IL_0793: ldloc.0
-		IL_0794: stelem.ref
-		IL_0795: ldnull
-		IL_0796: ldc.r8 3
-		IL_079f: box [System.Runtime]System.Double
-		IL_07a4: callvirt instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::run(object[], object, object)
-		IL_07a9: stloc.s 35
-		IL_07ab: br IL_07cd
+		IL_0781: ldc.i4.1
+		IL_0782: newarr [System.Runtime]System.Object
+		IL_0787: dup
+		IL_0788: ldc.i4.0
+		IL_0789: ldloc.0
+		IL_078a: stelem.ref
+		IL_078b: ldnull
+		IL_078c: ldc.r8 3
+		IL_0795: box [System.Runtime]System.Double
+		IL_079a: callvirt instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::run(object[], object, object)
+		IL_079f: stloc.s 35
+		IL_07a1: br IL_07c3
 
-		IL_07b0: pop
-		IL_07b1: ldloc.s 16
-		IL_07b3: ldstr "run"
-		IL_07b8: ldc.r8 3
-		IL_07c1: box [System.Runtime]System.Double
-		IL_07c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07cb: stloc.s 35
+		IL_07a6: pop
+		IL_07a7: ldloc.s 16
+		IL_07a9: ldstr "run"
+		IL_07ae: ldc.r8 3
+		IL_07b7: box [System.Runtime]System.Double
+		IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07c1: stloc.s 35
 
-		IL_07cd: ldloc.s 35
-		IL_07cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07d4: ldstr "next"
-		IL_07d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_07de: stloc.s 35
-		IL_07e0: ldloc.s 35
-		IL_07e2: ldstr "value"
-		IL_07e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07ec: stloc.s 35
-		IL_07ee: ldc.i4.1
-		IL_07ef: newarr [System.Runtime]System.Object
-		IL_07f4: dup
-		IL_07f5: ldc.i4.0
-		IL_07f6: ldc.r8 40
-		IL_07ff: box [System.Runtime]System.Double
-		IL_0804: stelem.ref
-		IL_0805: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_080a: ldc.r8 40
-		IL_0813: box [System.Runtime]System.Double
-		IL_0818: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::.ctor(object)
-		IL_081d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0822: stloc.s 45
-		IL_0824: ldloc.s 45
-		IL_0826: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
-		IL_082b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0830: ldstr "prototype"
-		IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_083a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_083f: ldloc.s 45
-		IL_0841: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0846: stloc.s 36
-		IL_0848: ldloc.s 36
-		IL_084a: isinst Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
-		IL_084f: dup
-		IL_0850: brfalse IL_087a
+		IL_07c3: ldloc.s 35
+		IL_07c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07ca: ldstr "next"
+		IL_07cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_07d4: stloc.s 35
+		IL_07d6: ldloc.s 35
+		IL_07d8: ldstr "value"
+		IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07e2: stloc.s 35
+		IL_07e4: ldc.i4.1
+		IL_07e5: newarr [System.Runtime]System.Object
+		IL_07ea: dup
+		IL_07eb: ldc.i4.0
+		IL_07ec: ldc.r8 40
+		IL_07f5: box [System.Runtime]System.Double
+		IL_07fa: stelem.ref
+		IL_07fb: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0800: ldc.r8 40
+		IL_0809: box [System.Runtime]System.Double
+		IL_080e: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::.ctor(object)
+		IL_0813: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0818: stloc.s 45
+		IL_081a: ldloc.s 45
+		IL_081c: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
+		IL_0821: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0826: ldstr "prototype"
+		IL_082b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0830: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0835: ldloc.s 45
+		IL_0837: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_083c: stloc.s 36
+		IL_083e: ldloc.s 36
+		IL_0840: isinst Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
+		IL_0845: dup
+		IL_0846: brfalse IL_0870
 
-		IL_0855: ldc.i4.1
-		IL_0856: newarr [System.Runtime]System.Object
-		IL_085b: dup
-		IL_085c: ldc.i4.0
-		IL_085d: ldloc.0
-		IL_085e: stelem.ref
-		IL_085f: ldnull
-		IL_0860: ldc.r8 4
-		IL_0869: box [System.Runtime]System.Double
-		IL_086e: callvirt instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::run(object[], object, object)
-		IL_0873: stloc.s 36
-		IL_0875: br IL_0897
+		IL_084b: ldc.i4.1
+		IL_084c: newarr [System.Runtime]System.Object
+		IL_0851: dup
+		IL_0852: ldc.i4.0
+		IL_0853: ldloc.0
+		IL_0854: stelem.ref
+		IL_0855: ldnull
+		IL_0856: ldc.r8 4
+		IL_085f: box [System.Runtime]System.Double
+		IL_0864: callvirt instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::run(object[], object, object)
+		IL_0869: stloc.s 36
+		IL_086b: br IL_088d
 
-		IL_087a: pop
-		IL_087b: ldloc.s 36
-		IL_087d: ldstr "run"
-		IL_0882: ldc.r8 4
-		IL_088b: box [System.Runtime]System.Double
-		IL_0890: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0895: stloc.s 36
+		IL_0870: pop
+		IL_0871: ldloc.s 36
+		IL_0873: ldstr "run"
+		IL_0878: ldc.r8 4
+		IL_0881: box [System.Runtime]System.Double
+		IL_0886: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_088b: stloc.s 36
 
-		IL_0897: ldloc.s 36
-		IL_0899: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_089e: ldstr "next"
-		IL_08a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_08a8: stloc.s 36
-		IL_08aa: ldloc.s 36
-		IL_08ac: ldstr "value"
-		IL_08b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08b6: stloc.s 36
-		IL_08b8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_08bd: stloc.s 29
-		IL_08bf: ldloc.s 17
-		IL_08c1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
-		IL_08c6: stloc.s 34
-		IL_08c8: ldloc.s 29
-		IL_08ca: ldnull
-		IL_08cb: ldc.r8 5
-		IL_08d4: box [System.Runtime]System.Double
-		IL_08d9: call object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::twice(object[], object, object)
-		IL_08de: stloc.s 33
-		IL_08e0: ldloc.s 33
-		IL_08e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08e7: ldstr "next"
-		IL_08ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_08f1: stloc.s 33
-		IL_08f3: ldloc.s 33
-		IL_08f5: ldstr "value"
-		IL_08fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08ff: stloc.s 33
-		IL_0901: ldloc.s 16
-		IL_0903: ldstr "run"
-		IL_0908: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_090d: stloc.s 34
-		IL_090f: ldloc.s 34
-		IL_0911: ldstr "prototype"
-		IL_0916: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_091b: box [System.Runtime]System.Boolean
-		IL_0920: stloc.s 41
-		IL_0922: ldloc.s 17
-		IL_0924: ldstr "prototype"
-		IL_0929: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_092e: stloc.s 34
-		IL_0930: ldloc.s 34
-		IL_0932: ldstr "run"
-		IL_0937: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_093c: stloc.s 34
-		IL_093e: ldloc.s 34
-		IL_0940: ldstr "prototype"
-		IL_0945: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_094a: box [System.Runtime]System.Boolean
-		IL_094f: stloc.s 39
-		IL_0951: ldloc.s 17
-		IL_0953: ldstr "twice"
-		IL_0958: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_095d: stloc.s 34
-		IL_095f: ldloc.s 34
-		IL_0961: ldstr "prototype"
-		IL_0966: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_096b: box [System.Runtime]System.Boolean
-		IL_0970: stloc.s 38
-		IL_0972: ldloc.s 31
-		IL_0974: ldc.i4.7
-		IL_0975: newarr [System.Runtime]System.Object
-		IL_097a: dup
-		IL_097b: ldc.i4.0
-		IL_097c: ldstr "methods"
+		IL_088d: ldloc.s 36
+		IL_088f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0894: ldstr "next"
+		IL_0899: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_089e: stloc.s 36
+		IL_08a0: ldloc.s 36
+		IL_08a2: ldstr "value"
+		IL_08a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08ac: stloc.s 36
+		IL_08ae: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_08b3: stloc.s 29
+		IL_08b5: ldloc.s 17
+		IL_08b7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_08bc: stloc.s 34
+		IL_08be: ldloc.s 29
+		IL_08c0: ldnull
+		IL_08c1: ldc.r8 5
+		IL_08ca: box [System.Runtime]System.Double
+		IL_08cf: call object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::twice(object[], object, object)
+		IL_08d4: stloc.s 33
+		IL_08d6: ldloc.s 33
+		IL_08d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08dd: ldstr "next"
+		IL_08e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_08e7: stloc.s 33
+		IL_08e9: ldloc.s 33
+		IL_08eb: ldstr "value"
+		IL_08f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08f5: stloc.s 33
+		IL_08f7: ldloc.s 16
+		IL_08f9: ldstr "run"
+		IL_08fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0903: stloc.s 34
+		IL_0905: ldloc.s 34
+		IL_0907: ldstr "prototype"
+		IL_090c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0911: box [System.Runtime]System.Boolean
+		IL_0916: stloc.s 41
+		IL_0918: ldloc.s 17
+		IL_091a: ldstr "prototype"
+		IL_091f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0924: stloc.s 34
+		IL_0926: ldloc.s 34
+		IL_0928: ldstr "run"
+		IL_092d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0932: stloc.s 34
+		IL_0934: ldloc.s 34
+		IL_0936: ldstr "prototype"
+		IL_093b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0940: box [System.Runtime]System.Boolean
+		IL_0945: stloc.s 39
+		IL_0947: ldloc.s 17
+		IL_0949: ldstr "twice"
+		IL_094e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0953: stloc.s 34
+		IL_0955: ldloc.s 34
+		IL_0957: ldstr "prototype"
+		IL_095c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0961: box [System.Runtime]System.Boolean
+		IL_0966: stloc.s 38
+		IL_0968: ldloc.s 31
+		IL_096a: ldc.i4.7
+		IL_096b: newarr [System.Runtime]System.Object
+		IL_0970: dup
+		IL_0971: ldc.i4.0
+		IL_0972: ldstr "methods"
+		IL_0977: stelem.ref
+		IL_0978: dup
+		IL_0979: ldc.i4.1
+		IL_097a: ldloc.s 35
+		IL_097c: stelem.ref
+		IL_097d: dup
+		IL_097e: ldc.i4.2
+		IL_097f: ldloc.s 36
 		IL_0981: stelem.ref
 		IL_0982: dup
-		IL_0983: ldc.i4.1
-		IL_0984: ldloc.s 35
+		IL_0983: ldc.i4.3
+		IL_0984: ldloc.s 33
 		IL_0986: stelem.ref
 		IL_0987: dup
-		IL_0988: ldc.i4.2
-		IL_0989: ldloc.s 36
+		IL_0988: ldc.i4.4
+		IL_0989: ldloc.s 41
 		IL_098b: stelem.ref
 		IL_098c: dup
-		IL_098d: ldc.i4.3
-		IL_098e: ldloc.s 33
+		IL_098d: ldc.i4.5
+		IL_098e: ldloc.s 39
 		IL_0990: stelem.ref
 		IL_0991: dup
-		IL_0992: ldc.i4.4
-		IL_0993: ldloc.s 41
+		IL_0992: ldc.i4.6
+		IL_0993: ldloc.s 38
 		IL_0995: stelem.ref
-		IL_0996: dup
-		IL_0997: ldc.i4.5
-		IL_0998: ldloc.s 39
-		IL_099a: stelem.ref
-		IL_099b: dup
-		IL_099c: ldc.i4.6
-		IL_099d: ldloc.s 38
-		IL_099f: stelem.ref
-		IL_09a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_09a5: pop
-		IL_09a6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_09ab: stloc.s 19
-		IL_09ad: ldloc.s 17
-		IL_09af: ldstr "prototype"
-		IL_09b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09b9: stloc.s 33
-		IL_09bb: ldloc.s 33
-		IL_09bd: ldstr "run"
-		IL_09c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09c7: stloc.s 33
-		IL_09c9: ldloc.s 33
-		IL_09cb: ldstr "prototype"
-		IL_09d0: ldloc.s 19
-		IL_09d2: ldc.i4.0
-		IL_09d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_09d8: pop
-		IL_09d9: ldc.i4.1
-		IL_09da: newarr [System.Runtime]System.Object
-		IL_09df: dup
-		IL_09e0: ldc.i4.0
-		IL_09e1: ldc.r8 50
-		IL_09ea: box [System.Runtime]System.Double
-		IL_09ef: stelem.ref
-		IL_09f0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_09f5: ldc.r8 50
-		IL_09fe: box [System.Runtime]System.Double
-		IL_0a03: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::.ctor(object)
-		IL_0a08: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0a0d: stloc.s 20
-		IL_0a0f: ldloc.s 20
-		IL_0a11: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
-		IL_0a16: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0a1b: ldstr "prototype"
-		IL_0a20: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0a25: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0a2a: ldc.i4.1
-		IL_0a2b: newarr [System.Runtime]System.Object
-		IL_0a30: dup
-		IL_0a31: ldc.i4.0
-		IL_0a32: ldc.r8 60
-		IL_0a3b: box [System.Runtime]System.Double
-		IL_0a40: stelem.ref
-		IL_0a41: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0a46: ldloc.s 18
-		IL_0a48: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_0a4d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0a52: ldc.r8 60
-		IL_0a5b: box [System.Runtime]System.Double
-		IL_0a60: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass::.ctor(object)
-		IL_0a65: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_0a6a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0a6f: dup
-		IL_0a70: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
-		IL_0a75: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0a7a: ldstr "prototype"
-		IL_0a7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0a84: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0a89: stloc.s 21
-		IL_0a8b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0a90: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_0a95: stloc.s 21
-		IL_0a97: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_0a9c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0aa1: stloc.s 31
-		IL_0aa3: ldloc.s 20
-		IL_0aa5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass>(!!0)
-		IL_0aaa: stloc.s 45
-		IL_0aac: ldloc.s 45
-		IL_0aae: ldc.r8 6
-		IL_0ab7: box [System.Runtime]System.Double
-		IL_0abc: callvirt instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::callRun(object)
-		IL_0ac1: stloc.s 33
-		IL_0ac3: ldloc.s 33
-		IL_0ac5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0aca: stloc.s 33
-		IL_0acc: ldloc.s 33
-		IL_0ace: ldloc.s 19
-		IL_0ad0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0ad5: stloc.s 37
-		IL_0ad7: ldloc.s 37
-		IL_0ad9: box [System.Runtime]System.Boolean
-		IL_0ade: stloc.s 38
-		IL_0ae0: ldloc.s 21
-		IL_0ae2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0ae7: stloc.s 33
-		IL_0ae9: ldloc.s 33
-		IL_0aeb: isinst Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
-		IL_0af0: dup
-		IL_0af1: brfalse IL_0b10
+		IL_0996: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_099b: pop
+		IL_099c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_09a1: stloc.s 19
+		IL_09a3: ldloc.s 17
+		IL_09a5: ldstr "prototype"
+		IL_09aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09af: stloc.s 33
+		IL_09b1: ldloc.s 33
+		IL_09b3: ldstr "run"
+		IL_09b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09bd: stloc.s 33
+		IL_09bf: ldloc.s 33
+		IL_09c1: ldstr "prototype"
+		IL_09c6: ldloc.s 19
+		IL_09c8: ldc.i4.0
+		IL_09c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_09ce: pop
+		IL_09cf: ldc.i4.1
+		IL_09d0: newarr [System.Runtime]System.Object
+		IL_09d5: dup
+		IL_09d6: ldc.i4.0
+		IL_09d7: ldc.r8 50
+		IL_09e0: box [System.Runtime]System.Double
+		IL_09e5: stelem.ref
+		IL_09e6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_09eb: ldc.r8 50
+		IL_09f4: box [System.Runtime]System.Double
+		IL_09f9: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::.ctor(object)
+		IL_09fe: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0a03: stloc.s 20
+		IL_0a05: ldloc.s 20
+		IL_0a07: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
+		IL_0a0c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0a11: ldstr "prototype"
+		IL_0a16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0a1b: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0a20: ldc.i4.1
+		IL_0a21: newarr [System.Runtime]System.Object
+		IL_0a26: dup
+		IL_0a27: ldc.i4.0
+		IL_0a28: ldc.r8 60
+		IL_0a31: box [System.Runtime]System.Double
+		IL_0a36: stelem.ref
+		IL_0a37: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0a3c: ldloc.s 18
+		IL_0a3e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0a43: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0a48: ldc.r8 60
+		IL_0a51: box [System.Runtime]System.Double
+		IL_0a56: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass::.ctor(object)
+		IL_0a5b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_0a60: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0a65: dup
+		IL_0a66: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
+		IL_0a6b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0a70: ldstr "prototype"
+		IL_0a75: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0a7a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0a7f: stloc.s 21
+		IL_0a81: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0a86: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0a8b: stloc.s 21
+		IL_0a8d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_0a92: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0a97: stloc.s 31
+		IL_0a99: ldloc.s 20
+		IL_0a9b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass>(!!0)
+		IL_0aa0: stloc.s 45
+		IL_0aa2: ldloc.s 45
+		IL_0aa4: ldc.r8 6
+		IL_0aad: box [System.Runtime]System.Double
+		IL_0ab2: callvirt instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::callRun(object)
+		IL_0ab7: stloc.s 33
+		IL_0ab9: ldloc.s 33
+		IL_0abb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0ac0: stloc.s 33
+		IL_0ac2: ldloc.s 33
+		IL_0ac4: ldloc.s 19
+		IL_0ac6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0acb: stloc.s 37
+		IL_0acd: ldloc.s 37
+		IL_0acf: box [System.Runtime]System.Boolean
+		IL_0ad4: stloc.s 38
+		IL_0ad6: ldloc.s 21
+		IL_0ad8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0add: stloc.s 33
+		IL_0adf: ldloc.s 33
+		IL_0ae1: isinst Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
+		IL_0ae6: dup
+		IL_0ae7: brfalse IL_0b06
 
-		IL_0af6: ldc.r8 7
-		IL_0aff: box [System.Runtime]System.Double
-		IL_0b04: callvirt instance object Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass::callSuper(object)
-		IL_0b09: stloc.s 33
-		IL_0b0b: br IL_0b2d
+		IL_0aec: ldc.r8 7
+		IL_0af5: box [System.Runtime]System.Double
+		IL_0afa: callvirt instance object Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass::callSuper(object)
+		IL_0aff: stloc.s 33
+		IL_0b01: br IL_0b23
 
-		IL_0b10: pop
-		IL_0b11: ldloc.s 33
-		IL_0b13: ldstr "callSuper"
-		IL_0b18: ldc.r8 7
-		IL_0b21: box [System.Runtime]System.Double
-		IL_0b26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0b2b: stloc.s 33
+		IL_0b06: pop
+		IL_0b07: ldloc.s 33
+		IL_0b09: ldstr "callSuper"
+		IL_0b0e: ldc.r8 7
+		IL_0b17: box [System.Runtime]System.Double
+		IL_0b1c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0b21: stloc.s 33
 
-		IL_0b2d: ldloc.s 33
-		IL_0b2f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0b34: stloc.s 33
-		IL_0b36: ldloc.s 33
-		IL_0b38: ldloc.s 19
-		IL_0b3a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0b3f: stloc.s 37
-		IL_0b41: ldloc.s 37
-		IL_0b43: box [System.Runtime]System.Boolean
-		IL_0b48: stloc.s 39
-		IL_0b4a: ldloc.s 31
-		IL_0b4c: ldstr "internalMethods"
-		IL_0b51: ldloc.s 38
-		IL_0b53: ldloc.s 39
-		IL_0b55: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0b5a: pop
-		IL_0b5b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0b60: stloc.s 22
-		IL_0b62: ldloc.0
-		IL_0b63: ldfld object Modules.Generator_GeneratedFunctionObject_Semantics/Scope::expression
-		IL_0b68: stloc.s 33
-		IL_0b6a: ldloc.s 33
-		IL_0b6c: ldstr "prototype"
-		IL_0b71: ldloc.s 22
-		IL_0b73: ldc.i4.0
-		IL_0b74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0b79: pop
-		IL_0b7a: nop
-		IL_0b7b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0b80: stloc.s 31
-		IL_0b82: ldloc.0
-		IL_0b83: castclass Modules.Generator_GeneratedFunctionObject_Semantics/Scope
-		IL_0b88: ldnull
-		IL_0b89: call object Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator::__js_call__(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope, object)
-		IL_0b8e: stloc.s 33
-		IL_0b90: ldloc.s 33
-		IL_0b92: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0b97: stloc.s 33
-		IL_0b99: ldloc.s 33
-		IL_0b9b: ldloc.s 22
-		IL_0b9d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0ba2: stloc.s 37
-		IL_0ba4: ldloc.s 37
-		IL_0ba6: box [System.Runtime]System.Boolean
-		IL_0bab: stloc.s 39
-		IL_0bad: ldloc.s 31
-		IL_0baf: ldstr "tail"
-		IL_0bb4: ldloc.s 39
-		IL_0bb6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0bbb: pop
-		IL_0bbc: nop
-		IL_0bbd: ldc.i4.0
-		IL_0bbe: stloc.s 23
-		IL_0bc0: ldc.i4.0
-		IL_0bc1: box [System.Runtime]System.Boolean
-		IL_0bc6: stloc.s 24
+		IL_0b23: ldloc.s 33
+		IL_0b25: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0b2a: stloc.s 33
+		IL_0b2c: ldloc.s 33
+		IL_0b2e: ldloc.s 19
+		IL_0b30: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0b35: stloc.s 37
+		IL_0b37: ldloc.s 37
+		IL_0b39: box [System.Runtime]System.Boolean
+		IL_0b3e: stloc.s 39
+		IL_0b40: ldloc.s 31
+		IL_0b42: ldstr "internalMethods"
+		IL_0b47: ldloc.s 38
+		IL_0b49: ldloc.s 39
+		IL_0b4b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0b50: pop
+		IL_0b51: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0b56: stloc.s 22
+		IL_0b58: ldloc.0
+		IL_0b59: ldfld object Modules.Generator_GeneratedFunctionObject_Semantics/Scope::expression
+		IL_0b5e: stloc.s 33
+		IL_0b60: ldloc.s 33
+		IL_0b62: ldstr "prototype"
+		IL_0b67: ldloc.s 22
+		IL_0b69: ldc.i4.0
+		IL_0b6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0b6f: pop
+		IL_0b70: nop
+		IL_0b71: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0b76: stloc.s 31
+		IL_0b78: ldloc.0
+		IL_0b79: castclass Modules.Generator_GeneratedFunctionObject_Semantics/Scope
+		IL_0b7e: ldnull
+		IL_0b7f: call object Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator::__js_call__(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope, object)
+		IL_0b84: stloc.s 33
+		IL_0b86: ldloc.s 33
+		IL_0b88: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0b8d: stloc.s 33
+		IL_0b8f: ldloc.s 33
+		IL_0b91: ldloc.s 22
+		IL_0b93: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0b98: stloc.s 37
+		IL_0b9a: ldloc.s 37
+		IL_0b9c: box [System.Runtime]System.Boolean
+		IL_0ba1: stloc.s 39
+		IL_0ba3: ldloc.s 31
+		IL_0ba5: ldstr "tail"
+		IL_0baa: ldloc.s 39
+		IL_0bac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0bb1: pop
+		IL_0bb2: nop
+		IL_0bb3: ldc.i4.0
+		IL_0bb4: stloc.s 23
+		IL_0bb6: ldc.i4.0
+		IL_0bb7: box [System.Runtime]System.Boolean
+		IL_0bbc: stloc.s 24
 		.try
 		{
-			IL_0bc8: nop
-			IL_0bc9: ldloc.s 5
-			IL_0bcb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0bd0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0bd5: stloc.s 33
-			IL_0bd7: ldloc.s 33
-			IL_0bd9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0bde: ldstr "next"
-			IL_0be3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0be8: pop
-			IL_0be9: leave IL_0c4d
+			IL_0bbe: nop
+			IL_0bbf: ldloc.s 5
+			IL_0bc1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0bc6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0bcb: stloc.s 33
+			IL_0bcd: ldloc.s 33
+			IL_0bcf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0bd4: ldstr "next"
+			IL_0bd9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0bde: pop
+			IL_0bdf: leave IL_0c43
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0bee: stloc.s 25
-			IL_0bf0: ldloc.s 25
-			IL_0bf2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0bf7: dup
-			IL_0bf8: brtrue IL_0c0e
+			IL_0be4: stloc.s 25
+			IL_0be6: ldloc.s 25
+			IL_0be8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0bed: dup
+			IL_0bee: brtrue IL_0c04
 
-			IL_0bfd: pop
-			IL_0bfe: ldloc.s 25
-			IL_0c00: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0c05: dup
-			IL_0c06: brtrue IL_0c1a
+			IL_0bf3: pop
+			IL_0bf4: ldloc.s 25
+			IL_0bf6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0bfb: dup
+			IL_0bfc: brtrue IL_0c10
 
-			IL_0c0b: pop
-			IL_0c0c: rethrow
+			IL_0c01: pop
+			IL_0c02: rethrow
 
-			IL_0c0e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0c13: stloc.s 26
-			IL_0c15: br IL_0c1c
+			IL_0c04: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0c09: stloc.s 26
+			IL_0c0b: br IL_0c12
 
-			IL_0c1a: stloc.s 26
+			IL_0c10: stloc.s 26
 
-			IL_0c1c: ldloc.s 26
-			IL_0c1e: stloc.s 27
-			IL_0c20: ldloc.s 27
-			IL_0c22: stloc.s 33
-			IL_0c24: ldstr "ReferenceError"
-			IL_0c29: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0c2e: stloc.s 36
-			IL_0c30: ldloc.s 33
-			IL_0c32: ldloc.s 36
-			IL_0c34: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0c39: stloc.s 37
-			IL_0c3b: ldloc.s 37
-			IL_0c3d: box [System.Runtime]System.Boolean
-			IL_0c42: stloc.s 39
-			IL_0c44: ldloc.s 39
-			IL_0c46: stloc.s 24
-			IL_0c48: leave IL_0c4d
+			IL_0c12: ldloc.s 26
+			IL_0c14: stloc.s 27
+			IL_0c16: ldloc.s 27
+			IL_0c18: stloc.s 33
+			IL_0c1a: ldstr "ReferenceError"
+			IL_0c1f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0c24: stloc.s 36
+			IL_0c26: ldloc.s 33
+			IL_0c28: ldloc.s 36
+			IL_0c2a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0c2f: stloc.s 37
+			IL_0c31: ldloc.s 37
+			IL_0c33: box [System.Runtime]System.Boolean
+			IL_0c38: stloc.s 39
+			IL_0c3a: ldloc.s 39
+			IL_0c3c: stloc.s 24
+			IL_0c3e: leave IL_0c43
 		} // end handler
 
-		IL_0c4d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0c52: stloc.s 31
-		IL_0c54: ldloc.s 23
-		IL_0c56: box [System.Runtime]System.Boolean
-		IL_0c5b: stloc.s 39
-		IL_0c5d: ldloc.s 31
-		IL_0c5f: ldstr "parameterSetup"
-		IL_0c64: ldloc.s 39
-		IL_0c66: ldloc.s 24
-		IL_0c68: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0c6d: pop
-		IL_0c6e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0c73: stloc.s 31
-		IL_0c75: ldnull
-		IL_0c76: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
-		IL_0c7b: stloc.s 36
-		IL_0c7d: ldnull
-		IL_0c7e: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
-		IL_0c83: stloc.s 33
-		IL_0c85: ldloc.s 36
-		IL_0c87: ldloc.s 33
-		IL_0c89: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0c8e: stloc.s 37
-		IL_0c90: ldloc.s 37
-		IL_0c92: box [System.Runtime]System.Boolean
-		IL_0c97: stloc.s 39
-		IL_0c99: ldloc.s 31
-		IL_0c9b: ldstr "identity"
-		IL_0ca0: ldloc.s 39
-		IL_0ca2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0ca7: pop
-		IL_0ca8: ldnull
-		IL_0ca9: stloc.s 28
-		IL_0cab: ret
+		IL_0c43: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0c48: stloc.s 31
+		IL_0c4a: ldloc.s 23
+		IL_0c4c: box [System.Runtime]System.Boolean
+		IL_0c51: stloc.s 39
+		IL_0c53: ldloc.s 31
+		IL_0c55: ldstr "parameterSetup"
+		IL_0c5a: ldloc.s 39
+		IL_0c5c: ldloc.s 24
+		IL_0c5e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0c63: pop
+		IL_0c64: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0c69: stloc.s 31
+		IL_0c6b: ldnull
+		IL_0c6c: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
+		IL_0c71: stloc.s 36
+		IL_0c73: ldnull
+		IL_0c74: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
+		IL_0c79: stloc.s 33
+		IL_0c7b: ldloc.s 36
+		IL_0c7d: ldloc.s 33
+		IL_0c7f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0c84: stloc.s 37
+		IL_0c86: ldloc.s 37
+		IL_0c88: box [System.Runtime]System.Boolean
+		IL_0c8d: stloc.s 39
+		IL_0c8f: ldloc.s 31
+		IL_0c91: ldstr "identity"
+		IL_0c96: ldloc.s 39
+		IL_0c98: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0c9d: pop
+		IL_0c9e: ldnull
+		IL_0c9f: stloc.s 28
+		IL_0ca1: ret
 	} // end of method Generator_GeneratedFunctionObject_Semantics::__js_module_init__
 
 } // end of class Modules.Generator_GeneratedFunctionObject_Semantics

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Inheritance_SuperIteratorMethod.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Inheritance_SuperIteratorMethod.verified.txt
@@ -701,7 +701,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 397 (0x18d)
+		// Code size: 392 (0x188)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_Inheritance_SuperIteratorMethod/Scope,
@@ -778,67 +778,66 @@
 		IL_00c4: ldc.i4.1
 		IL_00c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0, float64, string, bool, bool)
 		IL_00ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0)
-		IL_00cf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0)
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00d9: pop
-		IL_00da: ldc.i4.1
-		IL_00db: newarr [System.Runtime]System.Object
-		IL_00e0: dup
-		IL_00e1: ldc.i4.0
-		IL_00e2: ldloc.0
-		IL_00e3: stelem.ref
-		IL_00e4: stloc.s 5
-		IL_00e6: ldloc.3
-		IL_00e7: ldloc.s 5
-		IL_00e9: ldc.r8 0.0
-		IL_00f2: box [System.Runtime]System.Double
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00fc: stloc.s 4
-		IL_00fe: ldloc.s 4
-		IL_0100: ldloc.1
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0106: stloc.s 4
-		IL_0108: ldloc.s 4
-		IL_010a: stloc.2
-		IL_010b: ldc.i4.0
-		IL_010c: newarr [System.Runtime]System.Object
-		IL_0111: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0116: ldloc.2
-		IL_0117: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_011c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0121: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived::.ctor()
-		IL_0126: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_012b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0130: dup
-		IL_0131: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-		IL_0136: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_013b: ldstr "prototype"
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0145: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_014a: stloc.s 4
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_0156: stloc.s 4
-		IL_0158: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_015d: ldloc.s 4
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0164: stloc.s 4
-		IL_0166: ldloc.s 4
-		IL_0168: isinst Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-		IL_016d: dup
-		IL_016e: brfalse IL_017e
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00d4: pop
+		IL_00d5: ldc.i4.1
+		IL_00d6: newarr [System.Runtime]System.Object
+		IL_00db: dup
+		IL_00dc: ldc.i4.0
+		IL_00dd: ldloc.0
+		IL_00de: stelem.ref
+		IL_00df: stloc.s 5
+		IL_00e1: ldloc.3
+		IL_00e2: ldloc.s 5
+		IL_00e4: ldc.r8 0.0
+		IL_00ed: box [System.Runtime]System.Double
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00f7: stloc.s 4
+		IL_00f9: ldloc.s 4
+		IL_00fb: ldloc.1
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_0101: stloc.s 4
+		IL_0103: ldloc.s 4
+		IL_0105: stloc.2
+		IL_0106: ldc.i4.0
+		IL_0107: newarr [System.Runtime]System.Object
+		IL_010c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0111: ldloc.2
+		IL_0112: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0117: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_011c: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived::.ctor()
+		IL_0121: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_0126: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_012b: dup
+		IL_012c: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
+		IL_0131: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0136: ldstr "prototype"
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0140: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0145: stloc.s 4
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0151: stloc.s 4
+		IL_0153: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_0158: ldloc.s 4
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015f: stloc.s 4
+		IL_0161: ldloc.s 4
+		IL_0163: isinst Modules.Generator_Inheritance_SuperIteratorMethod/Derived
+		IL_0168: dup
+		IL_0169: brfalse IL_0179
 
-		IL_0173: callvirt instance object Modules.Generator_Inheritance_SuperIteratorMethod/Derived::run()
-		IL_0178: pop
-		IL_0179: br IL_018c
+		IL_016e: callvirt instance object Modules.Generator_Inheritance_SuperIteratorMethod/Derived::run()
+		IL_0173: pop
+		IL_0174: br IL_0187
 
-		IL_017e: pop
-		IL_017f: ldloc.s 4
-		IL_0181: ldstr "run"
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_018b: pop
+		IL_0179: pop
+		IL_017a: ldloc.s 4
+		IL_017c: ldstr "run"
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0186: pop
 
-		IL_018c: ret
+		IL_0187: ret
 	} // end of method Generator_Inheritance_SuperIteratorMethod::__js_module_init__
 
 } // end of class Modules.Generator_Inheritance_SuperIteratorMethod

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
@@ -1025,8 +1025,8 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 209 (0xd1)
-		.maxstack 13
+		// Code size: 184 (0xb8)
+		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -1065,58 +1065,49 @@
 		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject_FunctionExpression_986BE060_L6C8>(!!0, float64, string, bool, bool)
 		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject_FunctionExpression_986BE060_L6C8>(!!0)
 		IL_004c: stloc.3
-		IL_004d: ldloc.3
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject_FunctionExpression_986BE060_L6C8>(!!0)
-		IL_0053: stloc.3
-		IL_0054: ldloc.1
-		IL_0055: ldstr "inc"
-		IL_005a: ldloc.3
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0060: pop
-		IL_0061: ldc.i4.1
-		IL_0062: newarr [System.Runtime]System.Object
-		IL_0067: dup
-		IL_0068: ldc.i4.0
-		IL_0069: ldloc.0
-		IL_006a: stelem.ref
-		IL_006b: stloc.2
-		IL_006c: ldloc.2
-		IL_006d: ldc.i4.0
-		IL_006e: ldelem.ref
-		IL_006f: castclass Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope
-		IL_0074: newobj instance void Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14::.ctor(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope)
+		IL_004d: ldloc.1
+		IL_004e: ldstr "inc"
+		IL_0053: ldloc.3
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0059: pop
+		IL_005a: ldc.i4.1
+		IL_005b: newarr [System.Runtime]System.Object
+		IL_0060: dup
+		IL_0061: ldc.i4.0
+		IL_0062: ldloc.0
+		IL_0063: stelem.ref
+		IL_0064: stloc.2
+		IL_0065: ldloc.2
+		IL_0066: ldc.i4.0
+		IL_0067: ldelem.ref
+		IL_0068: castclass Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope
+		IL_006d: newobj instance void Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14::.ctor(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope)
+		IL_0072: ldc.i4.0
+		IL_0073: conv.r8
+		IL_0074: ldstr ""
 		IL_0079: ldc.i4.0
-		IL_007a: conv.r8
-		IL_007b: ldstr ""
-		IL_0080: ldc.i4.0
-		IL_0081: ldc.i4.1
-		IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14>(!!0, float64, string, bool, bool)
-		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14>(!!0)
-		IL_008c: stloc.s 4
-		IL_008e: ldloc.s 4
-		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14>(!!0)
-		IL_0095: stloc.s 4
-		IL_0097: ldloc.s 4
-		IL_0099: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14>(!!0)
-		IL_009e: stloc.s 4
-		IL_00a0: ldloc.s 4
-		IL_00a2: ldstr "value"
-		IL_00a7: ldstr "get"
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_00b1: stloc.s 5
-		IL_00b3: ldloc.1
-		IL_00b4: ldstr "value"
-		IL_00b9: ldloc.s 5
-		IL_00bb: ldnull
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_00c1: pop
-		IL_00c2: ldarg.2
-		IL_00c3: ldstr "exports"
-		IL_00c8: ldloc.1
-		IL_00c9: ldc.i4.1
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00cf: pop
-		IL_00d0: ret
+		IL_007a: ldc.i4.1
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14>(!!0)
+		IL_0085: stloc.s 4
+		IL_0087: ldloc.s 4
+		IL_0089: ldstr "value"
+		IL_008e: ldstr "get"
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_0098: stloc.s 5
+		IL_009a: ldloc.1
+		IL_009b: ldstr "value"
+		IL_00a0: ldloc.s 5
+		IL_00a2: ldnull
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_00a8: pop
+		IL_00a9: ldarg.2
+		IL_00aa: ldstr "exports"
+		IL_00af: ldloc.1
+		IL_00b0: ldc.i4.1
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_00b6: pop
+		IL_00b7: ret
 	} // end of method Import_DynamicImport_Cjs_Namespace_Lib::__js_module_init__
 
 } // end of class Modules.Import_DynamicImport_Cjs_Namespace_Lib

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
@@ -5684,7 +5684,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 105 (0x69)
+		// Code size: 98 (0x62)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportNamedFrom_LibA/Scope,
@@ -5719,21 +5719,18 @@
 		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11/FunctionObject_FunctionExpression_B2972973_L5C12>(!!0, float64, string, bool, bool)
 		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11/FunctionObject_FunctionExpression_B2972973_L5C12>(!!0)
 		IL_0045: stloc.3
-		IL_0046: ldloc.3
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11/FunctionObject_FunctionExpression_B2972973_L5C12>(!!0)
-		IL_004c: stloc.3
-		IL_004d: ldloc.1
-		IL_004e: ldstr "doubled"
-		IL_0053: ldloc.3
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0059: pop
-		IL_005a: ldarg.2
-		IL_005b: ldstr "exports"
-		IL_0060: ldloc.1
-		IL_0061: ldc.i4.1
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0067: pop
-		IL_0068: ret
+		IL_0046: ldloc.1
+		IL_0047: ldstr "doubled"
+		IL_004c: ldloc.3
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0052: pop
+		IL_0053: ldarg.2
+		IL_0054: ldstr "exports"
+		IL_0059: ldloc.1
+		IL_005a: ldc.i4.1
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0060: pop
+		IL_0061: ret
 	} // end of method Import_ExportNamedFrom_LibA::__js_module_init__
 
 } // end of class Modules.Import_ExportNamedFrom_LibA

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -3154,7 +3154,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 756 (0x2f4)
+		// Code size: 736 (0x2e0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_PrimeJavaScript/Scope,
@@ -3286,135 +3286,131 @@
 		IL_0186: ldc.i4.1
 		IL_0187: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
 		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0)
-		IL_0191: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0)
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_019b: pop
-		IL_019c: ldc.i4.1
-		IL_019d: newarr [System.Runtime]System.Object
-		IL_01a2: dup
-		IL_01a3: ldc.i4.0
-		IL_01a4: ldloc.0
-		IL_01a5: stelem.ref
-		IL_01a6: stloc.s 10
-		IL_01a8: ldloc.s 6
-		IL_01aa: ldstr "setBitsTrue"
-		IL_01af: ldloc.s 10
-		IL_01b1: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::.ctor(object[])
-		IL_01b6: ldc.i4.3
-		IL_01b7: conv.r8
-		IL_01b8: ldstr "setBitsTrue"
-		IL_01bd: ldc.i4.1
-		IL_01be: ldc.i4.1
-		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0)
-		IL_01c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0)
-		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01d3: pop
-		IL_01d4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01d9: stloc.s 10
-		IL_01db: ldloc.s 6
-		IL_01dd: ldstr "testBitTrue"
-		IL_01e2: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::.ctor()
-		IL_01e7: ldc.i4.1
-		IL_01e8: conv.r8
-		IL_01e9: ldstr "testBitTrue"
-		IL_01ee: ldc.i4.1
-		IL_01ef: ldc.i4.1
-		IL_01f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
-		IL_01f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0)
-		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0)
-		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0204: pop
-		IL_0205: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_020a: stloc.s 10
-		IL_020c: ldloc.s 6
-		IL_020e: ldstr "searchBitFalse"
-		IL_0213: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::.ctor()
-		IL_0218: ldc.i4.1
-		IL_0219: conv.r8
-		IL_021a: ldstr "searchBitFalse"
-		IL_021f: ldc.i4.1
-		IL_0220: ldc.i4.1
-		IL_0221: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
-		IL_0226: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0)
-		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0)
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0235: pop
-		IL_0236: ldc.i4.1
-		IL_0237: newarr [System.Runtime]System.Object
-		IL_023c: dup
-		IL_023d: ldc.i4.0
-		IL_023e: ldloc.0
-		IL_023f: stelem.ref
-		IL_0240: stloc.s 10
-		IL_0242: ldloc.s 9
-		IL_0244: ldloc.s 10
-		IL_0246: ldc.r8 1
-		IL_024f: box [System.Runtime]System.Double
-		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0259: stloc.s 6
-		IL_025b: ldloc.0
-		IL_025c: ldloc.s 6
-		IL_025e: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
-		IL_0263: nop
-		IL_0264: ldc.i4.1
-		IL_0265: newarr [System.Runtime]System.Object
-		IL_026a: dup
-		IL_026b: ldc.i4.0
-		IL_026c: ldloc.0
-		IL_026d: stelem.ref
-		IL_026e: stloc.s 10
-		IL_0270: ldloc.s 10
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0196: pop
+		IL_0197: ldc.i4.1
+		IL_0198: newarr [System.Runtime]System.Object
+		IL_019d: dup
+		IL_019e: ldc.i4.0
+		IL_019f: ldloc.0
+		IL_01a0: stelem.ref
+		IL_01a1: stloc.s 10
+		IL_01a3: ldloc.s 6
+		IL_01a5: ldstr "setBitsTrue"
+		IL_01aa: ldloc.s 10
+		IL_01ac: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::.ctor(object[])
+		IL_01b1: ldc.i4.3
+		IL_01b2: conv.r8
+		IL_01b3: ldstr "setBitsTrue"
+		IL_01b8: ldc.i4.1
+		IL_01b9: ldc.i4.1
+		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
+		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0)
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01c9: pop
+		IL_01ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01cf: stloc.s 10
+		IL_01d1: ldloc.s 6
+		IL_01d3: ldstr "testBitTrue"
+		IL_01d8: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::.ctor()
+		IL_01dd: ldc.i4.1
+		IL_01de: conv.r8
+		IL_01df: ldstr "testBitTrue"
+		IL_01e4: ldc.i4.1
+		IL_01e5: ldc.i4.1
+		IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
+		IL_01eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0)
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01f5: pop
+		IL_01f6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01fb: stloc.s 10
+		IL_01fd: ldloc.s 6
+		IL_01ff: ldstr "searchBitFalse"
+		IL_0204: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::.ctor()
+		IL_0209: ldc.i4.1
+		IL_020a: conv.r8
+		IL_020b: ldstr "searchBitFalse"
+		IL_0210: ldc.i4.1
+		IL_0211: ldc.i4.1
+		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
+		IL_0217: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0)
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0221: pop
+		IL_0222: ldc.i4.1
+		IL_0223: newarr [System.Runtime]System.Object
+		IL_0228: dup
+		IL_0229: ldc.i4.0
+		IL_022a: ldloc.0
+		IL_022b: stelem.ref
+		IL_022c: stloc.s 10
+		IL_022e: ldloc.s 9
+		IL_0230: ldloc.s 10
+		IL_0232: ldc.r8 1
+		IL_023b: box [System.Runtime]System.Double
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0245: stloc.s 6
+		IL_0247: ldloc.0
+		IL_0248: ldloc.s 6
+		IL_024a: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
+		IL_024f: nop
+		IL_0250: ldc.i4.1
+		IL_0251: newarr [System.Runtime]System.Object
+		IL_0256: dup
+		IL_0257: ldc.i4.0
+		IL_0258: ldloc.0
+		IL_0259: stelem.ref
+		IL_025a: stloc.s 10
+		IL_025c: ldloc.s 10
+		IL_025e: ldc.i4.0
+		IL_025f: ldelem.ref
+		IL_0260: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_0265: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
+		IL_026a: ldc.i4.1
+		IL_026b: conv.r8
+		IL_026c: ldstr ""
+		IL_0271: ldc.i4.0
 		IL_0272: ldc.i4.0
-		IL_0273: ldelem.ref
-		IL_0274: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_0279: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
-		IL_027e: ldc.i4.1
-		IL_027f: conv.r8
-		IL_0280: ldstr ""
-		IL_0285: ldc.i4.0
-		IL_0286: ldc.i4.0
-		IL_0287: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_028c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0)
-		IL_0291: stloc.s 11
-		IL_0293: ldloc.s 11
-		IL_0295: ldstr "runSieveBatch"
-		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_029f: stloc.s 6
-		IL_02a1: ldloc.0
-		IL_02a2: ldloc.s 6
-		IL_02a4: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-		IL_02a9: ldc.i4.1
-		IL_02aa: newarr [System.Runtime]System.Object
-		IL_02af: dup
-		IL_02b0: ldc.i4.0
-		IL_02b1: ldloc.0
-		IL_02b2: stelem.ref
-		IL_02b3: stloc.s 10
-		IL_02b5: ldloc.s 10
+		IL_0273: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0278: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0)
+		IL_027d: stloc.s 11
+		IL_027f: ldloc.s 11
+		IL_0281: ldstr "runSieveBatch"
+		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_028b: stloc.s 6
+		IL_028d: ldloc.0
+		IL_028e: ldloc.s 6
+		IL_0290: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+		IL_0295: ldc.i4.1
+		IL_0296: newarr [System.Runtime]System.Object
+		IL_029b: dup
+		IL_029c: ldc.i4.0
+		IL_029d: ldloc.0
+		IL_029e: stelem.ref
+		IL_029f: stloc.s 10
+		IL_02a1: ldloc.s 10
+		IL_02a3: ldc.i4.0
+		IL_02a4: ldelem.ref
+		IL_02a5: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_02aa: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
+		IL_02af: ldc.i4.1
+		IL_02b0: conv.r8
+		IL_02b1: ldstr ""
+		IL_02b6: ldc.i4.0
 		IL_02b7: ldc.i4.0
-		IL_02b8: ldelem.ref
-		IL_02b9: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_02be: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
-		IL_02c3: ldc.i4.1
-		IL_02c4: conv.r8
-		IL_02c5: ldstr ""
-		IL_02ca: ldc.i4.0
-		IL_02cb: ldc.i4.0
-		IL_02cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject>(!!0)
-		IL_02d6: stloc.s 12
-		IL_02d8: ldloc.s 12
-		IL_02da: ldstr "main"
-		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_02e4: stloc.3
-		IL_02e5: ldloc.0
-		IL_02e6: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_02eb: ldnull
-		IL_02ec: ldloc.1
-		IL_02ed: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_02f2: pop
-		IL_02f3: ret
+		IL_02b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14/FunctionObject>(!!0)
+		IL_02c2: stloc.s 12
+		IL_02c4: ldloc.s 12
+		IL_02c6: ldstr "main"
+		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_02d0: stloc.3
+		IL_02d1: ldloc.0
+		IL_02d2: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_02d7: ldnull
+		IL_02d8: ldloc.1
+		IL_02d9: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_02de: pop
+		IL_02df: ret
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -1731,7 +1731,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 666 (0x29a)
+			// Code size: 630 (0x276)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/Scope,
@@ -1817,170 +1817,158 @@
 			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15/FunctionObject_FunctionExpression_15C44BEA_L61C16>(!!0, float64, string, bool, bool)
 			IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15/FunctionObject_FunctionExpression_15C44BEA_L61C16>(!!0)
 			IL_00cc: stloc.s 7
-			IL_00ce: ldloc.s 7
-			IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15/FunctionObject_FunctionExpression_15C44BEA_L61C16>(!!0)
-			IL_00d5: stloc.s 7
-			IL_00d7: ldloc.s 5
-			IL_00d9: ldstr "replacement"
-			IL_00de: ldloc.s 7
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_00e5: pop
-			IL_00e6: ldloc.3
-			IL_00e7: ldstr "addRule"
-			IL_00ec: ldstr "ecmaHeadings"
-			IL_00f1: ldloc.s 5
-			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00f8: pop
-			IL_00f9: ldloc.1
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ff: stloc.3
-			IL_0100: ldc.i4.3
-			IL_0101: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0106: dup
-			IL_0107: ldstr "emu-val"
-			IL_010c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0111: dup
-			IL_0112: ldstr "emu-const"
-			IL_0117: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_011c: dup
-			IL_011d: ldstr "var"
-			IL_0122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0127: stloc.s 4
-			IL_0129: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_012e: stloc.s 5
-			IL_0130: ldloc.s 5
-			IL_0132: ldstr "filter"
-			IL_0137: ldloc.s 4
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_013e: pop
-			IL_013f: ldc.i4.1
-			IL_0140: newarr [System.Runtime]System.Object
-			IL_0145: dup
-			IL_0146: ldc.i4.0
-			IL_0147: ldarg.0
-			IL_0148: stelem.ref
-			IL_0149: stloc.s 6
-			IL_014b: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject_FunctionExpression_8A5C527C_L74C16::.ctor()
-			IL_0150: ldc.i4.1
-			IL_0151: conv.r8
-			IL_0152: ldstr ""
-			IL_0157: ldc.i4.0
-			IL_0158: ldc.i4.1
-			IL_0159: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject_FunctionExpression_8A5C527C_L74C16>(!!0, float64, string, bool, bool)
-			IL_015e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject_FunctionExpression_8A5C527C_L74C16>(!!0)
-			IL_0163: stloc.s 8
-			IL_0165: ldloc.s 8
-			IL_0167: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject_FunctionExpression_8A5C527C_L74C16>(!!0)
-			IL_016c: stloc.s 8
-			IL_016e: ldloc.s 5
-			IL_0170: ldstr "replacement"
-			IL_0175: ldloc.s 8
-			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_017c: pop
-			IL_017d: ldloc.3
-			IL_017e: ldstr "addRule"
-			IL_0183: ldstr "ecmarkupInlineCode"
-			IL_0188: ldloc.s 5
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_018f: pop
-			IL_0190: ldloc.1
-			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0196: stloc.3
-			IL_0197: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_019c: stloc.s 5
-			IL_019e: ldc.i4.1
-			IL_019f: newarr [System.Runtime]System.Object
-			IL_01a4: dup
-			IL_01a5: ldc.i4.0
-			IL_01a6: ldarg.0
-			IL_01a7: stelem.ref
-			IL_01a8: stloc.s 6
-			IL_01aa: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject_FunctionExpression_DD415412_L82C11::.ctor()
-			IL_01af: ldc.i4.1
-			IL_01b0: conv.r8
-			IL_01b1: ldstr ""
-			IL_01b6: ldc.i4.0
-			IL_01b7: ldc.i4.1
-			IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject_FunctionExpression_DD415412_L82C11>(!!0, float64, string, bool, bool)
-			IL_01bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject_FunctionExpression_DD415412_L82C11>(!!0)
-			IL_01c2: stloc.s 9
-			IL_01c4: ldloc.s 9
-			IL_01c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject_FunctionExpression_DD415412_L82C11>(!!0)
-			IL_01cb: stloc.s 9
-			IL_01cd: ldloc.s 5
-			IL_01cf: ldstr "filter"
-			IL_01d4: ldloc.s 9
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_01db: pop
-			IL_01dc: ldc.i4.2
-			IL_01dd: newarr [System.Runtime]System.Object
-			IL_01e2: dup
-			IL_01e3: ldc.i4.0
-			IL_01e4: ldarg.0
-			IL_01e5: stelem.ref
-			IL_01e6: dup
-			IL_01e7: ldc.i4.1
-			IL_01e8: ldloc.0
-			IL_01e9: stelem.ref
-			IL_01ea: stloc.s 6
-			IL_01ec: ldloc.s 6
-			IL_01ee: ldc.i4.0
-			IL_01ef: ldelem.ref
-			IL_01f0: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-			IL_01f5: ldloc.s 6
-			IL_01f7: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object[])
-			IL_01fc: ldc.i4.2
-			IL_01fd: conv.r8
-			IL_01fe: ldstr ""
-			IL_0203: ldc.i4.0
-			IL_0204: ldc.i4.1
-			IL_0205: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16>(!!0, float64, string, bool, bool)
-			IL_020a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16>(!!0)
-			IL_020f: stloc.s 10
-			IL_0211: ldloc.s 10
-			IL_0213: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16>(!!0)
-			IL_0218: stloc.s 10
-			IL_021a: ldloc.s 5
-			IL_021c: ldstr "replacement"
-			IL_0221: ldloc.s 10
-			IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0228: pop
-			IL_0229: ldloc.3
-			IL_022a: ldstr "addRule"
-			IL_022f: ldstr "fencedCodeWithLanguage"
-			IL_0234: ldloc.s 5
-			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_023b: pop
-			IL_023c: ldloc.1
-			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0242: ldstr "turndown"
-			IL_0247: ldarg.2
-			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_024d: stloc.2
-			IL_024e: ldloc.2
-			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ce: ldloc.s 5
+			IL_00d0: ldstr "replacement"
+			IL_00d5: ldloc.s 7
+			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_00dc: pop
+			IL_00dd: ldloc.3
+			IL_00de: ldstr "addRule"
+			IL_00e3: ldstr "ecmaHeadings"
+			IL_00e8: ldloc.s 5
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00ef: pop
+			IL_00f0: ldloc.1
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f6: stloc.3
+			IL_00f7: ldc.i4.3
+			IL_00f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00fd: dup
+			IL_00fe: ldstr "emu-val"
+			IL_0103: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0108: dup
+			IL_0109: ldstr "emu-const"
+			IL_010e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0113: dup
+			IL_0114: ldstr "var"
+			IL_0119: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_011e: stloc.s 4
+			IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0125: stloc.s 5
+			IL_0127: ldloc.s 5
+			IL_0129: ldstr "filter"
+			IL_012e: ldloc.s 4
+			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0135: pop
+			IL_0136: ldc.i4.1
+			IL_0137: newarr [System.Runtime]System.Object
+			IL_013c: dup
+			IL_013d: ldc.i4.0
+			IL_013e: ldarg.0
+			IL_013f: stelem.ref
+			IL_0140: stloc.s 6
+			IL_0142: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject_FunctionExpression_8A5C527C_L74C16::.ctor()
+			IL_0147: ldc.i4.1
+			IL_0148: conv.r8
+			IL_0149: ldstr ""
+			IL_014e: ldc.i4.0
+			IL_014f: ldc.i4.1
+			IL_0150: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject_FunctionExpression_8A5C527C_L74C16>(!!0, float64, string, bool, bool)
+			IL_0155: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject_FunctionExpression_8A5C527C_L74C16>(!!0)
+			IL_015a: stloc.s 8
+			IL_015c: ldloc.s 5
+			IL_015e: ldstr "replacement"
+			IL_0163: ldloc.s 8
+			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_016a: pop
+			IL_016b: ldloc.3
+			IL_016c: ldstr "addRule"
+			IL_0171: ldstr "ecmarkupInlineCode"
+			IL_0176: ldloc.s 5
+			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_017d: pop
+			IL_017e: ldloc.1
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0184: stloc.3
+			IL_0185: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_018a: stloc.s 5
+			IL_018c: ldc.i4.1
+			IL_018d: newarr [System.Runtime]System.Object
+			IL_0192: dup
+			IL_0193: ldc.i4.0
+			IL_0194: ldarg.0
+			IL_0195: stelem.ref
+			IL_0196: stloc.s 6
+			IL_0198: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject_FunctionExpression_DD415412_L82C11::.ctor()
+			IL_019d: ldc.i4.1
+			IL_019e: conv.r8
+			IL_019f: ldstr ""
+			IL_01a4: ldc.i4.0
+			IL_01a5: ldc.i4.1
+			IL_01a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject_FunctionExpression_DD415412_L82C11>(!!0, float64, string, bool, bool)
+			IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject_FunctionExpression_DD415412_L82C11>(!!0)
+			IL_01b0: stloc.s 9
+			IL_01b2: ldloc.s 5
+			IL_01b4: ldstr "filter"
+			IL_01b9: ldloc.s 9
+			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_01c0: pop
+			IL_01c1: ldc.i4.2
+			IL_01c2: newarr [System.Runtime]System.Object
+			IL_01c7: dup
+			IL_01c8: ldc.i4.0
+			IL_01c9: ldarg.0
+			IL_01ca: stelem.ref
+			IL_01cb: dup
+			IL_01cc: ldc.i4.1
+			IL_01cd: ldloc.0
+			IL_01ce: stelem.ref
+			IL_01cf: stloc.s 6
+			IL_01d1: ldloc.s 6
+			IL_01d3: ldc.i4.0
+			IL_01d4: ldelem.ref
+			IL_01d5: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
+			IL_01da: ldloc.s 6
+			IL_01dc: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object[])
+			IL_01e1: ldc.i4.2
+			IL_01e2: conv.r8
+			IL_01e3: ldstr ""
+			IL_01e8: ldc.i4.0
+			IL_01e9: ldc.i4.1
+			IL_01ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16>(!!0, float64, string, bool, bool)
+			IL_01ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16>(!!0)
+			IL_01f4: stloc.s 10
+			IL_01f6: ldloc.s 5
+			IL_01f8: ldstr "replacement"
+			IL_01fd: ldloc.s 10
+			IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0204: pop
+			IL_0205: ldloc.3
+			IL_0206: ldstr "addRule"
+			IL_020b: ldstr "fencedCodeWithLanguage"
+			IL_0210: ldloc.s 5
+			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0217: pop
+			IL_0218: ldloc.1
+			IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021e: ldstr "turndown"
+			IL_0223: ldarg.2
+			IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0229: stloc.2
+			IL_022a: ldloc.2
+			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0230: stloc.3
+			IL_0231: ldstr "\\n{4,}"
+			IL_0236: ldstr "g"
+			IL_023b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0240: stloc.s 11
+			IL_0242: ldloc.3
+			IL_0243: ldstr "replace"
+			IL_0248: ldloc.s 11
+			IL_024a: ldstr "\n\n\n"
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 			IL_0254: stloc.3
-			IL_0255: ldstr "\\n{4,}"
-			IL_025a: ldstr "g"
-			IL_025f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0264: stloc.s 11
+			IL_0255: ldloc.3
+			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_025b: ldstr "trim"
+			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0265: stloc.3
 			IL_0266: ldloc.3
-			IL_0267: ldstr "replace"
-			IL_026c: ldloc.s 11
-			IL_026e: ldstr "\n\n\n"
-			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0278: stloc.3
-			IL_0279: ldloc.3
-			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027f: ldstr "trim"
-			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0289: stloc.3
-			IL_028a: ldloc.3
-			IL_028b: ldstr "\n"
-			IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0295: stloc.s 12
-			IL_0297: ldloc.s 12
-			IL_0299: ret
+			IL_0267: ldstr "\n"
+			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0271: stloc.s 12
+			IL_0273: ldloc.s 12
+			IL_0275: ret
 		} // end of method convertHtmlToMarkdown::__js_call__
 
 	} // end of class convertHtmlToMarkdown

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
@@ -586,7 +586,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 224 (0xe0)
+				// Code size: 208 (0xd0)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope,
@@ -645,65 +645,59 @@
 				IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25>(!!0, float64, string, bool, bool)
 				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25>(!!0)
 				IL_0068: stloc.3
-				IL_0069: ldloc.3
-				IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25>(!!0)
-				IL_006f: stloc.3
-				IL_0070: ldloc.1
-				IL_0071: ldstr "next"
-				IL_0076: ldloc.3
-				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-				IL_007c: pop
-				IL_007d: ldc.i4.3
-				IL_007e: newarr [System.Runtime]System.Object
-				IL_0083: dup
-				IL_0084: ldc.i4.0
-				IL_0085: ldarg.0
-				IL_0086: ldc.i4.0
-				IL_0087: ldelem.ref
-				IL_0088: stelem.ref
-				IL_0089: dup
-				IL_008a: ldc.i4.1
-				IL_008b: ldarg.0
-				IL_008c: ldc.i4.1
-				IL_008d: ldelem.ref
-				IL_008e: stelem.ref
-				IL_008f: dup
-				IL_0090: ldc.i4.2
-				IL_0091: ldloc.0
-				IL_0092: stelem.ref
-				IL_0093: stloc.2
-				IL_0094: ldloc.2
-				IL_0095: ldc.i4.0
-				IL_0096: ldelem.ref
-				IL_0097: castclass Modules.Iterator_Helper_Cleanup/Scope
-				IL_009c: ldloc.2
-				IL_009d: ldc.i4.1
-				IL_009e: ldelem.ref
-				IL_009f: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
-				IL_00a4: ldloc.2
-				IL_00a5: ldc.i4.2
-				IL_00a6: ldelem.ref
-				IL_00a7: castclass Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope
-				IL_00ac: ldloc.2
-				IL_00ad: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope, object[])
+				IL_0069: ldloc.1
+				IL_006a: ldstr "next"
+				IL_006f: ldloc.3
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+				IL_0075: pop
+				IL_0076: ldc.i4.3
+				IL_0077: newarr [System.Runtime]System.Object
+				IL_007c: dup
+				IL_007d: ldc.i4.0
+				IL_007e: ldarg.0
+				IL_007f: ldc.i4.0
+				IL_0080: ldelem.ref
+				IL_0081: stelem.ref
+				IL_0082: dup
+				IL_0083: ldc.i4.1
+				IL_0084: ldarg.0
+				IL_0085: ldc.i4.1
+				IL_0086: ldelem.ref
+				IL_0087: stelem.ref
+				IL_0088: dup
+				IL_0089: ldc.i4.2
+				IL_008a: ldloc.0
+				IL_008b: stelem.ref
+				IL_008c: stloc.2
+				IL_008d: ldloc.2
+				IL_008e: ldc.i4.0
+				IL_008f: ldelem.ref
+				IL_0090: castclass Modules.Iterator_Helper_Cleanup/Scope
+				IL_0095: ldloc.2
+				IL_0096: ldc.i4.1
+				IL_0097: ldelem.ref
+				IL_0098: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
+				IL_009d: ldloc.2
+				IL_009e: ldc.i4.2
+				IL_009f: ldelem.ref
+				IL_00a0: castclass Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope
+				IL_00a5: ldloc.2
+				IL_00a6: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope, object[])
+				IL_00ab: ldc.i4.0
+				IL_00ac: conv.r8
+				IL_00ad: ldstr ""
 				IL_00b2: ldc.i4.0
-				IL_00b3: conv.r8
-				IL_00b4: ldstr ""
-				IL_00b9: ldc.i4.0
-				IL_00ba: ldc.i4.1
-				IL_00bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27>(!!0, float64, string, bool, bool)
-				IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27>(!!0)
-				IL_00c5: stloc.s 4
-				IL_00c7: ldloc.s 4
-				IL_00c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27>(!!0)
-				IL_00ce: stloc.s 4
-				IL_00d0: ldloc.1
-				IL_00d1: ldstr "return"
-				IL_00d6: ldloc.s 4
-				IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-				IL_00dd: pop
-				IL_00de: ldloc.1
-				IL_00df: ret
+				IL_00b3: ldc.i4.1
+				IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27>(!!0, float64, string, bool, bool)
+				IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27>(!!0)
+				IL_00be: stloc.s 4
+				IL_00c0: ldloc.1
+				IL_00c1: ldstr "return"
+				IL_00c6: ldloc.s 4
+				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+				IL_00cd: pop
+				IL_00ce: ldloc.1
+				IL_00cf: ret
 			} // end of method FunctionExpression_L10C29::__js_call__
 
 		} // end of class FunctionExpression_L10C29
@@ -858,7 +852,7 @@
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
 			// Header size: 12
-			// Code size: 222 (0xde)
+			// Code size: 210 (0xd2)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Iterator_Helper_Cleanup/makeIterable/Scope,
@@ -909,59 +903,55 @@
 			IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18>(!!0, float64, string, bool, bool)
 			IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18>(!!0)
 			IL_005f: stloc.3
-			IL_0060: ldloc.3
-			IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18>(!!0)
-			IL_0066: stloc.3
-			IL_0067: ldloc.1
-			IL_0068: ldstr "getClosed"
-			IL_006d: ldloc.3
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0073: pop
-			IL_0074: ldstr "iterator"
-			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-			IL_007e: stloc.s 4
-			IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0085: stloc.s 5
-			IL_0087: ldc.i4.2
-			IL_0088: newarr [System.Runtime]System.Object
-			IL_008d: dup
-			IL_008e: ldc.i4.0
-			IL_008f: ldarg.0
-			IL_0090: stelem.ref
-			IL_0091: dup
-			IL_0092: ldc.i4.1
-			IL_0093: ldloc.0
-			IL_0094: stelem.ref
-			IL_0095: stloc.2
-			IL_0096: ldloc.s 5
-			IL_0098: ldloc.s 4
-			IL_009a: ldloc.2
-			IL_009b: ldc.i4.0
-			IL_009c: ldelem.ref
-			IL_009d: castclass Modules.Iterator_Helper_Cleanup/Scope
-			IL_00a2: ldloc.2
-			IL_00a3: ldc.i4.1
-			IL_00a4: ldelem.ref
-			IL_00a5: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
-			IL_00aa: ldloc.2
-			IL_00ab: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, object[])
+			IL_0060: ldloc.1
+			IL_0061: ldstr "getClosed"
+			IL_0066: ldloc.3
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_006c: pop
+			IL_006d: ldstr "iterator"
+			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+			IL_0077: stloc.s 4
+			IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_007e: stloc.s 5
+			IL_0080: ldc.i4.2
+			IL_0081: newarr [System.Runtime]System.Object
+			IL_0086: dup
+			IL_0087: ldc.i4.0
+			IL_0088: ldarg.0
+			IL_0089: stelem.ref
+			IL_008a: dup
+			IL_008b: ldc.i4.1
+			IL_008c: ldloc.0
+			IL_008d: stelem.ref
+			IL_008e: stloc.2
+			IL_008f: ldloc.s 5
+			IL_0091: ldloc.s 4
+			IL_0093: ldloc.2
+			IL_0094: ldc.i4.0
+			IL_0095: ldelem.ref
+			IL_0096: castclass Modules.Iterator_Helper_Cleanup/Scope
+			IL_009b: ldloc.2
+			IL_009c: ldc.i4.1
+			IL_009d: ldelem.ref
+			IL_009e: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
+			IL_00a3: ldloc.2
+			IL_00a4: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, object[])
+			IL_00a9: ldc.i4.0
+			IL_00aa: conv.r8
+			IL_00ab: ldstr ""
 			IL_00b0: ldc.i4.0
-			IL_00b1: conv.r8
-			IL_00b2: ldstr ""
-			IL_00b7: ldc.i4.0
-			IL_00b8: ldc.i4.1
-			IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30>(!!0, float64, string, bool, bool)
-			IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30>(!!0)
-			IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30>(!!0)
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-			IL_00cd: pop
-			IL_00ce: ldloc.1
-			IL_00cf: ldstr "iterable"
-			IL_00d4: ldloc.s 5
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_00db: pop
-			IL_00dc: ldloc.1
-			IL_00dd: ret
+			IL_00b1: ldc.i4.1
+			IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30>(!!0, float64, string, bool, bool)
+			IL_00b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30>(!!0)
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+			IL_00c1: pop
+			IL_00c2: ldloc.1
+			IL_00c3: ldstr "iterable"
+			IL_00c8: ldloc.s 5
+			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_00cf: pop
+			IL_00d0: ldloc.1
+			IL_00d1: ret
 		} // end of method makeIterable::__js_call__
 
 	} // end of class makeIterable
@@ -1792,7 +1782,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 216 (0xd8)
+				// Code size: 200 (0xc8)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope,
@@ -1851,65 +1841,59 @@
 				IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17>(!!0, float64, string, bool, bool)
 				IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17>(!!0)
 				IL_0060: stloc.3
-				IL_0061: ldloc.3
-				IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17>(!!0)
-				IL_0067: stloc.3
-				IL_0068: ldloc.1
-				IL_0069: ldstr "next"
-				IL_006e: ldloc.3
-				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-				IL_0074: pop
-				IL_0075: ldc.i4.3
-				IL_0076: newarr [System.Runtime]System.Object
-				IL_007b: dup
-				IL_007c: ldc.i4.0
-				IL_007d: ldarg.0
-				IL_007e: ldc.i4.0
-				IL_007f: ldelem.ref
-				IL_0080: stelem.ref
-				IL_0081: dup
-				IL_0082: ldc.i4.1
-				IL_0083: ldarg.0
-				IL_0084: ldc.i4.1
-				IL_0085: ldelem.ref
-				IL_0086: stelem.ref
-				IL_0087: dup
-				IL_0088: ldc.i4.2
-				IL_0089: ldloc.0
-				IL_008a: stelem.ref
-				IL_008b: stloc.2
-				IL_008c: ldloc.2
-				IL_008d: ldc.i4.0
-				IL_008e: ldelem.ref
-				IL_008f: castclass Modules.Iterator_Helper_Cleanup/Scope
-				IL_0094: ldloc.2
-				IL_0095: ldc.i4.1
-				IL_0096: ldelem.ref
-				IL_0097: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope
-				IL_009c: ldloc.2
-				IL_009d: ldc.i4.2
-				IL_009e: ldelem.ref
-				IL_009f: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope
-				IL_00a4: ldloc.2
-				IL_00a5: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope, object[])
+				IL_0061: ldloc.1
+				IL_0062: ldstr "next"
+				IL_0067: ldloc.3
+				IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+				IL_006d: pop
+				IL_006e: ldc.i4.3
+				IL_006f: newarr [System.Runtime]System.Object
+				IL_0074: dup
+				IL_0075: ldc.i4.0
+				IL_0076: ldarg.0
+				IL_0077: ldc.i4.0
+				IL_0078: ldelem.ref
+				IL_0079: stelem.ref
+				IL_007a: dup
+				IL_007b: ldc.i4.1
+				IL_007c: ldarg.0
+				IL_007d: ldc.i4.1
+				IL_007e: ldelem.ref
+				IL_007f: stelem.ref
+				IL_0080: dup
+				IL_0081: ldc.i4.2
+				IL_0082: ldloc.0
+				IL_0083: stelem.ref
+				IL_0084: stloc.2
+				IL_0085: ldloc.2
+				IL_0086: ldc.i4.0
+				IL_0087: ldelem.ref
+				IL_0088: castclass Modules.Iterator_Helper_Cleanup/Scope
+				IL_008d: ldloc.2
+				IL_008e: ldc.i4.1
+				IL_008f: ldelem.ref
+				IL_0090: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope
+				IL_0095: ldloc.2
+				IL_0096: ldc.i4.2
+				IL_0097: ldelem.ref
+				IL_0098: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope
+				IL_009d: ldloc.2
+				IL_009e: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope, object[])
+				IL_00a3: ldc.i4.0
+				IL_00a4: conv.r8
+				IL_00a5: ldstr ""
 				IL_00aa: ldc.i4.0
-				IL_00ab: conv.r8
-				IL_00ac: ldstr ""
-				IL_00b1: ldc.i4.0
-				IL_00b2: ldc.i4.1
-				IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19>(!!0, float64, string, bool, bool)
-				IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19>(!!0)
-				IL_00bd: stloc.s 4
-				IL_00bf: ldloc.s 4
-				IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19>(!!0)
-				IL_00c6: stloc.s 4
-				IL_00c8: ldloc.1
-				IL_00c9: ldstr "return"
-				IL_00ce: ldloc.s 4
-				IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-				IL_00d5: pop
-				IL_00d6: ldloc.1
-				IL_00d7: ret
+				IL_00ab: ldc.i4.1
+				IL_00ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19>(!!0, float64, string, bool, bool)
+				IL_00b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19>(!!0)
+				IL_00b6: stloc.s 4
+				IL_00b8: ldloc.1
+				IL_00b9: ldstr "return"
+				IL_00be: ldloc.s 4
+				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+				IL_00c5: pop
+				IL_00c6: ldloc.1
+				IL_00c7: ret
 			} // end of method FunctionExpression_flatHelper::__js_call__
 
 		} // end of class FunctionExpression_flatHelper
@@ -2023,7 +2007,7 @@
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
 			// Header size: 12
-			// Code size: 101 (0x65)
+			// Code size: 96 (0x60)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope,
@@ -2072,11 +2056,10 @@
 			IL_004d: ldc.i4.1
 			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22>(!!0, float64, string, bool, bool)
 			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22>(!!0)
-			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22>(!!0)
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-			IL_0062: pop
-			IL_0063: ldloc.2
-			IL_0064: ret
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+			IL_005d: pop
+			IL_005e: ldloc.2
+			IL_005f: ret
 		} // end of method ArrowFunction_L60C47::__js_call__
 
 	} // end of class ArrowFunction_L60C47
@@ -2640,7 +2623,7 @@
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
 			// Header size: 12
-			// Code size: 184 (0xb8)
+			// Code size: 168 (0xa8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope,
@@ -2687,53 +2670,47 @@
 			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17>(!!0, float64, string, bool, bool)
 			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17>(!!0)
 			IL_0050: stloc.3
-			IL_0051: ldloc.3
-			IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17>(!!0)
-			IL_0057: stloc.3
-			IL_0058: ldloc.1
-			IL_0059: ldstr "next"
-			IL_005e: ldloc.3
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0064: pop
-			IL_0065: ldc.i4.2
-			IL_0066: newarr [System.Runtime]System.Object
-			IL_006b: dup
-			IL_006c: ldc.i4.0
-			IL_006d: ldarg.0
-			IL_006e: stelem.ref
-			IL_006f: dup
-			IL_0070: ldc.i4.1
-			IL_0071: ldloc.0
-			IL_0072: stelem.ref
-			IL_0073: stloc.2
-			IL_0074: ldloc.2
-			IL_0075: ldc.i4.0
-			IL_0076: ldelem.ref
-			IL_0077: castclass Modules.Iterator_Helper_Cleanup/Scope
-			IL_007c: ldloc.2
-			IL_007d: ldc.i4.1
-			IL_007e: ldelem.ref
-			IL_007f: castclass Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope
-			IL_0084: ldloc.2
-			IL_0085: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope, object[])
+			IL_0051: ldloc.1
+			IL_0052: ldstr "next"
+			IL_0057: ldloc.3
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_005d: pop
+			IL_005e: ldc.i4.2
+			IL_005f: newarr [System.Runtime]System.Object
+			IL_0064: dup
+			IL_0065: ldc.i4.0
+			IL_0066: ldarg.0
+			IL_0067: stelem.ref
+			IL_0068: dup
+			IL_0069: ldc.i4.1
+			IL_006a: ldloc.0
+			IL_006b: stelem.ref
+			IL_006c: stloc.2
+			IL_006d: ldloc.2
+			IL_006e: ldc.i4.0
+			IL_006f: ldelem.ref
+			IL_0070: castclass Modules.Iterator_Helper_Cleanup/Scope
+			IL_0075: ldloc.2
+			IL_0076: ldc.i4.1
+			IL_0077: ldelem.ref
+			IL_0078: castclass Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope
+			IL_007d: ldloc.2
+			IL_007e: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope, object[])
+			IL_0083: ldc.i4.0
+			IL_0084: conv.r8
+			IL_0085: ldstr ""
 			IL_008a: ldc.i4.0
-			IL_008b: conv.r8
-			IL_008c: ldstr ""
-			IL_0091: ldc.i4.0
-			IL_0092: ldc.i4.1
-			IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19>(!!0, float64, string, bool, bool)
-			IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19>(!!0)
-			IL_009d: stloc.s 4
-			IL_009f: ldloc.s 4
-			IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19>(!!0)
-			IL_00a6: stloc.s 4
-			IL_00a8: ldloc.1
-			IL_00a9: ldstr "return"
-			IL_00ae: ldloc.s 4
-			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_00b5: pop
-			IL_00b6: ldloc.1
-			IL_00b7: ret
+			IL_008b: ldc.i4.1
+			IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19>(!!0, float64, string, bool, bool)
+			IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19>(!!0)
+			IL_0096: stloc.s 4
+			IL_0098: ldloc.1
+			IL_0099: ldstr "return"
+			IL_009e: ldloc.s 4
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_00a5: pop
+			IL_00a6: ldloc.1
+			IL_00a7: ret
 		} // end of method FunctionExpression_flatThrowHelper::__js_call__
 
 	} // end of class FunctionExpression_flatThrowHelper
@@ -3103,7 +3080,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 153 (0x99)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/Scope,
@@ -3135,57 +3112,51 @@
 				IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_F596D986_L116C17>(!!0, float64, string, bool, bool)
 				IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_F596D986_L116C17>(!!0)
 				IL_0031: stloc.3
-				IL_0032: ldloc.3
-				IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_F596D986_L116C17>(!!0)
-				IL_0038: stloc.3
-				IL_0039: ldloc.1
-				IL_003a: ldstr "next"
-				IL_003f: ldloc.3
-				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-				IL_0045: pop
-				IL_0046: ldc.i4.3
-				IL_0047: newarr [System.Runtime]System.Object
-				IL_004c: dup
-				IL_004d: ldc.i4.0
-				IL_004e: ldarg.0
-				IL_004f: ldc.i4.0
-				IL_0050: ldelem.ref
-				IL_0051: stelem.ref
-				IL_0052: dup
-				IL_0053: ldc.i4.1
-				IL_0054: ldarg.0
-				IL_0055: ldc.i4.1
-				IL_0056: ldelem.ref
-				IL_0057: stelem.ref
-				IL_0058: dup
-				IL_0059: ldc.i4.2
-				IL_005a: ldloc.0
-				IL_005b: stelem.ref
-				IL_005c: stloc.2
-				IL_005d: ldloc.2
-				IL_005e: ldc.i4.0
-				IL_005f: ldelem.ref
-				IL_0060: castclass Modules.Iterator_Helper_Cleanup/Scope
-				IL_0065: ldloc.2
-				IL_0066: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, object[])
+				IL_0032: ldloc.1
+				IL_0033: ldstr "next"
+				IL_0038: ldloc.3
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+				IL_003e: pop
+				IL_003f: ldc.i4.3
+				IL_0040: newarr [System.Runtime]System.Object
+				IL_0045: dup
+				IL_0046: ldc.i4.0
+				IL_0047: ldarg.0
+				IL_0048: ldc.i4.0
+				IL_0049: ldelem.ref
+				IL_004a: stelem.ref
+				IL_004b: dup
+				IL_004c: ldc.i4.1
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.1
+				IL_004f: ldelem.ref
+				IL_0050: stelem.ref
+				IL_0051: dup
+				IL_0052: ldc.i4.2
+				IL_0053: ldloc.0
+				IL_0054: stelem.ref
+				IL_0055: stloc.2
+				IL_0056: ldloc.2
+				IL_0057: ldc.i4.0
+				IL_0058: ldelem.ref
+				IL_0059: castclass Modules.Iterator_Helper_Cleanup/Scope
+				IL_005e: ldloc.2
+				IL_005f: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, object[])
+				IL_0064: ldc.i4.0
+				IL_0065: conv.r8
+				IL_0066: ldstr ""
 				IL_006b: ldc.i4.0
-				IL_006c: conv.r8
-				IL_006d: ldstr ""
-				IL_0072: ldc.i4.0
-				IL_0073: ldc.i4.1
-				IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19>(!!0, float64, string, bool, bool)
-				IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19>(!!0)
-				IL_007e: stloc.s 4
-				IL_0080: ldloc.s 4
-				IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19>(!!0)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldstr "return"
-				IL_008f: ldloc.s 4
-				IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-				IL_0096: pop
-				IL_0097: ldloc.1
-				IL_0098: ret
+				IL_006c: ldc.i4.1
+				IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19>(!!0, float64, string, bool, bool)
+				IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19>(!!0)
+				IL_0077: stloc.s 4
+				IL_0079: ldloc.1
+				IL_007a: ldstr "return"
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+				IL_0086: pop
+				IL_0087: ldloc.1
+				IL_0088: ret
 			} // end of method FunctionExpression_flatThrowHelper::__js_call__
 
 		} // end of class FunctionExpression_flatThrowHelper
@@ -3299,7 +3270,7 @@
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 81 (0x51)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/Scope,
@@ -3341,11 +3312,10 @@
 			IL_003e: ldc.i4.1
 			IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22>(!!0, float64, string, bool, bool)
 			IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22>(!!0)
-			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22>(!!0)
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-			IL_0053: pop
-			IL_0054: ldloc.2
-			IL_0055: ret
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+			IL_004e: pop
+			IL_004f: ldloc.2
+			IL_0050: ret
 		} // end of method ArrowFunction_L113C12::__js_call__
 
 	} // end of class ArrowFunction_L113C12
@@ -3554,7 +3524,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1882 (0x75a)
+		// Code size: 1877 (0x755)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Iterator_Helper_Cleanup/Scope,
@@ -4150,106 +4120,105 @@
 		IL_0655: ldc.i4.1
 		IL_0656: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22>(!!0, float64, string, bool, bool)
 		IL_065b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22>(!!0)
-		IL_0660: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22>(!!0)
-		IL_0665: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_066a: pop
-		IL_066b: ldloc.s 29
-		IL_066d: ldstr "from"
-		IL_0672: ldloc.s 37
-		IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0679: stloc.s 29
-		IL_067b: ldloc.s 29
-		IL_067d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0682: stloc.s 29
-		IL_0684: ldc.i4.1
-		IL_0685: newarr [System.Runtime]System.Object
-		IL_068a: dup
-		IL_068b: ldc.i4.0
-		IL_068c: ldloc.0
-		IL_068d: stelem.ref
-		IL_068e: stloc.s 27
-		IL_0690: ldloc.s 27
-		IL_0692: ldc.i4.0
-		IL_0693: ldelem.ref
-		IL_0694: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0699: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
-		IL_069e: ldc.i4.1
-		IL_069f: conv.r8
-		IL_06a0: ldstr ""
-		IL_06a5: ldc.i4.0
-		IL_06a6: ldc.i4.0
-		IL_06a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0)
-		IL_06b1: stloc.s 38
-		IL_06b3: ldloc.s 29
-		IL_06b5: ldstr "flatMap"
-		IL_06ba: ldloc.s 38
-		IL_06bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06c1: stloc.s 22
+		IL_0660: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0665: pop
+		IL_0666: ldloc.s 29
+		IL_0668: ldstr "from"
+		IL_066d: ldloc.s 37
+		IL_066f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0674: stloc.s 29
+		IL_0676: ldloc.s 29
+		IL_0678: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_067d: stloc.s 29
+		IL_067f: ldc.i4.1
+		IL_0680: newarr [System.Runtime]System.Object
+		IL_0685: dup
+		IL_0686: ldc.i4.0
+		IL_0687: ldloc.0
+		IL_0688: stelem.ref
+		IL_0689: stloc.s 27
+		IL_068b: ldloc.s 27
+		IL_068d: ldc.i4.0
+		IL_068e: ldelem.ref
+		IL_068f: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0694: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
+		IL_0699: ldc.i4.1
+		IL_069a: conv.r8
+		IL_069b: ldstr ""
+		IL_06a0: ldc.i4.0
+		IL_06a1: ldc.i4.0
+		IL_06a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0)
+		IL_06ac: stloc.s 38
+		IL_06ae: ldloc.s 29
+		IL_06b0: ldstr "flatMap"
+		IL_06b5: ldloc.s 38
+		IL_06b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06bc: stloc.s 22
 		.try
 		{
-			IL_06c3: nop
-			IL_06c4: ldloc.s 22
-			IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06cb: ldstr "next"
-			IL_06d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_06d5: pop
-			IL_06d6: ldloc.s 22
-			IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06dd: ldstr "next"
-			IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_06e7: pop
-			IL_06e8: leave IL_0724
+			IL_06be: nop
+			IL_06bf: ldloc.s 22
+			IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06c6: ldstr "next"
+			IL_06cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_06d0: pop
+			IL_06d1: ldloc.s 22
+			IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06d8: ldstr "next"
+			IL_06dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_06e2: pop
+			IL_06e3: leave IL_071f
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_06ed: stloc.s 23
-			IL_06ef: ldloc.s 23
-			IL_06f1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_06f6: dup
-			IL_06f7: brtrue IL_070d
+			IL_06e8: stloc.s 23
+			IL_06ea: ldloc.s 23
+			IL_06ec: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_06f1: dup
+			IL_06f2: brtrue IL_0708
 
-			IL_06fc: pop
-			IL_06fd: ldloc.s 23
-			IL_06ff: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0704: dup
-			IL_0705: brtrue IL_0719
+			IL_06f7: pop
+			IL_06f8: ldloc.s 23
+			IL_06fa: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_06ff: dup
+			IL_0700: brtrue IL_0714
 
-			IL_070a: pop
-			IL_070b: rethrow
+			IL_0705: pop
+			IL_0706: rethrow
 
-			IL_070d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0712: stloc.s 24
-			IL_0714: br IL_071b
+			IL_0708: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_070d: stloc.s 24
+			IL_070f: br IL_0716
 
-			IL_0719: stloc.s 24
+			IL_0714: stloc.s 24
 
-			IL_071b: ldloc.s 24
-			IL_071d: stloc.s 25
-			IL_071f: leave IL_0724
+			IL_0716: ldloc.s 24
+			IL_0718: stloc.s 25
+			IL_071a: leave IL_071f
 		} // end handler
 
-		IL_0724: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0729: stloc.s 31
-		IL_072b: ldloc.0
-		IL_072c: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-		IL_0731: stloc.s 29
-		IL_0733: ldloc.s 31
-		IL_0735: ldloc.s 29
-		IL_0737: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_073c: pop
-		IL_073d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0742: stloc.s 31
-		IL_0744: ldloc.0
-		IL_0745: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-		IL_074a: stloc.s 29
-		IL_074c: ldloc.s 31
-		IL_074e: ldloc.s 29
-		IL_0750: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0755: pop
-		IL_0756: ldnull
-		IL_0757: stloc.s 26
-		IL_0759: ret
+		IL_071f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0724: stloc.s 31
+		IL_0726: ldloc.0
+		IL_0727: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+		IL_072c: stloc.s 29
+		IL_072e: ldloc.s 31
+		IL_0730: ldloc.s 29
+		IL_0732: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0737: pop
+		IL_0738: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_073d: stloc.s 31
+		IL_073f: ldloc.0
+		IL_0740: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+		IL_0745: stloc.s 29
+		IL_0747: ldloc.s 31
+		IL_0749: ldloc.s 29
+		IL_074b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0750: pop
+		IL_0751: ldnull
+		IL_0752: stloc.s 26
+		IL_0754: ret
 	} // end of method Iterator_Helper_Cleanup::__js_module_init__
 
 } // end of class Modules.Iterator_Helper_Cleanup

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Next_Return.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Next_Return.verified.txt
@@ -434,7 +434,7 @@
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
 			// Header size: 12
-			// Code size: 192 (0xc0)
+			// Code size: 176 (0xb0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope,
@@ -481,53 +481,47 @@
 			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17>(!!0, float64, string, bool, bool)
 			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17>(!!0)
 			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17>(!!0)
-			IL_005f: stloc.3
-			IL_0060: ldloc.1
-			IL_0061: ldstr "next"
-			IL_0066: ldloc.3
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_006c: pop
-			IL_006d: ldc.i4.2
-			IL_006e: newarr [System.Runtime]System.Object
-			IL_0073: dup
-			IL_0074: ldc.i4.0
-			IL_0075: ldarg.0
-			IL_0076: stelem.ref
-			IL_0077: dup
-			IL_0078: ldc.i4.1
-			IL_0079: ldloc.0
-			IL_007a: stelem.ref
-			IL_007b: stloc.2
-			IL_007c: ldloc.2
-			IL_007d: ldc.i4.0
-			IL_007e: ldelem.ref
-			IL_007f: castclass Modules.Iterator_Helper_Next_Return/Scope
-			IL_0084: ldloc.2
-			IL_0085: ldc.i4.1
-			IL_0086: ldelem.ref
-			IL_0087: castclass Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope
-			IL_008c: ldloc.2
-			IL_008d: newobj instance void Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19::.ctor(class Modules.Iterator_Helper_Next_Return/Scope, class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope, object[])
+			IL_0059: ldloc.1
+			IL_005a: ldstr "next"
+			IL_005f: ldloc.3
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0065: pop
+			IL_0066: ldc.i4.2
+			IL_0067: newarr [System.Runtime]System.Object
+			IL_006c: dup
+			IL_006d: ldc.i4.0
+			IL_006e: ldarg.0
+			IL_006f: stelem.ref
+			IL_0070: dup
+			IL_0071: ldc.i4.1
+			IL_0072: ldloc.0
+			IL_0073: stelem.ref
+			IL_0074: stloc.2
+			IL_0075: ldloc.2
+			IL_0076: ldc.i4.0
+			IL_0077: ldelem.ref
+			IL_0078: castclass Modules.Iterator_Helper_Next_Return/Scope
+			IL_007d: ldloc.2
+			IL_007e: ldc.i4.1
+			IL_007f: ldelem.ref
+			IL_0080: castclass Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope
+			IL_0085: ldloc.2
+			IL_0086: newobj instance void Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19::.ctor(class Modules.Iterator_Helper_Next_Return/Scope, class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope, object[])
+			IL_008b: ldc.i4.0
+			IL_008c: conv.r8
+			IL_008d: ldstr ""
 			IL_0092: ldc.i4.0
-			IL_0093: conv.r8
-			IL_0094: ldstr ""
-			IL_0099: ldc.i4.0
-			IL_009a: ldc.i4.1
-			IL_009b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19>(!!0, float64, string, bool, bool)
-			IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19>(!!0)
-			IL_00a5: stloc.s 4
-			IL_00a7: ldloc.s 4
-			IL_00a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19>(!!0)
-			IL_00ae: stloc.s 4
-			IL_00b0: ldloc.1
-			IL_00b1: ldstr "return"
-			IL_00b6: ldloc.s 4
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_00bd: pop
-			IL_00be: ldloc.1
-			IL_00bf: ret
+			IL_0093: ldc.i4.1
+			IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19>(!!0, float64, string, bool, bool)
+			IL_0099: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19>(!!0)
+			IL_009e: stloc.s 4
+			IL_00a0: ldloc.1
+			IL_00a1: ldstr "return"
+			IL_00a6: ldloc.s 4
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_00ad: pop
+			IL_00ae: ldloc.1
+			IL_00af: ret
 		} // end of method FunctionExpression_iterable::__js_call__
 
 	} // end of class FunctionExpression_iterable
@@ -683,7 +677,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1025 (0x401)
+		// Code size: 1020 (0x3fc)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Iterator_Helper_Next_Return/Scope,
@@ -738,295 +732,294 @@
 		IL_0054: ldc.i4.1
 		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22>(!!0, float64, string, bool, bool)
 		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22>(!!0)
-		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22>(!!0)
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_0069: pop
-		IL_006a: ldloc.s 8
-		IL_006c: stloc.1
-		IL_006d: ldstr "Iterator"
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007c: ldstr "from"
-		IL_0081: ldloc.1
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0087: stloc.s 7
-		IL_0089: ldloc.s 7
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0090: stloc.s 7
-		IL_0092: ldc.i4.1
-		IL_0093: newarr [System.Runtime]System.Object
-		IL_0098: dup
-		IL_0099: ldc.i4.0
-		IL_009a: ldloc.0
-		IL_009b: stelem.ref
-		IL_009c: stloc.s 9
-		IL_009e: newobj instance void Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject::.ctor()
-		IL_00a3: ldc.i4.1
-		IL_00a4: conv.r8
-		IL_00a5: ldstr ""
-		IL_00aa: ldc.i4.0
-		IL_00ab: ldc.i4.0
-		IL_00ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject>(!!0)
-		IL_00b6: stloc.s 10
-		IL_00b8: ldloc.s 7
-		IL_00ba: ldstr "map"
-		IL_00bf: ldloc.s 10
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c6: stloc.2
-		IL_00c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00cc: stloc.s 11
-		IL_00ce: ldloc.2
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d4: ldstr "iterator"
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_00de: ldc.i4.0
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_00e9: stloc.s 7
-		IL_00eb: ldloc.s 7
-		IL_00ed: ldloc.2
-		IL_00ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f3: stloc.s 12
-		IL_00f5: ldloc.s 12
-		IL_00f7: box [System.Runtime]System.Boolean
-		IL_00fc: stloc.s 13
-		IL_00fe: ldloc.s 11
-		IL_0100: ldloc.s 13
-		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0107: pop
-		IL_0108: ldloc.2
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010e: ldstr "next"
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0118: stloc.3
-		IL_0119: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_011e: stloc.s 11
-		IL_0120: ldloc.3
-		IL_0121: ldstr "value"
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012b: stloc.s 7
-		IL_012d: ldloc.s 11
-		IL_012f: ldloc.s 7
-		IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0136: pop
-		IL_0137: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013c: stloc.s 11
-		IL_013e: ldloc.3
-		IL_013f: ldstr "done"
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0149: stloc.s 7
-		IL_014b: ldloc.s 11
-		IL_014d: ldloc.s 7
-		IL_014f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0154: pop
-		IL_0155: ldloc.2
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015b: ldstr "return"
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0165: stloc.s 4
-		IL_0167: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016c: stloc.s 11
-		IL_016e: ldloc.s 4
-		IL_0170: ldstr "done"
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017a: stloc.s 7
-		IL_017c: ldloc.s 11
-		IL_017e: ldloc.s 7
-		IL_0180: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0185: pop
-		IL_0186: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_018b: stloc.s 11
-		IL_018d: ldloc.0
-		IL_018e: ldfld object Modules.Iterator_Helper_Next_Return/Scope::closed
-		IL_0193: stloc.s 7
-		IL_0195: ldloc.s 11
-		IL_0197: ldloc.s 7
-		IL_0199: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_019e: pop
-		IL_019f: ldloc.2
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a5: ldstr "next"
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01af: stloc.s 7
-		IL_01b1: ldloc.s 7
-		IL_01b3: stloc.3
-		IL_01b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b9: stloc.s 11
-		IL_01bb: ldloc.3
-		IL_01bc: ldstr "done"
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c6: stloc.s 7
-		IL_01c8: ldloc.s 11
-		IL_01ca: ldloc.s 7
-		IL_01cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d1: pop
-		IL_01d2: ldc.i4.2
-		IL_01d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01d8: dup
-		IL_01d9: ldc.r8 7
-		IL_01e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01e7: dup
-		IL_01e8: ldc.r8 8
-		IL_01f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01f6: stloc.s 14
-		IL_01f8: ldloc.s 14
-		IL_01fa: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Array::values()
-		IL_01ff: stloc.s 5
-		IL_0201: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0206: stloc.s 11
-		IL_0208: ldstr "Iterator"
-		IL_020d: call string [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::TypeOfGlobalBinding(string)
-		IL_0212: stloc.s 15
-		IL_0214: ldloc.s 11
-		IL_0216: ldloc.s 15
-		IL_0218: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_021d: pop
-		IL_021e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0223: stloc.s 11
-		IL_0225: ldstr "Iterator"
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_022f: ldstr "from"
-		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0239: stloc.s 7
-		IL_023b: ldloc.s 7
-		IL_023d: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0242: stloc.s 15
-		IL_0244: ldloc.s 11
-		IL_0246: ldloc.s 15
-		IL_0248: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_024d: pop
-		IL_024e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0253: stloc.s 11
-		IL_0255: ldstr "Iterator"
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_025f: ldstr "prototype"
-		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0269: stloc.s 7
-		IL_026b: ldloc.s 7
-		IL_026d: ldstr "map"
-		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0277: stloc.s 7
-		IL_0279: ldloc.s 7
-		IL_027b: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0280: stloc.s 15
-		IL_0282: ldloc.s 11
-		IL_0284: ldloc.s 15
-		IL_0286: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_028b: pop
-		IL_028c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0291: stloc.s 11
-		IL_0293: ldloc.s 5
-		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_029a: ldstr "iterator"
-		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_02a4: ldc.i4.0
-		IL_02a5: newarr [System.Runtime]System.Object
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_02af: stloc.s 7
-		IL_02b1: ldloc.s 7
-		IL_02b3: ldloc.s 5
-		IL_02b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02ba: stloc.s 12
-		IL_02bc: ldloc.s 12
-		IL_02be: box [System.Runtime]System.Boolean
-		IL_02c3: stloc.s 13
-		IL_02c5: ldloc.s 11
-		IL_02c7: ldloc.s 13
-		IL_02c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ce: pop
-		IL_02cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02d4: stloc.s 11
-		IL_02d6: ldloc.s 5
-		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02dd: ldstr "next"
-		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_02e7: stloc.s 7
-		IL_02e9: ldloc.s 7
-		IL_02eb: ldstr "value"
-		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02f5: stloc.s 7
-		IL_02f7: ldloc.s 11
-		IL_02f9: ldloc.s 7
-		IL_02fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0300: pop
-		IL_0301: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0306: stloc.s 11
-		IL_0308: ldloc.s 5
-		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_030f: ldstr "next"
-		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0319: stloc.s 7
-		IL_031b: ldloc.s 7
-		IL_031d: ldstr "value"
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0327: stloc.s 7
-		IL_0329: ldloc.s 11
-		IL_032b: ldloc.s 7
-		IL_032d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0332: pop
-		IL_0333: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0338: stloc.s 11
-		IL_033a: ldloc.s 5
-		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0341: ldstr "next"
-		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_034b: stloc.s 7
-		IL_034d: ldloc.s 7
-		IL_034f: ldstr "done"
-		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0359: stloc.s 7
-		IL_035b: ldloc.s 11
-		IL_035d: ldloc.s 7
-		IL_035f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0364: pop
-		IL_0365: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_036a: dup
-		IL_036b: ldstr "kind"
-		IL_0370: ldstr "async"
-		IL_0375: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_037a: stloc.s 6
-		IL_037c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0381: stloc.s 11
-		IL_0383: ldstr "AsyncIterator"
-		IL_0388: call string [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::TypeOfGlobalBinding(string)
-		IL_038d: stloc.s 15
-		IL_038f: ldloc.s 11
-		IL_0391: ldloc.s 15
-		IL_0393: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0398: pop
-		IL_0399: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_039e: stloc.s 11
-		IL_03a0: ldstr "AsyncIterator"
-		IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03aa: ldstr "prototype"
-		IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03b4: stloc.s 7
-		IL_03b6: ldstr "asyncIterator"
-		IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_03c0: stloc.s 16
-		IL_03c2: ldloc.s 7
-		IL_03c4: ldloc.s 16
-		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_03cb: stloc.s 16
-		IL_03cd: ldloc.s 16
-		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d4: ldstr "call"
-		IL_03d9: ldloc.s 6
-		IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03e0: stloc.s 16
-		IL_03e2: ldloc.s 16
-		IL_03e4: ldloc.s 6
-		IL_03e6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03eb: stloc.s 12
-		IL_03ed: ldloc.s 12
-		IL_03ef: box [System.Runtime]System.Boolean
-		IL_03f4: stloc.s 13
-		IL_03f6: ldloc.s 11
-		IL_03f8: ldloc.s 13
-		IL_03fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03ff: pop
-		IL_0400: ret
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0064: pop
+		IL_0065: ldloc.s 8
+		IL_0067: stloc.1
+		IL_0068: ldstr "Iterator"
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0077: ldstr "from"
+		IL_007c: ldloc.1
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0082: stloc.s 7
+		IL_0084: ldloc.s 7
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008b: stloc.s 7
+		IL_008d: ldc.i4.1
+		IL_008e: newarr [System.Runtime]System.Object
+		IL_0093: dup
+		IL_0094: ldc.i4.0
+		IL_0095: ldloc.0
+		IL_0096: stelem.ref
+		IL_0097: stloc.s 9
+		IL_0099: newobj instance void Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject::.ctor()
+		IL_009e: ldc.i4.1
+		IL_009f: conv.r8
+		IL_00a0: ldstr ""
+		IL_00a5: ldc.i4.0
+		IL_00a6: ldc.i4.0
+		IL_00a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject>(!!0)
+		IL_00b1: stloc.s 10
+		IL_00b3: ldloc.s 7
+		IL_00b5: ldstr "map"
+		IL_00ba: ldloc.s 10
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c1: stloc.2
+		IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c7: stloc.s 11
+		IL_00c9: ldloc.2
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cf: ldstr "iterator"
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_00d9: ldc.i4.0
+		IL_00da: newarr [System.Runtime]System.Object
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_00e4: stloc.s 7
+		IL_00e6: ldloc.s 7
+		IL_00e8: ldloc.2
+		IL_00e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00ee: stloc.s 12
+		IL_00f0: ldloc.s 12
+		IL_00f2: box [System.Runtime]System.Boolean
+		IL_00f7: stloc.s 13
+		IL_00f9: ldloc.s 11
+		IL_00fb: ldloc.s 13
+		IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0102: pop
+		IL_0103: ldloc.2
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0109: ldstr "next"
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0113: stloc.3
+		IL_0114: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0119: stloc.s 11
+		IL_011b: ldloc.3
+		IL_011c: ldstr "value"
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0126: stloc.s 7
+		IL_0128: ldloc.s 11
+		IL_012a: ldloc.s 7
+		IL_012c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0131: pop
+		IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0137: stloc.s 11
+		IL_0139: ldloc.3
+		IL_013a: ldstr "done"
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0144: stloc.s 7
+		IL_0146: ldloc.s 11
+		IL_0148: ldloc.s 7
+		IL_014a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_014f: pop
+		IL_0150: ldloc.2
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0156: ldstr "return"
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0160: stloc.s 4
+		IL_0162: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0167: stloc.s 11
+		IL_0169: ldloc.s 4
+		IL_016b: ldstr "done"
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0175: stloc.s 7
+		IL_0177: ldloc.s 11
+		IL_0179: ldloc.s 7
+		IL_017b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0180: pop
+		IL_0181: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0186: stloc.s 11
+		IL_0188: ldloc.0
+		IL_0189: ldfld object Modules.Iterator_Helper_Next_Return/Scope::closed
+		IL_018e: stloc.s 7
+		IL_0190: ldloc.s 11
+		IL_0192: ldloc.s 7
+		IL_0194: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0199: pop
+		IL_019a: ldloc.2
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a0: ldstr "next"
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01aa: stloc.s 7
+		IL_01ac: ldloc.s 7
+		IL_01ae: stloc.3
+		IL_01af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b4: stloc.s 11
+		IL_01b6: ldloc.3
+		IL_01b7: ldstr "done"
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c1: stloc.s 7
+		IL_01c3: ldloc.s 11
+		IL_01c5: ldloc.s 7
+		IL_01c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01cc: pop
+		IL_01cd: ldc.i4.2
+		IL_01ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01d3: dup
+		IL_01d4: ldc.r8 7
+		IL_01dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01e2: dup
+		IL_01e3: ldc.r8 8
+		IL_01ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01f1: stloc.s 14
+		IL_01f3: ldloc.s 14
+		IL_01f5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Array::values()
+		IL_01fa: stloc.s 5
+		IL_01fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0201: stloc.s 11
+		IL_0203: ldstr "Iterator"
+		IL_0208: call string [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::TypeOfGlobalBinding(string)
+		IL_020d: stloc.s 15
+		IL_020f: ldloc.s 11
+		IL_0211: ldloc.s 15
+		IL_0213: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0218: pop
+		IL_0219: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_021e: stloc.s 11
+		IL_0220: ldstr "Iterator"
+		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022a: ldstr "from"
+		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0234: stloc.s 7
+		IL_0236: ldloc.s 7
+		IL_0238: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_023d: stloc.s 15
+		IL_023f: ldloc.s 11
+		IL_0241: ldloc.s 15
+		IL_0243: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0248: pop
+		IL_0249: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_024e: stloc.s 11
+		IL_0250: ldstr "Iterator"
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_025a: ldstr "prototype"
+		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0264: stloc.s 7
+		IL_0266: ldloc.s 7
+		IL_0268: ldstr "map"
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0272: stloc.s 7
+		IL_0274: ldloc.s 7
+		IL_0276: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_027b: stloc.s 15
+		IL_027d: ldloc.s 11
+		IL_027f: ldloc.s 15
+		IL_0281: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0286: pop
+		IL_0287: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_028c: stloc.s 11
+		IL_028e: ldloc.s 5
+		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0295: ldstr "iterator"
+		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_029f: ldc.i4.0
+		IL_02a0: newarr [System.Runtime]System.Object
+		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_02aa: stloc.s 7
+		IL_02ac: ldloc.s 7
+		IL_02ae: ldloc.s 5
+		IL_02b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02b5: stloc.s 12
+		IL_02b7: ldloc.s 12
+		IL_02b9: box [System.Runtime]System.Boolean
+		IL_02be: stloc.s 13
+		IL_02c0: ldloc.s 11
+		IL_02c2: ldloc.s 13
+		IL_02c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c9: pop
+		IL_02ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02cf: stloc.s 11
+		IL_02d1: ldloc.s 5
+		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d8: ldstr "next"
+		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02e2: stloc.s 7
+		IL_02e4: ldloc.s 7
+		IL_02e6: ldstr "value"
+		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02f0: stloc.s 7
+		IL_02f2: ldloc.s 11
+		IL_02f4: ldloc.s 7
+		IL_02f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02fb: pop
+		IL_02fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0301: stloc.s 11
+		IL_0303: ldloc.s 5
+		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_030a: ldstr "next"
+		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0314: stloc.s 7
+		IL_0316: ldloc.s 7
+		IL_0318: ldstr "value"
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0322: stloc.s 7
+		IL_0324: ldloc.s 11
+		IL_0326: ldloc.s 7
+		IL_0328: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_032d: pop
+		IL_032e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0333: stloc.s 11
+		IL_0335: ldloc.s 5
+		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_033c: ldstr "next"
+		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0346: stloc.s 7
+		IL_0348: ldloc.s 7
+		IL_034a: ldstr "done"
+		IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0354: stloc.s 7
+		IL_0356: ldloc.s 11
+		IL_0358: ldloc.s 7
+		IL_035a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_035f: pop
+		IL_0360: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0365: dup
+		IL_0366: ldstr "kind"
+		IL_036b: ldstr "async"
+		IL_0370: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0375: stloc.s 6
+		IL_0377: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_037c: stloc.s 11
+		IL_037e: ldstr "AsyncIterator"
+		IL_0383: call string [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::TypeOfGlobalBinding(string)
+		IL_0388: stloc.s 15
+		IL_038a: ldloc.s 11
+		IL_038c: ldloc.s 15
+		IL_038e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0393: pop
+		IL_0394: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0399: stloc.s 11
+		IL_039b: ldstr "AsyncIterator"
+		IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03a5: ldstr "prototype"
+		IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03af: stloc.s 7
+		IL_03b1: ldstr "asyncIterator"
+		IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_03bb: stloc.s 16
+		IL_03bd: ldloc.s 7
+		IL_03bf: ldloc.s 16
+		IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_03c6: stloc.s 16
+		IL_03c8: ldloc.s 16
+		IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03cf: ldstr "call"
+		IL_03d4: ldloc.s 6
+		IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03db: stloc.s 16
+		IL_03dd: ldloc.s 16
+		IL_03df: ldloc.s 6
+		IL_03e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_03e6: stloc.s 12
+		IL_03e8: ldloc.s 12
+		IL_03ea: box [System.Runtime]System.Boolean
+		IL_03ef: stloc.s 13
+		IL_03f1: ldloc.s 11
+		IL_03f3: ldloc.s 13
+		IL_03f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03fa: pop
+		IL_03fb: ret
 	} // end of method Iterator_Helper_Next_Return::__js_module_init__
 
 } // end of class Modules.Iterator_Helper_Next_Return

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
@@ -341,7 +341,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 243 (0xf3)
+			// Code size: 234 (0xea)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope,
@@ -424,16 +424,13 @@
 			IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17>(!!0, float64, string, bool, bool)
 			IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17>(!!0)
 			IL_00d8: stloc.s 4
-			IL_00da: ldloc.s 4
-			IL_00dc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17>(!!0)
-			IL_00e1: stloc.s 4
-			IL_00e3: ldloc.2
-			IL_00e4: ldstr "next"
-			IL_00e9: ldloc.s 4
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_00f0: pop
-			IL_00f1: ldloc.2
-			IL_00f2: ret
+			IL_00da: ldloc.2
+			IL_00db: ldstr "next"
+			IL_00e0: ldloc.s 4
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_00e7: pop
+			IL_00e8: ldloc.2
+			IL_00e9: ret
 		} // end of method FunctionExpression_iterable::__js_call__
 
 	} // end of class FunctionExpression_iterable
@@ -902,7 +899,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 286 (0x11e)
+			// Code size: 268 (0x10c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope,
@@ -976,53 +973,47 @@
 			IL_00a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17>(!!0, float64, string, bool, bool)
 			IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17>(!!0)
 			IL_00b2: stloc.s 4
-			IL_00b4: ldloc.s 4
-			IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17>(!!0)
-			IL_00bb: stloc.s 4
-			IL_00bd: ldloc.2
-			IL_00be: ldstr "next"
-			IL_00c3: ldloc.s 4
-			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_00ca: pop
-			IL_00cb: ldc.i4.2
-			IL_00cc: newarr [System.Runtime]System.Object
-			IL_00d1: dup
+			IL_00b4: ldloc.2
+			IL_00b5: ldstr "next"
+			IL_00ba: ldloc.s 4
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_00c1: pop
+			IL_00c2: ldc.i4.2
+			IL_00c3: newarr [System.Runtime]System.Object
+			IL_00c8: dup
+			IL_00c9: ldc.i4.0
+			IL_00ca: ldarg.0
+			IL_00cb: stelem.ref
+			IL_00cc: dup
+			IL_00cd: ldc.i4.1
+			IL_00ce: ldloc.0
+			IL_00cf: stelem.ref
+			IL_00d0: stloc.3
+			IL_00d1: ldloc.3
 			IL_00d2: ldc.i4.0
-			IL_00d3: ldarg.0
-			IL_00d4: stelem.ref
-			IL_00d5: dup
-			IL_00d6: ldc.i4.1
-			IL_00d7: ldloc.0
-			IL_00d8: stelem.ref
-			IL_00d9: stloc.3
-			IL_00da: ldloc.3
-			IL_00db: ldc.i4.0
-			IL_00dc: ldelem.ref
-			IL_00dd: castclass Modules.Map_Constructor_Iterable/Scope
-			IL_00e2: ldloc.3
-			IL_00e3: ldc.i4.1
-			IL_00e4: ldelem.ref
-			IL_00e5: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
-			IL_00ea: ldloc.3
-			IL_00eb: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope, object[])
-			IL_00f0: ldc.i4.0
-			IL_00f1: conv.r8
-			IL_00f2: ldstr ""
-			IL_00f7: ldc.i4.0
-			IL_00f8: ldc.i4.1
-			IL_00f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19>(!!0, float64, string, bool, bool)
-			IL_00fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19>(!!0)
-			IL_0103: stloc.s 5
-			IL_0105: ldloc.s 5
-			IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19>(!!0)
-			IL_010c: stloc.s 5
-			IL_010e: ldloc.2
-			IL_010f: ldstr "return"
-			IL_0114: ldloc.s 5
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_011b: pop
-			IL_011c: ldloc.2
-			IL_011d: ret
+			IL_00d3: ldelem.ref
+			IL_00d4: castclass Modules.Map_Constructor_Iterable/Scope
+			IL_00d9: ldloc.3
+			IL_00da: ldc.i4.1
+			IL_00db: ldelem.ref
+			IL_00dc: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
+			IL_00e1: ldloc.3
+			IL_00e2: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope, object[])
+			IL_00e7: ldc.i4.0
+			IL_00e8: conv.r8
+			IL_00e9: ldstr ""
+			IL_00ee: ldc.i4.0
+			IL_00ef: ldc.i4.1
+			IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19>(!!0, float64, string, bool, bool)
+			IL_00f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19>(!!0)
+			IL_00fa: stloc.s 5
+			IL_00fc: ldloc.2
+			IL_00fd: ldstr "return"
+			IL_0102: ldloc.s 5
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0109: pop
+			IL_010a: ldloc.2
+			IL_010b: ret
 		} // end of method FunctionExpression_closableIterable::__js_call__
 
 	} // end of class FunctionExpression_closableIterable
@@ -1450,7 +1441,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 184 (0xb8)
+			// Code size: 168 (0xa8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope,
@@ -1497,53 +1488,47 @@
 			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17>(!!0, float64, string, bool, bool)
 			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17>(!!0)
 			IL_0050: stloc.3
-			IL_0051: ldloc.3
-			IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17>(!!0)
-			IL_0057: stloc.3
-			IL_0058: ldloc.1
-			IL_0059: ldstr "next"
-			IL_005e: ldloc.3
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0064: pop
-			IL_0065: ldc.i4.2
-			IL_0066: newarr [System.Runtime]System.Object
-			IL_006b: dup
-			IL_006c: ldc.i4.0
-			IL_006d: ldarg.0
-			IL_006e: stelem.ref
-			IL_006f: dup
-			IL_0070: ldc.i4.1
-			IL_0071: ldloc.0
-			IL_0072: stelem.ref
-			IL_0073: stloc.2
-			IL_0074: ldloc.2
-			IL_0075: ldc.i4.0
-			IL_0076: ldelem.ref
-			IL_0077: castclass Modules.Map_Constructor_Iterable/Scope
-			IL_007c: ldloc.2
-			IL_007d: ldc.i4.1
-			IL_007e: ldelem.ref
-			IL_007f: castclass Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope
-			IL_0084: ldloc.2
-			IL_0085: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope, object[])
+			IL_0051: ldloc.1
+			IL_0052: ldstr "next"
+			IL_0057: ldloc.3
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_005d: pop
+			IL_005e: ldc.i4.2
+			IL_005f: newarr [System.Runtime]System.Object
+			IL_0064: dup
+			IL_0065: ldc.i4.0
+			IL_0066: ldarg.0
+			IL_0067: stelem.ref
+			IL_0068: dup
+			IL_0069: ldc.i4.1
+			IL_006a: ldloc.0
+			IL_006b: stelem.ref
+			IL_006c: stloc.2
+			IL_006d: ldloc.2
+			IL_006e: ldc.i4.0
+			IL_006f: ldelem.ref
+			IL_0070: castclass Modules.Map_Constructor_Iterable/Scope
+			IL_0075: ldloc.2
+			IL_0076: ldc.i4.1
+			IL_0077: ldelem.ref
+			IL_0078: castclass Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope
+			IL_007d: ldloc.2
+			IL_007e: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope, object[])
+			IL_0083: ldc.i4.0
+			IL_0084: conv.r8
+			IL_0085: ldstr ""
 			IL_008a: ldc.i4.0
-			IL_008b: conv.r8
-			IL_008c: ldstr ""
-			IL_0091: ldc.i4.0
-			IL_0092: ldc.i4.1
-			IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19>(!!0, float64, string, bool, bool)
-			IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19>(!!0)
-			IL_009d: stloc.s 4
-			IL_009f: ldloc.s 4
-			IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19>(!!0)
-			IL_00a6: stloc.s 4
-			IL_00a8: ldloc.1
-			IL_00a9: ldstr "return"
-			IL_00ae: ldloc.s 4
-			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_00b5: pop
-			IL_00b6: ldloc.1
-			IL_00b7: ret
+			IL_008b: ldc.i4.1
+			IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19>(!!0, float64, string, bool, bool)
+			IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19>(!!0)
+			IL_0096: stloc.s 4
+			IL_0098: ldloc.1
+			IL_0099: ldstr "return"
+			IL_009e: ldloc.s 4
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_00a5: pop
+			IL_00a6: ldloc.1
+			IL_00a7: ret
 		} // end of method FunctionExpression_invalidIterable::__js_call__
 
 	} // end of class FunctionExpression_invalidIterable
@@ -1633,7 +1618,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 729 (0x2d9)
+		// Code size: 714 (0x2ca)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Constructor_Iterable/Scope,
@@ -1685,244 +1670,241 @@
 		IL_0040: ldc.i4.1
 		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22>(!!0, float64, string, bool, bool)
 		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22>(!!0)
-		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22>(!!0)
-		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_0055: pop
-		IL_0056: ldloc.s 12
-		IL_0058: stloc.1
-		IL_0059: ldloc.1
-		IL_005a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_005f: stloc.2
-		IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0065: stloc.s 14
-		IL_0067: ldloc.2
-		IL_0068: ldstr "size"
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0072: stloc.s 11
-		IL_0074: ldloc.s 14
-		IL_0076: ldloc.s 11
-		IL_0078: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007d: pop
-		IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0083: stloc.s 14
-		IL_0085: ldloc.2
-		IL_0086: ldstr "get"
-		IL_008b: ldstr "alpha"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0095: stloc.s 11
-		IL_0097: ldloc.s 14
-		IL_0099: ldloc.s 11
-		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a0: pop
-		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a6: stloc.s 14
-		IL_00a8: ldloc.2
-		IL_00a9: ldstr "get"
-		IL_00ae: ldstr "beta"
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b8: stloc.s 11
-		IL_00ba: ldloc.s 14
-		IL_00bc: ldloc.s 11
-		IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c3: pop
-		IL_00c4: ldloc.0
-		IL_00c5: ldc.i4.0
-		IL_00c6: box [System.Runtime]System.Boolean
-		IL_00cb: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_00d0: ldstr "iterator"
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_00da: stloc.s 11
-		IL_00dc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00e1: stloc.s 12
-		IL_00e3: ldc.i4.1
-		IL_00e4: newarr [System.Runtime]System.Object
-		IL_00e9: dup
-		IL_00ea: ldc.i4.0
-		IL_00eb: ldloc.0
-		IL_00ec: stelem.ref
-		IL_00ed: stloc.s 13
-		IL_00ef: ldloc.s 12
-		IL_00f1: ldloc.s 11
-		IL_00f3: ldloc.s 13
-		IL_00f5: ldc.i4.0
-		IL_00f6: ldelem.ref
-		IL_00f7: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_00fc: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
-		IL_0101: ldc.i4.0
-		IL_0102: conv.r8
-		IL_0103: ldstr ""
-		IL_0108: ldc.i4.0
-		IL_0109: ldc.i4.1
-		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22>(!!0, float64, string, bool, bool)
-		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22>(!!0)
-		IL_0114: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22>(!!0)
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_011e: pop
-		IL_011f: ldloc.s 12
-		IL_0121: stloc.3
-		IL_0122: ldloc.3
-		IL_0123: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_0128: stloc.s 4
-		IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012f: stloc.s 14
-		IL_0131: ldloc.0
-		IL_0132: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_0137: stloc.s 11
-		IL_0139: ldloc.s 14
-		IL_013b: ldloc.s 11
-		IL_013d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0142: pop
-		IL_0143: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0148: stloc.s 14
-		IL_014a: ldloc.s 4
-		IL_014c: ldstr "size"
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0156: stloc.s 11
-		IL_0158: ldloc.s 14
-		IL_015a: ldloc.s 11
-		IL_015c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0161: pop
-		IL_0162: ldc.i4.1
-		IL_0163: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0168: dup
-		IL_0169: ldc.i4.1
-		IL_016a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_016f: dup
-		IL_0170: ldstr "short"
-		IL_0175: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_017a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_017f: stloc.s 15
-		IL_0181: ldloc.s 15
-		IL_0183: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_0188: stloc.s 5
-		IL_018a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_018f: stloc.s 14
-		IL_0191: ldloc.s 5
-		IL_0193: ldstr "has"
-		IL_0198: ldstr "short"
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a2: stloc.s 11
-		IL_01a4: ldloc.s 14
-		IL_01a6: ldloc.s 11
-		IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ad: pop
-		IL_01ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b3: stloc.s 14
-		IL_01b5: ldloc.s 5
-		IL_01b7: ldstr "get"
-		IL_01bc: ldstr "short"
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c6: stloc.s 11
-		IL_01c8: ldloc.s 11
-		IL_01ca: ldnull
-		IL_01cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01d0: stloc.s 16
-		IL_01d2: ldloc.s 16
-		IL_01d4: box [System.Runtime]System.Boolean
-		IL_01d9: stloc.s 17
-		IL_01db: ldloc.s 14
-		IL_01dd: ldloc.s 17
-		IL_01df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e4: pop
-		IL_01e5: ldloc.0
-		IL_01e6: ldc.i4.0
-		IL_01e7: box [System.Runtime]System.Boolean
-		IL_01ec: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
-		IL_01f1: ldstr "iterator"
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_01fb: stloc.s 11
-		IL_01fd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0202: stloc.s 12
-		IL_0204: ldc.i4.1
-		IL_0205: newarr [System.Runtime]System.Object
-		IL_020a: dup
-		IL_020b: ldc.i4.0
-		IL_020c: ldloc.0
-		IL_020d: stelem.ref
-		IL_020e: stloc.s 13
-		IL_0210: ldloc.s 12
-		IL_0212: ldloc.s 11
-		IL_0214: ldloc.s 13
-		IL_0216: ldc.i4.0
-		IL_0217: ldelem.ref
-		IL_0218: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_021d: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
-		IL_0222: ldc.i4.0
-		IL_0223: conv.r8
-		IL_0224: ldstr ""
-		IL_0229: ldc.i4.0
-		IL_022a: ldc.i4.1
-		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22>(!!0, float64, string, bool, bool)
-		IL_0230: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22>(!!0)
-		IL_0235: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22>(!!0)
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_023f: pop
-		IL_0240: ldloc.s 12
-		IL_0242: stloc.s 6
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0050: pop
+		IL_0051: ldloc.s 12
+		IL_0053: stloc.1
+		IL_0054: ldloc.1
+		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+		IL_005a: stloc.2
+		IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0060: stloc.s 14
+		IL_0062: ldloc.2
+		IL_0063: ldstr "size"
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006d: stloc.s 11
+		IL_006f: ldloc.s 14
+		IL_0071: ldloc.s 11
+		IL_0073: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0078: pop
+		IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007e: stloc.s 14
+		IL_0080: ldloc.2
+		IL_0081: ldstr "get"
+		IL_0086: ldstr "alpha"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0090: stloc.s 11
+		IL_0092: ldloc.s 14
+		IL_0094: ldloc.s 11
+		IL_0096: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009b: pop
+		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a1: stloc.s 14
+		IL_00a3: ldloc.2
+		IL_00a4: ldstr "get"
+		IL_00a9: ldstr "beta"
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b3: stloc.s 11
+		IL_00b5: ldloc.s 14
+		IL_00b7: ldloc.s 11
+		IL_00b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00be: pop
+		IL_00bf: ldloc.0
+		IL_00c0: ldc.i4.0
+		IL_00c1: box [System.Runtime]System.Boolean
+		IL_00c6: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_00cb: ldstr "iterator"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_00d5: stloc.s 11
+		IL_00d7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00dc: stloc.s 12
+		IL_00de: ldc.i4.1
+		IL_00df: newarr [System.Runtime]System.Object
+		IL_00e4: dup
+		IL_00e5: ldc.i4.0
+		IL_00e6: ldloc.0
+		IL_00e7: stelem.ref
+		IL_00e8: stloc.s 13
+		IL_00ea: ldloc.s 12
+		IL_00ec: ldloc.s 11
+		IL_00ee: ldloc.s 13
+		IL_00f0: ldc.i4.0
+		IL_00f1: ldelem.ref
+		IL_00f2: castclass Modules.Map_Constructor_Iterable/Scope
+		IL_00f7: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
+		IL_00fc: ldc.i4.0
+		IL_00fd: conv.r8
+		IL_00fe: ldstr ""
+		IL_0103: ldc.i4.0
+		IL_0104: ldc.i4.1
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22>(!!0, float64, string, bool, bool)
+		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22>(!!0)
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0114: pop
+		IL_0115: ldloc.s 12
+		IL_0117: stloc.3
+		IL_0118: ldloc.3
+		IL_0119: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+		IL_011e: stloc.s 4
+		IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0125: stloc.s 14
+		IL_0127: ldloc.0
+		IL_0128: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_012d: stloc.s 11
+		IL_012f: ldloc.s 14
+		IL_0131: ldloc.s 11
+		IL_0133: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0138: pop
+		IL_0139: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013e: stloc.s 14
+		IL_0140: ldloc.s 4
+		IL_0142: ldstr "size"
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_014c: stloc.s 11
+		IL_014e: ldloc.s 14
+		IL_0150: ldloc.s 11
+		IL_0152: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0157: pop
+		IL_0158: ldc.i4.1
+		IL_0159: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_015e: dup
+		IL_015f: ldc.i4.1
+		IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0165: dup
+		IL_0166: ldstr "short"
+		IL_016b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0170: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0175: stloc.s 15
+		IL_0177: ldloc.s 15
+		IL_0179: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+		IL_017e: stloc.s 5
+		IL_0180: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0185: stloc.s 14
+		IL_0187: ldloc.s 5
+		IL_0189: ldstr "has"
+		IL_018e: ldstr "short"
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0198: stloc.s 11
+		IL_019a: ldloc.s 14
+		IL_019c: ldloc.s 11
+		IL_019e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a3: pop
+		IL_01a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a9: stloc.s 14
+		IL_01ab: ldloc.s 5
+		IL_01ad: ldstr "get"
+		IL_01b2: ldstr "short"
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bc: stloc.s 11
+		IL_01be: ldloc.s 11
+		IL_01c0: ldnull
+		IL_01c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01c6: stloc.s 16
+		IL_01c8: ldloc.s 16
+		IL_01ca: box [System.Runtime]System.Boolean
+		IL_01cf: stloc.s 17
+		IL_01d1: ldloc.s 14
+		IL_01d3: ldloc.s 17
+		IL_01d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01da: pop
+		IL_01db: ldloc.0
+		IL_01dc: ldc.i4.0
+		IL_01dd: box [System.Runtime]System.Boolean
+		IL_01e2: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
+		IL_01e7: ldstr "iterator"
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_01f1: stloc.s 11
+		IL_01f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01f8: stloc.s 12
+		IL_01fa: ldc.i4.1
+		IL_01fb: newarr [System.Runtime]System.Object
+		IL_0200: dup
+		IL_0201: ldc.i4.0
+		IL_0202: ldloc.0
+		IL_0203: stelem.ref
+		IL_0204: stloc.s 13
+		IL_0206: ldloc.s 12
+		IL_0208: ldloc.s 11
+		IL_020a: ldloc.s 13
+		IL_020c: ldc.i4.0
+		IL_020d: ldelem.ref
+		IL_020e: castclass Modules.Map_Constructor_Iterable/Scope
+		IL_0213: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
+		IL_0218: ldc.i4.0
+		IL_0219: conv.r8
+		IL_021a: ldstr ""
+		IL_021f: ldc.i4.0
+		IL_0220: ldc.i4.1
+		IL_0221: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22>(!!0, float64, string, bool, bool)
+		IL_0226: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22>(!!0)
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0230: pop
+		IL_0231: ldloc.s 12
+		IL_0233: stloc.s 6
 		.try
 		{
-			IL_0244: nop
-			IL_0245: ldloc.s 6
-			IL_0247: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-			IL_024c: pop
-			IL_024d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0252: stloc.s 14
-			IL_0254: ldloc.s 14
-			IL_0256: ldstr "no error"
-			IL_025b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0260: pop
-			IL_0261: leave IL_02bc
+			IL_0235: nop
+			IL_0236: ldloc.s 6
+			IL_0238: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+			IL_023d: pop
+			IL_023e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0243: stloc.s 14
+			IL_0245: ldloc.s 14
+			IL_0247: ldstr "no error"
+			IL_024c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0251: pop
+			IL_0252: leave IL_02ad
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0266: stloc.s 7
-			IL_0268: ldloc.s 7
-			IL_026a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_026f: dup
-			IL_0270: brtrue IL_0286
+			IL_0257: stloc.s 7
+			IL_0259: ldloc.s 7
+			IL_025b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0260: dup
+			IL_0261: brtrue IL_0277
 
-			IL_0275: pop
-			IL_0276: ldloc.s 7
-			IL_0278: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_027d: dup
-			IL_027e: brtrue IL_0292
+			IL_0266: pop
+			IL_0267: ldloc.s 7
+			IL_0269: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_026e: dup
+			IL_026f: brtrue IL_0283
 
-			IL_0283: pop
-			IL_0284: rethrow
+			IL_0274: pop
+			IL_0275: rethrow
 
-			IL_0286: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_028b: stloc.s 8
-			IL_028d: br IL_0294
+			IL_0277: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_027c: stloc.s 8
+			IL_027e: br IL_0285
 
-			IL_0292: stloc.s 8
+			IL_0283: stloc.s 8
 
-			IL_0294: ldloc.s 8
-			IL_0296: stloc.s 9
-			IL_0298: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_029d: stloc.s 14
-			IL_029f: ldloc.s 9
-			IL_02a1: ldstr "name"
-			IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ab: stloc.s 11
-			IL_02ad: ldloc.s 14
-			IL_02af: ldloc.s 11
-			IL_02b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02b6: pop
-			IL_02b7: leave IL_02bc
+			IL_0285: ldloc.s 8
+			IL_0287: stloc.s 9
+			IL_0289: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_028e: stloc.s 14
+			IL_0290: ldloc.s 9
+			IL_0292: ldstr "name"
+			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_029c: stloc.s 11
+			IL_029e: ldloc.s 14
+			IL_02a0: ldloc.s 11
+			IL_02a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02a7: pop
+			IL_02a8: leave IL_02ad
 		} // end handler
 
-		IL_02bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02c1: stloc.s 14
-		IL_02c3: ldloc.0
-		IL_02c4: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
-		IL_02c9: stloc.s 11
-		IL_02cb: ldloc.s 14
-		IL_02cd: ldloc.s 11
-		IL_02cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02d4: pop
-		IL_02d5: ldnull
-		IL_02d6: stloc.s 10
-		IL_02d8: ret
+		IL_02ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02b2: stloc.s 14
+		IL_02b4: ldloc.0
+		IL_02b5: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
+		IL_02ba: stloc.s 11
+		IL_02bc: ldloc.s 14
+		IL_02be: ldloc.s 11
+		IL_02c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c5: pop
+		IL_02c6: ldnull
+		IL_02c7: stloc.s 10
+		IL_02c9: ret
 	} // end of method Map_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Map_Constructor_Iterable

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -3101,7 +3101,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1052 (0x41c)
+		// Code size: 1012 (0x3f4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope,
@@ -3234,240 +3234,232 @@
 		IL_0186: ldc.i4.1
 		IL_0187: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
 		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0)
-		IL_0191: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0)
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_019b: pop
-		IL_019c: ldc.i4.1
-		IL_019d: newarr [System.Runtime]System.Object
-		IL_01a2: dup
-		IL_01a3: ldc.i4.0
-		IL_01a4: ldloc.0
-		IL_01a5: stelem.ref
-		IL_01a6: stloc.s 11
-		IL_01a8: ldloc.s 7
-		IL_01aa: ldstr "setBitsTrue"
-		IL_01af: ldloc.s 11
-		IL_01b1: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::.ctor(object[])
-		IL_01b6: ldc.i4.3
-		IL_01b7: conv.r8
-		IL_01b8: ldstr "setBitsTrue"
-		IL_01bd: ldc.i4.1
-		IL_01be: ldc.i4.1
-		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0)
-		IL_01c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0)
-		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01d3: pop
-		IL_01d4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01d9: stloc.s 11
-		IL_01db: ldloc.s 7
-		IL_01dd: ldstr "testBitTrue"
-		IL_01e2: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::.ctor()
-		IL_01e7: ldc.i4.1
-		IL_01e8: conv.r8
-		IL_01e9: ldstr "testBitTrue"
-		IL_01ee: ldc.i4.1
-		IL_01ef: ldc.i4.1
-		IL_01f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
-		IL_01f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0)
-		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0)
-		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0204: pop
-		IL_0205: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_020a: stloc.s 11
-		IL_020c: ldloc.s 7
-		IL_020e: ldstr "searchBitFalse"
-		IL_0213: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::.ctor()
-		IL_0218: ldc.i4.1
-		IL_0219: conv.r8
-		IL_021a: ldstr "searchBitFalse"
-		IL_021f: ldc.i4.1
-		IL_0220: ldc.i4.1
-		IL_0221: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
-		IL_0226: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0)
-		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0)
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0235: pop
-		IL_0236: ldc.i4.1
-		IL_0237: newarr [System.Runtime]System.Object
-		IL_023c: dup
-		IL_023d: ldc.i4.0
-		IL_023e: ldloc.0
-		IL_023f: stelem.ref
-		IL_0240: stloc.s 11
-		IL_0242: ldloc.s 10
-		IL_0244: ldloc.s 11
-		IL_0246: ldc.r8 1
-		IL_024f: box [System.Runtime]System.Double
-		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0259: stloc.s 7
-		IL_025b: ldloc.0
-		IL_025c: ldloc.s 7
-		IL_025e: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
-		IL_0263: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0268: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_026d: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0272: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0277: stloc.s 10
-		IL_0279: ldloc.s 10
-		IL_027b: ldstr "prototype"
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0285: stloc.s 7
-		IL_0287: ldc.i4.1
-		IL_0288: newarr [System.Runtime]System.Object
-		IL_028d: dup
-		IL_028e: ldc.i4.0
-		IL_028f: ldloc.0
-		IL_0290: stelem.ref
-		IL_0291: stloc.s 11
-		IL_0293: ldloc.s 7
-		IL_0295: ldstr "runSieve"
-		IL_029a: ldloc.s 11
-		IL_029c: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::.ctor(object[])
-		IL_02a1: ldc.i4.0
-		IL_02a2: conv.r8
-		IL_02a3: ldstr "runSieve"
-		IL_02a8: ldc.i4.1
-		IL_02a9: ldc.i4.1
-		IL_02aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0, float64, string, bool, bool)
-		IL_02af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0)
-		IL_02b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0)
-		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02be: pop
-		IL_02bf: ldc.i4.1
-		IL_02c0: newarr [System.Runtime]System.Object
-		IL_02c5: dup
-		IL_02c6: ldc.i4.0
-		IL_02c7: ldloc.0
-		IL_02c8: stelem.ref
-		IL_02c9: stloc.s 11
-		IL_02cb: ldloc.s 7
-		IL_02cd: ldstr "countPrimes"
-		IL_02d2: ldloc.s 11
-		IL_02d4: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::.ctor(object[])
-		IL_02d9: ldc.i4.0
-		IL_02da: conv.r8
-		IL_02db: ldstr "countPrimes"
-		IL_02e0: ldc.i4.1
-		IL_02e1: ldc.i4.1
-		IL_02e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0, float64, string, bool, bool)
-		IL_02e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0)
-		IL_02ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0)
-		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02f6: pop
-		IL_02f7: ldc.i4.1
-		IL_02f8: newarr [System.Runtime]System.Object
-		IL_02fd: dup
-		IL_02fe: ldc.i4.0
-		IL_02ff: ldloc.0
-		IL_0300: stelem.ref
-		IL_0301: stloc.s 11
-		IL_0303: ldloc.s 7
-		IL_0305: ldstr "getPrimes"
-		IL_030a: ldloc.s 11
-		IL_030c: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::.ctor(object[])
-		IL_0311: ldc.i4.0
-		IL_0312: conv.r8
-		IL_0313: ldstr "getPrimes"
-		IL_0318: ldc.i4.1
-		IL_0319: ldc.i4.1
-		IL_031a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0, float64, string, bool, bool)
-		IL_031f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0)
-		IL_0324: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0)
-		IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_032e: pop
-		IL_032f: ldc.i4.1
-		IL_0330: newarr [System.Runtime]System.Object
-		IL_0335: dup
-		IL_0336: ldc.i4.0
-		IL_0337: ldloc.0
-		IL_0338: stelem.ref
-		IL_0339: stloc.s 11
-		IL_033b: ldloc.s 7
-		IL_033d: ldstr "validatePrimeCount"
-		IL_0342: ldloc.s 11
-		IL_0344: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::.ctor(object[])
-		IL_0349: ldc.i4.1
-		IL_034a: conv.r8
-		IL_034b: ldstr "validatePrimeCount"
-		IL_0350: ldc.i4.1
-		IL_0351: ldc.i4.1
-		IL_0352: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0, float64, string, bool, bool)
-		IL_0357: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0)
-		IL_035c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0)
-		IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0366: pop
-		IL_0367: ldc.i4.1
-		IL_0368: newarr [System.Runtime]System.Object
-		IL_036d: dup
-		IL_036e: ldc.i4.0
-		IL_036f: ldloc.0
-		IL_0370: stelem.ref
-		IL_0371: stloc.s 11
-		IL_0373: ldloc.s 10
-		IL_0375: ldloc.s 11
-		IL_0377: ldc.r8 1
-		IL_0380: box [System.Runtime]System.Double
-		IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_038a: stloc.s 7
-		IL_038c: ldloc.0
-		IL_038d: ldloc.s 7
-		IL_038f: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
-		IL_0394: ldc.i4.1
-		IL_0395: newarr [System.Runtime]System.Object
-		IL_039a: dup
-		IL_039b: ldc.i4.0
-		IL_039c: ldloc.0
-		IL_039d: stelem.ref
-		IL_039e: stloc.s 11
-		IL_03a0: ldloc.s 11
-		IL_03a2: ldc.i4.0
-		IL_03a3: ldelem.ref
-		IL_03a4: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_03a9: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope)
-		IL_03ae: ldc.i4.1
-		IL_03af: conv.r8
-		IL_03b0: ldstr ""
-		IL_03b5: ldc.i4.0
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0196: pop
+		IL_0197: ldc.i4.1
+		IL_0198: newarr [System.Runtime]System.Object
+		IL_019d: dup
+		IL_019e: ldc.i4.0
+		IL_019f: ldloc.0
+		IL_01a0: stelem.ref
+		IL_01a1: stloc.s 11
+		IL_01a3: ldloc.s 7
+		IL_01a5: ldstr "setBitsTrue"
+		IL_01aa: ldloc.s 11
+		IL_01ac: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::.ctor(object[])
+		IL_01b1: ldc.i4.3
+		IL_01b2: conv.r8
+		IL_01b3: ldstr "setBitsTrue"
+		IL_01b8: ldc.i4.1
+		IL_01b9: ldc.i4.1
+		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
+		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0)
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01c9: pop
+		IL_01ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01cf: stloc.s 11
+		IL_01d1: ldloc.s 7
+		IL_01d3: ldstr "testBitTrue"
+		IL_01d8: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::.ctor()
+		IL_01dd: ldc.i4.1
+		IL_01de: conv.r8
+		IL_01df: ldstr "testBitTrue"
+		IL_01e4: ldc.i4.1
+		IL_01e5: ldc.i4.1
+		IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
+		IL_01eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0)
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01f5: pop
+		IL_01f6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01fb: stloc.s 11
+		IL_01fd: ldloc.s 7
+		IL_01ff: ldstr "searchBitFalse"
+		IL_0204: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::.ctor()
+		IL_0209: ldc.i4.1
+		IL_020a: conv.r8
+		IL_020b: ldstr "searchBitFalse"
+		IL_0210: ldc.i4.1
+		IL_0211: ldc.i4.1
+		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
+		IL_0217: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0)
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0221: pop
+		IL_0222: ldc.i4.1
+		IL_0223: newarr [System.Runtime]System.Object
+		IL_0228: dup
+		IL_0229: ldc.i4.0
+		IL_022a: ldloc.0
+		IL_022b: stelem.ref
+		IL_022c: stloc.s 11
+		IL_022e: ldloc.s 10
+		IL_0230: ldloc.s 11
+		IL_0232: ldc.r8 1
+		IL_023b: box [System.Runtime]System.Double
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0245: stloc.s 7
+		IL_0247: ldloc.0
+		IL_0248: ldloc.s 7
+		IL_024a: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
+		IL_024f: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_0254: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0259: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_025e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0263: stloc.s 10
+		IL_0265: ldloc.s 10
+		IL_0267: ldstr "prototype"
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0271: stloc.s 7
+		IL_0273: ldc.i4.1
+		IL_0274: newarr [System.Runtime]System.Object
+		IL_0279: dup
+		IL_027a: ldc.i4.0
+		IL_027b: ldloc.0
+		IL_027c: stelem.ref
+		IL_027d: stloc.s 11
+		IL_027f: ldloc.s 7
+		IL_0281: ldstr "runSieve"
+		IL_0286: ldloc.s 11
+		IL_0288: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::.ctor(object[])
+		IL_028d: ldc.i4.0
+		IL_028e: conv.r8
+		IL_028f: ldstr "runSieve"
+		IL_0294: ldc.i4.1
+		IL_0295: ldc.i4.1
+		IL_0296: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0, float64, string, bool, bool)
+		IL_029b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0)
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02a5: pop
+		IL_02a6: ldc.i4.1
+		IL_02a7: newarr [System.Runtime]System.Object
+		IL_02ac: dup
+		IL_02ad: ldc.i4.0
+		IL_02ae: ldloc.0
+		IL_02af: stelem.ref
+		IL_02b0: stloc.s 11
+		IL_02b2: ldloc.s 7
+		IL_02b4: ldstr "countPrimes"
+		IL_02b9: ldloc.s 11
+		IL_02bb: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::.ctor(object[])
+		IL_02c0: ldc.i4.0
+		IL_02c1: conv.r8
+		IL_02c2: ldstr "countPrimes"
+		IL_02c7: ldc.i4.1
+		IL_02c8: ldc.i4.1
+		IL_02c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0, float64, string, bool, bool)
+		IL_02ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0)
+		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02d8: pop
+		IL_02d9: ldc.i4.1
+		IL_02da: newarr [System.Runtime]System.Object
+		IL_02df: dup
+		IL_02e0: ldc.i4.0
+		IL_02e1: ldloc.0
+		IL_02e2: stelem.ref
+		IL_02e3: stloc.s 11
+		IL_02e5: ldloc.s 7
+		IL_02e7: ldstr "getPrimes"
+		IL_02ec: ldloc.s 11
+		IL_02ee: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::.ctor(object[])
+		IL_02f3: ldc.i4.0
+		IL_02f4: conv.r8
+		IL_02f5: ldstr "getPrimes"
+		IL_02fa: ldc.i4.1
+		IL_02fb: ldc.i4.1
+		IL_02fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0, float64, string, bool, bool)
+		IL_0301: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0)
+		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_030b: pop
+		IL_030c: ldc.i4.1
+		IL_030d: newarr [System.Runtime]System.Object
+		IL_0312: dup
+		IL_0313: ldc.i4.0
+		IL_0314: ldloc.0
+		IL_0315: stelem.ref
+		IL_0316: stloc.s 11
+		IL_0318: ldloc.s 7
+		IL_031a: ldstr "validatePrimeCount"
+		IL_031f: ldloc.s 11
+		IL_0321: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::.ctor(object[])
+		IL_0326: ldc.i4.1
+		IL_0327: conv.r8
+		IL_0328: ldstr "validatePrimeCount"
+		IL_032d: ldc.i4.1
+		IL_032e: ldc.i4.1
+		IL_032f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0, float64, string, bool, bool)
+		IL_0334: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0)
+		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_033e: pop
+		IL_033f: ldc.i4.1
+		IL_0340: newarr [System.Runtime]System.Object
+		IL_0345: dup
+		IL_0346: ldc.i4.0
+		IL_0347: ldloc.0
+		IL_0348: stelem.ref
+		IL_0349: stloc.s 11
+		IL_034b: ldloc.s 10
+		IL_034d: ldloc.s 11
+		IL_034f: ldc.r8 1
+		IL_0358: box [System.Runtime]System.Double
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0362: stloc.s 7
+		IL_0364: ldloc.0
+		IL_0365: ldloc.s 7
+		IL_0367: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
+		IL_036c: ldc.i4.1
+		IL_036d: newarr [System.Runtime]System.Object
+		IL_0372: dup
+		IL_0373: ldc.i4.0
+		IL_0374: ldloc.0
+		IL_0375: stelem.ref
+		IL_0376: stloc.s 11
+		IL_0378: ldloc.s 11
+		IL_037a: ldc.i4.0
+		IL_037b: ldelem.ref
+		IL_037c: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_0381: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope)
+		IL_0386: ldc.i4.1
+		IL_0387: conv.r8
+		IL_0388: ldstr ""
+		IL_038d: ldc.i4.0
+		IL_038e: ldc.i4.0
+		IL_038f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0394: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject>(!!0)
+		IL_0399: stloc.s 12
+		IL_039b: ldloc.s 12
+		IL_039d: ldstr "runSieveBatch"
+		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_03a7: stloc.3
+		IL_03a8: ldc.i4.1
+		IL_03a9: newarr [System.Runtime]System.Object
+		IL_03ae: dup
+		IL_03af: ldc.i4.0
+		IL_03b0: ldloc.0
+		IL_03b1: stelem.ref
+		IL_03b2: stloc.s 11
+		IL_03b4: ldloc.s 11
 		IL_03b6: ldc.i4.0
-		IL_03b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/FunctionObject>(!!0)
-		IL_03c1: stloc.s 12
-		IL_03c3: ldloc.s 12
-		IL_03c5: ldstr "runSieveBatch"
-		IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_03cf: stloc.3
-		IL_03d0: ldc.i4.1
-		IL_03d1: newarr [System.Runtime]System.Object
-		IL_03d6: dup
-		IL_03d7: ldc.i4.0
-		IL_03d8: ldloc.0
-		IL_03d9: stelem.ref
-		IL_03da: stloc.s 11
-		IL_03dc: ldloc.s 11
-		IL_03de: ldc.i4.0
-		IL_03df: ldelem.ref
-		IL_03e0: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_03e5: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope)
-		IL_03ea: ldc.i4.1
-		IL_03eb: conv.r8
-		IL_03ec: ldstr ""
-		IL_03f1: ldc.i4.0
-		IL_03f2: ldc.i4.0
-		IL_03f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject>(!!0)
-		IL_03fd: stloc.s 13
-		IL_03ff: ldloc.s 13
-		IL_0401: ldstr "main"
-		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_040b: stloc.s 4
-		IL_040d: ldloc.0
-		IL_040e: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0413: ldnull
-		IL_0414: ldloc.1
-		IL_0415: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_041a: pop
-		IL_041b: ret
+		IL_03b7: ldelem.ref
+		IL_03b8: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_03bd: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope)
+		IL_03c2: ldc.i4.1
+		IL_03c3: conv.r8
+		IL_03c4: ldstr ""
+		IL_03c9: ldc.i4.0
+		IL_03ca: ldc.i4.0
+		IL_03cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14/FunctionObject>(!!0)
+		IL_03d5: stloc.s 13
+		IL_03d7: ldloc.s 13
+		IL_03d9: ldstr "main"
+		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_03e3: stloc.s 4
+		IL_03e5: ldloc.0
+		IL_03e6: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_03eb: ldnull
+		IL_03ec: ldloc.1
+		IL_03ed: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_03f2: pop
+		IL_03f3: ret
 	} // end of method Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes::__js_module_init__
 
 } // end of class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_ComputedGlobalPropertyReplacement.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_ComputedGlobalPropertyReplacement.verified.txt
@@ -183,7 +183,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 185 (0xb9)
+		// Code size: 176 (0xb0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/Scope,
@@ -232,28 +232,25 @@
 		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_BD585917_L3C8>(!!0, float64, string, bool, bool)
 		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_BD585917_L3C8>(!!0)
 		IL_0072: stloc.s 4
-		IL_0074: ldloc.s 4
-		IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_BD585917_L3C8>(!!0)
-		IL_007b: stloc.s 4
-		IL_007d: ldloc.2
-		IL_007e: ldstr "log"
-		IL_0083: ldloc.s 4
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_008a: pop
-		IL_008b: ldloc.1
-		IL_008c: ldstr "console"
-		IL_0091: ldloc.2
-		IL_0092: ldc.i4.0
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0098: pop
-		IL_0099: ldstr "console"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a8: ldstr "log"
-		IL_00ad: ldstr "global"
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b7: pop
-		IL_00b8: ret
+		IL_0074: ldloc.2
+		IL_0075: ldstr "log"
+		IL_007a: ldloc.s 4
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0081: pop
+		IL_0082: ldloc.1
+		IL_0083: ldstr "console"
+		IL_0088: ldloc.2
+		IL_0089: ldc.i4.0
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_008f: pop
+		IL_0090: ldstr "console"
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009f: ldstr "log"
+		IL_00a4: ldstr "global"
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ae: pop
+		IL_00af: ret
 	} // end of method Console_GlobalLog_ComputedGlobalPropertyReplacement::__js_module_init__
 
 } // end of class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_DescriptorReplacement.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_DescriptorReplacement.verified.txt
@@ -183,7 +183,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 226 (0xe2)
+		// Code size: 217 (0xd9)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Console_GlobalLog_DescriptorReplacement/Scope,
@@ -232,41 +232,38 @@
 		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject_FunctionExpression_D2A375B9_L4C12>(!!0, float64, string, bool, bool)
 		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject_FunctionExpression_D2A375B9_L4C12>(!!0)
 		IL_0072: stloc.s 4
-		IL_0074: ldloc.s 4
-		IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject_FunctionExpression_D2A375B9_L4C12>(!!0)
-		IL_007b: stloc.s 4
-		IL_007d: ldloc.2
-		IL_007e: ldstr "log"
-		IL_0083: ldloc.s 4
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_008a: pop
-		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0090: dup
-		IL_0091: ldstr "value"
-		IL_0096: ldloc.2
-		IL_0097: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_009c: dup
-		IL_009d: ldstr "configurable"
-		IL_00a2: ldc.i4.1
-		IL_00a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_00a8: dup
-		IL_00a9: ldstr "writable"
-		IL_00ae: ldc.i4.1
-		IL_00af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_00b4: stloc.2
-		IL_00b5: ldloc.1
-		IL_00b6: ldstr "console"
-		IL_00bb: ldloc.2
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_00c1: pop
-		IL_00c2: ldstr "console"
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d1: ldstr "log"
-		IL_00d6: ldstr "global"
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e0: pop
-		IL_00e1: ret
+		IL_0074: ldloc.2
+		IL_0075: ldstr "log"
+		IL_007a: ldloc.s 4
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0081: pop
+		IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0087: dup
+		IL_0088: ldstr "value"
+		IL_008d: ldloc.2
+		IL_008e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0093: dup
+		IL_0094: ldstr "configurable"
+		IL_0099: ldc.i4.1
+		IL_009a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_009f: dup
+		IL_00a0: ldstr "writable"
+		IL_00a5: ldc.i4.1
+		IL_00a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_00ab: stloc.2
+		IL_00ac: ldloc.1
+		IL_00ad: ldstr "console"
+		IL_00b2: ldloc.2
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_00b8: pop
+		IL_00b9: ldstr "console"
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c8: ldstr "log"
+		IL_00cd: ldstr "global"
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d7: pop
+		IL_00d8: ret
 	} // end of method Console_GlobalLog_DescriptorReplacement::__js_module_init__
 
 } // end of class Modules.Console_GlobalLog_DescriptorReplacement

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_GlobalPropertyReplacement.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_GlobalPropertyReplacement.verified.txt
@@ -183,7 +183,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 185 (0xb9)
+		// Code size: 176 (0xb0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Console_GlobalLog_GlobalPropertyReplacement/Scope,
@@ -232,28 +232,25 @@
 		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_47874DFA_L3C8>(!!0, float64, string, bool, bool)
 		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_47874DFA_L3C8>(!!0)
 		IL_0072: stloc.s 4
-		IL_0074: ldloc.s 4
-		IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_47874DFA_L3C8>(!!0)
-		IL_007b: stloc.s 4
-		IL_007d: ldloc.2
-		IL_007e: ldstr "log"
-		IL_0083: ldloc.s 4
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_008a: pop
-		IL_008b: ldloc.1
-		IL_008c: ldstr "console"
-		IL_0091: ldloc.2
-		IL_0092: ldc.i4.0
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0098: pop
-		IL_0099: ldstr "console"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a8: ldstr "log"
-		IL_00ad: ldstr "global"
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b7: pop
-		IL_00b8: ret
+		IL_0074: ldloc.2
+		IL_0075: ldstr "log"
+		IL_007a: ldloc.s 4
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0081: pop
+		IL_0082: ldloc.1
+		IL_0083: ldstr "console"
+		IL_0088: ldloc.2
+		IL_0089: ldc.i4.0
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_008f: pop
+		IL_0090: ldstr "console"
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009f: ldstr "log"
+		IL_00a4: ldstr "global"
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ae: pop
+		IL_00af: ret
 	} // end of method Console_GlobalLog_GlobalPropertyReplacement::__js_module_init__
 
 } // end of class Modules.Console_GlobalLog_GlobalPropertyReplacement

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_GlobalThisAliasReplacement.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_GlobalThisAliasReplacement.verified.txt
@@ -183,7 +183,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 187 (0xbb)
+		// Code size: 178 (0xb2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Console_GlobalLog_GlobalThisAliasReplacement/Scope,
@@ -233,28 +233,25 @@
 		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject_FunctionExpression_64F88AA8_L4C8>(!!0, float64, string, bool, bool)
 		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject_FunctionExpression_64F88AA8_L4C8>(!!0)
 		IL_0074: stloc.s 5
-		IL_0076: ldloc.s 5
-		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject_FunctionExpression_64F88AA8_L4C8>(!!0)
-		IL_007d: stloc.s 5
-		IL_007f: ldloc.3
-		IL_0080: ldstr "log"
-		IL_0085: ldloc.s 5
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_008c: pop
-		IL_008d: ldloc.1
-		IL_008e: ldstr "console"
-		IL_0093: ldloc.3
-		IL_0094: ldc.i4.0
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_009a: pop
-		IL_009b: ldstr "console"
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00aa: ldstr "log"
-		IL_00af: ldstr "global"
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b9: pop
-		IL_00ba: ret
+		IL_0076: ldloc.3
+		IL_0077: ldstr "log"
+		IL_007c: ldloc.s 5
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0083: pop
+		IL_0084: ldloc.1
+		IL_0085: ldstr "console"
+		IL_008a: ldloc.3
+		IL_008b: ldc.i4.0
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0091: pop
+		IL_0092: ldstr "console"
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a1: ldstr "log"
+		IL_00a6: ldstr "global"
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b0: pop
+		IL_00b1: ret
 	} // end of method Console_GlobalLog_GlobalThisAliasReplacement::__js_module_init__
 
 } // end of class Modules.Console_GlobalLog_GlobalThisAliasReplacement

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_LocalBindingShadowing.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_LocalBindingShadowing.verified.txt
@@ -169,7 +169,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 92 (0x5c)
+		// Code size: 83 (0x53)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Console_GlobalLog_LocalBindingShadowing/Scope,
@@ -199,22 +199,19 @@
 		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject_FunctionExpression_C90D3773_L2C8>(!!0, float64, string, bool, bool)
 		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject_FunctionExpression_C90D3773_L2C8>(!!0)
 		IL_002f: stloc.s 4
-		IL_0031: ldloc.s 4
-		IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject_FunctionExpression_C90D3773_L2C8>(!!0)
-		IL_0038: stloc.s 4
-		IL_003a: ldloc.2
-		IL_003b: ldstr "log"
-		IL_0040: ldloc.s 4
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0047: pop
-		IL_0048: ldloc.2
-		IL_0049: stloc.1
-		IL_004a: ldloc.1
-		IL_004b: ldstr "log"
-		IL_0050: ldstr "local"
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005a: pop
-		IL_005b: ret
+		IL_0031: ldloc.2
+		IL_0032: ldstr "log"
+		IL_0037: ldloc.s 4
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_003e: pop
+		IL_003f: ldloc.2
+		IL_0040: stloc.1
+		IL_0041: ldloc.1
+		IL_0042: ldstr "log"
+		IL_0047: ldstr "local"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0051: pop
+		IL_0052: ret
 	} // end of method Console_GlobalLog_LocalBindingShadowing::__js_module_init__
 
 } // end of class Modules.Console_GlobalLog_LocalBindingShadowing

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_Undici_Transform_Table.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_Undici_Transform_Table.verified.txt
@@ -160,7 +160,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 457 (0x1c9)
+		// Code size: 448 (0x1c0)
 		.maxstack 11
 		.locals init (
 			[0] class Modules.Console_Undici_Transform_Table/Scope,
@@ -239,92 +239,89 @@
 		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_Undici_Transform_Table/FunctionExpression_output/FunctionObject_FunctionExpression_B23CAF09_L7C12>(!!0, float64, string, bool, bool)
 		IL_00a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_Undici_Transform_Table/FunctionExpression_output/FunctionObject_FunctionExpression_B23CAF09_L7C12>(!!0)
 		IL_00ae: stloc.s 9
-		IL_00b0: ldloc.s 9
-		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_Undici_Transform_Table/FunctionExpression_output/FunctionObject_FunctionExpression_B23CAF09_L7C12>(!!0)
-		IL_00b7: stloc.s 9
-		IL_00b9: ldloc.s 7
-		IL_00bb: ldstr "transform"
-		IL_00c0: ldloc.s 9
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_00c7: pop
-		IL_00c8: ldloc.1
-		IL_00c9: ldc.i4.1
-		IL_00ca: newarr [System.Runtime]System.Object
-		IL_00cf: dup
-		IL_00d0: ldc.i4.0
-		IL_00d1: ldloc.s 7
-		IL_00d3: stelem.ref
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_00d9: stloc.3
-		IL_00da: ldloc.2
-		IL_00db: ldc.i4.1
-		IL_00dc: newarr [System.Runtime]System.Object
-		IL_00e1: dup
-		IL_00e2: ldc.i4.0
-		IL_00e3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00e8: dup
-		IL_00e9: ldstr "stdout"
-		IL_00ee: ldloc.3
-		IL_00ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00f4: dup
-		IL_00f5: ldstr "inspectOptions"
-		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00ff: dup
-		IL_0100: ldstr "colors"
-		IL_0105: ldc.i4.0
-		IL_0106: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_010b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0110: stelem.ref
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_0116: stloc.s 4
-		IL_0118: ldloc.s 4
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011f: ldc.i4.2
-		IL_0120: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0125: dup
-		IL_0126: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_012b: dup
-		IL_012c: ldstr "name"
-		IL_0131: ldstr "first"
-		IL_0136: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_013b: dup
-		IL_013c: ldstr "value"
-		IL_0141: ldc.r8 1
-		IL_014a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_014f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0154: dup
-		IL_0155: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_015a: dup
-		IL_015b: ldstr "name"
-		IL_0160: ldstr "second"
-		IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_016a: dup
-		IL_016b: ldstr "value"
-		IL_0170: ldc.r8 2
-		IL_0179: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_017e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0183: stloc.s 10
-		IL_0185: ldstr "table"
-		IL_018a: ldloc.s 10
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0191: pop
-		IL_0192: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0197: stloc.s 11
-		IL_0199: ldloc.3
-		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019f: ldstr "read"
-		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01a9: stloc.s 12
-		IL_01ab: ldloc.s 12
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b2: ldstr "toString"
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01bc: stloc.s 12
-		IL_01be: ldloc.s 11
-		IL_01c0: ldloc.s 12
-		IL_01c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01c7: pop
-		IL_01c8: ret
+		IL_00b0: ldloc.s 7
+		IL_00b2: ldstr "transform"
+		IL_00b7: ldloc.s 9
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_00be: pop
+		IL_00bf: ldloc.1
+		IL_00c0: ldc.i4.1
+		IL_00c1: newarr [System.Runtime]System.Object
+		IL_00c6: dup
+		IL_00c7: ldc.i4.0
+		IL_00c8: ldloc.s 7
+		IL_00ca: stelem.ref
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_00d0: stloc.3
+		IL_00d1: ldloc.2
+		IL_00d2: ldc.i4.1
+		IL_00d3: newarr [System.Runtime]System.Object
+		IL_00d8: dup
+		IL_00d9: ldc.i4.0
+		IL_00da: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00df: dup
+		IL_00e0: ldstr "stdout"
+		IL_00e5: ldloc.3
+		IL_00e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00eb: dup
+		IL_00ec: ldstr "inspectOptions"
+		IL_00f1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00f6: dup
+		IL_00f7: ldstr "colors"
+		IL_00fc: ldc.i4.0
+		IL_00fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0102: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0107: stelem.ref
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_010d: stloc.s 4
+		IL_010f: ldloc.s 4
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0116: ldc.i4.2
+		IL_0117: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_011c: dup
+		IL_011d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0122: dup
+		IL_0123: ldstr "name"
+		IL_0128: ldstr "first"
+		IL_012d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0132: dup
+		IL_0133: ldstr "value"
+		IL_0138: ldc.r8 1
+		IL_0141: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0146: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_014b: dup
+		IL_014c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0151: dup
+		IL_0152: ldstr "name"
+		IL_0157: ldstr "second"
+		IL_015c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0161: dup
+		IL_0162: ldstr "value"
+		IL_0167: ldc.r8 2
+		IL_0170: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0175: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_017a: stloc.s 10
+		IL_017c: ldstr "table"
+		IL_0181: ldloc.s 10
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0188: pop
+		IL_0189: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_018e: stloc.s 11
+		IL_0190: ldloc.3
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0196: ldstr "read"
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01a0: stloc.s 12
+		IL_01a2: ldloc.s 12
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a9: ldstr "toString"
+		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01b3: stloc.s 12
+		IL_01b5: ldloc.s 11
+		IL_01b7: ldloc.s 12
+		IL_01b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01be: pop
+		IL_01bf: ret
 	} // end of method Console_Undici_Transform_Table::__js_module_init__
 
 } // end of class Modules.Console_Undici_Transform_Table

--- a/tests/Jroc.Tests/Node/Snapshots/GeneratorTests.PerfHooks_DestructuredPerformanceOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Snapshots/GeneratorTests.PerfHooks_DestructuredPerformanceOverride.verified.txt
@@ -137,7 +137,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 237 (0xed)
+		// Code size: 228 (0xe4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.PerfHooks_DestructuredPerformanceOverride/Scope,
@@ -176,66 +176,63 @@
 		IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7/FunctionObject_FunctionExpression_60CA76E0_L5C8>(!!0, float64, string, bool, bool)
 		IL_0038: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7/FunctionObject_FunctionExpression_60CA76E0_L5C8>(!!0)
 		IL_003d: stloc.s 5
-		IL_003f: ldloc.s 5
-		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7/FunctionObject_FunctionExpression_60CA76E0_L5C8>(!!0)
-		IL_0046: stloc.s 5
-		IL_0048: ldloc.3
-		IL_0049: ldstr "now"
-		IL_004e: ldloc.s 5
-		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0055: pop
-		IL_0056: ldloc.3
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
-		IL_005c: stloc.s 6
-		IL_005e: ldloc.1
-		IL_005f: ldstr "performance"
-		IL_0064: ldloc.s 6
-		IL_0066: ldc.i4.1
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_006c: pop
-		IL_006d: ldarg.1
-		IL_006e: ldstr "perf_hooks"
-		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
-		IL_0078: stloc.s 7
-		IL_007a: ldloc.s 7
-		IL_007c: brfalse IL_008d
+		IL_003f: ldloc.3
+		IL_0040: ldstr "now"
+		IL_0045: ldloc.s 5
+		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_004c: pop
+		IL_004d: ldloc.3
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
+		IL_0053: stloc.s 6
+		IL_0055: ldloc.1
+		IL_0056: ldstr "performance"
+		IL_005b: ldloc.s 6
+		IL_005d: ldc.i4.1
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0063: pop
+		IL_0064: ldarg.1
+		IL_0065: ldstr "perf_hooks"
+		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
+		IL_006f: stloc.s 7
+		IL_0071: ldloc.s 7
+		IL_0073: brfalse IL_0084
 
-		IL_0081: ldloc.s 7
-		IL_0083: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0088: brfalse IL_009e
+		IL_0078: ldloc.s 7
+		IL_007a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_007f: brfalse IL_0095
 
-		IL_008d: ldloc.s 7
-		IL_008f: ldstr ""
-		IL_0094: ldstr "performance"
-		IL_0099: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_0084: ldloc.s 7
+		IL_0086: ldstr ""
+		IL_008b: ldstr "performance"
+		IL_0090: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_009e: ldloc.s 7
-		IL_00a0: ldstr "performance"
-		IL_00a5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_00aa: brtrue IL_00bc
+		IL_0095: ldloc.s 7
+		IL_0097: ldstr "performance"
+		IL_009c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_00a1: brtrue IL_00b3
 
-		IL_00af: ldloc.s 7
-		IL_00b1: callvirt instance class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule::get_performance()
-		IL_00b6: stloc.2
-		IL_00b7: br IL_00c9
+		IL_00a6: ldloc.s 7
+		IL_00a8: callvirt instance class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksPerformance [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule::get_performance()
+		IL_00ad: stloc.2
+		IL_00ae: br IL_00c0
 
-		IL_00bc: ldloc.s 7
-		IL_00be: ldstr "performance"
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00c8: stloc.2
+		IL_00b3: ldloc.s 7
+		IL_00b5: ldstr "performance"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00bf: stloc.2
 
-		IL_00c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ce: stloc.s 8
-		IL_00d0: ldloc.2
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d6: ldstr "now"
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00e0: stloc.s 6
-		IL_00e2: ldloc.s 8
-		IL_00e4: ldloc.s 6
-		IL_00e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00eb: pop
-		IL_00ec: ret
+		IL_00c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c5: stloc.s 8
+		IL_00c7: ldloc.2
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cd: ldstr "now"
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00d7: stloc.s 6
+		IL_00d9: ldloc.s 8
+		IL_00db: ldloc.s 6
+		IL_00dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e2: pop
+		IL_00e3: ret
 	} // end of method PerfHooks_DestructuredPerformanceOverride::__js_module_init__
 
 } // end of class Modules.PerfHooks_DestructuredPerformanceOverride

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_AccessorDefinitions.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_AccessorDefinitions.verified.txt
@@ -574,8 +574,8 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 957 (0x3bd)
-		.maxstack 13
+		// Code size: 875 (0x36b)
+		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_AccessorDefinitions/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -621,301 +621,275 @@
 		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject_FunctionExpression_131FC9A5_L5C12>(!!0)
 		IL_0048: stloc.s 7
 		IL_004a: ldloc.s 7
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject_FunctionExpression_131FC9A5_L5C12>(!!0)
-		IL_0051: stloc.s 7
-		IL_0053: ldloc.s 7
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject_FunctionExpression_131FC9A5_L5C12>(!!0)
-		IL_005a: stloc.s 7
-		IL_005c: ldloc.s 7
-		IL_005e: ldstr "value"
-		IL_0063: ldstr "get"
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_006d: stloc.s 8
-		IL_006f: ldloc.s 5
-		IL_0071: ldstr "value"
-		IL_0076: ldloc.s 8
-		IL_0078: ldnull
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_007e: pop
-		IL_007f: ldc.i4.1
-		IL_0080: newarr [System.Runtime]System.Object
-		IL_0085: dup
-		IL_0086: ldc.i4.0
-		IL_0087: ldloc.0
-		IL_0088: stelem.ref
-		IL_0089: stloc.s 6
-		IL_008b: ldloc.s 5
-		IL_008d: ldstr "value"
-		IL_0092: ldnull
-		IL_0093: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12::.ctor()
-		IL_0098: ldc.i4.1
-		IL_0099: conv.r8
-		IL_009a: ldstr ""
-		IL_009f: ldc.i4.1
-		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0, float64, string, bool, bool)
-		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0)
-		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0)
-		IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0)
-		IL_00b5: ldstr "value"
-		IL_00ba: ldstr "set"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_00c9: pop
-		IL_00ca: ldc.i4.1
-		IL_00cb: newarr [System.Runtime]System.Object
-		IL_00d0: dup
-		IL_00d1: ldc.i4.0
-		IL_00d2: ldloc.0
-		IL_00d3: stelem.ref
-		IL_00d4: stloc.s 6
-		IL_00d6: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17::.ctor()
-		IL_00db: ldc.i4.0
-		IL_00dc: conv.r8
-		IL_00dd: ldstr ""
-		IL_00e2: ldc.i4.1
-		IL_00e3: ldc.i4.1
-		IL_00e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0, float64, string, bool, bool)
-		IL_00e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0)
-		IL_00ee: stloc.s 9
-		IL_00f0: ldloc.s 9
-		IL_00f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0)
-		IL_00f7: stloc.s 9
-		IL_00f9: ldloc.s 9
-		IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0)
-		IL_0100: stloc.s 9
-		IL_0102: ldloc.s 9
-		IL_0104: ldstr "double"
-		IL_0109: ldstr "get"
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_0113: stloc.s 8
-		IL_0115: ldloc.s 5
-		IL_0117: ldstr "double"
-		IL_011c: ldloc.s 8
-		IL_011e: ldnull
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_0124: pop
-		IL_0125: ldloc.s 5
-		IL_0127: stloc.1
-		IL_0128: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012d: stloc.s 10
-		IL_012f: ldloc.1
-		IL_0130: ldstr "value"
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013a: stloc.s 8
-		IL_013c: ldloc.s 10
-		IL_013e: ldloc.s 8
-		IL_0140: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0145: pop
-		IL_0146: ldloc.1
-		IL_0147: ldstr "value"
-		IL_014c: ldc.r8 7
-		IL_0155: ldc.i4.1
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_015b: pop
-		IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0161: stloc.s 10
-		IL_0163: ldloc.1
-		IL_0164: ldstr "base"
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_016e: stloc.s 8
-		IL_0170: ldloc.s 10
-		IL_0172: ldloc.s 8
-		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0179: pop
-		IL_017a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017f: stloc.s 10
-		IL_0181: ldloc.1
-		IL_0182: ldstr "value"
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018c: stloc.s 8
-		IL_018e: ldloc.s 10
-		IL_0190: ldloc.s 8
-		IL_0192: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0197: pop
-		IL_0198: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_019d: stloc.s 10
-		IL_019f: ldloc.1
-		IL_01a0: ldstr "double"
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01aa: stloc.s 8
-		IL_01ac: ldloc.s 10
-		IL_01ae: ldloc.s 8
-		IL_01b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b5: pop
-		IL_01b6: ldloc.1
-		IL_01b7: ldstr "value"
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_01c1: stloc.2
-		IL_01c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c7: stloc.s 10
-		IL_01c9: ldloc.2
-		IL_01ca: ldstr "get"
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01d4: stloc.s 8
-		IL_01d6: ldloc.s 8
-		IL_01d8: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_01dd: stloc.s 11
-		IL_01df: ldloc.s 10
-		IL_01e1: ldloc.s 11
-		IL_01e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e8: pop
-		IL_01e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ee: stloc.s 10
-		IL_01f0: ldloc.2
-		IL_01f1: ldstr "set"
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01fb: stloc.s 8
-		IL_01fd: ldloc.s 8
-		IL_01ff: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0204: stloc.s 11
-		IL_0206: ldloc.s 10
-		IL_0208: ldloc.s 11
-		IL_020a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_020f: pop
-		IL_0210: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0215: stloc.s 10
-		IL_0217: ldloc.2
-		IL_0218: ldstr "enumerable"
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0222: stloc.s 8
-		IL_0224: ldloc.s 10
-		IL_0226: ldloc.s 8
-		IL_0228: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_022d: pop
-		IL_022e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0233: stloc.s 10
-		IL_0235: ldloc.2
-		IL_0236: ldstr "configurable"
-		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0240: stloc.s 8
-		IL_0242: ldloc.s 10
-		IL_0244: ldloc.s 8
-		IL_0246: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_024b: pop
-		IL_024c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0251: stloc.s 10
-		IL_0253: ldloc.1
-		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025e: ldstr "join"
-		IL_0263: ldstr ","
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026d: stloc.s 8
-		IL_026f: ldloc.s 10
-		IL_0271: ldloc.s 8
-		IL_0273: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0278: pop
-		IL_0279: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_027e: stloc.s 5
-		IL_0280: ldc.i4.1
-		IL_0281: newarr [System.Runtime]System.Object
-		IL_0286: dup
-		IL_0287: ldc.i4.0
-		IL_0288: ldloc.0
-		IL_0289: stelem.ref
-		IL_028a: stloc.s 6
-		IL_028c: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8::.ctor()
-		IL_0291: ldc.i4.0
-		IL_0292: conv.r8
-		IL_0293: ldstr ""
-		IL_0298: ldc.i4.0
-		IL_0299: ldc.i4.1
-		IL_029a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0, float64, string, bool, bool)
-		IL_029f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0)
-		IL_02a4: stloc.s 12
-		IL_02a6: ldloc.s 12
-		IL_02a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0)
-		IL_02ad: stloc.s 12
-		IL_02af: ldloc.s 12
-		IL_02b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0)
-		IL_02b6: stloc.s 12
-		IL_02b8: ldloc.s 12
-		IL_02ba: ldstr "x"
-		IL_02bf: ldstr "get"
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_02c9: stloc.s 8
-		IL_02cb: ldloc.s 5
-		IL_02cd: ldstr "x"
-		IL_02d2: ldloc.s 8
-		IL_02d4: ldnull
-		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_02da: pop
-		IL_02db: ldloc.s 5
-		IL_02dd: ldstr "x"
-		IL_02e2: ldc.r8 5
-		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
-		IL_02f0: pop
-		IL_02f1: ldloc.s 5
-		IL_02f3: stloc.3
-		IL_02f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f9: stloc.s 10
-		IL_02fb: ldloc.3
-		IL_02fc: ldstr "x"
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0306: stloc.s 8
-		IL_0308: ldloc.s 10
-		IL_030a: ldloc.s 8
-		IL_030c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0311: pop
-		IL_0312: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0317: stloc.s 5
-		IL_0319: ldc.i4.1
-		IL_031a: newarr [System.Runtime]System.Object
-		IL_031f: dup
-		IL_0320: ldc.i4.0
-		IL_0321: ldloc.0
-		IL_0322: stelem.ref
-		IL_0323: stloc.s 6
-		IL_0325: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8::.ctor()
-		IL_032a: ldc.i4.0
-		IL_032b: conv.r8
-		IL_032c: ldstr ""
-		IL_0331: ldc.i4.0
-		IL_0332: ldc.i4.1
-		IL_0333: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0, float64, string, bool, bool)
-		IL_0338: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0)
-		IL_033d: stloc.s 13
-		IL_033f: ldloc.s 13
-		IL_0341: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0)
-		IL_0346: stloc.s 13
-		IL_0348: ldloc.s 13
-		IL_034a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0)
-		IL_034f: stloc.s 13
-		IL_0351: ldloc.s 13
-		IL_0353: ldstr "x"
-		IL_0358: ldstr "get"
-		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_0362: stloc.s 8
-		IL_0364: ldloc.s 5
-		IL_0366: ldstr "x"
-		IL_036b: ldloc.s 8
-		IL_036d: ldnull
-		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_0373: pop
-		IL_0374: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0379: dup
-		IL_037a: ldstr "x"
-		IL_037f: ldc.r8 9
-		IL_0388: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_038d: stloc.s 14
-		IL_038f: ldloc.s 5
-		IL_0391: ldloc.s 14
-		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
-		IL_0398: pop
-		IL_0399: ldloc.s 5
-		IL_039b: stloc.s 4
-		IL_039d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03a2: stloc.s 10
-		IL_03a4: ldloc.s 4
-		IL_03a6: ldstr "x"
-		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03b0: stloc.s 8
-		IL_03b2: ldloc.s 10
-		IL_03b4: ldloc.s 8
-		IL_03b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03bb: pop
-		IL_03bc: ret
+		IL_004c: ldstr "value"
+		IL_0051: ldstr "get"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_005b: stloc.s 8
+		IL_005d: ldloc.s 5
+		IL_005f: ldstr "value"
+		IL_0064: ldloc.s 8
+		IL_0066: ldnull
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_006c: pop
+		IL_006d: ldc.i4.1
+		IL_006e: newarr [System.Runtime]System.Object
+		IL_0073: dup
+		IL_0074: ldc.i4.0
+		IL_0075: ldloc.0
+		IL_0076: stelem.ref
+		IL_0077: stloc.s 6
+		IL_0079: ldloc.s 5
+		IL_007b: ldstr "value"
+		IL_0080: ldnull
+		IL_0081: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12::.ctor()
+		IL_0086: ldc.i4.1
+		IL_0087: conv.r8
+		IL_0088: ldstr ""
+		IL_008d: ldc.i4.1
+		IL_008e: ldc.i4.1
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0)
+		IL_0099: ldstr "value"
+		IL_009e: ldstr "set"
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_00ad: pop
+		IL_00ae: ldc.i4.1
+		IL_00af: newarr [System.Runtime]System.Object
+		IL_00b4: dup
+		IL_00b5: ldc.i4.0
+		IL_00b6: ldloc.0
+		IL_00b7: stelem.ref
+		IL_00b8: stloc.s 6
+		IL_00ba: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17::.ctor()
+		IL_00bf: ldc.i4.0
+		IL_00c0: conv.r8
+		IL_00c1: ldstr ""
+		IL_00c6: ldc.i4.1
+		IL_00c7: ldc.i4.1
+		IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0, float64, string, bool, bool)
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0)
+		IL_00d2: stloc.s 9
+		IL_00d4: ldloc.s 9
+		IL_00d6: ldstr "double"
+		IL_00db: ldstr "get"
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_00e5: stloc.s 8
+		IL_00e7: ldloc.s 5
+		IL_00e9: ldstr "double"
+		IL_00ee: ldloc.s 8
+		IL_00f0: ldnull
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_00f6: pop
+		IL_00f7: ldloc.s 5
+		IL_00f9: stloc.1
+		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ff: stloc.s 10
+		IL_0101: ldloc.1
+		IL_0102: ldstr "value"
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010c: stloc.s 8
+		IL_010e: ldloc.s 10
+		IL_0110: ldloc.s 8
+		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0117: pop
+		IL_0118: ldloc.1
+		IL_0119: ldstr "value"
+		IL_011e: ldc.r8 7
+		IL_0127: ldc.i4.1
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_012d: pop
+		IL_012e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0133: stloc.s 10
+		IL_0135: ldloc.1
+		IL_0136: ldstr "base"
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0140: stloc.s 8
+		IL_0142: ldloc.s 10
+		IL_0144: ldloc.s 8
+		IL_0146: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_014b: pop
+		IL_014c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0151: stloc.s 10
+		IL_0153: ldloc.1
+		IL_0154: ldstr "value"
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015e: stloc.s 8
+		IL_0160: ldloc.s 10
+		IL_0162: ldloc.s 8
+		IL_0164: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0169: pop
+		IL_016a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016f: stloc.s 10
+		IL_0171: ldloc.1
+		IL_0172: ldstr "double"
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_017c: stloc.s 8
+		IL_017e: ldloc.s 10
+		IL_0180: ldloc.s 8
+		IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0187: pop
+		IL_0188: ldloc.1
+		IL_0189: ldstr "value"
+		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0193: stloc.2
+		IL_0194: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0199: stloc.s 10
+		IL_019b: ldloc.2
+		IL_019c: ldstr "get"
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a6: stloc.s 8
+		IL_01a8: ldloc.s 8
+		IL_01aa: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_01af: stloc.s 11
+		IL_01b1: ldloc.s 10
+		IL_01b3: ldloc.s 11
+		IL_01b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ba: pop
+		IL_01bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c0: stloc.s 10
+		IL_01c2: ldloc.2
+		IL_01c3: ldstr "set"
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01cd: stloc.s 8
+		IL_01cf: ldloc.s 8
+		IL_01d1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_01d6: stloc.s 11
+		IL_01d8: ldloc.s 10
+		IL_01da: ldloc.s 11
+		IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01e1: pop
+		IL_01e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e7: stloc.s 10
+		IL_01e9: ldloc.2
+		IL_01ea: ldstr "enumerable"
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01f4: stloc.s 8
+		IL_01f6: ldloc.s 10
+		IL_01f8: ldloc.s 8
+		IL_01fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ff: pop
+		IL_0200: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0205: stloc.s 10
+		IL_0207: ldloc.2
+		IL_0208: ldstr "configurable"
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0212: stloc.s 8
+		IL_0214: ldloc.s 10
+		IL_0216: ldloc.s 8
+		IL_0218: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_021d: pop
+		IL_021e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0223: stloc.s 10
+		IL_0225: ldloc.1
+		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0230: ldstr "join"
+		IL_0235: ldstr ","
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023f: stloc.s 8
+		IL_0241: ldloc.s 10
+		IL_0243: ldloc.s 8
+		IL_0245: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_024a: pop
+		IL_024b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0250: stloc.s 5
+		IL_0252: ldc.i4.1
+		IL_0253: newarr [System.Runtime]System.Object
+		IL_0258: dup
+		IL_0259: ldc.i4.0
+		IL_025a: ldloc.0
+		IL_025b: stelem.ref
+		IL_025c: stloc.s 6
+		IL_025e: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8::.ctor()
+		IL_0263: ldc.i4.0
+		IL_0264: conv.r8
+		IL_0265: ldstr ""
+		IL_026a: ldc.i4.0
+		IL_026b: ldc.i4.1
+		IL_026c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0, float64, string, bool, bool)
+		IL_0271: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0)
+		IL_0276: stloc.s 12
+		IL_0278: ldloc.s 12
+		IL_027a: ldstr "x"
+		IL_027f: ldstr "get"
+		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_0289: stloc.s 8
+		IL_028b: ldloc.s 5
+		IL_028d: ldstr "x"
+		IL_0292: ldloc.s 8
+		IL_0294: ldnull
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_029a: pop
+		IL_029b: ldloc.s 5
+		IL_029d: ldstr "x"
+		IL_02a2: ldc.r8 5
+		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
+		IL_02b0: pop
+		IL_02b1: ldloc.s 5
+		IL_02b3: stloc.3
+		IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02b9: stloc.s 10
+		IL_02bb: ldloc.3
+		IL_02bc: ldstr "x"
+		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02c6: stloc.s 8
+		IL_02c8: ldloc.s 10
+		IL_02ca: ldloc.s 8
+		IL_02cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d1: pop
+		IL_02d2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02d7: stloc.s 5
+		IL_02d9: ldc.i4.1
+		IL_02da: newarr [System.Runtime]System.Object
+		IL_02df: dup
+		IL_02e0: ldc.i4.0
+		IL_02e1: ldloc.0
+		IL_02e2: stelem.ref
+		IL_02e3: stloc.s 6
+		IL_02e5: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8::.ctor()
+		IL_02ea: ldc.i4.0
+		IL_02eb: conv.r8
+		IL_02ec: ldstr ""
+		IL_02f1: ldc.i4.0
+		IL_02f2: ldc.i4.1
+		IL_02f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0, float64, string, bool, bool)
+		IL_02f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0)
+		IL_02fd: stloc.s 13
+		IL_02ff: ldloc.s 13
+		IL_0301: ldstr "x"
+		IL_0306: ldstr "get"
+		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_0310: stloc.s 8
+		IL_0312: ldloc.s 5
+		IL_0314: ldstr "x"
+		IL_0319: ldloc.s 8
+		IL_031b: ldnull
+		IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_0321: pop
+		IL_0322: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0327: dup
+		IL_0328: ldstr "x"
+		IL_032d: ldc.r8 9
+		IL_0336: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_033b: stloc.s 14
+		IL_033d: ldloc.s 5
+		IL_033f: ldloc.s 14
+		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
+		IL_0346: pop
+		IL_0347: ldloc.s 5
+		IL_0349: stloc.s 4
+		IL_034b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0350: stloc.s 10
+		IL_0352: ldloc.s 4
+		IL_0354: ldstr "x"
+		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_035e: stloc.s 8
+		IL_0360: ldloc.s 10
+		IL_0362: ldloc.s 8
+		IL_0364: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0369: pop
+		IL_036a: ret
 	} // end of method ObjectLiteral_AccessorDefinitions::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_AccessorDefinitions

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_GeneratedMethodFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_GeneratedMethodFunctionObjects.verified.txt
@@ -690,8 +690,8 @@
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 351 (0x15f)
-			.maxstack 13
+			// Code size: 311 (0x137)
+			.maxstack 8
 			.locals init (
 				[0] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -738,112 +738,100 @@
 			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject_FunctionExpression_B788F5CE_L7C12>(!!0, float64, string, bool, bool)
 			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject_FunctionExpression_B788F5CE_L7C12>(!!0)
 			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject_FunctionExpression_B788F5CE_L7C12>(!!0)
-			IL_005f: stloc.3
-			IL_0060: ldloc.1
-			IL_0061: ldstr "add"
-			IL_0066: ldloc.3
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_006c: pop
-			IL_006d: ldc.i4.2
-			IL_006e: newarr [System.Runtime]System.Object
-			IL_0073: dup
-			IL_0074: ldc.i4.0
-			IL_0075: ldarg.0
-			IL_0076: stelem.ref
-			IL_0077: dup
-			IL_0078: ldc.i4.1
-			IL_0079: ldloc.0
-			IL_007a: stelem.ref
-			IL_007b: stloc.2
-			IL_007c: ldloc.2
-			IL_007d: ldc.i4.1
-			IL_007e: ldelem.ref
-			IL_007f: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope
-			IL_0084: ldloc.2
-			IL_0085: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope, object[])
-			IL_008a: ldc.i4.0
-			IL_008b: conv.r8
-			IL_008c: ldstr ""
-			IL_0091: ldc.i4.1
-			IL_0092: ldc.i4.1
-			IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20>(!!0, float64, string, bool, bool)
-			IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20>(!!0)
-			IL_009d: stloc.s 4
-			IL_009f: ldloc.s 4
-			IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20>(!!0)
-			IL_00a6: stloc.s 4
-			IL_00a8: ldloc.s 4
-			IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20>(!!0)
-			IL_00af: stloc.s 4
-			IL_00b1: ldloc.s 4
-			IL_00b3: ldstr "current"
-			IL_00b8: ldstr "get"
-			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-			IL_00c2: stloc.s 5
-			IL_00c4: ldloc.1
-			IL_00c5: ldstr "current"
-			IL_00ca: ldloc.s 5
-			IL_00cc: ldnull
-			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-			IL_00d2: pop
-			IL_00d3: ldc.i4.2
-			IL_00d4: newarr [System.Runtime]System.Object
-			IL_00d9: dup
-			IL_00da: ldc.i4.0
-			IL_00db: ldarg.0
-			IL_00dc: stelem.ref
-			IL_00dd: dup
+			IL_0059: ldloc.1
+			IL_005a: ldstr "add"
+			IL_005f: ldloc.3
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0065: pop
+			IL_0066: ldc.i4.2
+			IL_0067: newarr [System.Runtime]System.Object
+			IL_006c: dup
+			IL_006d: ldc.i4.0
+			IL_006e: ldarg.0
+			IL_006f: stelem.ref
+			IL_0070: dup
+			IL_0071: ldc.i4.1
+			IL_0072: ldloc.0
+			IL_0073: stelem.ref
+			IL_0074: stloc.2
+			IL_0075: ldloc.2
+			IL_0076: ldc.i4.1
+			IL_0077: ldelem.ref
+			IL_0078: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope
+			IL_007d: ldloc.2
+			IL_007e: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope, object[])
+			IL_0083: ldc.i4.0
+			IL_0084: conv.r8
+			IL_0085: ldstr ""
+			IL_008a: ldc.i4.1
+			IL_008b: ldc.i4.1
+			IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20>(!!0, float64, string, bool, bool)
+			IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20>(!!0)
+			IL_0096: stloc.s 4
+			IL_0098: ldloc.s 4
+			IL_009a: ldstr "current"
+			IL_009f: ldstr "get"
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+			IL_00a9: stloc.s 5
+			IL_00ab: ldloc.1
+			IL_00ac: ldstr "current"
+			IL_00b1: ldloc.s 5
+			IL_00b3: ldnull
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+			IL_00b9: pop
+			IL_00ba: ldc.i4.2
+			IL_00bb: newarr [System.Runtime]System.Object
+			IL_00c0: dup
+			IL_00c1: ldc.i4.0
+			IL_00c2: ldarg.0
+			IL_00c3: stelem.ref
+			IL_00c4: dup
+			IL_00c5: ldc.i4.1
+			IL_00c6: ldloc.0
+			IL_00c7: stelem.ref
+			IL_00c8: stloc.2
+			IL_00c9: ldloc.1
+			IL_00ca: ldstr "current"
+			IL_00cf: ldnull
+			IL_00d0: ldloc.2
+			IL_00d1: ldc.i4.1
+			IL_00d2: ldelem.ref
+			IL_00d3: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope
+			IL_00d8: ldloc.2
+			IL_00d9: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope, object[])
 			IL_00de: ldc.i4.1
-			IL_00df: ldloc.0
-			IL_00e0: stelem.ref
-			IL_00e1: stloc.2
-			IL_00e2: ldloc.1
-			IL_00e3: ldstr "current"
-			IL_00e8: ldnull
-			IL_00e9: ldloc.2
-			IL_00ea: ldc.i4.1
-			IL_00eb: ldelem.ref
-			IL_00ec: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope
-			IL_00f1: ldloc.2
-			IL_00f2: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope, object[])
-			IL_00f7: ldc.i4.1
-			IL_00f8: conv.r8
-			IL_00f9: ldstr ""
-			IL_00fe: ldc.i4.1
-			IL_00ff: ldc.i4.1
-			IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0, float64, string, bool, bool)
-			IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0)
-			IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0)
-			IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0)
-			IL_0114: ldstr "current"
-			IL_0119: ldstr "set"
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-			IL_0128: pop
-			IL_0129: ldc.i4.1
-			IL_012a: newarr [System.Runtime]System.Object
-			IL_012f: dup
-			IL_0130: ldc.i4.0
-			IL_0131: ldarg.0
-			IL_0132: stelem.ref
-			IL_0133: stloc.2
-			IL_0134: ldloc.1
-			IL_0135: ldstr "computed"
-			IL_013a: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21::.ctor()
-			IL_013f: ldc.i4.1
-			IL_0140: conv.r8
-			IL_0141: ldstr ""
-			IL_0146: ldc.i4.1
-			IL_0147: ldc.i4.1
-			IL_0148: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21>(!!0, float64, string, bool, bool)
-			IL_014d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21>(!!0)
-			IL_0152: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21>(!!0)
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_015c: pop
-			IL_015d: ldloc.1
-			IL_015e: ret
+			IL_00df: conv.r8
+			IL_00e0: ldstr ""
+			IL_00e5: ldc.i4.1
+			IL_00e6: ldc.i4.1
+			IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0, float64, string, bool, bool)
+			IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0)
+			IL_00f1: ldstr "current"
+			IL_00f6: ldstr "set"
+			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+			IL_0105: pop
+			IL_0106: ldc.i4.1
+			IL_0107: newarr [System.Runtime]System.Object
+			IL_010c: dup
+			IL_010d: ldc.i4.0
+			IL_010e: ldarg.0
+			IL_010f: stelem.ref
+			IL_0110: stloc.2
+			IL_0111: ldloc.1
+			IL_0112: ldstr "computed"
+			IL_0117: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21::.ctor()
+			IL_011c: ldc.i4.1
+			IL_011d: conv.r8
+			IL_011e: ldstr ""
+			IL_0123: ldc.i4.1
+			IL_0124: ldc.i4.1
+			IL_0125: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21>(!!0, float64, string, bool, bool)
+			IL_012a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21>(!!0)
+			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0134: pop
+			IL_0135: ldloc.1
+			IL_0136: ret
 		} // end of method makeObject::__js_call__
 
 	} // end of class makeObject
@@ -1173,7 +1161,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1482 (0x5ca)
+		// Code size: 1464 (0x5b8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope,
@@ -1615,102 +1603,96 @@
 		IL_049f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject_FunctionExpression_0A328BE2_L58C10>(!!0, float64, string, bool, bool)
 		IL_04a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject_FunctionExpression_0A328BE2_L58C10>(!!0)
 		IL_04a9: stloc.s 28
-		IL_04ab: ldloc.s 28
-		IL_04ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject_FunctionExpression_0A328BE2_L58C10>(!!0)
-		IL_04b2: stloc.s 28
-		IL_04b4: ldloc.s 19
-		IL_04b6: ldstr "label"
-		IL_04bb: ldloc.s 28
-		IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_04c2: pop
-		IL_04c3: ldloc.s 19
-		IL_04c5: stloc.s 10
-		IL_04c7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04cc: stloc.s 19
-		IL_04ce: ldloc.s 19
-		IL_04d0: ldloc.s 10
-		IL_04d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetObjectLiteralPrototype(object, object)
-		IL_04d7: pop
-		IL_04d8: ldc.i4.1
-		IL_04d9: newarr [System.Runtime]System.Object
-		IL_04de: dup
-		IL_04df: ldc.i4.0
-		IL_04e0: ldloc.0
-		IL_04e1: stelem.ref
-		IL_04e2: stloc.s 15
-		IL_04e4: ldloc.s 19
-		IL_04e6: ldloc.s 15
-		IL_04e8: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10::.ctor(class [System.Runtime]System.Object, object[])
-		IL_04ed: ldc.i4.0
-		IL_04ee: conv.r8
-		IL_04ef: ldstr ""
-		IL_04f4: ldc.i4.1
-		IL_04f5: ldc.i4.1
-		IL_04f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10>(!!0, float64, string, bool, bool)
-		IL_04fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10>(!!0)
-		IL_0500: stloc.s 29
-		IL_0502: ldloc.s 29
-		IL_0504: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10>(!!0)
-		IL_0509: stloc.s 29
-		IL_050b: ldloc.s 19
-		IL_050d: ldstr "label"
-		IL_0512: ldloc.s 29
-		IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0519: pop
-		IL_051a: ldloc.s 19
-		IL_051c: stloc.s 11
-		IL_051e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0523: stloc.s 16
-		IL_0525: ldloc.s 11
-		IL_0527: ldstr "label"
-		IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0531: stloc.s 22
-		IL_0533: ldloc.s 16
-		IL_0535: ldstr "super"
-		IL_053a: ldloc.s 22
-		IL_053c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0541: pop
-		IL_0542: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0547: stloc.s 15
-		IL_0549: ldloc.1
-		IL_054a: ldloc.s 15
-		IL_054c: ldc.r8 0.0
-		IL_0555: box [System.Runtime]System.Double
-		IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_055f: stloc.s 12
-		IL_0561: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0566: stloc.s 15
-		IL_0568: ldloc.1
-		IL_0569: ldloc.s 15
-		IL_056b: ldc.r8 0.0
-		IL_0574: box [System.Runtime]System.Double
-		IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_057e: stloc.s 13
-		IL_0580: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0585: stloc.s 16
-		IL_0587: ldloc.s 12
-		IL_0589: ldstr "add"
-		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0593: stloc.s 22
-		IL_0595: ldloc.s 13
-		IL_0597: ldstr "add"
-		IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05a1: stloc.s 21
-		IL_05a3: ldloc.s 22
-		IL_05a5: ldloc.s 21
-		IL_05a7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_05ac: stloc.s 23
-		IL_05ae: ldloc.s 23
-		IL_05b0: box [System.Runtime]System.Boolean
-		IL_05b5: stloc.s 26
-		IL_05b7: ldloc.s 16
-		IL_05b9: ldstr "identity"
-		IL_05be: ldloc.s 26
-		IL_05c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_05c5: pop
-		IL_05c6: ldnull
-		IL_05c7: stloc.s 14
-		IL_05c9: ret
+		IL_04ab: ldloc.s 19
+		IL_04ad: ldstr "label"
+		IL_04b2: ldloc.s 28
+		IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_04b9: pop
+		IL_04ba: ldloc.s 19
+		IL_04bc: stloc.s 10
+		IL_04be: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04c3: stloc.s 19
+		IL_04c5: ldloc.s 19
+		IL_04c7: ldloc.s 10
+		IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetObjectLiteralPrototype(object, object)
+		IL_04ce: pop
+		IL_04cf: ldc.i4.1
+		IL_04d0: newarr [System.Runtime]System.Object
+		IL_04d5: dup
+		IL_04d6: ldc.i4.0
+		IL_04d7: ldloc.0
+		IL_04d8: stelem.ref
+		IL_04d9: stloc.s 15
+		IL_04db: ldloc.s 19
+		IL_04dd: ldloc.s 15
+		IL_04df: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10::.ctor(class [System.Runtime]System.Object, object[])
+		IL_04e4: ldc.i4.0
+		IL_04e5: conv.r8
+		IL_04e6: ldstr ""
+		IL_04eb: ldc.i4.1
+		IL_04ec: ldc.i4.1
+		IL_04ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10>(!!0, float64, string, bool, bool)
+		IL_04f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10>(!!0)
+		IL_04f7: stloc.s 29
+		IL_04f9: ldloc.s 19
+		IL_04fb: ldstr "label"
+		IL_0500: ldloc.s 29
+		IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0507: pop
+		IL_0508: ldloc.s 19
+		IL_050a: stloc.s 11
+		IL_050c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0511: stloc.s 16
+		IL_0513: ldloc.s 11
+		IL_0515: ldstr "label"
+		IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_051f: stloc.s 22
+		IL_0521: ldloc.s 16
+		IL_0523: ldstr "super"
+		IL_0528: ldloc.s 22
+		IL_052a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_052f: pop
+		IL_0530: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0535: stloc.s 15
+		IL_0537: ldloc.1
+		IL_0538: ldloc.s 15
+		IL_053a: ldc.r8 0.0
+		IL_0543: box [System.Runtime]System.Double
+		IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_054d: stloc.s 12
+		IL_054f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0554: stloc.s 15
+		IL_0556: ldloc.1
+		IL_0557: ldloc.s 15
+		IL_0559: ldc.r8 0.0
+		IL_0562: box [System.Runtime]System.Double
+		IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_056c: stloc.s 13
+		IL_056e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0573: stloc.s 16
+		IL_0575: ldloc.s 12
+		IL_0577: ldstr "add"
+		IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0581: stloc.s 22
+		IL_0583: ldloc.s 13
+		IL_0585: ldstr "add"
+		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_058f: stloc.s 21
+		IL_0591: ldloc.s 22
+		IL_0593: ldloc.s 21
+		IL_0595: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_059a: stloc.s 23
+		IL_059c: ldloc.s 23
+		IL_059e: box [System.Runtime]System.Boolean
+		IL_05a3: stloc.s 26
+		IL_05a5: ldloc.s 16
+		IL_05a7: ldstr "identity"
+		IL_05ac: ldloc.s 26
+		IL_05ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_05b3: pop
+		IL_05b4: ldnull
+		IL_05b5: stloc.s 14
+		IL_05b7: ret
 	} // end of method ObjectLiteral_GeneratedMethodFunctionObjects::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_GeneratedMethodFunctionObjects

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ShorthandAndMethod.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ShorthandAndMethod.verified.txt
@@ -144,7 +144,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 188 (0xbc)
+		// Code size: 179 (0xb3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_ShorthandAndMethod/Scope,
@@ -201,27 +201,24 @@
 		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o/FunctionObject_FunctionExpression_95740A33_L8C20>(!!0, float64, string, bool, bool)
 		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o/FunctionObject_FunctionExpression_95740A33_L8C20>(!!0)
 		IL_0082: stloc.s 7
-		IL_0084: ldloc.s 7
-		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o/FunctionObject_FunctionExpression_95740A33_L8C20>(!!0)
-		IL_008b: stloc.s 7
-		IL_008d: ldloc.s 4
-		IL_008f: ldstr "m"
-		IL_0094: ldloc.s 7
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_009b: pop
-		IL_009c: ldloc.s 4
-		IL_009e: stloc.2
-		IL_009f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a4: stloc.3
-		IL_00a5: ldloc.2
-		IL_00a6: ldstr "m"
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00b0: stloc.s 5
-		IL_00b2: ldloc.3
-		IL_00b3: ldloc.s 5
-		IL_00b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ba: pop
-		IL_00bb: ret
+		IL_0084: ldloc.s 4
+		IL_0086: ldstr "m"
+		IL_008b: ldloc.s 7
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0092: pop
+		IL_0093: ldloc.s 4
+		IL_0095: stloc.2
+		IL_0096: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009b: stloc.3
+		IL_009c: ldloc.2
+		IL_009d: ldstr "m"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00a7: stloc.s 5
+		IL_00a9: ldloc.3
+		IL_00aa: ldloc.s 5
+		IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b1: pop
+		IL_00b2: ret
 	} // end of method ObjectLiteral_ShorthandAndMethod::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_ShorthandAndMethod

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
@@ -341,7 +341,7 @@
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 189 (0xbd)
+			// Code size: 180 (0xb4)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope,
@@ -406,16 +406,13 @@
 			IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17>(!!0, float64, string, bool, bool)
 			IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17>(!!0)
 			IL_00a2: stloc.s 4
-			IL_00a4: ldloc.s 4
-			IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17>(!!0)
-			IL_00ab: stloc.s 4
-			IL_00ad: ldloc.2
-			IL_00ae: ldstr "next"
-			IL_00b3: ldloc.s 4
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_00ba: pop
-			IL_00bb: ldloc.2
-			IL_00bc: ret
+			IL_00a4: ldloc.2
+			IL_00a5: ldstr "next"
+			IL_00aa: ldloc.s 4
+			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_00b1: pop
+			IL_00b2: ldloc.2
+			IL_00b3: ret
 		} // end of method FunctionExpression_iterable::__js_call__
 
 	} // end of class FunctionExpression_iterable
@@ -884,7 +881,7 @@
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 240 (0xf0)
+			// Code size: 222 (0xde)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope,
@@ -944,53 +941,47 @@
 			IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17>(!!0, float64, string, bool, bool)
 			IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17>(!!0)
 			IL_0084: stloc.s 4
-			IL_0086: ldloc.s 4
-			IL_0088: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17>(!!0)
-			IL_008d: stloc.s 4
-			IL_008f: ldloc.2
-			IL_0090: ldstr "next"
-			IL_0095: ldloc.s 4
-			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_009c: pop
-			IL_009d: ldc.i4.2
-			IL_009e: newarr [System.Runtime]System.Object
-			IL_00a3: dup
+			IL_0086: ldloc.2
+			IL_0087: ldstr "next"
+			IL_008c: ldloc.s 4
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0093: pop
+			IL_0094: ldc.i4.2
+			IL_0095: newarr [System.Runtime]System.Object
+			IL_009a: dup
+			IL_009b: ldc.i4.0
+			IL_009c: ldarg.0
+			IL_009d: stelem.ref
+			IL_009e: dup
+			IL_009f: ldc.i4.1
+			IL_00a0: ldloc.0
+			IL_00a1: stelem.ref
+			IL_00a2: stloc.3
+			IL_00a3: ldloc.3
 			IL_00a4: ldc.i4.0
-			IL_00a5: ldarg.0
-			IL_00a6: stelem.ref
-			IL_00a7: dup
-			IL_00a8: ldc.i4.1
-			IL_00a9: ldloc.0
-			IL_00aa: stelem.ref
-			IL_00ab: stloc.3
-			IL_00ac: ldloc.3
-			IL_00ad: ldc.i4.0
-			IL_00ae: ldelem.ref
-			IL_00af: castclass Modules.Set_Constructor_Iterable/Scope
-			IL_00b4: ldloc.3
-			IL_00b5: ldc.i4.1
-			IL_00b6: ldelem.ref
-			IL_00b7: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
-			IL_00bc: ldloc.3
-			IL_00bd: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope, object[])
-			IL_00c2: ldc.i4.0
-			IL_00c3: conv.r8
-			IL_00c4: ldstr ""
-			IL_00c9: ldc.i4.0
-			IL_00ca: ldc.i4.1
-			IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19>(!!0, float64, string, bool, bool)
-			IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19>(!!0)
-			IL_00d5: stloc.s 5
-			IL_00d7: ldloc.s 5
-			IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19>(!!0)
-			IL_00de: stloc.s 5
-			IL_00e0: ldloc.2
-			IL_00e1: ldstr "return"
-			IL_00e6: ldloc.s 5
-			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_00ed: pop
-			IL_00ee: ldloc.2
-			IL_00ef: ret
+			IL_00a5: ldelem.ref
+			IL_00a6: castclass Modules.Set_Constructor_Iterable/Scope
+			IL_00ab: ldloc.3
+			IL_00ac: ldc.i4.1
+			IL_00ad: ldelem.ref
+			IL_00ae: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
+			IL_00b3: ldloc.3
+			IL_00b4: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope, object[])
+			IL_00b9: ldc.i4.0
+			IL_00ba: conv.r8
+			IL_00bb: ldstr ""
+			IL_00c0: ldc.i4.0
+			IL_00c1: ldc.i4.1
+			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19>(!!0, float64, string, bool, bool)
+			IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19>(!!0)
+			IL_00cc: stloc.s 5
+			IL_00ce: ldloc.2
+			IL_00cf: ldstr "return"
+			IL_00d4: ldloc.s 5
+			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_00db: pop
+			IL_00dc: ldloc.2
+			IL_00dd: ret
 		} // end of method FunctionExpression_closableIterable::__js_call__
 
 	} // end of class FunctionExpression_closableIterable
@@ -1588,7 +1579,7 @@
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 240 (0xf0)
+			// Code size: 222 (0xde)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope,
@@ -1648,53 +1639,47 @@
 			IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17>(!!0, float64, string, bool, bool)
 			IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17>(!!0)
 			IL_0084: stloc.s 4
-			IL_0086: ldloc.s 4
-			IL_0088: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17>(!!0)
-			IL_008d: stloc.s 4
-			IL_008f: ldloc.2
-			IL_0090: ldstr "next"
-			IL_0095: ldloc.s 4
-			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_009c: pop
-			IL_009d: ldc.i4.2
-			IL_009e: newarr [System.Runtime]System.Object
-			IL_00a3: dup
+			IL_0086: ldloc.2
+			IL_0087: ldstr "next"
+			IL_008c: ldloc.s 4
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0093: pop
+			IL_0094: ldc.i4.2
+			IL_0095: newarr [System.Runtime]System.Object
+			IL_009a: dup
+			IL_009b: ldc.i4.0
+			IL_009c: ldarg.0
+			IL_009d: stelem.ref
+			IL_009e: dup
+			IL_009f: ldc.i4.1
+			IL_00a0: ldloc.0
+			IL_00a1: stelem.ref
+			IL_00a2: stloc.3
+			IL_00a3: ldloc.3
 			IL_00a4: ldc.i4.0
-			IL_00a5: ldarg.0
-			IL_00a6: stelem.ref
-			IL_00a7: dup
-			IL_00a8: ldc.i4.1
-			IL_00a9: ldloc.0
-			IL_00aa: stelem.ref
-			IL_00ab: stloc.3
-			IL_00ac: ldloc.3
-			IL_00ad: ldc.i4.0
-			IL_00ae: ldelem.ref
-			IL_00af: castclass Modules.Set_Constructor_Iterable/Scope
-			IL_00b4: ldloc.3
-			IL_00b5: ldc.i4.1
-			IL_00b6: ldelem.ref
-			IL_00b7: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope
-			IL_00bc: ldloc.3
-			IL_00bd: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope, object[])
-			IL_00c2: ldc.i4.0
-			IL_00c3: conv.r8
-			IL_00c4: ldstr ""
-			IL_00c9: ldc.i4.0
-			IL_00ca: ldc.i4.1
-			IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19>(!!0, float64, string, bool, bool)
-			IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19>(!!0)
-			IL_00d5: stloc.s 5
-			IL_00d7: ldloc.s 5
-			IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19>(!!0)
-			IL_00de: stloc.s 5
-			IL_00e0: ldloc.2
-			IL_00e1: ldstr "return"
-			IL_00e6: ldloc.s 5
-			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_00ed: pop
-			IL_00ee: ldloc.2
-			IL_00ef: ret
+			IL_00a5: ldelem.ref
+			IL_00a6: castclass Modules.Set_Constructor_Iterable/Scope
+			IL_00ab: ldloc.3
+			IL_00ac: ldc.i4.1
+			IL_00ad: ldelem.ref
+			IL_00ae: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope
+			IL_00b3: ldloc.3
+			IL_00b4: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope, object[])
+			IL_00b9: ldc.i4.0
+			IL_00ba: conv.r8
+			IL_00bb: ldstr ""
+			IL_00c0: ldc.i4.0
+			IL_00c1: ldc.i4.1
+			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19>(!!0, float64, string, bool, bool)
+			IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19>(!!0)
+			IL_00cc: stloc.s 5
+			IL_00ce: ldloc.2
+			IL_00cf: ldstr "return"
+			IL_00d4: ldloc.s 5
+			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_00db: pop
+			IL_00dc: ldloc.2
+			IL_00dd: ret
 		} // end of method FunctionExpression_unionSetLike_L58C8::__js_call__
 
 	} // end of class FunctionExpression_unionSetLike_L58C8
@@ -1744,7 +1729,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 736 (0x2e0)
+		// Code size: 708 (0x2c4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Constructor_Iterable/Scope,
@@ -1791,223 +1776,215 @@
 		IL_0040: ldc.i4.1
 		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22>(!!0, float64, string, bool, bool)
 		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22>(!!0)
-		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22>(!!0)
-		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_0055: pop
-		IL_0056: ldloc.s 8
-		IL_0058: stloc.1
-		IL_0059: ldloc.1
-		IL_005a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_005f: stloc.2
-		IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0065: stloc.s 10
-		IL_0067: ldloc.2
-		IL_0068: ldstr "size"
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0072: stloc.s 7
-		IL_0074: ldloc.s 10
-		IL_0076: ldloc.s 7
-		IL_0078: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007d: pop
-		IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0083: stloc.s 10
-		IL_0085: ldloc.2
-		IL_0086: ldstr "has"
-		IL_008b: ldc.r8 1
-		IL_0094: box [System.Runtime]System.Double
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009e: stloc.s 7
-		IL_00a0: ldloc.s 10
-		IL_00a2: ldloc.s 7
-		IL_00a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a9: pop
-		IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00af: stloc.s 10
-		IL_00b1: ldloc.2
-		IL_00b2: ldstr "has"
-		IL_00b7: ldc.r8 3
-		IL_00c0: box [System.Runtime]System.Double
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ca: stloc.s 7
-		IL_00cc: ldloc.s 10
-		IL_00ce: ldloc.s 7
-		IL_00d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d5: pop
-		IL_00d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00db: stloc.s 10
-		IL_00dd: ldloc.2
-		IL_00de: ldstr "has"
-		IL_00e3: ldc.r8 4
-		IL_00ec: box [System.Runtime]System.Double
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f6: stloc.s 7
-		IL_00f8: ldloc.s 10
-		IL_00fa: ldloc.s 7
-		IL_00fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0101: pop
-		IL_0102: ldloc.0
-		IL_0103: ldc.i4.0
-		IL_0104: box [System.Runtime]System.Boolean
-		IL_0109: stfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_010e: ldstr "iterator"
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0118: stloc.s 7
-		IL_011a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_011f: stloc.s 8
-		IL_0121: ldc.i4.1
-		IL_0122: newarr [System.Runtime]System.Object
-		IL_0127: dup
-		IL_0128: ldc.i4.0
-		IL_0129: ldloc.0
-		IL_012a: stelem.ref
-		IL_012b: stloc.s 9
-		IL_012d: ldloc.s 8
-		IL_012f: ldloc.s 7
-		IL_0131: ldloc.s 9
-		IL_0133: ldc.i4.0
-		IL_0134: ldelem.ref
-		IL_0135: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_013a: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22::.ctor(class Modules.Set_Constructor_Iterable/Scope)
-		IL_013f: ldc.i4.0
-		IL_0140: conv.r8
-		IL_0141: ldstr ""
-		IL_0146: ldc.i4.0
-		IL_0147: ldc.i4.1
-		IL_0148: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22>(!!0, float64, string, bool, bool)
-		IL_014d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22>(!!0)
-		IL_0152: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22>(!!0)
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_015c: pop
-		IL_015d: ldloc.s 8
-		IL_015f: stloc.3
-		IL_0160: ldloc.3
-		IL_0161: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_0166: stloc.s 4
-		IL_0168: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016d: stloc.s 10
-		IL_016f: ldloc.0
-		IL_0170: ldfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_0175: stloc.s 7
-		IL_0177: ldloc.s 10
-		IL_0179: ldloc.s 7
-		IL_017b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0180: pop
-		IL_0181: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0186: stloc.s 10
-		IL_0188: ldloc.s 4
-		IL_018a: ldstr "size"
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0194: stloc.s 7
-		IL_0196: ldloc.s 10
-		IL_0198: ldloc.s 7
-		IL_019a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_019f: pop
-		IL_01a0: ldloc.0
-		IL_01a1: ldc.i4.0
-		IL_01a2: box [System.Runtime]System.Boolean
-		IL_01a7: stfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
-		IL_01ac: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01b1: stloc.s 8
-		IL_01b3: ldloc.s 8
-		IL_01b5: ldstr "size"
-		IL_01ba: ldc.r8 2
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
-		IL_01c8: pop
-		IL_01c9: ldc.i4.1
-		IL_01ca: newarr [System.Runtime]System.Object
-		IL_01cf: dup
-		IL_01d0: ldc.i4.0
-		IL_01d1: ldloc.0
-		IL_01d2: stelem.ref
-		IL_01d3: stloc.s 9
-		IL_01d5: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8::.ctor()
-		IL_01da: ldc.i4.1
-		IL_01db: conv.r8
-		IL_01dc: ldstr ""
-		IL_01e1: ldc.i4.0
-		IL_01e2: ldc.i4.1
-		IL_01e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8>(!!0, float64, string, bool, bool)
-		IL_01e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8>(!!0)
-		IL_01ed: stloc.s 11
-		IL_01ef: ldloc.s 11
-		IL_01f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8>(!!0)
-		IL_01f6: stloc.s 11
-		IL_01f8: ldloc.s 8
-		IL_01fa: ldstr "has"
-		IL_01ff: ldloc.s 11
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0206: pop
-		IL_0207: ldc.i4.1
-		IL_0208: newarr [System.Runtime]System.Object
-		IL_020d: dup
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0050: pop
+		IL_0051: ldloc.s 8
+		IL_0053: stloc.1
+		IL_0054: ldloc.1
+		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_005a: stloc.2
+		IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0060: stloc.s 10
+		IL_0062: ldloc.2
+		IL_0063: ldstr "size"
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006d: stloc.s 7
+		IL_006f: ldloc.s 10
+		IL_0071: ldloc.s 7
+		IL_0073: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0078: pop
+		IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007e: stloc.s 10
+		IL_0080: ldloc.2
+		IL_0081: ldstr "has"
+		IL_0086: ldc.r8 1
+		IL_008f: box [System.Runtime]System.Double
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0099: stloc.s 7
+		IL_009b: ldloc.s 10
+		IL_009d: ldloc.s 7
+		IL_009f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a4: pop
+		IL_00a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00aa: stloc.s 10
+		IL_00ac: ldloc.2
+		IL_00ad: ldstr "has"
+		IL_00b2: ldc.r8 3
+		IL_00bb: box [System.Runtime]System.Double
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c5: stloc.s 7
+		IL_00c7: ldloc.s 10
+		IL_00c9: ldloc.s 7
+		IL_00cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d0: pop
+		IL_00d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d6: stloc.s 10
+		IL_00d8: ldloc.2
+		IL_00d9: ldstr "has"
+		IL_00de: ldc.r8 4
+		IL_00e7: box [System.Runtime]System.Double
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f1: stloc.s 7
+		IL_00f3: ldloc.s 10
+		IL_00f5: ldloc.s 7
+		IL_00f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fc: pop
+		IL_00fd: ldloc.0
+		IL_00fe: ldc.i4.0
+		IL_00ff: box [System.Runtime]System.Boolean
+		IL_0104: stfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_0109: ldstr "iterator"
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0113: stloc.s 7
+		IL_0115: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_011a: stloc.s 8
+		IL_011c: ldc.i4.1
+		IL_011d: newarr [System.Runtime]System.Object
+		IL_0122: dup
+		IL_0123: ldc.i4.0
+		IL_0124: ldloc.0
+		IL_0125: stelem.ref
+		IL_0126: stloc.s 9
+		IL_0128: ldloc.s 8
+		IL_012a: ldloc.s 7
+		IL_012c: ldloc.s 9
+		IL_012e: ldc.i4.0
+		IL_012f: ldelem.ref
+		IL_0130: castclass Modules.Set_Constructor_Iterable/Scope
+		IL_0135: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22::.ctor(class Modules.Set_Constructor_Iterable/Scope)
+		IL_013a: ldc.i4.0
+		IL_013b: conv.r8
+		IL_013c: ldstr ""
+		IL_0141: ldc.i4.0
+		IL_0142: ldc.i4.1
+		IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22>(!!0, float64, string, bool, bool)
+		IL_0148: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22>(!!0)
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0152: pop
+		IL_0153: ldloc.s 8
+		IL_0155: stloc.3
+		IL_0156: ldloc.3
+		IL_0157: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_015c: stloc.s 4
+		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0163: stloc.s 10
+		IL_0165: ldloc.0
+		IL_0166: ldfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_016b: stloc.s 7
+		IL_016d: ldloc.s 10
+		IL_016f: ldloc.s 7
+		IL_0171: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0176: pop
+		IL_0177: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017c: stloc.s 10
+		IL_017e: ldloc.s 4
+		IL_0180: ldstr "size"
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018a: stloc.s 7
+		IL_018c: ldloc.s 10
+		IL_018e: ldloc.s 7
+		IL_0190: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0195: pop
+		IL_0196: ldloc.0
+		IL_0197: ldc.i4.0
+		IL_0198: box [System.Runtime]System.Boolean
+		IL_019d: stfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
+		IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01a7: stloc.s 8
+		IL_01a9: ldloc.s 8
+		IL_01ab: ldstr "size"
+		IL_01b0: ldc.r8 2
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
+		IL_01be: pop
+		IL_01bf: ldc.i4.1
+		IL_01c0: newarr [System.Runtime]System.Object
+		IL_01c5: dup
+		IL_01c6: ldc.i4.0
+		IL_01c7: ldloc.0
+		IL_01c8: stelem.ref
+		IL_01c9: stloc.s 9
+		IL_01cb: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8::.ctor()
+		IL_01d0: ldc.i4.1
+		IL_01d1: conv.r8
+		IL_01d2: ldstr ""
+		IL_01d7: ldc.i4.0
+		IL_01d8: ldc.i4.1
+		IL_01d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8>(!!0, float64, string, bool, bool)
+		IL_01de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8>(!!0)
+		IL_01e3: stloc.s 11
+		IL_01e5: ldloc.s 8
+		IL_01e7: ldstr "has"
+		IL_01ec: ldloc.s 11
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_01f3: pop
+		IL_01f4: ldc.i4.1
+		IL_01f5: newarr [System.Runtime]System.Object
+		IL_01fa: dup
+		IL_01fb: ldc.i4.0
+		IL_01fc: ldloc.0
+		IL_01fd: stelem.ref
+		IL_01fe: stloc.s 9
+		IL_0200: ldloc.s 9
+		IL_0202: ldc.i4.0
+		IL_0203: ldelem.ref
+		IL_0204: castclass Modules.Set_Constructor_Iterable/Scope
+		IL_0209: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9::.ctor(class Modules.Set_Constructor_Iterable/Scope)
 		IL_020e: ldc.i4.0
-		IL_020f: ldloc.0
-		IL_0210: stelem.ref
-		IL_0211: stloc.s 9
-		IL_0213: ldloc.s 9
+		IL_020f: conv.r8
+		IL_0210: ldstr ""
 		IL_0215: ldc.i4.0
-		IL_0216: ldelem.ref
-		IL_0217: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_021c: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9::.ctor(class Modules.Set_Constructor_Iterable/Scope)
-		IL_0221: ldc.i4.0
-		IL_0222: conv.r8
-		IL_0223: ldstr ""
-		IL_0228: ldc.i4.0
-		IL_0229: ldc.i4.1
-		IL_022a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9>(!!0, float64, string, bool, bool)
-		IL_022f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9>(!!0)
-		IL_0234: stloc.s 12
-		IL_0236: ldloc.s 12
-		IL_0238: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9>(!!0)
-		IL_023d: stloc.s 12
-		IL_023f: ldloc.s 8
-		IL_0241: ldstr "keys"
-		IL_0246: ldloc.s 12
-		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_024d: pop
-		IL_024e: ldloc.s 8
-		IL_0250: stloc.s 5
-		IL_0252: ldloc.s 4
-		IL_0254: ldstr "union"
-		IL_0259: ldloc.s 5
-		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0260: stloc.s 6
-		IL_0262: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0267: stloc.s 10
-		IL_0269: ldloc.0
-		IL_026a: ldfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
-		IL_026f: stloc.s 7
-		IL_0271: ldloc.s 10
-		IL_0273: ldloc.s 7
-		IL_0275: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_027a: pop
-		IL_027b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0280: stloc.s 10
-		IL_0282: ldloc.s 6
-		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0289: ldstr "has"
-		IL_028e: ldc.r8 4
-		IL_0297: box [System.Runtime]System.Double
-		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a1: stloc.s 7
-		IL_02a3: ldloc.s 10
-		IL_02a5: ldloc.s 7
-		IL_02a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ac: pop
-		IL_02ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b2: stloc.s 10
-		IL_02b4: ldloc.s 6
-		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02bb: ldstr "has"
-		IL_02c0: ldc.r8 6
-		IL_02c9: box [System.Runtime]System.Double
-		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d3: stloc.s 7
-		IL_02d5: ldloc.s 10
-		IL_02d7: ldloc.s 7
-		IL_02d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02de: pop
-		IL_02df: ret
+		IL_0216: ldc.i4.1
+		IL_0217: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9>(!!0, float64, string, bool, bool)
+		IL_021c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9>(!!0)
+		IL_0221: stloc.s 12
+		IL_0223: ldloc.s 8
+		IL_0225: ldstr "keys"
+		IL_022a: ldloc.s 12
+		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0231: pop
+		IL_0232: ldloc.s 8
+		IL_0234: stloc.s 5
+		IL_0236: ldloc.s 4
+		IL_0238: ldstr "union"
+		IL_023d: ldloc.s 5
+		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0244: stloc.s 6
+		IL_0246: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_024b: stloc.s 10
+		IL_024d: ldloc.0
+		IL_024e: ldfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
+		IL_0253: stloc.s 7
+		IL_0255: ldloc.s 10
+		IL_0257: ldloc.s 7
+		IL_0259: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_025e: pop
+		IL_025f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0264: stloc.s 10
+		IL_0266: ldloc.s 6
+		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_026d: ldstr "has"
+		IL_0272: ldc.r8 4
+		IL_027b: box [System.Runtime]System.Double
+		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0285: stloc.s 7
+		IL_0287: ldloc.s 10
+		IL_0289: ldloc.s 7
+		IL_028b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0290: pop
+		IL_0291: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0296: stloc.s 10
+		IL_0298: ldloc.s 6
+		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_029f: ldstr "has"
+		IL_02a4: ldc.r8 6
+		IL_02ad: box [System.Runtime]System.Double
+		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b7: stloc.s 7
+		IL_02b9: ldloc.s 10
+		IL_02bb: ldloc.s 7
+		IL_02bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c2: pop
+		IL_02c3: ret
 	} // end of method Set_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Set_Constructor_Iterable

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.BeanCounter_Class_Index_Assign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.BeanCounter_Class_Index_Assign.verified.txt
@@ -300,7 +300,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 270 (0x10e)
+		// Code size: 265 (0x109)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BeanCounter_Class_Index_Assign/Scope,
@@ -337,61 +337,60 @@
 		IL_0044: ldc.i4.1
 		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0, float64, string, bool, bool)
 		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0)
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0)
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0059: pop
-		IL_005a: ldc.i4.1
-		IL_005b: newarr [System.Runtime]System.Object
-		IL_0060: dup
-		IL_0061: ldc.i4.0
-		IL_0062: ldloc.0
-		IL_0063: stelem.ref
-		IL_0064: stloc.s 5
-		IL_0066: ldloc.3
-		IL_0067: ldloc.s 5
-		IL_0069: ldc.r8 0.0
-		IL_0072: box [System.Runtime]System.Double
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_007c: stloc.s 4
-		IL_007e: ldloc.s 4
-		IL_0080: stloc.1
-		IL_0081: ldc.i4.0
-		IL_0082: newarr [System.Runtime]System.Object
-		IL_0087: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_008c: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter::.ctor()
-		IL_0091: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0096: stloc.2
-		IL_0097: ldloc.2
-		IL_0098: ldtoken Modules.BeanCounter_Class_Index_Assign/BeanCounter
-		IL_009d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00a2: ldstr "prototype"
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00ac: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00b1: ldloc.2
-		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.BeanCounter_Class_Index_Assign/BeanCounter>(!!0)
-		IL_00b7: stloc.s 6
-		IL_00b9: ldloc.s 6
-		IL_00bb: ldc.r8 1
-		IL_00c4: box [System.Runtime]System.Double
-		IL_00c9: ldc.r8 42
-		IL_00d2: box [System.Runtime]System.Double
-		IL_00d7: callvirt instance object Modules.BeanCounter_Class_Index_Assign/BeanCounter::setBeanCount(object, object)
-		IL_00dc: pop
-		IL_00dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e2: stloc.s 7
-		IL_00e4: ldloc.2
-		IL_00e5: ldstr "beanCounts"
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ef: stloc.s 4
-		IL_00f1: ldloc.s 4
-		IL_00f3: ldc.r8 1
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0101: stloc.s 4
-		IL_0103: ldloc.s 7
-		IL_0105: ldloc.s 4
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010c: pop
-		IL_010d: ret
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0054: pop
+		IL_0055: ldc.i4.1
+		IL_0056: newarr [System.Runtime]System.Object
+		IL_005b: dup
+		IL_005c: ldc.i4.0
+		IL_005d: ldloc.0
+		IL_005e: stelem.ref
+		IL_005f: stloc.s 5
+		IL_0061: ldloc.3
+		IL_0062: ldloc.s 5
+		IL_0064: ldc.r8 0.0
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.s 4
+		IL_007b: stloc.1
+		IL_007c: ldc.i4.0
+		IL_007d: newarr [System.Runtime]System.Object
+		IL_0082: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0087: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter::.ctor()
+		IL_008c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0091: stloc.2
+		IL_0092: ldloc.2
+		IL_0093: ldtoken Modules.BeanCounter_Class_Index_Assign/BeanCounter
+		IL_0098: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_009d: ldstr "prototype"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00a7: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00ac: ldloc.2
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.BeanCounter_Class_Index_Assign/BeanCounter>(!!0)
+		IL_00b2: stloc.s 6
+		IL_00b4: ldloc.s 6
+		IL_00b6: ldc.r8 1
+		IL_00bf: box [System.Runtime]System.Double
+		IL_00c4: ldc.r8 42
+		IL_00cd: box [System.Runtime]System.Double
+		IL_00d2: callvirt instance object Modules.BeanCounter_Class_Index_Assign/BeanCounter::setBeanCount(object, object)
+		IL_00d7: pop
+		IL_00d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00dd: stloc.s 7
+		IL_00df: ldloc.2
+		IL_00e0: ldstr "beanCounts"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ea: stloc.s 4
+		IL_00ec: ldloc.s 4
+		IL_00ee: ldc.r8 1
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00fc: stloc.s 4
+		IL_00fe: ldloc.s 7
+		IL_0100: ldloc.s 4
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0107: pop
+		IL_0108: ret
 	} // end of method BeanCounter_Class_Index_Assign::__js_module_init__
 
 } // end of class Modules.BeanCounter_Class_Index_Assign

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -1235,7 +1235,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1557 (0x615)
+		// Code size: 1542 (0x606)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope,
@@ -1285,481 +1285,478 @@
 		IL_0046: ldc.i4.1
 		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
 		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0)
-		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0)
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005b: pop
-		IL_005c: ldc.i4.1
-		IL_005d: newarr [System.Runtime]System.Object
-		IL_0062: dup
-		IL_0063: ldc.i4.0
-		IL_0064: ldloc.0
-		IL_0065: stelem.ref
-		IL_0066: stloc.s 9
-		IL_0068: ldloc.s 8
-		IL_006a: ldstr "setBitsTrue"
-		IL_006f: ldloc.s 9
-		IL_0071: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::.ctor(object[])
-		IL_0076: ldc.i4.3
-		IL_0077: conv.r8
-		IL_0078: ldstr "setBitsTrue"
-		IL_007d: ldc.i4.1
-		IL_007e: ldc.i4.1
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0)
-		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0)
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0093: pop
-		IL_0094: ldc.i4.1
-		IL_0095: newarr [System.Runtime]System.Object
-		IL_009a: dup
-		IL_009b: ldc.i4.0
-		IL_009c: ldloc.0
-		IL_009d: stelem.ref
-		IL_009e: stloc.s 9
-		IL_00a0: ldloc.s 8
-		IL_00a2: ldstr "setBitsTrue_Naive"
-		IL_00a7: ldloc.s 9
-		IL_00a9: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::.ctor(object[])
-		IL_00ae: ldc.i4.3
-		IL_00af: conv.r8
-		IL_00b0: ldstr "setBitsTrue_Naive"
-		IL_00b5: ldc.i4.1
-		IL_00b6: ldc.i4.1
-		IL_00b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0, float64, string, bool, bool)
-		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0)
-		IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0)
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00cb: pop
-		IL_00cc: ldc.i4.1
-		IL_00cd: newarr [System.Runtime]System.Object
-		IL_00d2: dup
-		IL_00d3: ldc.i4.0
-		IL_00d4: ldloc.0
-		IL_00d5: stelem.ref
-		IL_00d6: stloc.s 9
-		IL_00d8: ldloc.s 7
-		IL_00da: ldloc.s 9
-		IL_00dc: ldc.r8 1
-		IL_00e5: box [System.Runtime]System.Double
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00ef: stloc.s 8
-		IL_00f1: ldloc.s 8
-		IL_00f3: stloc.1
-		IL_00f4: ldloc.0
-		IL_00f5: ldc.r8 2048
-		IL_00fe: box [System.Runtime]System.Double
-		IL_0103: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_0108: ldloc.0
-		IL_0109: ldc.r8 1
-		IL_0112: box [System.Runtime]System.Double
-		IL_0117: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_011c: ldloc.0
-		IL_011d: ldc.r8 17
-		IL_0126: box [System.Runtime]System.Double
-		IL_012b: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_0130: ldloc.0
-		IL_0131: ldc.r8 600
-		IL_013a: box [System.Runtime]System.Double
-		IL_013f: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_0144: ldc.i4.1
-		IL_0145: newarr [System.Runtime]System.Object
-		IL_014a: dup
-		IL_014b: ldc.i4.0
-		IL_014c: ldloc.0
-		IL_014d: stelem.ref
-		IL_014e: stloc.s 9
-		IL_0150: ldloc.0
-		IL_0151: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_0156: ldstr "Cannot access 'size' before initialization"
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0160: stloc.s 8
-		IL_0162: ldloc.s 9
-		IL_0164: ldc.i4.1
-		IL_0165: newarr [System.Runtime]System.Object
-		IL_016a: dup
-		IL_016b: ldc.i4.0
-		IL_016c: ldloc.s 8
-		IL_016e: stelem.ref
-		IL_016f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0174: ldloc.s 8
-		IL_0176: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_017b: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
-		IL_0180: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0185: stloc.2
-		IL_0186: ldloc.2
-		IL_0187: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_018c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0191: ldstr "prototype"
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_019b: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_01a0: ldc.i4.1
-		IL_01a1: newarr [System.Runtime]System.Object
-		IL_01a6: dup
-		IL_01a7: ldc.i4.0
-		IL_01a8: ldloc.0
-		IL_01a9: stelem.ref
-		IL_01aa: stloc.s 9
-		IL_01ac: ldloc.0
-		IL_01ad: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_01b2: ldstr "Cannot access 'size' before initialization"
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01bc: stloc.s 8
-		IL_01be: ldloc.s 9
-		IL_01c0: ldc.i4.1
-		IL_01c1: newarr [System.Runtime]System.Object
-		IL_01c6: dup
-		IL_01c7: ldc.i4.0
-		IL_01c8: ldloc.s 8
-		IL_01ca: stelem.ref
-		IL_01cb: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_01d0: ldloc.s 8
-		IL_01d2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_01d7: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
-		IL_01dc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_01e1: stloc.3
-		IL_01e2: ldloc.3
-		IL_01e3: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_01e8: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01ed: ldstr "prototype"
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_01f7: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_01fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0201: stloc.s 10
-		IL_0203: ldloc.2
-		IL_0204: ldstr "wordArray"
-		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_020e: stloc.s 8
-		IL_0210: ldloc.s 8
-		IL_0212: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0217: stloc.s 11
-		IL_0219: ldloc.3
-		IL_021a: ldstr "wordArray"
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0224: stloc.s 8
-		IL_0226: ldloc.s 8
-		IL_0228: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_022d: stloc.s 12
-		IL_022f: ldloc.s 10
-		IL_0231: ldstr "types"
-		IL_0236: ldloc.s 11
-		IL_0238: ldloc.s 12
-		IL_023a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_023f: pop
-		IL_0240: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0245: stloc.s 10
-		IL_0247: ldloc.2
-		IL_0248: ldstr "wordArray"
-		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0252: stloc.s 8
-		IL_0254: ldloc.s 8
-		IL_0256: ldstr "length"
-		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0260: stloc.s 8
-		IL_0262: ldloc.3
-		IL_0263: ldstr "wordArray"
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_026d: stloc.s 13
-		IL_026f: ldloc.s 13
-		IL_0271: ldstr "length"
-		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_027b: stloc.s 13
-		IL_027d: ldloc.s 10
-		IL_027f: ldstr "lens"
-		IL_0284: ldloc.s 8
-		IL_0286: ldloc.s 13
-		IL_0288: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_028d: pop
-		IL_028e: ldloc.2
-		IL_028f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
-		IL_0294: stloc.s 14
-		IL_0296: ldloc.0
-		IL_0297: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_029c: ldstr "Cannot access 'range_start' before initialization"
-		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02a6: stloc.s 13
-		IL_02a8: ldloc.0
-		IL_02a9: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_02ae: ldstr "Cannot access 'step' before initialization"
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02b8: stloc.s 8
-		IL_02ba: ldloc.0
-		IL_02bb: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_02c0: ldstr "Cannot access 'range_stop' before initialization"
-		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02ca: stloc.s 15
-		IL_02cc: ldloc.s 14
-		IL_02ce: ldloc.s 13
-		IL_02d0: ldloc.s 8
-		IL_02d2: ldloc.s 15
-		IL_02d4: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
-		IL_02d9: pop
-		IL_02da: ldloc.3
-		IL_02db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
-		IL_02e0: stloc.s 14
-		IL_02e2: ldloc.0
-		IL_02e3: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_02e8: ldstr "Cannot access 'range_start' before initialization"
-		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02f2: stloc.s 15
-		IL_02f4: ldloc.0
-		IL_02f5: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_02fa: ldstr "Cannot access 'step' before initialization"
-		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0304: stloc.s 8
-		IL_0306: ldloc.0
-		IL_0307: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_030c: ldstr "Cannot access 'range_stop' before initialization"
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0316: stloc.s 13
-		IL_0318: ldloc.s 14
-		IL_031a: ldloc.s 15
-		IL_031c: ldloc.s 8
-		IL_031e: ldloc.s 13
-		IL_0320: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
-		IL_0325: pop
-		IL_0326: ldc.r8 0.0
-		IL_032f: stloc.s 4
-		IL_0331: ldc.r8 1
-		IL_033a: neg
-		IL_033b: stloc.s 16
-		IL_033d: ldloc.s 16
-		IL_033f: box [System.Runtime]System.Double
-		IL_0344: stloc.s 5
-		IL_0346: ldc.r8 0.0
-		IL_034f: stloc.s 6
-		// loop start (head: IL_0351)
-			IL_0351: ldloc.s 6
-			IL_0353: stloc.s 16
-			IL_0355: ldloc.2
-			IL_0356: ldstr "wordArray"
-			IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0360: stloc.s 13
-			IL_0362: ldloc.s 13
-			IL_0364: ldstr "length"
-			IL_0369: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_036e: stloc.s 17
-			IL_0370: ldloc.s 16
-			IL_0372: ldloc.s 17
-			IL_0374: clt
-			IL_0376: brfalse IL_0416
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0056: pop
+		IL_0057: ldc.i4.1
+		IL_0058: newarr [System.Runtime]System.Object
+		IL_005d: dup
+		IL_005e: ldc.i4.0
+		IL_005f: ldloc.0
+		IL_0060: stelem.ref
+		IL_0061: stloc.s 9
+		IL_0063: ldloc.s 8
+		IL_0065: ldstr "setBitsTrue"
+		IL_006a: ldloc.s 9
+		IL_006c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::.ctor(object[])
+		IL_0071: ldc.i4.3
+		IL_0072: conv.r8
+		IL_0073: ldstr "setBitsTrue"
+		IL_0078: ldc.i4.1
+		IL_0079: ldc.i4.1
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0)
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0089: pop
+		IL_008a: ldc.i4.1
+		IL_008b: newarr [System.Runtime]System.Object
+		IL_0090: dup
+		IL_0091: ldc.i4.0
+		IL_0092: ldloc.0
+		IL_0093: stelem.ref
+		IL_0094: stloc.s 9
+		IL_0096: ldloc.s 8
+		IL_0098: ldstr "setBitsTrue_Naive"
+		IL_009d: ldloc.s 9
+		IL_009f: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::.ctor(object[])
+		IL_00a4: ldc.i4.3
+		IL_00a5: conv.r8
+		IL_00a6: ldstr "setBitsTrue_Naive"
+		IL_00ab: ldc.i4.1
+		IL_00ac: ldc.i4.1
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0, float64, string, bool, bool)
+		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0)
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00bc: pop
+		IL_00bd: ldc.i4.1
+		IL_00be: newarr [System.Runtime]System.Object
+		IL_00c3: dup
+		IL_00c4: ldc.i4.0
+		IL_00c5: ldloc.0
+		IL_00c6: stelem.ref
+		IL_00c7: stloc.s 9
+		IL_00c9: ldloc.s 7
+		IL_00cb: ldloc.s 9
+		IL_00cd: ldc.r8 1
+		IL_00d6: box [System.Runtime]System.Double
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00e0: stloc.s 8
+		IL_00e2: ldloc.s 8
+		IL_00e4: stloc.1
+		IL_00e5: ldloc.0
+		IL_00e6: ldc.r8 2048
+		IL_00ef: box [System.Runtime]System.Double
+		IL_00f4: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_00f9: ldloc.0
+		IL_00fa: ldc.r8 1
+		IL_0103: box [System.Runtime]System.Double
+		IL_0108: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_010d: ldloc.0
+		IL_010e: ldc.r8 17
+		IL_0117: box [System.Runtime]System.Double
+		IL_011c: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_0121: ldloc.0
+		IL_0122: ldc.r8 600
+		IL_012b: box [System.Runtime]System.Double
+		IL_0130: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_0135: ldc.i4.1
+		IL_0136: newarr [System.Runtime]System.Object
+		IL_013b: dup
+		IL_013c: ldc.i4.0
+		IL_013d: ldloc.0
+		IL_013e: stelem.ref
+		IL_013f: stloc.s 9
+		IL_0141: ldloc.0
+		IL_0142: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_0147: ldstr "Cannot access 'size' before initialization"
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0151: stloc.s 8
+		IL_0153: ldloc.s 9
+		IL_0155: ldc.i4.1
+		IL_0156: newarr [System.Runtime]System.Object
+		IL_015b: dup
+		IL_015c: ldc.i4.0
+		IL_015d: ldloc.s 8
+		IL_015f: stelem.ref
+		IL_0160: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0165: ldloc.s 8
+		IL_0167: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_016c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
+		IL_0171: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0176: stloc.2
+		IL_0177: ldloc.2
+		IL_0178: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_017d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0182: ldstr "prototype"
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_018c: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0191: ldc.i4.1
+		IL_0192: newarr [System.Runtime]System.Object
+		IL_0197: dup
+		IL_0198: ldc.i4.0
+		IL_0199: ldloc.0
+		IL_019a: stelem.ref
+		IL_019b: stloc.s 9
+		IL_019d: ldloc.0
+		IL_019e: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_01a3: ldstr "Cannot access 'size' before initialization"
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_01ad: stloc.s 8
+		IL_01af: ldloc.s 9
+		IL_01b1: ldc.i4.1
+		IL_01b2: newarr [System.Runtime]System.Object
+		IL_01b7: dup
+		IL_01b8: ldc.i4.0
+		IL_01b9: ldloc.s 8
+		IL_01bb: stelem.ref
+		IL_01bc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_01c1: ldloc.s 8
+		IL_01c3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_01c8: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
+		IL_01cd: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_01d2: stloc.3
+		IL_01d3: ldloc.3
+		IL_01d4: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_01d9: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_01de: ldstr "prototype"
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_01e8: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_01ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f2: stloc.s 10
+		IL_01f4: ldloc.2
+		IL_01f5: ldstr "wordArray"
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ff: stloc.s 8
+		IL_0201: ldloc.s 8
+		IL_0203: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0208: stloc.s 11
+		IL_020a: ldloc.3
+		IL_020b: ldstr "wordArray"
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0215: stloc.s 8
+		IL_0217: ldloc.s 8
+		IL_0219: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_021e: stloc.s 12
+		IL_0220: ldloc.s 10
+		IL_0222: ldstr "types"
+		IL_0227: ldloc.s 11
+		IL_0229: ldloc.s 12
+		IL_022b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0230: pop
+		IL_0231: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0236: stloc.s 10
+		IL_0238: ldloc.2
+		IL_0239: ldstr "wordArray"
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0243: stloc.s 8
+		IL_0245: ldloc.s 8
+		IL_0247: ldstr "length"
+		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0251: stloc.s 8
+		IL_0253: ldloc.3
+		IL_0254: ldstr "wordArray"
+		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_025e: stloc.s 13
+		IL_0260: ldloc.s 13
+		IL_0262: ldstr "length"
+		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_026c: stloc.s 13
+		IL_026e: ldloc.s 10
+		IL_0270: ldstr "lens"
+		IL_0275: ldloc.s 8
+		IL_0277: ldloc.s 13
+		IL_0279: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_027e: pop
+		IL_027f: ldloc.2
+		IL_0280: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
+		IL_0285: stloc.s 14
+		IL_0287: ldloc.0
+		IL_0288: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_028d: ldstr "Cannot access 'range_start' before initialization"
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0297: stloc.s 13
+		IL_0299: ldloc.0
+		IL_029a: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_029f: ldstr "Cannot access 'step' before initialization"
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_02a9: stloc.s 8
+		IL_02ab: ldloc.0
+		IL_02ac: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_02b1: ldstr "Cannot access 'range_stop' before initialization"
+		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_02bb: stloc.s 15
+		IL_02bd: ldloc.s 14
+		IL_02bf: ldloc.s 13
+		IL_02c1: ldloc.s 8
+		IL_02c3: ldloc.s 15
+		IL_02c5: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
+		IL_02ca: pop
+		IL_02cb: ldloc.3
+		IL_02cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
+		IL_02d1: stloc.s 14
+		IL_02d3: ldloc.0
+		IL_02d4: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_02d9: ldstr "Cannot access 'range_start' before initialization"
+		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_02e3: stloc.s 15
+		IL_02e5: ldloc.0
+		IL_02e6: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_02eb: ldstr "Cannot access 'step' before initialization"
+		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_02f5: stloc.s 8
+		IL_02f7: ldloc.0
+		IL_02f8: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_02fd: ldstr "Cannot access 'range_stop' before initialization"
+		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0307: stloc.s 13
+		IL_0309: ldloc.s 14
+		IL_030b: ldloc.s 15
+		IL_030d: ldloc.s 8
+		IL_030f: ldloc.s 13
+		IL_0311: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
+		IL_0316: pop
+		IL_0317: ldc.r8 0.0
+		IL_0320: stloc.s 4
+		IL_0322: ldc.r8 1
+		IL_032b: neg
+		IL_032c: stloc.s 16
+		IL_032e: ldloc.s 16
+		IL_0330: box [System.Runtime]System.Double
+		IL_0335: stloc.s 5
+		IL_0337: ldc.r8 0.0
+		IL_0340: stloc.s 6
+		// loop start (head: IL_0342)
+			IL_0342: ldloc.s 6
+			IL_0344: stloc.s 16
+			IL_0346: ldloc.2
+			IL_0347: ldstr "wordArray"
+			IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0351: stloc.s 13
+			IL_0353: ldloc.s 13
+			IL_0355: ldstr "length"
+			IL_035a: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_035f: stloc.s 17
+			IL_0361: ldloc.s 16
+			IL_0363: ldloc.s 17
+			IL_0365: clt
+			IL_0367: brfalse IL_0407
 
-			IL_037b: ldloc.2
-			IL_037c: ldstr "wordArray"
-			IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0386: stloc.s 13
-			IL_0388: ldloc.s 13
-			IL_038a: ldloc.s 6
-			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0391: stloc.s 13
-			IL_0393: ldloc.3
-			IL_0394: ldstr "wordArray"
-			IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_039e: stloc.s 8
-			IL_03a0: ldloc.s 8
-			IL_03a2: ldloc.s 6
-			IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03a9: stloc.s 8
-			IL_03ab: ldloc.s 13
-			IL_03ad: ldloc.s 8
-			IL_03af: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_03b4: stloc.s 18
-			IL_03b6: ldloc.s 18
-			IL_03b8: brfalse IL_0403
+			IL_036c: ldloc.2
+			IL_036d: ldstr "wordArray"
+			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0377: stloc.s 13
+			IL_0379: ldloc.s 13
+			IL_037b: ldloc.s 6
+			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0382: stloc.s 13
+			IL_0384: ldloc.3
+			IL_0385: ldstr "wordArray"
+			IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_038f: stloc.s 8
+			IL_0391: ldloc.s 8
+			IL_0393: ldloc.s 6
+			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_039a: stloc.s 8
+			IL_039c: ldloc.s 13
+			IL_039e: ldloc.s 8
+			IL_03a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_03a5: stloc.s 18
+			IL_03a7: ldloc.s 18
+			IL_03a9: brfalse IL_03f4
 
-			IL_03bd: ldloc.s 4
-			IL_03bf: ldc.r8 1
-			IL_03c8: add
-			IL_03c9: stloc.s 4
-			IL_03cb: ldloc.s 5
-			IL_03cd: stloc.s 19
-			IL_03cf: ldc.r8 1
-			IL_03d8: neg
-			IL_03d9: stloc.s 17
-			IL_03db: ldloc.s 17
-			IL_03dd: box [System.Runtime]System.Double
-			IL_03e2: stloc.s 20
-			IL_03e4: ldloc.s 19
-			IL_03e6: ldloc.s 20
-			IL_03e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_03ed: stloc.s 18
-			IL_03ef: ldloc.s 18
-			IL_03f1: brfalse IL_0403
+			IL_03ae: ldloc.s 4
+			IL_03b0: ldc.r8 1
+			IL_03b9: add
+			IL_03ba: stloc.s 4
+			IL_03bc: ldloc.s 5
+			IL_03be: stloc.s 19
+			IL_03c0: ldc.r8 1
+			IL_03c9: neg
+			IL_03ca: stloc.s 17
+			IL_03cc: ldloc.s 17
+			IL_03ce: box [System.Runtime]System.Double
+			IL_03d3: stloc.s 20
+			IL_03d5: ldloc.s 19
+			IL_03d7: ldloc.s 20
+			IL_03d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_03de: stloc.s 18
+			IL_03e0: ldloc.s 18
+			IL_03e2: brfalse IL_03f4
 
-			IL_03f6: ldloc.s 6
-			IL_03f8: box [System.Runtime]System.Double
-			IL_03fd: stloc.s 20
-			IL_03ff: ldloc.s 20
-			IL_0401: stloc.s 5
+			IL_03e7: ldloc.s 6
+			IL_03e9: box [System.Runtime]System.Double
+			IL_03ee: stloc.s 20
+			IL_03f0: ldloc.s 20
+			IL_03f2: stloc.s 5
 
-			IL_0403: ldloc.s 6
-			IL_0405: ldc.r8 1
-			IL_040e: add
-			IL_040f: stloc.s 6
-			IL_0411: br IL_0351
+			IL_03f4: ldloc.s 6
+			IL_03f6: ldc.r8 1
+			IL_03ff: add
+			IL_0400: stloc.s 6
+			IL_0402: br IL_0342
 		// end loop
 
-		IL_0416: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_041b: stloc.s 10
-		IL_041d: ldloc.s 4
-		IL_041f: box [System.Runtime]System.Double
-		IL_0424: stloc.s 20
-		IL_0426: ldloc.s 10
-		IL_0428: ldstr "diffs"
-		IL_042d: ldloc.s 20
-		IL_042f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0434: pop
-		IL_0435: ldloc.s 5
-		IL_0437: stloc.s 20
-		IL_0439: ldc.r8 1
-		IL_0442: neg
-		IL_0443: stloc.s 17
-		IL_0445: ldloc.s 17
-		IL_0447: box [System.Runtime]System.Double
-		IL_044c: stloc.s 19
-		IL_044e: ldloc.s 20
-		IL_0450: ldloc.s 19
-		IL_0452: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0457: stloc.s 18
-		IL_0459: ldloc.s 18
-		IL_045b: brfalse IL_04bc
+		IL_0407: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_040c: stloc.s 10
+		IL_040e: ldloc.s 4
+		IL_0410: box [System.Runtime]System.Double
+		IL_0415: stloc.s 20
+		IL_0417: ldloc.s 10
+		IL_0419: ldstr "diffs"
+		IL_041e: ldloc.s 20
+		IL_0420: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0425: pop
+		IL_0426: ldloc.s 5
+		IL_0428: stloc.s 20
+		IL_042a: ldc.r8 1
+		IL_0433: neg
+		IL_0434: stloc.s 17
+		IL_0436: ldloc.s 17
+		IL_0438: box [System.Runtime]System.Double
+		IL_043d: stloc.s 19
+		IL_043f: ldloc.s 20
+		IL_0441: ldloc.s 19
+		IL_0443: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0448: stloc.s 18
+		IL_044a: ldloc.s 18
+		IL_044c: brfalse IL_04ad
 
-		IL_0460: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0465: stloc.s 10
-		IL_0467: ldloc.2
-		IL_0468: ldstr "wordArray"
-		IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0472: stloc.s 8
-		IL_0474: ldloc.s 8
-		IL_0476: ldloc.s 5
-		IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_047d: stloc.s 8
-		IL_047f: ldloc.3
-		IL_0480: ldstr "wordArray"
-		IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_048a: stloc.s 13
-		IL_048c: ldloc.s 13
-		IL_048e: ldloc.s 5
-		IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_0495: stloc.s 13
-		IL_0497: ldloc.s 10
-		IL_0499: ldc.i4.4
-		IL_049a: newarr [System.Runtime]System.Object
-		IL_049f: dup
-		IL_04a0: ldc.i4.0
-		IL_04a1: ldstr "first"
+		IL_0451: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0456: stloc.s 10
+		IL_0458: ldloc.2
+		IL_0459: ldstr "wordArray"
+		IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0463: stloc.s 8
+		IL_0465: ldloc.s 8
+		IL_0467: ldloc.s 5
+		IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_046e: stloc.s 8
+		IL_0470: ldloc.3
+		IL_0471: ldstr "wordArray"
+		IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_047b: stloc.s 13
+		IL_047d: ldloc.s 13
+		IL_047f: ldloc.s 5
+		IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_0486: stloc.s 13
+		IL_0488: ldloc.s 10
+		IL_048a: ldc.i4.4
+		IL_048b: newarr [System.Runtime]System.Object
+		IL_0490: dup
+		IL_0491: ldc.i4.0
+		IL_0492: ldstr "first"
+		IL_0497: stelem.ref
+		IL_0498: dup
+		IL_0499: ldc.i4.1
+		IL_049a: ldloc.s 5
+		IL_049c: stelem.ref
+		IL_049d: dup
+		IL_049e: ldc.i4.2
+		IL_049f: ldloc.s 8
+		IL_04a1: stelem.ref
+		IL_04a2: dup
+		IL_04a3: ldc.i4.3
+		IL_04a4: ldloc.s 13
 		IL_04a6: stelem.ref
-		IL_04a7: dup
-		IL_04a8: ldc.i4.1
-		IL_04a9: ldloc.s 5
-		IL_04ab: stelem.ref
-		IL_04ac: dup
-		IL_04ad: ldc.i4.2
-		IL_04ae: ldloc.s 8
-		IL_04b0: stelem.ref
-		IL_04b1: dup
-		IL_04b2: ldc.i4.3
-		IL_04b3: ldloc.s 13
-		IL_04b5: stelem.ref
-		IL_04b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_04bb: pop
+		IL_04a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_04ac: pop
 
-		IL_04bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04c1: stloc.s 10
-		IL_04c3: ldloc.2
-		IL_04c4: ldstr "wordArray"
-		IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04ce: stloc.s 13
-		IL_04d0: ldloc.s 13
-		IL_04d2: ldc.r8 0.0
-		IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_04e0: stloc.s 13
-		IL_04e2: ldloc.3
-		IL_04e3: ldstr "wordArray"
-		IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04ed: stloc.s 8
-		IL_04ef: ldloc.s 8
-		IL_04f1: ldc.r8 0.0
-		IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_04ff: stloc.s 8
-		IL_0501: ldloc.s 10
-		IL_0503: ldstr "w0"
-		IL_0508: ldloc.s 13
-		IL_050a: ldloc.s 8
-		IL_050c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0511: pop
-		IL_0512: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0517: stloc.s 10
-		IL_0519: ldloc.2
-		IL_051a: ldstr "wordArray"
-		IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0524: stloc.s 8
-		IL_0526: ldloc.s 8
-		IL_0528: ldc.r8 1
-		IL_0531: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0536: stloc.s 8
-		IL_0538: ldloc.3
-		IL_0539: ldstr "wordArray"
-		IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0543: stloc.s 13
-		IL_0545: ldloc.s 13
-		IL_0547: ldc.r8 1
-		IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0555: stloc.s 13
-		IL_0557: ldloc.s 10
-		IL_0559: ldstr "w1"
-		IL_055e: ldloc.s 8
-		IL_0560: ldloc.s 13
-		IL_0562: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0567: pop
-		IL_0568: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_056d: stloc.s 10
-		IL_056f: ldloc.2
-		IL_0570: ldstr "wordArray"
-		IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_057a: stloc.s 13
-		IL_057c: ldloc.s 13
-		IL_057e: ldc.r8 2
-		IL_0587: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_058c: stloc.s 13
-		IL_058e: ldloc.3
-		IL_058f: ldstr "wordArray"
-		IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0599: stloc.s 8
-		IL_059b: ldloc.s 8
-		IL_059d: ldc.r8 2
-		IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05ab: stloc.s 8
-		IL_05ad: ldloc.s 10
-		IL_05af: ldstr "w2"
-		IL_05b4: ldloc.s 13
-		IL_05b6: ldloc.s 8
-		IL_05b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_05bd: pop
-		IL_05be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05c3: stloc.s 10
-		IL_05c5: ldloc.2
-		IL_05c6: ldstr "wordArray"
-		IL_05cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05d0: stloc.s 8
-		IL_05d2: ldloc.s 8
-		IL_05d4: ldc.r8 3
-		IL_05dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05e2: stloc.s 8
-		IL_05e4: ldloc.3
-		IL_05e5: ldstr "wordArray"
-		IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05ef: stloc.s 13
-		IL_05f1: ldloc.s 13
-		IL_05f3: ldc.r8 3
-		IL_05fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0601: stloc.s 13
-		IL_0603: ldloc.s 10
-		IL_0605: ldstr "w3"
-		IL_060a: ldloc.s 8
-		IL_060c: ldloc.s 13
-		IL_060e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0613: pop
-		IL_0614: ret
+		IL_04ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04b2: stloc.s 10
+		IL_04b4: ldloc.2
+		IL_04b5: ldstr "wordArray"
+		IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04bf: stloc.s 13
+		IL_04c1: ldloc.s 13
+		IL_04c3: ldc.r8 0.0
+		IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_04d1: stloc.s 13
+		IL_04d3: ldloc.3
+		IL_04d4: ldstr "wordArray"
+		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04de: stloc.s 8
+		IL_04e0: ldloc.s 8
+		IL_04e2: ldc.r8 0.0
+		IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_04f0: stloc.s 8
+		IL_04f2: ldloc.s 10
+		IL_04f4: ldstr "w0"
+		IL_04f9: ldloc.s 13
+		IL_04fb: ldloc.s 8
+		IL_04fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0502: pop
+		IL_0503: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0508: stloc.s 10
+		IL_050a: ldloc.2
+		IL_050b: ldstr "wordArray"
+		IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0515: stloc.s 8
+		IL_0517: ldloc.s 8
+		IL_0519: ldc.r8 1
+		IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0527: stloc.s 8
+		IL_0529: ldloc.3
+		IL_052a: ldstr "wordArray"
+		IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0534: stloc.s 13
+		IL_0536: ldloc.s 13
+		IL_0538: ldc.r8 1
+		IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0546: stloc.s 13
+		IL_0548: ldloc.s 10
+		IL_054a: ldstr "w1"
+		IL_054f: ldloc.s 8
+		IL_0551: ldloc.s 13
+		IL_0553: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0558: pop
+		IL_0559: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_055e: stloc.s 10
+		IL_0560: ldloc.2
+		IL_0561: ldstr "wordArray"
+		IL_0566: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_056b: stloc.s 13
+		IL_056d: ldloc.s 13
+		IL_056f: ldc.r8 2
+		IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_057d: stloc.s 13
+		IL_057f: ldloc.3
+		IL_0580: ldstr "wordArray"
+		IL_0585: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_058a: stloc.s 8
+		IL_058c: ldloc.s 8
+		IL_058e: ldc.r8 2
+		IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_059c: stloc.s 8
+		IL_059e: ldloc.s 10
+		IL_05a0: ldstr "w2"
+		IL_05a5: ldloc.s 13
+		IL_05a7: ldloc.s 8
+		IL_05a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_05ae: pop
+		IL_05af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05b4: stloc.s 10
+		IL_05b6: ldloc.2
+		IL_05b7: ldstr "wordArray"
+		IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05c1: stloc.s 8
+		IL_05c3: ldloc.s 8
+		IL_05c5: ldc.r8 3
+		IL_05ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05d3: stloc.s 8
+		IL_05d5: ldloc.3
+		IL_05d6: ldstr "wordArray"
+		IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05e0: stloc.s 13
+		IL_05e2: ldloc.s 13
+		IL_05e4: ldc.r8 3
+		IL_05ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05f2: stloc.s 13
+		IL_05f4: ldloc.s 10
+		IL_05f6: ldstr "w3"
+		IL_05fb: ldloc.s 8
+		IL_05fd: ldloc.s 13
+		IL_05ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0604: pop
+		IL_0605: ret
 	} // end of method Prime_SetBitsTrue_LargeStep_OptimizedVsNaive::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
@@ -1070,7 +1070,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1006 (0x3ee)
+		// Code size: 991 (0x3df)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope,
@@ -1116,271 +1116,268 @@
 		IL_0046: ldc.i4.1
 		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
 		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0)
-		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0)
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005b: pop
-		IL_005c: ldc.i4.1
-		IL_005d: newarr [System.Runtime]System.Object
-		IL_0062: dup
-		IL_0063: ldc.i4.0
-		IL_0064: ldloc.0
-		IL_0065: stelem.ref
-		IL_0066: stloc.s 11
-		IL_0068: ldloc.s 10
-		IL_006a: ldstr "setBitsTrue"
-		IL_006f: ldloc.s 11
-		IL_0071: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::.ctor(object[])
-		IL_0076: ldc.i4.3
-		IL_0077: conv.r8
-		IL_0078: ldstr "setBitsTrue"
-		IL_007d: ldc.i4.1
-		IL_007e: ldc.i4.1
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0)
-		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0)
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0093: pop
-		IL_0094: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0099: stloc.s 11
-		IL_009b: ldloc.s 10
-		IL_009d: ldstr "testBitTrue"
-		IL_00a2: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::.ctor()
-		IL_00a7: ldc.i4.1
-		IL_00a8: conv.r8
-		IL_00a9: ldstr "testBitTrue"
-		IL_00ae: ldc.i4.1
-		IL_00af: ldc.i4.1
-		IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
-		IL_00b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0)
-		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0)
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_00c4: pop
-		IL_00c5: ldc.i4.1
-		IL_00c6: newarr [System.Runtime]System.Object
-		IL_00cb: dup
-		IL_00cc: ldc.i4.0
-		IL_00cd: ldloc.0
-		IL_00ce: stelem.ref
-		IL_00cf: stloc.s 11
-		IL_00d1: ldloc.s 9
-		IL_00d3: ldloc.s 11
-		IL_00d5: ldc.r8 1
-		IL_00de: box [System.Runtime]System.Double
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00e8: stloc.s 10
-		IL_00ea: ldloc.s 10
-		IL_00ec: stloc.1
-		IL_00ed: ldc.i4.1
-		IL_00ee: newarr [System.Runtime]System.Object
-		IL_00f3: dup
-		IL_00f4: ldc.i4.0
-		IL_00f5: ldloc.0
-		IL_00f6: stelem.ref
-		IL_00f7: stloc.s 11
-		IL_00f9: ldloc.s 11
-		IL_00fb: ldc.i4.1
-		IL_00fc: newarr [System.Runtime]System.Object
-		IL_0101: dup
-		IL_0102: ldc.i4.0
-		IL_0103: ldc.r8 64
-		IL_010c: box [System.Runtime]System.Double
-		IL_0111: stelem.ref
-		IL_0112: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0117: ldc.r8 64
-		IL_0120: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::.ctor(object[], float64)
-		IL_0125: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_012a: stloc.2
-		IL_012b: ldloc.2
-		IL_012c: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_0131: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0136: ldstr "prototype"
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0140: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0145: ldc.r8 3
-		IL_014e: box [System.Runtime]System.Double
-		IL_0153: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_0158: stloc.3
-		IL_0159: ldc.r8 0.0
-		IL_0162: stloc.s 4
-		IL_0164: ldloc.3
-		IL_0165: ldloc.s 4
-		IL_0167: ldc.r8 16
-		IL_0170: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-		IL_0175: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017a: stloc.s 12
-		IL_017c: ldloc.3
-		IL_017d: ldc.r8 0.0
-		IL_0186: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_018b: box [System.Runtime]System.Double
-		IL_0190: stloc.s 13
-		IL_0192: ldloc.s 12
-		IL_0194: ldstr "varIndexSet"
-		IL_0199: ldloc.s 13
-		IL_019b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01a0: pop
-		IL_01a1: ldloc.2
-		IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_01a7: stloc.s 14
-		IL_01a9: ldloc.s 14
-		IL_01ab: ldc.r8 4
-		IL_01b4: box [System.Runtime]System.Double
-		IL_01b9: ldc.r8 3
-		IL_01c2: box [System.Runtime]System.Double
-		IL_01c7: ldc.r8 64
-		IL_01d0: box [System.Runtime]System.Double
-		IL_01d5: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
-		IL_01da: pop
-		IL_01db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01e0: stloc.s 12
-		IL_01e2: ldloc.2
-		IL_01e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_01e8: stloc.s 14
-		IL_01ea: ldloc.s 14
-		IL_01ec: ldc.r8 4
-		IL_01f5: box [System.Runtime]System.Double
-		IL_01fa: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_01ff: stloc.s 15
-		IL_0201: ldloc.s 15
-		IL_0203: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_0208: stloc.s 16
-		IL_020a: ldloc.s 16
-		IL_020c: brfalse IL_0226
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0056: pop
+		IL_0057: ldc.i4.1
+		IL_0058: newarr [System.Runtime]System.Object
+		IL_005d: dup
+		IL_005e: ldc.i4.0
+		IL_005f: ldloc.0
+		IL_0060: stelem.ref
+		IL_0061: stloc.s 11
+		IL_0063: ldloc.s 10
+		IL_0065: ldstr "setBitsTrue"
+		IL_006a: ldloc.s 11
+		IL_006c: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::.ctor(object[])
+		IL_0071: ldc.i4.3
+		IL_0072: conv.r8
+		IL_0073: ldstr "setBitsTrue"
+		IL_0078: ldc.i4.1
+		IL_0079: ldc.i4.1
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0)
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0089: pop
+		IL_008a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_008f: stloc.s 11
+		IL_0091: ldloc.s 10
+		IL_0093: ldstr "testBitTrue"
+		IL_0098: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::.ctor()
+		IL_009d: ldc.i4.1
+		IL_009e: conv.r8
+		IL_009f: ldstr "testBitTrue"
+		IL_00a4: ldc.i4.1
+		IL_00a5: ldc.i4.1
+		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
+		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0)
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_00b5: pop
+		IL_00b6: ldc.i4.1
+		IL_00b7: newarr [System.Runtime]System.Object
+		IL_00bc: dup
+		IL_00bd: ldc.i4.0
+		IL_00be: ldloc.0
+		IL_00bf: stelem.ref
+		IL_00c0: stloc.s 11
+		IL_00c2: ldloc.s 9
+		IL_00c4: ldloc.s 11
+		IL_00c6: ldc.r8 1
+		IL_00cf: box [System.Runtime]System.Double
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00d9: stloc.s 10
+		IL_00db: ldloc.s 10
+		IL_00dd: stloc.1
+		IL_00de: ldc.i4.1
+		IL_00df: newarr [System.Runtime]System.Object
+		IL_00e4: dup
+		IL_00e5: ldc.i4.0
+		IL_00e6: ldloc.0
+		IL_00e7: stelem.ref
+		IL_00e8: stloc.s 11
+		IL_00ea: ldloc.s 11
+		IL_00ec: ldc.i4.1
+		IL_00ed: newarr [System.Runtime]System.Object
+		IL_00f2: dup
+		IL_00f3: ldc.i4.0
+		IL_00f4: ldc.r8 64
+		IL_00fd: box [System.Runtime]System.Double
+		IL_0102: stelem.ref
+		IL_0103: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0108: ldc.r8 64
+		IL_0111: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::.ctor(object[], float64)
+		IL_0116: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_011b: stloc.2
+		IL_011c: ldloc.2
+		IL_011d: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_0122: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0127: ldstr "prototype"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0131: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0136: ldc.r8 3
+		IL_013f: box [System.Runtime]System.Double
+		IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_0149: stloc.3
+		IL_014a: ldc.r8 0.0
+		IL_0153: stloc.s 4
+		IL_0155: ldloc.3
+		IL_0156: ldloc.s 4
+		IL_0158: ldc.r8 16
+		IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+		IL_0166: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016b: stloc.s 12
+		IL_016d: ldloc.3
+		IL_016e: ldc.r8 0.0
+		IL_0177: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_017c: box [System.Runtime]System.Double
+		IL_0181: stloc.s 13
+		IL_0183: ldloc.s 12
+		IL_0185: ldstr "varIndexSet"
+		IL_018a: ldloc.s 13
+		IL_018c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0191: pop
+		IL_0192: ldloc.2
+		IL_0193: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0198: stloc.s 14
+		IL_019a: ldloc.s 14
+		IL_019c: ldc.r8 4
+		IL_01a5: box [System.Runtime]System.Double
+		IL_01aa: ldc.r8 3
+		IL_01b3: box [System.Runtime]System.Double
+		IL_01b8: ldc.r8 64
+		IL_01c1: box [System.Runtime]System.Double
+		IL_01c6: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
+		IL_01cb: pop
+		IL_01cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01d1: stloc.s 12
+		IL_01d3: ldloc.2
+		IL_01d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_01d9: stloc.s 14
+		IL_01db: ldloc.s 14
+		IL_01dd: ldc.r8 4
+		IL_01e6: box [System.Runtime]System.Double
+		IL_01eb: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_01f0: stloc.s 15
+		IL_01f2: ldloc.s 15
+		IL_01f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_01f9: stloc.s 16
+		IL_01fb: ldloc.s 16
+		IL_01fd: brfalse IL_0217
 
-		IL_0211: ldc.r8 1
-		IL_021a: box [System.Runtime]System.Double
-		IL_021f: stloc.s 5
-		IL_0221: br IL_0236
+		IL_0202: ldc.r8 1
+		IL_020b: box [System.Runtime]System.Double
+		IL_0210: stloc.s 5
+		IL_0212: br IL_0227
 
-		IL_0226: ldc.r8 0.0
-		IL_022f: box [System.Runtime]System.Double
-		IL_0234: stloc.s 5
+		IL_0217: ldc.r8 0.0
+		IL_0220: box [System.Runtime]System.Double
+		IL_0225: stloc.s 5
 
-		IL_0236: ldloc.s 12
-		IL_0238: ldstr "bit4"
-		IL_023d: ldloc.s 5
-		IL_023f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0244: pop
-		IL_0245: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_024a: stloc.s 12
-		IL_024c: ldloc.2
-		IL_024d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_0252: stloc.s 14
-		IL_0254: ldloc.s 14
-		IL_0256: ldc.r8 7
-		IL_025f: box [System.Runtime]System.Double
-		IL_0264: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_0269: stloc.s 15
-		IL_026b: ldloc.s 15
-		IL_026d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_0272: stloc.s 16
-		IL_0274: ldloc.s 16
-		IL_0276: brfalse IL_0290
+		IL_0227: ldloc.s 12
+		IL_0229: ldstr "bit4"
+		IL_022e: ldloc.s 5
+		IL_0230: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0235: pop
+		IL_0236: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_023b: stloc.s 12
+		IL_023d: ldloc.2
+		IL_023e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0243: stloc.s 14
+		IL_0245: ldloc.s 14
+		IL_0247: ldc.r8 7
+		IL_0250: box [System.Runtime]System.Double
+		IL_0255: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_025a: stloc.s 15
+		IL_025c: ldloc.s 15
+		IL_025e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_0263: stloc.s 16
+		IL_0265: ldloc.s 16
+		IL_0267: brfalse IL_0281
 
-		IL_027b: ldc.r8 1
-		IL_0284: box [System.Runtime]System.Double
-		IL_0289: stloc.s 6
-		IL_028b: br IL_02a0
+		IL_026c: ldc.r8 1
+		IL_0275: box [System.Runtime]System.Double
+		IL_027a: stloc.s 6
+		IL_027c: br IL_0291
 
-		IL_0290: ldc.r8 0.0
-		IL_0299: box [System.Runtime]System.Double
-		IL_029e: stloc.s 6
+		IL_0281: ldc.r8 0.0
+		IL_028a: box [System.Runtime]System.Double
+		IL_028f: stloc.s 6
 
-		IL_02a0: ldloc.s 12
-		IL_02a2: ldstr "bit7"
-		IL_02a7: ldloc.s 6
-		IL_02a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02ae: pop
-		IL_02af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b4: stloc.s 12
-		IL_02b6: ldloc.2
-		IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_02bc: stloc.s 14
-		IL_02be: ldloc.s 14
-		IL_02c0: ldc.r8 31
-		IL_02c9: box [System.Runtime]System.Double
-		IL_02ce: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_02d3: stloc.s 15
-		IL_02d5: ldloc.s 15
-		IL_02d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_02dc: stloc.s 16
-		IL_02de: ldloc.s 16
-		IL_02e0: brfalse IL_02fa
+		IL_0291: ldloc.s 12
+		IL_0293: ldstr "bit7"
+		IL_0298: ldloc.s 6
+		IL_029a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_029f: pop
+		IL_02a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a5: stloc.s 12
+		IL_02a7: ldloc.2
+		IL_02a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_02ad: stloc.s 14
+		IL_02af: ldloc.s 14
+		IL_02b1: ldc.r8 31
+		IL_02ba: box [System.Runtime]System.Double
+		IL_02bf: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_02c4: stloc.s 15
+		IL_02c6: ldloc.s 15
+		IL_02c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_02cd: stloc.s 16
+		IL_02cf: ldloc.s 16
+		IL_02d1: brfalse IL_02eb
 
-		IL_02e5: ldc.r8 1
-		IL_02ee: box [System.Runtime]System.Double
-		IL_02f3: stloc.s 7
-		IL_02f5: br IL_030a
+		IL_02d6: ldc.r8 1
+		IL_02df: box [System.Runtime]System.Double
+		IL_02e4: stloc.s 7
+		IL_02e6: br IL_02fb
 
-		IL_02fa: ldc.r8 0.0
-		IL_0303: box [System.Runtime]System.Double
-		IL_0308: stloc.s 7
+		IL_02eb: ldc.r8 0.0
+		IL_02f4: box [System.Runtime]System.Double
+		IL_02f9: stloc.s 7
 
-		IL_030a: ldloc.s 12
-		IL_030c: ldstr "bit31"
-		IL_0311: ldloc.s 7
-		IL_0313: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0318: pop
-		IL_0319: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_031e: stloc.s 12
-		IL_0320: ldloc.2
-		IL_0321: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_0326: stloc.s 14
-		IL_0328: ldloc.s 14
-		IL_032a: ldc.r8 5
-		IL_0333: box [System.Runtime]System.Double
-		IL_0338: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_033d: stloc.s 15
-		IL_033f: ldloc.s 15
-		IL_0341: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_0346: stloc.s 16
-		IL_0348: ldloc.s 16
-		IL_034a: brfalse IL_0364
+		IL_02fb: ldloc.s 12
+		IL_02fd: ldstr "bit31"
+		IL_0302: ldloc.s 7
+		IL_0304: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0309: pop
+		IL_030a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_030f: stloc.s 12
+		IL_0311: ldloc.2
+		IL_0312: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0317: stloc.s 14
+		IL_0319: ldloc.s 14
+		IL_031b: ldc.r8 5
+		IL_0324: box [System.Runtime]System.Double
+		IL_0329: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_032e: stloc.s 15
+		IL_0330: ldloc.s 15
+		IL_0332: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_0337: stloc.s 16
+		IL_0339: ldloc.s 16
+		IL_033b: brfalse IL_0355
 
-		IL_034f: ldc.r8 1
-		IL_0358: box [System.Runtime]System.Double
-		IL_035d: stloc.s 8
-		IL_035f: br IL_0374
+		IL_0340: ldc.r8 1
+		IL_0349: box [System.Runtime]System.Double
+		IL_034e: stloc.s 8
+		IL_0350: br IL_0365
 
-		IL_0364: ldc.r8 0.0
-		IL_036d: box [System.Runtime]System.Double
-		IL_0372: stloc.s 8
+		IL_0355: ldc.r8 0.0
+		IL_035e: box [System.Runtime]System.Double
+		IL_0363: stloc.s 8
 
-		IL_0374: ldloc.s 12
-		IL_0376: ldstr "bit5"
-		IL_037b: ldloc.s 8
-		IL_037d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0382: pop
-		IL_0383: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0388: stloc.s 12
-		IL_038a: ldloc.2
-		IL_038b: ldstr "wordArray"
-		IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0395: stloc.s 10
-		IL_0397: ldloc.s 10
-		IL_0399: ldc.r8 0.0
-		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03a7: stloc.s 10
-		IL_03a9: ldloc.s 12
-		IL_03ab: ldstr "word0"
-		IL_03b0: ldloc.s 10
-		IL_03b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03b7: pop
-		IL_03b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03bd: stloc.s 12
-		IL_03bf: ldloc.2
-		IL_03c0: ldstr "wordArray"
-		IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03ca: stloc.s 10
-		IL_03cc: ldloc.s 10
-		IL_03ce: ldc.r8 1
-		IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03dc: stloc.s 10
-		IL_03de: ldloc.s 12
-		IL_03e0: ldstr "word1"
-		IL_03e5: ldloc.s 10
-		IL_03e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03ec: pop
-		IL_03ed: ret
+		IL_0365: ldloc.s 12
+		IL_0367: ldstr "bit5"
+		IL_036c: ldloc.s 8
+		IL_036e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0373: pop
+		IL_0374: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0379: stloc.s 12
+		IL_037b: ldloc.2
+		IL_037c: ldstr "wordArray"
+		IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0386: stloc.s 10
+		IL_0388: ldloc.s 10
+		IL_038a: ldc.r8 0.0
+		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0398: stloc.s 10
+		IL_039a: ldloc.s 12
+		IL_039c: ldstr "word0"
+		IL_03a1: ldloc.s 10
+		IL_03a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03a8: pop
+		IL_03a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03ae: stloc.s 12
+		IL_03b0: ldloc.2
+		IL_03b1: ldstr "wordArray"
+		IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03bb: stloc.s 10
+		IL_03bd: ldloc.s 10
+		IL_03bf: ldc.r8 1
+		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_03cd: stloc.s 10
+		IL_03cf: ldloc.s 12
+		IL_03d1: ldstr "word1"
+		IL_03d6: ldloc.s 10
+		IL_03d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03dd: pop
+		IL_03de: ret
 	} // end of method Prime_SetBitsTrue_SmallStep_WordValueOrAssign::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
@@ -213,7 +213,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1029 (0x405)
+		// Code size: 1020 (0x3fc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope,
@@ -443,90 +443,87 @@
 		IL_031b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject_FunctionExpression_0242BF45_L17C10>(!!0, float64, string, bool, bool)
 		IL_0320: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject_FunctionExpression_0242BF45_L17C10>(!!0)
 		IL_0325: stloc.s 16
-		IL_0327: ldloc.s 16
-		IL_0329: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject_FunctionExpression_0242BF45_L17C10>(!!0)
-		IL_032e: stloc.s 16
-		IL_0330: ldloc.s 14
-		IL_0332: ldstr "valueOf"
-		IL_0337: ldloc.s 16
-		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_033e: pop
-		IL_033f: ldloc.s 14
-		IL_0341: stloc.s 5
-		IL_0343: ldc.r8 0.0
-		IL_034c: box [System.Runtime]System.Double
-		IL_0351: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_0356: stloc.s 6
-		IL_0358: ldloc.s 6
-		IL_035a: ldc.r8 0.0
-		IL_0363: ldloc.s 5
-		IL_0365: ldc.i4.1
-		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_036b: pop
-		IL_036c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0371: stloc.s 12
-		IL_0373: ldloc.0
-		IL_0374: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
-		IL_0379: stloc.s 13
-		IL_037b: ldloc.s 12
-		IL_037d: ldloc.s 13
-		IL_037f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0384: pop
+		IL_0327: ldloc.s 14
+		IL_0329: ldstr "valueOf"
+		IL_032e: ldloc.s 16
+		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0335: pop
+		IL_0336: ldloc.s 14
+		IL_0338: stloc.s 5
+		IL_033a: ldc.r8 0.0
+		IL_0343: box [System.Runtime]System.Double
+		IL_0348: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_034d: stloc.s 6
+		IL_034f: ldloc.s 6
+		IL_0351: ldc.r8 0.0
+		IL_035a: ldloc.s 5
+		IL_035c: ldc.i4.1
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_0362: pop
+		IL_0363: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0368: stloc.s 12
+		IL_036a: ldloc.0
+		IL_036b: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
+		IL_0370: stloc.s 13
+		IL_0372: ldloc.s 12
+		IL_0374: ldloc.s 13
+		IL_0376: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_037b: pop
 		.try
 		{
-			IL_0385: nop
-			IL_0386: ldstr "value"
-			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
-			IL_0390: stloc.s 13
-			IL_0392: ldloc.s 6
-			IL_0394: ldc.r8 0.0
-			IL_039d: ldloc.s 13
-			IL_039f: ldc.i4.1
-			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_03a5: pop
-			IL_03a6: leave IL_0401
+			IL_037c: nop
+			IL_037d: ldstr "value"
+			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
+			IL_0387: stloc.s 13
+			IL_0389: ldloc.s 6
+			IL_038b: ldc.r8 0.0
+			IL_0394: ldloc.s 13
+			IL_0396: ldc.i4.1
+			IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_039c: pop
+			IL_039d: leave IL_03f8
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03ab: stloc.s 7
-			IL_03ad: ldloc.s 7
-			IL_03af: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03b4: dup
-			IL_03b5: brtrue IL_03cb
+			IL_03a2: stloc.s 7
+			IL_03a4: ldloc.s 7
+			IL_03a6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03ab: dup
+			IL_03ac: brtrue IL_03c2
 
-			IL_03ba: pop
-			IL_03bb: ldloc.s 7
-			IL_03bd: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03c2: dup
-			IL_03c3: brtrue IL_03d7
+			IL_03b1: pop
+			IL_03b2: ldloc.s 7
+			IL_03b4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03b9: dup
+			IL_03ba: brtrue IL_03ce
 
-			IL_03c8: pop
-			IL_03c9: rethrow
+			IL_03bf: pop
+			IL_03c0: rethrow
 
-			IL_03cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03d0: stloc.s 8
-			IL_03d2: br IL_03d9
+			IL_03c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03c7: stloc.s 8
+			IL_03c9: br IL_03d0
 
-			IL_03d7: stloc.s 8
+			IL_03ce: stloc.s 8
 
-			IL_03d9: ldloc.s 8
-			IL_03db: stloc.s 9
-			IL_03dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03e2: stloc.s 12
-			IL_03e4: ldloc.s 9
-			IL_03e6: ldstr "name"
-			IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03f0: stloc.s 13
-			IL_03f2: ldloc.s 12
-			IL_03f4: ldloc.s 13
-			IL_03f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03fb: pop
-			IL_03fc: leave IL_0401
+			IL_03d0: ldloc.s 8
+			IL_03d2: stloc.s 9
+			IL_03d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03d9: stloc.s 12
+			IL_03db: ldloc.s 9
+			IL_03dd: ldstr "name"
+			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e7: stloc.s 13
+			IL_03e9: ldloc.s 12
+			IL_03eb: ldloc.s 13
+			IL_03ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03f2: pop
+			IL_03f3: leave IL_03f8
 		} // end handler
 
-		IL_0401: ldnull
-		IL_0402: stloc.s 10
-		IL_0404: ret
+		IL_03f8: ldnull
+		IL_03f9: stloc.s 10
+		IL_03fb: ret
 	} // end of method TypedArray_SignedAndClamped_ConversionSemantics::__js_module_init__
 
 } // end of class Modules.TypedArray_SignedAndClamped_ConversionSemantics


### PR DESCRIPTION
Closes #1748.

## Summary

- Make the IL emitter the sole owner of `MarkUndefinedPrototype` for generated non-constructable function objects.
- Retain the mark in the delegate-backed fallback emitter path, preserving its runtime metadata behavior.
- Remove redundant lowering-layer marks for class methods, object methods, and object accessors.

The affected static class method now emits one prototype-omission call rather than two.
