### PR TITLE
feat(hosting): support exports and CLR interop with generated function objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime/hosting: close issue #1720 by projecting generated function exports
+  through the public runtime-owned `JsCallable` API, preserving per-module
+  identity and callback round trips across dynamic, typed, object-return, and
+  nested-value boundaries. Route host calls, construction, CLR delegate/method
+  adapters, receiver/argument normalization, and Promise-to-Task bridging
+  through centralized callable operations; add explicit `JsHostFunction`
+  metadata/constructability, Task-to-Promise callback results, packed
+  `object[]` host arguments, constructable `newTarget` validation, and
+  deterministic disposed-runtime behavior. Preserve the binary-compatible
+  `IDisposable` return type of non-generic `LoadModule(...)` and add
+  `LoadDynamicModule(...)` for the strongly typed dynamic surface, while
+  retaining `ModuleMainDelegate`/`RequireDelegate` only as internal CommonJS
+  bootstrap ABIs.
 - runtime/node: close issue #1719 by routing Promise, iterator, timer-promise,
   events, stream, util, and Node callback boundaries through
   `CallableOperations`; preserve generated callback identity for listener

--- a/docs/runtime/DotNetLibraryHosting.md
+++ b/docs/runtime/DotNetLibraryHosting.md
@@ -4,7 +4,7 @@
 >
 > This document is kept as an implementation-oriented design/reference.
 
-This document describes a proposed hosting mode where a compiled assembly can be consumed as a **.NET library**, and JavaScript `module.exports` is surfaced to C# as **strongly typed** APIs.
+This document describes the hosting mode where a compiled assembly can be consumed as a **.NET library**, and JavaScript `module.exports` is surfaced to C# through strongly typed and dynamic APIs.
 
 This is a design document and is intentionally implementation-oriented; it is not an ECMA-262 specification.
 
@@ -29,7 +29,7 @@ Calling `JsEngine.LoadModule(...)` creates a runtime instance that:
 - owns per-thread JavaScript runtime state,
 - returns a proxy to the module exports.
 
-Everything you interact with (exports, functions, constructors, object instances) is a proxy that marshals work to that script thread.
+Exports, callable wrappers, constructors, and object handles marshal work to that script thread. Generated function objects are exposed as `JsCallable`; callers never cast them to generated CLR types or CLR delegates.
 
 ### Hosted `child_process.fork()`
 
@@ -149,6 +149,83 @@ using var exports = JsEngine.LoadModule<IMyExports>("fetcher");
 await exports.RefreshAsync();
 ```
 
+### Exported function values
+
+Functions returned as values, including ordinary, async, generator, and nested
+functions, are projected as `JsCallable`:
+
+```csharp
+JsCallable callback = exports.GetCallback();
+
+var value = callback.Call(1, 2);
+var withReceiver = callback.CallWithReceiver(receiver, 1, 2);
+var asyncValue = await callback.CallAsync<double>(21);
+
+if (callback.IsConstructor)
+{
+      dynamic instance = callback.Construct("Ada");
+}
+```
+
+`Name`, `Length`, `IsConstructor`, `GetProperty(...)`, and `SetProperty(...)`
+expose the JavaScript function surface without exposing the generated CLR
+function-object type. `ConstructWithNewTarget(...)` is available when an
+explicit alternate `newTarget` is required. The alternate value must itself
+be constructable; otherwise the call fails with JavaScript `TypeError`.
+
+Repeated projection of the same JavaScript callable within one module runtime
+returns the same `JsCallable` reference. Passing that wrapper back to the same
+runtime unwraps it to the original callable, so strict JavaScript identity is
+preserved. Values from different runtime instances cannot be mixed.
+
+For a module whose complete `module.exports` value is callable, use the dynamic
+module boundary:
+
+```csharp
+using JsDynamicExports module = JsEngine.LoadDynamicModule(assembly, "plugin");
+var entry = (JsCallable)module.Value!;
+var result = entry.Call("input");
+```
+
+### CLR callbacks entering JavaScript
+
+Passing the same CLR delegate repeatedly through a hosting call creates one
+runtime-owned function adapter. The adapter has `Function.prototype`,
+`name`/`length` metadata, ordinary function properties, stable identity, and is
+non-constructable by default.
+
+Use `JsHostFunction` when the receiver, metadata, or constructability must be
+explicit:
+
+```csharp
+var callback = new JsHostFunction(
+      (receiver, args) => args[0],
+      name: "select",
+      length: 1);
+
+var constructor = new JsHostFunction(
+      (_, _) => null,
+      name: "HostBox",
+      length: 1,
+      constructor: (args, newTarget) => new Dictionary<string, object?>
+      {
+            ["value"] = args[0]
+      });
+```
+
+JavaScript invokes these adapters through `CallableOperations`, the same
+central call/construct boundary used by generated functions. An unannotated
+CLR delegate or method whose visible parameter is `object[]` receives all
+JavaScript arguments packed into that array; generated scope parameters are
+recognized only through generated delegate types or explicit internal ABI
+metadata.
+
+CLR delegates and `JsHostFunction` callbacks may return `Task` or `Task<T>`.
+Hosting exposes that result to JavaScript as a Promise without blocking a
+thread. Successful completion fulfills the Promise, faults reject it with the
+underlying exception, and cancellation rejects it with
+`TaskCanceledException`.
+
 ### Exported classes (constructors) and `new`
 
 If a module exports a class:
@@ -205,7 +282,9 @@ while (condition)
 
 Important safety property: the runtime should not shut down “too early” just because the exports proxy was garbage collected.
 
-This is achieved by ensuring that every proxy (exports, constructor, instance, etc.) keeps a reference to the underlying runtime instance and participates in reference counting.
+The module object returned by `LoadModule(...)` owns shutdown. Derived callable
+wrappers and handles keep the runtime reachable but do not independently
+dispose it.
 
 ---
 
@@ -250,8 +329,11 @@ public static class JsEngine
       public static TExports LoadModule<TExports>(string moduleId)
             where TExports : class;
 
-      // Dynamic / reflection-friendly form: caller specifies which compiled assembly contains modules.
-      public static object LoadModule(System.Reflection.Assembly compiledAssembly, string moduleId);
+      // Binary-compatible dynamic form retained from the original hosting API.
+      public static IDisposable LoadModule(System.Reflection.Assembly compiledAssembly, string moduleId);
+
+      // Strongly typed dynamic / reflection-friendly form.
+      public static JsDynamicExports LoadDynamicModule(System.Reflection.Assembly compiledAssembly, string moduleId);
 
       // Optional convenience for non-Assembly call sites:
       // public static object LoadModule(Type compiledAssemblyMarkerType, string moduleId);
@@ -262,7 +344,10 @@ Intended usage variations:
 
 1. **Strongly typed + no parameters**: `LoadModule<TExports>()` when `TExports` carries enough metadata (recommended).
 2. **Strongly typed + module id**: `LoadModule<TExports>(moduleId)` when module id is not embedded (still assembly-inferred).
-3. **Dynamic**: `LoadModule(compiledAssembly, moduleId)` when the host decides the target compiled assembly at runtime.
+3. **Dynamic**: `LoadDynamicModule(compiledAssembly, moduleId)` when the host
+   decides the target compiled assembly at runtime. The non-generic
+   `LoadModule(...)` overload remains available with its historical
+   `IDisposable` return type for binary compatibility.
 
 Notes:
 
@@ -310,7 +395,10 @@ information, for example via:
 - an attribute on `TExports` (e.g., module id and/or a stable module key), and/or
 - a compiled-assembly manifest that maps exports contract types → module ids.
 
-If required metadata is missing, `LoadModule<TExports>()` should throw a helpful exception telling the user to call `LoadModule<TExports>(moduleId)` or `LoadModule(compiledAssembly, moduleId)`.
+If required metadata is missing, `LoadModule<TExports>()` should throw a
+helpful exception telling the user to call
+`LoadModule<TExports>(moduleId)` or
+`LoadDynamicModule(compiledAssembly, moduleId)`.
 
 ### What if the module does not implement `TExports`?
 
@@ -443,6 +531,9 @@ Suggested conventions:
 - Generated exports interfaces should implement `IDisposable` (they are the runtime instance boundary).
 - Proxies representing JS object handles should implement `IJsHandle`.
 - Primitive results (`double`, `bool`, `string`) and `Task` are by-value and not disposable.
+- `JsCallable` is runtime-owned and is not independently disposable. Dispose
+  the owning module; subsequent calls or property access throw
+  `ObjectDisposedException`.
 
 ### CLR type mapping for exports
 
@@ -507,19 +598,35 @@ Because runtime state is thread-affine, all interactions from caller threads mus
 
 Exceptions thrown on the script thread are captured and rethrown on the calling thread.
 
-### Lifetime and reference counting
+### Lifetime and callable identity
 
-To prevent accidental premature shutdown (e.g., exports proxy is GC’d while a derived instance is still alive), the implementation should use reference counting:
+The exports proxy is the runtime owner. Disposing it faults queued invocations
+and pending Promise-to-Task bridges with `ObjectDisposedException`, stops the
+event loop, and terminates the script thread. Object handles only release their
+local proxy reference; `JsCallable` wrappers do not own or dispose the runtime.
 
-- The underlying runtime instance maintains a refcount.
-- Every proxy/handle increments the refcount when created.
-- Disposing a proxy decrements the refcount.
-- When the refcount reaches 0, the runtime shuts down and the script thread exits.
+Each runtime owns weak-key caches for:
 
-This model supports:
+- JavaScript callable → `JsCallable`
+- CLR delegate / `JsHostFunction` → JavaScript host function adapter
+- CLR method target + method → explicit method function adapter
 
-- deterministic shutdown via `Dispose()`
-- safe GC fallback (finalizers may call `Release()` as a safety net)
+The caches preserve identity without using process-global roots. Runtime state
+and exports are cleared during shutdown. A wrapper intentionally keeps its own
+target and disposed runtime reachable while the host still references that
+wrapper; using it after shutdown throws `ObjectDisposedException`.
+
+The owning module should normally remain alive until Promise-to-`Task` bridges
+settle. If it is disposed first, outstanding bridge tasks fault promptly with
+`ObjectDisposedException`; they are never left pending indefinitely.
+
+### Intentional delegate boundaries
+
+Generated JavaScript functions do not cross the public hosting boundary as CLR
+delegates. `LegacyDelegateFunctionAdapter` remains the explicit transitional
+runtime adapter for delegate-backed callable values. `ModuleMainDelegate` and
+`RequireDelegate` remain internal CommonJS bootstrap ABIs; they are not public
+hosting callable contracts and are not candidates for this migration.
 
 ### Module entry point
 

--- a/docs/runtime/JsFunctionObjectInvocationAbi.md
+++ b/docs/runtime/JsFunctionObjectInvocationAbi.md
@@ -79,6 +79,24 @@ Legacy delegates remain supported through
 delegate ABI requires an array; this is an explicit migration path, not the
 generated function-object ABI.
 
+The public .NET hosting boundary projects callable values as runtime-owned
+`Jroc.Runtime.JsCallable` wrappers. Calls, receiver-aware calls, construction,
+and alternate `newTarget` construction marshal to the owning script thread and
+then enter `CallableOperations`. Promise results can be bridged with
+`CallAsync<T>`. Per-runtime weak-key caches preserve wrapper identity and unwrap
+round-tripped wrappers to the original JavaScript callable.
+
+CLR delegates entering JavaScript through hosting are first adapted to explicit
+`JsFunctionObject` instances. Raw delegates remain supported only behind the
+transitional runtime adapter boundary. Unannotated public CLR `object[]`
+parameters are visible packed-argument parameters, not generated scope
+payloads. Only explicit callable ABI metadata and known generated delegate
+types retain the hidden scope convention. Callback results of type `Task` or
+`Task<T>` are converted to JavaScript Promises and settled on the owning
+runtime thread. CommonJS `ModuleMainDelegate` and `RequireDelegate` are
+intentional internal bootstrap signatures, not public compiled-function
+representations.
+
 ## Arity evidence
 
 Run the checked-in analyzer:

--- a/docs/runtime/OrdinaryObjectRepresentation.md
+++ b/docs/runtime/OrdinaryObjectRepresentation.md
@@ -112,10 +112,21 @@ Compiler-generated subclasses are tracked under
 
 ## Host boundary
 
-C# dynamic interoperability is a hosting concern. `JsObject` still carries
-transitional DLR support while [#1461](https://github.com/tomacox74/js2il/issues/1461)
-moves it to `JsDynamicValueProxy` and `JsDynamicExports`. Internal JavaScript
-execution does not dispatch through the DLR.
+C# dynamic interoperability is a hosting concern. `JsDynamicValueProxy` and
+`JsDynamicExports` marshal object access to the owning runtime thread, while
+callable values are projected as `JsCallable`. The callable projection exposes
+call/construct operations and function properties without exposing generated
+CLR types or requiring a CLR `Delegate`.
+
+Projection identity is scoped to one runtime instance. A per-runtime weak-key
+cache returns the same host wrapper for the same JavaScript callable, and a
+wrapper passed back into that runtime unwraps to the same `JsFunctionObject`.
+Cross-runtime wrapper use is rejected.
+
+CLR callbacks entering JavaScript are represented as explicit host
+`JsFunctionObject` adapters with `Function.prototype`, metadata, property
+storage, and explicit constructability. JavaScript dispatches them through
+`CallableOperations`; the DLR is never an internal JavaScript call path.
 
 External CLR dictionaries and POCOs remain host objects. They are supported
 through their normal host-object paths and are not treated as runtime-owned

--- a/docs/sdk/Index.md
+++ b/docs/sdk/Index.md
@@ -13,7 +13,8 @@ This page is the **canonical user documentation** for SDK consumers. The older d
 - Optional **debug symbols**: emit Portable PDB (`.pdb`) data for stepping and better stack traces against the original `.js` / `.mjs` source path, including rewritten `import` / `export` module code.
 - Two ways to call exports from hosted modules:
   - **Typed**: use compiler-generated C# contract interfaces and `JsEngine.LoadModule<TExports>()`.
-  - **Dynamic**: use `dynamic` with `JsEngine.LoadModule(Assembly, moduleId)`.
+  - **Dynamic**: use `dynamic` with
+    `JsEngine.LoadDynamicModule(Assembly, moduleId)`.
 - Stable SDK/runtime exception types (`JsModuleLoadException`, `JsInvocationException`, etc.).
 
 For build-integrated host projects, start with the `Jroc.SDK` NuGet package and declare one or more `JrocCompile` items in your `.csproj`. For source-text or artifact-only workflows, use the `Jroc.Core` in-memory APIs.
@@ -60,8 +61,8 @@ using System.Reflection;
 
 var asm = Assembly.LoadFrom("path\\to\\compiled.dll");
 
-// Returns an IDisposable dynamic exports proxy.
-using dynamic exports = JsEngine.LoadModule(asm, moduleId: "math");
+// Returns a JsDynamicExports dynamic exports proxy.
+using dynamic exports = JsEngine.LoadDynamicModule(asm, moduleId: "math");
 
 Console.WriteLine((string)exports.version);
 Console.WriteLine((double)exports.add(1, 2));

--- a/docs/sdk/api/Handles.md
+++ b/docs/sdk/api/Handles.md
@@ -2,6 +2,25 @@
 
 Hosting uses proxies to represent non-primitive JS values.
 
+## JsCallable
+
+Generated JavaScript function values are represented by the public
+`JsCallable` class, not by CLR delegates or generated CLR types.
+
+```csharp
+var result = callable.Call(1, 2);
+var resultWithThis = callable.CallWithReceiver(receiver, 1, 2);
+var asyncResult = await callable.CallAsync<double>(21);
+var instance = callable.Construct("Ada");
+var derivedInstance = callable.ConstructWithNewTarget(otherConstructor, "Ada");
+```
+
+`Name`, `Length`, `IsConstructor`, `GetProperty`, and `SetProperty` expose the
+function surface. Repeated retrieval of the same callable from one runtime
+returns the same wrapper reference. `JsCallable` is owned by the module runtime
+and is not separately disposable. `ConstructWithNewTarget` requires a
+constructable alternate target and reports JavaScript `TypeError` otherwise.
+
 ## IJsHandle
 
 ```csharp
@@ -34,6 +53,9 @@ Notes:
 
 If you call into JS and pass arguments that were previously returned via hosting proxies, the hosting layer unwraps them back to the underlying JS value before invoking.
 This avoids accidentally passing the proxy object itself into JS APIs.
+
+The same rule applies to `JsCallable`, preserving strict callback identity.
+Wrappers from different module runtimes cannot be mixed.
 
 ## Typed vs dynamic member access
 

--- a/docs/sdk/api/JsEngine.md
+++ b/docs/sdk/api/JsEngine.md
@@ -31,8 +31,22 @@ public static TExports LoadModule<TExports>(string moduleId) where TExports : cl
 public static IDisposable LoadModule(Assembly compiledAssembly, string moduleId)
 ```
 
-- Dynamic / reflection-friendly API.
-- Returns an **IDisposable dynamic exports proxy** (can be used via `dynamic`).
+- Binary-compatible dynamic API retained with its original
+  `IDisposable` return type.
+- The runtime object is still a dynamic exports proxy and can be assigned to
+  `dynamic`.
+
+## LoadDynamicModule(Assembly compiledAssembly, string moduleId)
+
+```csharp
+public static JsDynamicExports LoadDynamicModule(
+    Assembly compiledAssembly,
+    string moduleId)
+```
+
+- Preferred dynamic / reflection-friendly API for new source.
+- Exposes `JsDynamicExports.Value`, `Get(...)`, and `Invoke(...)` directly.
+- An overload accepts `JsModuleLoadOptions`.
 
 ## GetModuleIds(Assembly compiledAssembly)
 
@@ -46,5 +60,7 @@ public static IReadOnlyList<string> GetModuleIds(Assembly compiledAssembly)
 
 ## Threading model (high level)
 
-Each `LoadModule(...)` call creates a runtime instance with a dedicated script thread.
+Each load call creates a runtime instance with a dedicated script thread.
 All calls are marshalled onto that script thread; calls from within the script thread execute directly.
+Disposal faults queued calls and pending Promise bridge tasks rather than
+leaving callers blocked.

--- a/docs/sdk/api/TypeMapping.md
+++ b/docs/sdk/api/TypeMapping.md
@@ -16,14 +16,18 @@ This is the practical mapping you will see when hosting compiled JS from C#.
 
 Typed hosting:
 
+- JavaScript callable values are returned as `JsCallable`.
 - If your contract return type is `IJsHandle`, the hosting layer returns a handle proxy.
 - If your contract return type is `IJsConstructor<T>`, the hosting layer returns a constructor proxy.
-- If your contract return type is `object`, you will typically get the raw runtime object.
+- If your contract return type is `object`, runtime references remain behind a
+  dynamic proxy or `JsCallable`; raw generated/runtime object types are not
+  exposed.
 
 Dynamic hosting:
 
 - Primitives are returned as normal CLR values.
-- Most non-primitive values (including delegates/functions and objects) are wrapped in a dynamic proxy so that:
+- Function values are returned as stable `JsCallable` wrappers.
+- Other non-primitive values are wrapped in a dynamic proxy so that:
   - member access (`obj.foo`)
   - member invocation (`obj.foo(1,2)`)
   - invocation of function values (`fn(123)`)
@@ -33,4 +37,10 @@ Dynamic hosting:
 ## Async
 
 - A JS `Promise` can be projected as `Task`/`Task<T>`.
+- `JsCallable.CallAsync<T>(...)` bridges a callable's Promise result to
+  `Task<T>`.
 - If the contract expects `Task<T>` and the JS side returns a non-promise value, it is treated as an already-completed task with that value.
+- A CLR delegate or `JsHostFunction` callback result of type `Task`/`Task<T>`
+  is exposed to JavaScript as a Promise. Faults and cancellation reject it.
+- Disposing the owning runtime faults still-pending Promise-to-Task bridges
+  with `ObjectDisposedException`.

--- a/docs/sdk/tutorials/DynamicHosting.md
+++ b/docs/sdk/tutorials/DynamicHosting.md
@@ -14,8 +14,8 @@ using System.Reflection;
 
 var asm = Assembly.LoadFrom("path\\to\\compiled.dll");
 
-// The returned object is an IDisposable dynamic exports proxy.
-using dynamic exports = JsEngine.LoadModule(asm, moduleId: "math");
+// The returned object is the public dynamic exports proxy.
+using dynamic exports = JsEngine.LoadDynamicModule(asm, moduleId: "math");
 
 Console.WriteLine((string)exports.version);
 Console.WriteLine((double)exports.add(1, 2));
@@ -26,7 +26,7 @@ Console.WriteLine((double)exports.add(1, 2));
 Dynamic hosting wraps non-primitive return values so you can keep using dynamic member access and invocation:
 
 ```csharp
-using dynamic exports = JsEngine.LoadModule(asm, "nestedReturn");
+using dynamic exports = JsEngine.LoadDynamicModule(asm, "nestedReturn");
 
 dynamic win = exports.getWindow();
 Console.WriteLine((string)win.document.title);
@@ -63,3 +63,7 @@ obj.count = 123; // marshalled to the script thread
 
 Dynamic calls can throw the same hosting exceptions as typed calls.
 See [Diagnostics + exceptions](DiagnosticsAndExceptions.md).
+
+The older non-generic `JsEngine.LoadModule(Assembly, string)` overload remains
+available and returns `IDisposable` for binary compatibility. New source should
+use `LoadDynamicModule` when it needs the `JsDynamicExports` API directly.

--- a/docs/sdk/tutorials/GettingStarted.md
+++ b/docs/sdk/tutorials/GettingStarted.md
@@ -99,7 +99,7 @@ using Jroc.Runtime;
 using System.Reflection;
 
 var asm = Assembly.LoadFrom("..\\out\\math.dll");
-using dynamic exports = JsEngine.LoadModule(asm, moduleId: "math");
+using dynamic exports = JsEngine.LoadDynamicModule(asm, moduleId: "math");
 
 Console.WriteLine((string)exports.version);
 Console.WriteLine((double)exports.add(1, 2));

--- a/docs/sdk/tutorials/LifetimeAndDisposal.md
+++ b/docs/sdk/tutorials/LifetimeAndDisposal.md
@@ -11,6 +11,8 @@ Hosting introduces two distinct lifetimes:
   - For typed hosting, that’s the generated exports interface (it must implement `IDisposable`).
   - For dynamic hosting, that’s the dynamic exports proxy.
 - Dispose handle proxies (`IJsHandle`) when you’re done with them.
+- Do not dispose `JsCallable` values individually. They are identity-cached and
+  owned by the module runtime.
 
 ## Typed example
 
@@ -29,6 +31,13 @@ counter.Dispose();
 - If you dispose the **exports proxy**, the runtime instance is shut down.
 - Further calls on that exports proxy throw `ObjectDisposedException`.
 - Handles are also tied to that runtime; if the runtime is shut down, handle calls will fail.
+- Callable calls and property access also throw `ObjectDisposedException`
+  after the owning module is disposed.
+- Keep the module alive until Tasks returned by Promise bridges have settled
+  when their results are needed. Disposing first faults outstanding bridge
+  tasks promptly with `ObjectDisposedException`.
+- Invocations that were queued but not started are also faulted during
+  disposal; callers are not left blocked on abandoned queue entries.
 
 ## Common pitfalls
 

--- a/docs/sdk/tutorials/ModuleIdsAndDiscovery.md
+++ b/docs/sdk/tutorials/ModuleIdsAndDiscovery.md
@@ -8,7 +8,8 @@ When hosting, you select a module using a **module id** (CommonJS module specifi
   - `JsEngine.LoadModule<TExports>()` uses `[JsModule("<moduleId>")]` on the contract interface.
   - `JsEngine.LoadModule<TExports>(moduleId)` lets you override/select a module id explicitly.
 - Dynamic hosting:
-  - `JsEngine.LoadModule(Assembly compiledAssembly, string moduleId)` loads that module from that assembly.
+  - `JsEngine.LoadDynamicModule(Assembly compiledAssembly, string moduleId)`
+    loads that module from that assembly.
 
 ## Discover module ids in a compiled assembly
 

--- a/src/Compiler/JrocInMemoryCompiler.cs
+++ b/src/Compiler/JrocInMemoryCompiler.cs
@@ -61,7 +61,10 @@ public static class JrocInMemoryCompiler
         try
         {
             var resolvedModuleId = ResolveModuleId(request, artifact, moduleId);
-            var exports = JsEngine.LoadModule(loadedAssembly.Assembly, resolvedModuleId, options);
+            var exports = JsEngine.LoadDynamicModule(
+                loadedAssembly.Assembly,
+                resolvedModuleId,
+                options);
             return new JrocInMemoryModule(loadedAssembly, exports, exports);
         }
         catch

--- a/src/JavaScriptRuntime/Hosting/ExportMemberResolver.cs
+++ b/src/JavaScriptRuntime/Hosting/ExportMemberResolver.cs
@@ -1,110 +1,25 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Globalization;
-using System.Runtime.ExceptionServices;
 
 namespace Jroc.Runtime;
 
 internal static class ExportMemberResolver
 {
-    public static object? InvokeJsCallable(object callable, object?[] args)
+    public static object? InvokeJsCallable(
+        JsRuntimeInstance runtime,
+        object callable,
+        object?[] args,
+        object? receiver = null)
     {
-        if (callable is Delegate legacyDelegate)
-        {
-            return InvokeJsDelegate(legacyDelegate, args);
-        }
-
         if (JavaScriptRuntime.CallableOperations.IsCallable(callable))
         {
             return JavaScriptRuntime.CallableOperations.Call(
                 callable,
-                null,
-                NormalizeArgs(args));
+                runtime.NormalizeHostValue(receiver),
+                runtime.NormalizeHostArguments(args));
         }
 
         throw new ArgumentException("Value is not callable.", nameof(callable));
-    }
-
-    private static object[] CreateDefaultScopes(object? seed)
-    {
-        // Resumable callables assume scopes[0] exists (they probe it for the state-machine scope).
-        // When hosting invokes them directly, there may be no scopes array to thread through.
-        // Seed with a single entry so scopes[0] is in-range; use the instance/closure target when available.
-        return new object[] { seed! };
-    }
-
-    private static object[] NormalizeArgs(object?[] args)
-    {
-        if (args.Length == 0)
-        {
-            return Array.Empty<object>();
-        }
-
-        object[]? normalized = null;
-        for (var i = 0; i < args.Length; i++)
-        {
-            var original = args[i];
-            var converted = NormalizeArg(original);
-
-            if (!ReferenceEquals(converted, original))
-            {
-                if (normalized == null)
-                {
-                    normalized = new object[args.Length];
-
-                    for (var j = 0; j < i; j++)
-                    {
-                        normalized[j] = args[j]!;
-                    }
-                }
-
-                normalized[i] = converted!;
-                continue;
-            }
-
-            if (normalized != null)
-            {
-                normalized[i] = original!;
-            }
-        }
-
-        return normalized ?? (object[])(object)args;
-    }
-
-    private static object? NormalizeArg(object? arg)
-    {
-        if (arg is null)
-        {
-            return null;
-        }
-
-        // If the host passes values that were previously returned via the hosting layer,
-        // unwrap the proxy back to the underlying JS value before invoking into the runtime.
-        // This avoids passing proxy objects through JS APIs (which typically results in missing members).
-        arg = arg switch
-        {
-            JsDynamicValueProxy proxy => proxy.Unwrap(),
-            JsDynamicExports exports => exports.UnwrapExports(),
-            JsHandleProxy handleProxy => handleProxy.UnwrapTarget(),
-            JsConstructorProxy ctorProxy => ctorProxy.UnwrapConstructor(),
-            _ => arg,
-        };
-
-        // JS numbers are represented as System.Double throughout the runtime.
-        // Normalize common CLR numeric primitives to double so arithmetic behaves as expected.
-        return arg switch
-        {
-            double => arg,
-            float f => (double)f,
-            decimal m => (double)m,
-
-            sbyte or byte or short or ushort or int or uint or long or ulong
-                => Convert.ToDouble(arg, CultureInfo.InvariantCulture),
-
-            char c => c.ToString(),
-            _ => arg,
-        };
     }
 
     public static bool TryGetExportMember(object? exports, string contractName, out object? value)
@@ -162,7 +77,11 @@ internal static class ExportMemberResolver
         return value;
     }
 
-    public static void SetExportMember(object? exports, string contractName, object? value)
+    public static void SetExportMember(
+        JsRuntimeInstance runtime,
+        object? exports,
+        string contractName,
+        object? value)
     {
         if (exports == null)
         {
@@ -170,7 +89,10 @@ internal static class ExportMemberResolver
         }
 
         var targetName = ResolveExportWriteName(exports, contractName);
-        _ = JavaScriptRuntime.ObjectRuntime.SetItem(exports, targetName, NormalizeArg(value));
+        _ = JavaScriptRuntime.ObjectRuntime.SetItem(
+            exports,
+            targetName,
+            runtime.NormalizeHostValue(value));
     }
 
     public static IEnumerable<string> GetNameCandidates(string contractName)
@@ -224,176 +146,65 @@ internal static class ExportMemberResolver
         return type.GetField(candidate, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase) != null;
     }
 
-    public static object? InvokeJsDelegate(Delegate d, object?[] args)
-    {
-        var callArgs = NormalizeArgs(args);
-
-        // IMPORTANT:
-        // Use the delegate type's Invoke signature, not d.Method.
-        // For open-instance delegates, d.Method.GetParameters() omits the receiver
-        // (because it's an instance method), but Delegate.DynamicInvoke expects the
-        // full Invoke parameter list (which includes the receiver).
-        var invokeMethod = d.GetType().GetMethod("Invoke")
-            ?? throw new ArgumentException($"Delegate type '{d.GetType()}' does not define Invoke().", nameof(d));
-
-        var parameters = invokeMethod.GetParameters();
-        if (parameters.Length == 0)
-        {
-            return d.DynamicInvoke(Array.Empty<object?>());
-        }
-
-        var invokeArgs = new object?[parameters.Length];
-
-        var argIndex = 0;
-        var abi = JsCallableScopeAbiResolver.Resolve(d);
-        var hasScopes = abi.Kind != CallableScopeAbiKind.NoScopes;
-        var hasNewTarget = JsCallableScopeAbiResolver.HasNewTargetParameter(parameters, abi.Kind);
-
-        if (hasScopes)
-        {
-            var defaultScopes = CreateDefaultScopes(d.Target);
-            invokeArgs[0] = abi.Kind == CallableScopeAbiKind.ScopeArray
-                ? defaultScopes
-                : JsCallableScopeAbiResolver.GetSingleScopeArgument(defaultScopes, abi.SingleScopeType);
-            argIndex = 1;
-        }
-
-        if (hasNewTarget)
-        {
-            invokeArgs[argIndex++] = null;
-        }
-
-        for (var i = 0; i < callArgs.Length && argIndex < invokeArgs.Length; i++, argIndex++)
-        {
-            invokeArgs[argIndex] = callArgs[i];
-        }
-
-        while (argIndex < invokeArgs.Length)
-        {
-            invokeArgs[argIndex++] = null;
-        }
-
-        try
-        {
-            return d.DynamicInvoke(invokeArgs);
-        }
-        catch (TargetInvocationException tie) when (tie.InnerException != null)
-        {
-            ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
-            throw;
-        }
-    }
-
-    public static object? InvokeInstanceMethod(object target, string methodName, object?[] args)
+    public static object? InvokeInstanceMethod(
+        JsRuntimeInstance runtime,
+        object target,
+        string methodName,
+        object?[] args)
     {
         ArgumentNullException.ThrowIfNull(target);
         ArgumentException.ThrowIfNullOrWhiteSpace(methodName);
 
-        var callArgs = NormalizeArgs(args);
-
         foreach (var candidate in GetNameCandidates(methodName))
         {
-            if (TryInvokeMethod(target, candidate, callArgs, out var result))
+            var member = JavaScriptRuntime.ObjectRuntime.GetProperty(target, candidate);
+            if (JavaScriptRuntime.CallableOperations.IsCallable(member))
             {
-                return result;
+                return InvokeJsCallable(
+                    runtime,
+                    member!,
+                    args,
+                    receiver: target);
+            }
+
+            var method = target.GetType()
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                .FirstOrDefault(candidateMethod =>
+                    string.Equals(
+                        candidateMethod.Name,
+                        candidate,
+                        StringComparison.OrdinalIgnoreCase)
+                    && HostedMethodFunctionObject.CanAccept(
+                        candidateMethod,
+                        args.Length));
+            if (method != null)
+            {
+                var adapter = runtime.GetOrCreateHostMethodAdapter(target, method);
+                return InvokeJsCallable(
+                    runtime,
+                    adapter,
+                    args,
+                    receiver: target);
             }
         }
 
         throw new MissingMethodException($"Member method '{methodName}' not found on '{target.GetType().FullName}'.");
     }
 
-    public static object? Construct(object constructor, object?[] args)
+    public static object? Construct(
+        JsRuntimeInstance runtime,
+        object constructor,
+        object?[] args,
+        object? newTarget = null)
     {
         ArgumentNullException.ThrowIfNull(constructor);
 
-        var callArgs = NormalizeArgs(args);
-        return JavaScriptRuntime.ObjectRuntime.ConstructValue(constructor, callArgs);
-    }
-
-    private static bool TryInvokeMethod(object target, string methodName, object[] args, out object? result)
-    {
-        var methods = target.GetType()
-            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
-            .Where(m => string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase));
-
-        foreach (var method in methods)
-        {
-            if (TryBuildInvokeArgs(method.GetParameters(), args, target, out var invokeArgs))
-            {
-                try
-                {
-                    result = method.Invoke(target, invokeArgs);
-                }
-                catch (TargetInvocationException tie) when (tie.InnerException != null)
-                {
-                    ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
-                    throw;
-                }
-                return true;
-            }
-        }
-
-        result = null;
-        return false;
-    }
-
-    private static bool TryBuildInvokeArgs(ParameterInfo[] parameters, object[] args, object? target, out object?[] invokeArgs)
-    {
-        // Support varargs-style CLR methods like Foo(object[] args) by passing the entire argument list.
-        // But do NOT treat the jroc ABI scopes parameter (object[] scopes) as varargs.
-        if (parameters.Length == 1
-            && parameters[0].ParameterType == typeof(object[])
-            && !string.Equals(parameters[0].Name, "scopes", StringComparison.OrdinalIgnoreCase))
-        {
-            invokeArgs = new object?[] { args };
-            return true;
-        }
-
-        // jroc ABI callables may have hidden leading parameters:
-        // - scopes: object[]
-        // - newTarget: object (immediately after scopes)
-        // Hosting callers provide only JavaScript args; inject hidden ABI slots here.
-        var abi = parameters.Length == 0
-            ? new JsCallableScopeAbiDescriptor(CallableScopeAbiKind.NoScopes, SingleScopeType: null, IsFromAttribute: false)
-            : JsCallableScopeAbiResolver.Resolve(parameters[0].Member as MethodInfo
-                ?? throw new InvalidOperationException("Parameter metadata is missing a declaring method."));
-        var scopesOffset = abi.Kind == CallableScopeAbiKind.NoScopes ? 0 : 1;
-
-        var newTargetOffset = JsCallableScopeAbiResolver.HasNewTargetParameter(parameters, abi.Kind) ? 1 : 0;
-
-        var jsArgStart = scopesOffset + newTargetOffset;
-
-        if (args.Length > (parameters.Length - jsArgStart))
-        {
-            invokeArgs = Array.Empty<object?>();
-            return false;
-        }
-
-        invokeArgs = new object?[parameters.Length];
-
-        if (scopesOffset == 1)
-        {
-            var defaultScopes = CreateDefaultScopes(target);
-            invokeArgs[0] = abi.Kind == CallableScopeAbiKind.ScopeArray
-                ? defaultScopes
-                : JsCallableScopeAbiResolver.GetSingleScopeArgument(defaultScopes, abi.SingleScopeType);
-        }
-
-        if (newTargetOffset == 1)
-        {
-            invokeArgs[1] = null;
-        }
-
-        for (var i = 0; i < args.Length; i++)
-        {
-            invokeArgs[i + jsArgStart] = args[i];
-        }
-
-        for (var i = args.Length + jsArgStart; i < parameters.Length; i++)
-        {
-            invokeArgs[i] = parameters[i].HasDefaultValue ? Type.Missing : null;
-        }
-
-        return true;
+        var effectiveNewTarget = newTarget == null
+            ? constructor
+            : runtime.NormalizeHostValue(newTarget);
+        return JavaScriptRuntime.CallableOperations.Construct(
+            constructor,
+            runtime.NormalizeHostArguments(args),
+            effectiveNewTarget);
     }
 }

--- a/src/JavaScriptRuntime/Hosting/HostedFunctionObjects.cs
+++ b/src/JavaScriptRuntime/Hosting/HostedFunctionObjects.cs
@@ -1,0 +1,299 @@
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using JavaScriptRuntime;
+
+namespace Jroc.Runtime;
+
+internal sealed class HostedDelegateFunctionObject : JsFunctionObject
+{
+    private readonly JsRuntimeInstance _runtime;
+    private readonly Delegate _target;
+    private readonly ParameterInfo[] _parameters;
+    private readonly JsCallableScopeAbiDescriptor _abi;
+    private readonly int _jsArgumentStart;
+    private readonly bool _usesGeneratedAbi;
+
+    internal HostedDelegateFunctionObject(
+        JsRuntimeInstance runtime,
+        Delegate target)
+    {
+        _runtime = runtime;
+        _target = target;
+        _parameters = target.GetType().GetMethod(nameof(Action.Invoke))?.GetParameters()
+            ?? throw new ArgumentException(
+                $"Delegate type '{target.GetType()}' does not define Invoke().",
+                nameof(target));
+        _abi = JsCallableScopeAbiResolver.ResolveHosted(target);
+        _usesGeneratedAbi = _abi.IsFromAttribute
+            || JsFuncDelegates.IsJsFuncDelegateType(target.GetType());
+        _jsArgumentStart = HostedClrInvocation.GetJsArgumentStart(
+            _parameters,
+            _abi.Kind);
+
+        Function.InitializeFunctionInstance(
+            this,
+            HostedClrInvocation.GetVisibleLength(_parameters, _jsArgumentStart),
+            target.Method.Name,
+            requiresInvocationContext: false);
+    }
+
+    public override bool RequiresInvocationContext => false;
+
+    protected override object? CallCore(
+        object? thisArgument,
+        in JsCallArguments arguments)
+    {
+        var hostArguments = _usesGeneratedAbi
+            ? arguments.ToArray()
+            : _runtime.ProjectHostArguments(arguments.ToArray());
+        var invokeArguments = HostedClrInvocation.BuildArguments(
+            _parameters,
+            _abi,
+            new object[] { _target.Target! },
+            hostArguments);
+
+        object? result;
+        try
+        {
+            result = _target.DynamicInvoke(invokeArguments);
+        }
+        catch (TargetInvocationException exception)
+            when (exception.InnerException != null)
+        {
+            ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+            throw;
+        }
+
+        return _runtime.NormalizeHostValue(result);
+    }
+}
+
+internal sealed class HostedCallbackFunctionObject : JsFunctionObject
+{
+    private readonly JsRuntimeInstance _runtime;
+    private readonly JsHostFunction _hostFunction;
+
+    internal HostedCallbackFunctionObject(
+        JsRuntimeInstance runtime,
+        JsHostFunction hostFunction)
+    {
+        _runtime = runtime;
+        _hostFunction = hostFunction;
+
+        Function.InitializeFunctionInstance(
+            this,
+            hostFunction.Length,
+            hostFunction.Name,
+            requiresInvocationContext: false);
+    }
+
+    public override bool IsConstructor => _hostFunction.IsConstructor;
+
+    public override bool RequiresInvocationContext => false;
+
+    protected override object? CallCore(
+        object? thisArgument,
+        in JsCallArguments arguments)
+    {
+        var result = _hostFunction.Invoke(
+            _runtime.ProjectHostValue(thisArgument),
+            _runtime.ProjectHostArguments(arguments.ToArray()));
+        return _runtime.NormalizeHostValue(result);
+    }
+
+    protected override object? ConstructCore(
+        in JsCallArguments arguments,
+        object? newTarget)
+    {
+        var result = _hostFunction.Construct(
+            _runtime.ProjectHostArguments(arguments.ToArray()),
+            _runtime.ProjectHostValue(newTarget));
+        result = _runtime.NormalizeHostValue(result);
+        if (!TypeUtilities.IsConstructorReturnOverride(result))
+        {
+            throw new TypeError("Host constructor must return an object");
+        }
+
+        return result;
+    }
+}
+
+internal sealed class HostedMethodFunctionObject : JsFunctionObject
+{
+    private readonly JsRuntimeInstance _runtime;
+    private readonly object _target;
+    private readonly MethodInfo _method;
+    private readonly ParameterInfo[] _parameters;
+    private readonly JsCallableScopeAbiDescriptor _abi;
+    private readonly int _jsArgumentStart;
+
+    internal HostedMethodFunctionObject(
+        JsRuntimeInstance runtime,
+        object target,
+        MethodInfo method)
+    {
+        _runtime = runtime;
+        _target = target;
+        _method = method;
+        _parameters = method.GetParameters();
+        _abi = JsCallableScopeAbiResolver.ResolveHosted(method);
+        _jsArgumentStart = HostedClrInvocation.GetJsArgumentStart(
+            _parameters,
+            _abi.Kind);
+
+        Function.InitializeFunctionInstance(
+            this,
+            HostedClrInvocation.GetVisibleLength(
+                _parameters,
+                _jsArgumentStart),
+            method.Name,
+            requiresInvocationContext: false);
+    }
+
+    public override bool RequiresInvocationContext => false;
+
+    internal static bool CanAccept(MethodInfo method, int argumentCount)
+    {
+        var parameters = method.GetParameters();
+        var abi = JsCallableScopeAbiResolver.ResolveHosted(method);
+        var argumentStart = HostedClrInvocation.GetJsArgumentStart(
+            parameters,
+            abi.Kind);
+        var hasParamsArray = HostedClrInvocation.HasPackedArguments(
+            parameters,
+            argumentStart);
+        var visibleCount = parameters.Length - argumentStart;
+        return hasParamsArray || argumentCount <= visibleCount;
+    }
+
+    protected override object? CallCore(
+        object? thisArgument,
+        in JsCallArguments arguments)
+    {
+        var jsArguments = _abi.IsFromAttribute
+            ? arguments.ToArray()
+            : _runtime.ProjectHostArguments(arguments.ToArray());
+        var invokeArguments = HostedClrInvocation.BuildArguments(
+            _parameters,
+            _abi,
+            new object[] { _target },
+            jsArguments);
+
+        try
+        {
+            var result = _method.Invoke(_target, invokeArguments);
+            return _runtime.NormalizeHostValue(result);
+        }
+        catch (TargetInvocationException exception)
+            when (exception.InnerException != null)
+        {
+            ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+            throw;
+        }
+    }
+}
+
+internal static class HostedClrInvocation
+{
+    internal static int GetJsArgumentStart(
+        ParameterInfo[] parameters,
+        CallableScopeAbiKind abiKind)
+        => (abiKind == CallableScopeAbiKind.NoScopes ? 0 : 1)
+            + (JsCallableScopeAbiResolver.HasNewTargetParameter(
+                parameters,
+                abiKind)
+                ? 1
+                : 0);
+
+    internal static bool HasPackedArguments(
+        ParameterInfo[] parameters,
+        int jsArgumentStart)
+        => parameters.Length > jsArgumentStart
+            && (Attribute.IsDefined(
+                    parameters[^1],
+                    typeof(ParamArrayAttribute))
+                || parameters[^1].ParameterType == typeof(object[]));
+
+    internal static object?[] BuildArguments(
+        ParameterInfo[] parameters,
+        JsCallableScopeAbiDescriptor abi,
+        object[] scopes,
+        object?[] jsArguments)
+    {
+        var invokeArguments = new object?[parameters.Length];
+        var invokeIndex = 0;
+
+        if (abi.Kind != CallableScopeAbiKind.NoScopes)
+        {
+            invokeArguments[invokeIndex++] = abi.Kind == CallableScopeAbiKind.ScopeArray
+                ? scopes
+                : JsCallableScopeAbiResolver.GetSingleScopeArgument(
+                    scopes,
+                    abi.SingleScopeType);
+        }
+
+        if (JsCallableScopeAbiResolver.HasNewTargetParameter(
+                parameters,
+                abi.Kind))
+        {
+            invokeArguments[invokeIndex++] = null;
+        }
+
+        var jsArgumentStart = invokeIndex;
+        var hasPackedArguments = HasPackedArguments(
+            parameters,
+            jsArgumentStart);
+        var fixedCount = parameters.Length
+            - jsArgumentStart
+            - (hasPackedArguments ? 1 : 0);
+
+        for (var index = 0; index < fixedCount; index++)
+        {
+            invokeArguments[invokeIndex++] = index < jsArguments.Length
+                ? jsArguments[index]
+                : parameters[jsArgumentStart + index].HasDefaultValue
+                    ? Type.Missing
+                    : null;
+        }
+
+        if (hasPackedArguments)
+        {
+            var restCount = System.Math.Max(
+                0,
+                jsArguments.Length - fixedCount);
+            var elementType = parameters[^1].ParameterType.GetElementType()
+                ?? typeof(object);
+            var rest = System.Array.CreateInstance(elementType, restCount);
+            for (var index = 0; index < restCount; index++)
+            {
+                rest.SetValue(jsArguments[fixedCount + index], index);
+            }
+
+            invokeArguments[invokeIndex] = rest;
+        }
+
+        return invokeArguments;
+    }
+
+    internal static double GetVisibleLength(
+        ParameterInfo[] parameters,
+        int argumentStart)
+    {
+        var length = 0;
+        for (var index = argumentStart; index < parameters.Length; index++)
+        {
+            if (parameters[index].HasDefaultValue
+                || Attribute.IsDefined(
+                    parameters[index],
+                    typeof(ParamArrayAttribute))
+                || parameters[index].ParameterType == typeof(object[]))
+            {
+                break;
+            }
+
+            length++;
+        }
+
+        return length;
+    }
+}

--- a/src/JavaScriptRuntime/Hosting/JsCallable.cs
+++ b/src/JavaScriptRuntime/Hosting/JsCallable.cs
@@ -1,0 +1,195 @@
+using System.Dynamic;
+using System.Runtime.ExceptionServices;
+using JavaScriptRuntime;
+
+namespace Jroc.Runtime;
+
+/// <summary>
+/// Runtime-owned host projection of a JavaScript callable value.
+/// </summary>
+public sealed class JsCallable : DynamicObject
+{
+    private readonly JsRuntimeInstance _runtime;
+    private readonly object _target;
+
+    internal JsCallable(JsRuntimeInstance runtime, object target)
+    {
+        _runtime = runtime;
+        _target = target;
+    }
+
+    public string Name
+        => Convert.ToString(GetProperty("name"), System.Globalization.CultureInfo.InvariantCulture)
+            ?? string.Empty;
+
+    public double Length
+        => Convert.ToDouble(GetProperty("length"), System.Globalization.CultureInfo.InvariantCulture);
+
+    public bool IsConstructor
+        => InvokeWithTranslation(
+            "<is-constructor>",
+            () => CallableOperations.IsConstructor(_target));
+
+    public object? Call(params object?[] arguments)
+        => CallWithReceiver(receiver: null, arguments);
+
+    public object? CallWithReceiver(
+        object? receiver,
+        params object?[] arguments)
+    {
+        var result = InvokeWithTranslation(
+            "<call>",
+            () => CallableOperations.Call(
+                _target,
+                _runtime.NormalizeHostValue(receiver),
+                _runtime.NormalizeHostArguments(arguments)));
+        return _runtime.ProjectHostValue(result);
+    }
+
+    public Task<object?> CallAsync(params object?[] arguments)
+        => CallAsyncWithReceiver(receiver: null, arguments);
+
+    public Task<object?> CallAsyncWithReceiver(
+        object? receiver,
+        params object?[] arguments)
+        => CallAsyncWithReceiver<object?>(receiver, arguments);
+
+    public Task<T> CallAsync<T>(params object?[] arguments)
+        => CallAsyncWithReceiver<T>(receiver: null, arguments);
+
+    public Task<T> CallAsyncWithReceiver<T>(
+        object? receiver,
+        params object?[] arguments)
+    {
+        var result = InvokeWithTranslation(
+            "<call>",
+            () => CallableOperations.Call(
+                _target,
+                _runtime.NormalizeHostValue(receiver),
+                _runtime.NormalizeHostArguments(arguments)));
+
+        if (result is Promise promise)
+        {
+            return JsPromiseTaskInterop.ToTask<T>(_runtime, promise);
+        }
+
+        var converted = JsReturnConverter.ConvertReturn(_runtime, result, typeof(T));
+        return Task.FromResult((T)converted!);
+    }
+
+    public object? Construct(params object?[] arguments)
+        => ConstructWithNewTarget(_target, arguments);
+
+    public object? ConstructWithNewTarget(
+        object? newTarget,
+        params object?[] arguments)
+    {
+        var result = InvokeWithTranslation(
+            "<construct>",
+            () =>
+            {
+                var normalizedNewTarget = _runtime.NormalizeHostValue(newTarget);
+                if (!CallableOperations.IsConstructor(normalizedNewTarget))
+                {
+                    throw new TypeError("newTarget is not a constructor");
+                }
+
+                return CallableOperations.Construct(
+                    _target,
+                    _runtime.NormalizeHostArguments(arguments),
+                    normalizedNewTarget);
+            });
+        return _runtime.ProjectHostValue(result);
+    }
+
+    public object? GetProperty(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        var result = InvokeWithTranslation(
+            name,
+            () => ObjectRuntime.GetProperty(_target, name));
+        return _runtime.ProjectHostValue(result);
+    }
+
+    public void SetProperty(string name, object? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _ = InvokeWithTranslation(
+            name,
+            () => ObjectRuntime.SetItem(
+                _target,
+                name,
+                _runtime.NormalizeHostValue(value)));
+    }
+
+    internal object Unwrap(JsRuntimeInstance runtime)
+    {
+        if (!ReferenceEquals(_runtime, runtime))
+        {
+            throw new InvalidOperationException(
+                "JavaScript callable values cannot cross module runtime instances.");
+        }
+
+        return _target;
+    }
+
+    public override bool TryGetMember(
+        GetMemberBinder binder,
+        out object? result)
+    {
+        result = GetProperty(binder.Name);
+        return true;
+    }
+
+    public override bool TrySetMember(
+        SetMemberBinder binder,
+        object? value)
+    {
+        SetProperty(binder.Name, value);
+        return true;
+    }
+
+    public override bool TryInvoke(
+        InvokeBinder binder,
+        object?[]? args,
+        out object? result)
+    {
+        result = Call(args ?? System.Array.Empty<object?>());
+        return true;
+    }
+
+    public override bool TryInvokeMember(
+        InvokeMemberBinder binder,
+        object?[]? args,
+        out object? result)
+    {
+        result = InvokeWithTranslation(
+            binder.Name,
+            () => ObjectRuntime.CallMember(
+                _target,
+                binder.Name,
+                _runtime.NormalizeHostArguments(args)));
+        result = _runtime.ProjectHostValue(result);
+        return true;
+    }
+
+    private T InvokeWithTranslation<T>(
+        string memberName,
+        Func<T> operation)
+    {
+        try
+        {
+            return _runtime.Invoke(operation);
+        }
+        catch (Exception ex)
+        {
+            var translated = JsHostingExceptionTranslator.TranslateProxyCall(
+                ex,
+                _runtime,
+                memberName,
+                typeof(JsCallable));
+            ExceptionDispatchInfo.Capture(translated).Throw();
+            throw;
+        }
+    }
+}

--- a/src/JavaScriptRuntime/Hosting/JsCallableScopeAbiAttribute.cs
+++ b/src/JavaScriptRuntime/Hosting/JsCallableScopeAbiAttribute.cs
@@ -73,6 +73,48 @@ internal static class JsCallableScopeAbiResolver
         return InferFromParameters(method.GetParameters());
     }
 
+    public static JsCallableScopeAbiDescriptor ResolveHosted(Delegate del)
+    {
+        ArgumentNullException.ThrowIfNull(del);
+
+        var invoke = del.GetType().GetMethod("Invoke")
+            ?? throw new ArgumentException($"Delegate type '{del.GetType()}' does not define Invoke().", nameof(del));
+        var abiSource = GetAbiSourceDelegate(del);
+
+        if (TryResolveFromAttribute(abiSource.Method, out var descriptor))
+        {
+            if (descriptor.HasExplicitScopePayload
+                && IsFirstScopeParameterAlreadyBound(abiSource, invoke.GetParameters()))
+            {
+                return new JsCallableScopeAbiDescriptor(
+                    CallableScopeAbiKind.NoScopes,
+                    SingleScopeType: null,
+                    IsFromAttribute: true);
+            }
+
+            return descriptor;
+        }
+
+        return JavaScriptRuntime.JsFuncDelegates.IsJsFuncDelegateType(del.GetType())
+            ? InferFromParameters(invoke.GetParameters())
+            : new JsCallableScopeAbiDescriptor(
+                CallableScopeAbiKind.NoScopes,
+                SingleScopeType: null,
+                IsFromAttribute: false);
+    }
+
+    public static JsCallableScopeAbiDescriptor ResolveHosted(MethodInfo method)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+
+        return TryResolveFromAttribute(method, out var descriptor)
+            ? descriptor
+            : new JsCallableScopeAbiDescriptor(
+                CallableScopeAbiKind.NoScopes,
+                SingleScopeType: null,
+                IsFromAttribute: false);
+    }
+
     public static bool HasNewTargetParameter(ParameterInfo[] parameters, CallableScopeAbiKind kind)
     {
         ArgumentNullException.ThrowIfNull(parameters);

--- a/src/JavaScriptRuntime/Hosting/JsDynamicExports.cs
+++ b/src/JavaScriptRuntime/Hosting/JsDynamicExports.cs
@@ -7,7 +7,7 @@ namespace Jroc.Runtime;
 /// Reflection/dynamic-friendly exports proxy.
 /// Member access and invocations are marshalled onto the owning runtime thread.
 /// </summary>
-internal sealed class JsDynamicExports : DynamicObject, IDisposable
+public sealed class JsDynamicExports : DynamicObject, IDisposable
 {
     private readonly JsRuntimeInstance _runtime;
 
@@ -17,6 +17,43 @@ internal sealed class JsDynamicExports : DynamicObject, IDisposable
     }
 
     internal object UnwrapExports() => _runtime.Exports ?? throw new InvalidOperationException("Runtime exports are not available.");
+
+    internal object UnwrapExports(JsRuntimeInstance runtime)
+    {
+        if (!ReferenceEquals(_runtime, runtime))
+        {
+            throw new InvalidOperationException(
+                "Module exports cannot cross module runtime instances.");
+        }
+
+        return UnwrapExports();
+    }
+
+    /// <summary>
+    /// Gets the module's complete exports value through the public hosting projection.
+    /// This supports modules whose <c>module.exports</c> value is itself callable.
+    /// </summary>
+    public object? Value
+    {
+        get
+        {
+            try
+            {
+                var value = _runtime.Invoke(() => _runtime.Exports);
+                return _runtime.ProjectHostValue(value);
+            }
+            catch (Exception ex)
+            {
+                var translated = JsHostingExceptionTranslator.TranslateProxyCall(
+                    ex,
+                    _runtime,
+                    memberName: "<exports>",
+                    contractType: typeof(JsDynamicExports));
+                ExceptionDispatchInfo.Capture(translated).Throw();
+                throw;
+            }
+        }
+    }
 
     public void Dispose() => _runtime.Dispose();
 
@@ -32,7 +69,7 @@ internal sealed class JsDynamicExports : DynamicObject, IDisposable
         try
         {
             var value = _runtime.Invoke(() => ExportMemberResolver.GetExportMember(_runtime.Exports, name));
-            return JsDynamicValueProxy.Wrap(_runtime, value);
+            return _runtime.ProjectHostValue(value);
         }
         catch (Exception ex)
         {
@@ -56,10 +93,11 @@ internal sealed class JsDynamicExports : DynamicObject, IDisposable
                 }
 
                 return ExportMemberResolver.InvokeJsCallable(
+                    _runtime,
                     callable!,
                     args ?? Array.Empty<object?>());
             });
-            return JsDynamicValueProxy.Wrap(_runtime, value);
+            return _runtime.ProjectHostValue(value);
         }
         catch (Exception ex)
         {
@@ -74,7 +112,7 @@ internal sealed class JsDynamicExports : DynamicObject, IDisposable
         try
         {
             result = _runtime.Invoke(() => ExportMemberResolver.GetExportMember(_runtime.Exports, binder.Name));
-            result = JsDynamicValueProxy.Wrap(_runtime, result);
+            result = _runtime.ProjectHostValue(result);
             return true;
         }
         catch (MissingMemberException)
@@ -103,10 +141,11 @@ internal sealed class JsDynamicExports : DynamicObject, IDisposable
                 }
 
                 return ExportMemberResolver.InvokeJsCallable(
+                    _runtime,
                     callable!,
                     args ?? Array.Empty<object?>());
             });
-            result = JsDynamicValueProxy.Wrap(_runtime, result);
+            result = _runtime.ProjectHostValue(result);
             return true;
         }
         catch (MissingMemberException)
@@ -126,12 +165,47 @@ internal sealed class JsDynamicExports : DynamicObject, IDisposable
     {
         try
         {
-            _runtime.Invoke(() => ExportMemberResolver.SetExportMember(_runtime.Exports, binder.Name, value));
+            _runtime.Invoke(() => ExportMemberResolver.SetExportMember(_runtime, _runtime.Exports, binder.Name, value));
             return true;
         }
         catch (Exception ex)
         {
             var translated = JsHostingExceptionTranslator.TranslateProxyCall(ex, _runtime, memberName: binder.Name, contractType: null);
+            ExceptionDispatchInfo.Capture(translated).Throw();
+            throw;
+        }
+    }
+
+    public override bool TryInvoke(
+        InvokeBinder binder,
+        object?[]? args,
+        out object? result)
+    {
+        try
+        {
+            result = _runtime.Invoke(() =>
+            {
+                var callable = _runtime.Exports;
+                if (!JavaScriptRuntime.CallableOperations.IsCallable(callable))
+                {
+                    throw new MissingMethodException("The module exports value is not callable.");
+                }
+
+                return ExportMemberResolver.InvokeJsCallable(
+                    _runtime,
+                    callable!,
+                    args ?? Array.Empty<object?>());
+            });
+            result = _runtime.ProjectHostValue(result);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            var translated = JsHostingExceptionTranslator.TranslateProxyCall(
+                ex,
+                _runtime,
+                memberName: "<exports>",
+                contractType: typeof(JsDynamicExports));
             ExceptionDispatchInfo.Capture(translated).Throw();
             throw;
         }

--- a/src/JavaScriptRuntime/Hosting/JsDynamicValueProxy.cs
+++ b/src/JavaScriptRuntime/Hosting/JsDynamicValueProxy.cs
@@ -34,6 +34,11 @@ internal sealed class JsDynamicValueProxy : DynamicObject
             return value;
         }
 
+        if (JavaScriptRuntime.CallableOperations.IsCallable(value))
+        {
+            return runtime.GetOrCreateCallableWrapper(value);
+        }
+
         // Avoid wrapping primitives/value-types; callers expect normal CLR behavior here.
         if (value is string
             || value is bool
@@ -53,12 +58,23 @@ internal sealed class JsDynamicValueProxy : DynamicObject
             return value;
         }
 
-        // Wrap everything else (including delegates) so dynamic invocation and member access
-        // are marshalled to the runtime thread and use JS semantics.
+        // Wrap other reference values so dynamic member access is marshalled to the runtime
+        // thread and uses JavaScript semantics.
         return new JsDynamicValueProxy(runtime, value);
     }
 
     internal object Unwrap() => _target;
+
+    internal object Unwrap(JsRuntimeInstance runtime)
+    {
+        if (!ReferenceEquals(_runtime, runtime))
+        {
+            throw new InvalidOperationException(
+                "JavaScript values cannot cross module runtime instances.");
+        }
+
+        return _target;
+    }
 
     public override bool TryGetMember(GetMemberBinder binder, out object? result)
     {
@@ -80,8 +96,11 @@ internal sealed class JsDynamicValueProxy : DynamicObject
     {
         try
         {
-            var unwrapped = NormalizeArg(value);
-            _ = _runtime.Invoke(() => JavaScriptRuntime.ObjectRuntime.SetItem(_target, binder.Name, unwrapped));
+            _ = _runtime.Invoke(
+                () => JavaScriptRuntime.ObjectRuntime.SetItem(
+                    _target,
+                    binder.Name,
+                    _runtime.NormalizeHostValue(value)));
             return true;
         }
         catch (Exception ex)
@@ -96,8 +115,6 @@ internal sealed class JsDynamicValueProxy : DynamicObject
     {
         try
         {
-            var normalizedArgs = NormalizeArgs(args);
-
             if (!JavaScriptRuntime.CallableOperations.IsCallable(_target))
             {
                 result = null;
@@ -108,8 +125,8 @@ internal sealed class JsDynamicValueProxy : DynamicObject
                 () => JavaScriptRuntime.CallableOperations.Call(
                     _target,
                     thisArgument: null,
-                    normalizedArgs));
-            result = Wrap(_runtime, result);
+                    _runtime.NormalizeHostArguments(args)));
+            result = _runtime.ProjectHostValue(result);
             return true;
         }
         catch (Exception ex)
@@ -124,9 +141,12 @@ internal sealed class JsDynamicValueProxy : DynamicObject
     {
         try
         {
-            var normalizedArgs = NormalizeArgs(args);
-            result = _runtime.Invoke(() => JavaScriptRuntime.ObjectRuntime.CallMember(_target, binder.Name, normalizedArgs));
-            result = Wrap(_runtime, result);
+            result = _runtime.Invoke(
+                () => JavaScriptRuntime.ObjectRuntime.CallMember(
+                    _target,
+                    binder.Name,
+                    _runtime.NormalizeHostArguments(args)));
+            result = _runtime.ProjectHostValue(result);
             return true;
         }
         catch (Exception ex)
@@ -137,59 +157,4 @@ internal sealed class JsDynamicValueProxy : DynamicObject
         }
     }
 
-    private static object[] NormalizeArgs(object?[]? args)
-    {
-        if (args == null || args.Length == 0)
-        {
-            return Array.Empty<object>();
-        }
-
-        var normalized = new object[args.Length];
-        for (var i = 0; i < args.Length; i++)
-        {
-            normalized[i] = NormalizeArg(args[i])!;
-        }
-
-        return normalized;
-    }
-
-    private static object? NormalizeArg(object? arg)
-    {
-        if (arg is null)
-        {
-            return null;
-        }
-
-        // If the caller passes values previously returned by the hosting layer, unwrap them
-        // back to the underlying JS value so the runtime doesn't see the proxy object.
-        if (arg is JsDynamicValueProxy proxy)
-        {
-            arg = proxy.Unwrap();
-        }
-        else if (arg is JsDynamicExports exports)
-        {
-            arg = exports.UnwrapExports();
-        }
-        else if (arg is JsHandleProxy handleProxy)
-        {
-            arg = handleProxy.UnwrapTarget();
-        }
-        else if (arg is JsConstructorProxy ctorProxy)
-        {
-            arg = ctorProxy.UnwrapConstructor();
-        }
-
-        // JS numbers are represented as System.Double throughout the runtime.
-        return arg switch
-        {
-            double => arg,
-            float f => (double)f,
-            decimal m => (double)m,
-
-            sbyte or byte or short or ushort or int or uint or long or ulong => Convert.ToDouble(arg),
-
-            char c => c.ToString(),
-            _ => arg,
-        };
-    }
 }

--- a/src/JavaScriptRuntime/Hosting/JsEngine.cs
+++ b/src/JavaScriptRuntime/Hosting/JsEngine.cs
@@ -53,7 +53,7 @@ public static class JsEngine
         {
             throw new JsContractProjectionException(
                 $"{contractType.FullName} does not have {nameof(JsModuleAttribute)}. " +
-                $"Call {nameof(LoadModule)}<{contractType.Name}>(moduleId) or {nameof(LoadModule)}(compiledAssembly, moduleId) instead.",
+                $"Call {nameof(LoadModule)}<{contractType.Name}>(moduleId) or {nameof(LoadDynamicModule)}(compiledAssembly, moduleId) instead.",
                 contractType: contractType);
         }
 
@@ -71,15 +71,37 @@ public static class JsEngine
     }
 
     /// <summary>
-    /// Dynamic / reflection-friendly form: returns a dynamic exports proxy (also <see cref="IDisposable"/>).
+    /// Compatibility form: returns a dynamic exports proxy through its historical
+    /// <see cref="IDisposable"/> return type.
     /// </summary>
     public static IDisposable LoadModule(Assembly compiledAssembly, string moduleId)
         => LoadModule(compiledAssembly, moduleId, options: null);
 
     /// <summary>
-    /// Dynamic / reflection-friendly form: returns a dynamic exports proxy (also <see cref="IDisposable"/>).
+    /// Compatibility form: returns a dynamic exports proxy through its historical
+    /// <see cref="IDisposable"/> return type.
     /// </summary>
-    public static IDisposable LoadModule(Assembly compiledAssembly, string moduleId, JsModuleLoadOptions? options)
+    public static IDisposable LoadModule(
+        Assembly compiledAssembly,
+        string moduleId,
+        JsModuleLoadOptions? options)
+        => LoadDynamicModule(compiledAssembly, moduleId, options);
+
+    /// <summary>
+    /// Loads a module with a strongly typed dynamic/reflection-friendly exports surface.
+    /// </summary>
+    public static JsDynamicExports LoadDynamicModule(
+        Assembly compiledAssembly,
+        string moduleId)
+        => LoadDynamicModule(compiledAssembly, moduleId, options: null);
+
+    /// <summary>
+    /// Loads a module with a strongly typed dynamic/reflection-friendly exports surface.
+    /// </summary>
+    public static JsDynamicExports LoadDynamicModule(
+        Assembly compiledAssembly,
+        string moduleId,
+        JsModuleLoadOptions? options)
     {
         ArgumentNullException.ThrowIfNull(compiledAssembly);
         ArgumentException.ThrowIfNullOrWhiteSpace(moduleId);

--- a/src/JavaScriptRuntime/Hosting/JsExportsProxy.cs
+++ b/src/JavaScriptRuntime/Hosting/JsExportsProxy.cs
@@ -72,7 +72,7 @@ internal class JsExportsProxy : DispatchProxy
                 var name = targetMethod.Name.Substring(4);
                 try
                 {
-                    runtime.Invoke(() => ExportMemberResolver.SetExportMember(runtime.Exports, name, args is { Length: > 0 } ? args[0] : null));
+                    runtime.Invoke(() => ExportMemberResolver.SetExportMember(runtime, runtime.Exports, name, args is { Length: > 0 } ? args[0] : null));
                     return null;
                 }
                 catch (Exception ex)
@@ -97,6 +97,7 @@ internal class JsExportsProxy : DispatchProxy
                 }
 
                 var result = ExportMemberResolver.InvokeJsCallable(
+                    runtime,
                     callable!,
                     args ?? Array.Empty<object?>());
                 return JsReturnConverter.ConvertReturn(runtime, result, targetMethod.ReturnType);

--- a/src/JavaScriptRuntime/Hosting/JsHandleProxy.cs
+++ b/src/JavaScriptRuntime/Hosting/JsHandleProxy.cs
@@ -30,6 +30,17 @@ internal class JsHandleProxy : DispatchProxy
         return _target ?? throw new ObjectDisposedException(nameof(JsHandleProxy));
     }
 
+    internal object UnwrapTarget(JsRuntimeInstance runtime)
+    {
+        if (!ReferenceEquals(_runtime, runtime))
+        {
+            throw new InvalidOperationException(
+                "JavaScript handles cannot cross module runtime instances.");
+        }
+
+        return UnwrapTarget();
+    }
+
     protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
     {
         if (targetMethod == null)
@@ -88,7 +99,11 @@ internal class JsHandleProxy : DispatchProxy
         {
             return runtime.Invoke(() =>
             {
-                var result = ExportMemberResolver.InvokeInstanceMethod(target, methodName, args ?? Array.Empty<object?>());
+                var result = ExportMemberResolver.InvokeInstanceMethod(
+                    runtime,
+                    target,
+                    methodName,
+                    args ?? Array.Empty<object?>());
                 return JsReturnConverter.ConvertReturn(runtime, result, targetMethod.ReturnType);
             });
         }
@@ -148,6 +163,17 @@ internal class JsConstructorProxy : DispatchProxy
         return _constructor ?? throw new ObjectDisposedException(nameof(JsConstructorProxy));
     }
 
+    internal object UnwrapConstructor(JsRuntimeInstance runtime)
+    {
+        if (!ReferenceEquals(_runtime, runtime))
+        {
+            throw new InvalidOperationException(
+                "JavaScript constructors cannot cross module runtime instances.");
+        }
+
+        return UnwrapConstructor();
+    }
+
     protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
     {
         if (targetMethod == null)
@@ -190,7 +216,10 @@ internal class JsConstructorProxy : DispatchProxy
                     ? a
                     : (args ?? Array.Empty<object?>());
 
-                var result = ExportMemberResolver.Construct(constructor, ctorArgs);
+                var result = ExportMemberResolver.Construct(
+                    runtime,
+                    constructor,
+                    ctorArgs);
                 return JsReturnConverter.ConvertReturn(runtime, result, targetMethod.ReturnType);
             });
         }

--- a/src/JavaScriptRuntime/Hosting/JsHostFunction.cs
+++ b/src/JavaScriptRuntime/Hosting/JsHostFunction.cs
@@ -1,0 +1,59 @@
+namespace Jroc.Runtime;
+
+/// <summary>
+/// Callback used by an explicitly adapted CLR host function.
+/// </summary>
+public delegate object? JsHostFunctionCallback(
+    object? receiver,
+    object?[] arguments);
+
+/// <summary>
+/// Constructor callback used by an explicitly constructable CLR host function.
+/// </summary>
+public delegate object? JsHostConstructorCallback(
+    object?[] arguments,
+    object? newTarget);
+
+/// <summary>
+/// Describes a CLR callback that should enter JavaScript as a function object.
+/// </summary>
+public sealed class JsHostFunction
+{
+    private readonly JsHostFunctionCallback _callback;
+    private readonly JsHostConstructorCallback? _constructor;
+
+    public JsHostFunction(
+        JsHostFunctionCallback callback,
+        string? name = null,
+        double length = 0,
+        JsHostConstructorCallback? constructor = null)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        if (double.IsNaN(length) || double.IsInfinity(length) || length < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(length),
+                "Function length must be a finite, non-negative number.");
+        }
+
+        _callback = callback;
+        _constructor = constructor;
+        Name = name ?? callback.Method.Name;
+        Length = Math.Truncate(length);
+    }
+
+    public string Name { get; }
+
+    public double Length { get; }
+
+    public bool IsConstructor => _constructor != null;
+
+    internal object? Invoke(object? receiver, object?[] arguments)
+        => _callback(receiver, arguments);
+
+    internal object? Construct(object?[] arguments, object? newTarget)
+        => (_constructor
+            ?? throw new InvalidOperationException("The host function is not constructable."))(
+                arguments,
+                newTarget);
+}

--- a/src/JavaScriptRuntime/Hosting/JsPromiseTaskInterop.cs
+++ b/src/JavaScriptRuntime/Hosting/JsPromiseTaskInterop.cs
@@ -10,29 +10,38 @@ internal static class JsPromiseTaskInterop
         ArgumentNullException.ThrowIfNull(runtime);
         ArgumentNullException.ThrowIfNull(promise);
 
-        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        // IMPORTANT: Promise.then() queues microtasks via GlobalThis.ServiceProvider.
-        // That provider is only configured on the runtime's dedicated script thread.
-        // Subscribe to the promise on that thread so async/await works for hosts.
-        runtime.Invoke(() =>
+        var completion = new RuntimeTaskCompletion<object?>(runtime);
+        if (!runtime.TryRegisterRuntimeDependentOperation(completion))
         {
-            promise.then(
-                onFulfilled: new Func<object[]?, object?, object?>((_, _) =>
-                {
-                    tcs.TrySetResult(null);
-                    return null;
-                }),
-                onRejected: new Func<object[]?, object?, object?>((_, reason) =>
-                {
-                    tcs.TrySetException(ToException(reason));
-                    return null;
-                }));
+            return completion.Task;
+        }
 
-            return (object?)null;
-        });
+        try
+        {
+            // Promise.then() queues microtasks via the runtime-thread service provider.
+            runtime.Invoke(() =>
+            {
+                promise.then(
+                    onFulfilled: new Func<object[]?, object?, object?>((_, _) =>
+                    {
+                        completion.TrySetResult(null);
+                        return null;
+                    }),
+                    onRejected: new Func<object[]?, object?, object?>((_, reason) =>
+                    {
+                        completion.TrySetException(ToException(reason));
+                        return null;
+                    }));
 
-        return tcs.Task;
+                return (object?)null;
+            });
+        }
+        catch (Exception exception)
+        {
+            completion.TrySetException(exception);
+        }
+
+        return completion.Task;
     }
 
     internal static Task<T> ToTask<T>(JsRuntimeInstance runtime, Promise promise)
@@ -40,36 +49,46 @@ internal static class JsPromiseTaskInterop
         ArgumentNullException.ThrowIfNull(runtime);
         ArgumentNullException.ThrowIfNull(promise);
 
-        var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        // See note above: ensure promise wiring happens on the script thread.
-        runtime.Invoke(() =>
+        var completion = new RuntimeTaskCompletion<T>(runtime);
+        if (!runtime.TryRegisterRuntimeDependentOperation(completion))
         {
-            promise.then(
-                onFulfilled: new Func<object[]?, object?, object?>((_, value) =>
-                {
-                    try
+            return completion.Task;
+        }
+
+        try
+        {
+            runtime.Invoke(() =>
+            {
+                promise.then(
+                    onFulfilled: new Func<object[]?, object?, object?>((_, value) =>
                     {
-                        var converted = JsReturnConverter.ConvertReturn(runtime, value, typeof(T));
-                        tcs.TrySetResult((T)converted!);
-                    }
-                    catch (Exception ex)
+                        try
+                        {
+                            var converted = JsReturnConverter.ConvertReturn(runtime, value, typeof(T));
+                            completion.TrySetResult((T)converted!);
+                        }
+                        catch (Exception ex)
+                        {
+                            completion.TrySetException(ex);
+                        }
+
+                        return null;
+                    }),
+                    onRejected: new Func<object[]?, object?, object?>((_, reason) =>
                     {
-                        tcs.TrySetException(ex);
-                    }
+                        completion.TrySetException(ToException(reason));
+                        return null;
+                    }));
 
-                    return null;
-                }),
-                onRejected: new Func<object[]?, object?, object?>((_, reason) =>
-                {
-                    tcs.TrySetException(ToException(reason));
-                    return null;
-                }));
+                return (object?)null;
+            });
+        }
+        catch (Exception exception)
+        {
+            completion.TrySetException(exception);
+        }
 
-            return (object?)null;
-        });
-
-        return tcs.Task;
+        return completion.Task;
     }
 
     private static Exception ToException(object? reason)
@@ -80,5 +99,38 @@ internal static class JsPromiseTaskInterop
         }
 
         return new JsThrownValueException(reason);
+    }
+
+    private sealed class RuntimeTaskCompletion<T> : IRuntimeDependentOperation
+    {
+        private readonly JsRuntimeInstance _runtime;
+        private readonly TaskCompletionSource<T> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal RuntimeTaskCompletion(JsRuntimeInstance runtime)
+        {
+            _runtime = runtime;
+        }
+
+        internal Task<T> Task => _completion.Task;
+
+        internal void TrySetResult(T result)
+        {
+            if (_completion.TrySetResult(result))
+            {
+                _runtime.UnregisterRuntimeDependentOperation(this);
+            }
+        }
+
+        internal void TrySetException(Exception exception)
+        {
+            if (_completion.TrySetException(exception))
+            {
+                _runtime.UnregisterRuntimeDependentOperation(this);
+            }
+        }
+
+        public void OnRuntimeDisposed(ObjectDisposedException exception)
+            => _completion.TrySetException(exception);
     }
 }

--- a/src/JavaScriptRuntime/Hosting/JsReturnConverter.cs
+++ b/src/JavaScriptRuntime/Hosting/JsReturnConverter.cs
@@ -73,6 +73,17 @@ internal static class JsReturnConverter
             return returnType.IsValueType ? Activator.CreateInstance(returnType) : null;
         }
 
+        if (JavaScriptRuntime.CallableOperations.IsCallable(value))
+        {
+            var callable = runtime.GetOrCreateCallableWrapper(value);
+            if (returnType == typeof(object)
+                || returnType == typeof(JsCallable)
+                || returnType.IsInstanceOfType(callable))
+            {
+                return callable;
+            }
+        }
+
         if (returnType == typeof(object))
         {
             // An object-typed host contract erases whether the value is a JS reference.

--- a/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
+++ b/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using JavaScriptRuntime;
 using JavaScriptRuntime.CommonJS;
 using JavaScriptRuntime.DependencyInjection;
@@ -25,6 +27,8 @@ internal sealed class JsRuntimeInstance : IDisposable
 
     // Cross-thread work queue used to marshal calls onto the dedicated script thread.
     private readonly BlockingCollection<IWorkItem> _queue = new();
+    private readonly ConcurrentDictionary<IWorkItem, byte> _pendingWorkItems = new();
+    private readonly ConcurrentDictionary<IRuntimeDependentOperation, byte> _runtimeDependentOperations = new();
 
     // Dedicated thread that owns the engine, synchronization context, and event loop.
     private readonly Thread _thread;
@@ -46,6 +50,10 @@ internal sealed class JsRuntimeInstance : IDisposable
     // 0 -> not disposed, 1 -> dispose requested (used to guard multiple Dispose calls).
     private int _disposeSignaled;
     private readonly JsModuleLoadOptions? _options;
+    private readonly ConditionalWeakTable<object, JsCallable> _callableWrappers = new();
+    private readonly ConditionalWeakTable<Delegate, HostedDelegateFunctionObject> _hostDelegateAdapters = new();
+    private readonly ConditionalWeakTable<JsHostFunction, HostedCallbackFunctionObject> _hostFunctionAdapters = new();
+    private readonly ConditionalWeakTable<object, ConcurrentDictionary<MethodInfo, HostedMethodFunctionObject>> _hostMethodAdapters = new();
 
     public JsRuntimeInstance(Assembly compiledAssembly, string moduleId, JsModuleLoadOptions? options = null)
     {
@@ -106,16 +114,25 @@ internal sealed class JsRuntimeInstance : IDisposable
 
         // Marshal onto the script thread; the worker completes the TCS when done.
         var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var item = new WorkItem<TResult>(func, tcs);
+        RegisterWorkItem(item);
         try
         {
-            _queue.Add(new WorkItem<TResult>(func, tcs), _shutdown.Token);
+            _queue.Add(item, _shutdown.Token);
         }
         catch (OperationCanceledException)
         {
+            FailWorkItem(item);
+            throw new ObjectDisposedException(nameof(JsRuntimeInstance));
+        }
+        catch (ObjectDisposedException)
+        {
+            FailWorkItem(item);
             throw new ObjectDisposedException(nameof(JsRuntimeInstance));
         }
         catch (InvalidOperationException)
         {
+            FailWorkItem(item);
             throw new ObjectDisposedException(nameof(JsRuntimeInstance));
         }
         return tcs.Task.GetAwaiter().GetResult();
@@ -138,25 +155,29 @@ internal sealed class JsRuntimeInstance : IDisposable
         }
 
         var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var item = new WorkItem<object?>(() =>
+        {
+            action();
+            return null;
+        }, tcs);
+        RegisterWorkItem(item);
         try
         {
-            _queue.Add(new WorkItem<object?>(() =>
-            {
-                action();
-                return null;
-            }, tcs), _shutdown.Token);
+            _queue.Add(item, _shutdown.Token);
         }
         catch (OperationCanceledException)
         {
+            FailWorkItem(item);
             throw new ObjectDisposedException(nameof(JsRuntimeInstance));
         }
         catch (ObjectDisposedException)
         {
-            // The queue can be disposed by the script thread during shutdown.
+            FailWorkItem(item);
             throw new ObjectDisposedException(nameof(JsRuntimeInstance));
         }
         catch (InvalidOperationException)
         {
+            FailWorkItem(item);
             throw new ObjectDisposedException(nameof(JsRuntimeInstance));
         }
 
@@ -171,6 +192,8 @@ internal sealed class JsRuntimeInstance : IDisposable
         {
             return;
         }
+
+        FailPendingOperations();
 
         // Stop accepting work and wake the consuming enumerable.
         try
@@ -208,6 +231,8 @@ internal sealed class JsRuntimeInstance : IDisposable
 
     internal bool IsShutdown => _terminated.Task.IsCompleted;
 
+    internal int PendingWorkItemCount => _pendingWorkItems.Count;
+
     internal bool WaitForShutdown(TimeSpan timeout)
     {
         // Never block waiting for ourselves.
@@ -217,6 +242,164 @@ internal sealed class JsRuntimeInstance : IDisposable
         }
 
         return _terminated.Task.Wait(timeout);
+    }
+
+    internal JsCallable GetOrCreateCallableWrapper(object callable)
+    {
+        ArgumentNullException.ThrowIfNull(callable);
+        return _callableWrappers.GetValue(
+            callable,
+            target => new JsCallable(this, target));
+    }
+
+    internal HostedMethodFunctionObject GetOrCreateHostMethodAdapter(
+        object target,
+        MethodInfo method)
+    {
+        var methods = _hostMethodAdapters.GetOrCreateValue(target);
+        return methods.GetOrAdd(
+            method,
+            candidate => new HostedMethodFunctionObject(this, target, candidate));
+    }
+
+    internal bool TryPost(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (Volatile.Read(ref _disposeSignaled) != 0)
+        {
+            return false;
+        }
+
+        if (Thread.CurrentThread.ManagedThreadId == _thread.ManagedThreadId)
+        {
+            action();
+            return true;
+        }
+
+        var item = new PostedWorkItem(action);
+        if (!TryRegisterWorkItem(item))
+        {
+            return false;
+        }
+
+        try
+        {
+            _queue.Add(item, _shutdown.Token);
+            return true;
+        }
+        catch (Exception exception)
+            when (exception is OperationCanceledException
+                or ObjectDisposedException
+                or InvalidOperationException)
+        {
+            FailWorkItem(item);
+            return false;
+        }
+    }
+
+    internal bool TryRegisterRuntimeDependentOperation(
+        IRuntimeDependentOperation operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        if (Volatile.Read(ref _disposeSignaled) != 0)
+        {
+            operation.OnRuntimeDisposed(CreateDisposedException());
+            return false;
+        }
+
+        if (!_runtimeDependentOperations.TryAdd(operation, 0))
+        {
+            throw new InvalidOperationException("The runtime-dependent operation is already registered.");
+        }
+
+        if (Volatile.Read(ref _disposeSignaled) == 0)
+        {
+            return true;
+        }
+
+        if (_runtimeDependentOperations.TryRemove(operation, out _))
+        {
+            operation.OnRuntimeDisposed(CreateDisposedException());
+        }
+
+        return false;
+    }
+
+    internal void UnregisterRuntimeDependentOperation(
+        IRuntimeDependentOperation operation)
+        => _runtimeDependentOperations.TryRemove(operation, out _);
+
+    internal object? NormalizeHostValue(object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        value = value switch
+        {
+            JsCallable callable => callable.Unwrap(this),
+            JsDynamicValueProxy proxy => proxy.Unwrap(this),
+            JsDynamicExports exports => exports.UnwrapExports(this),
+            JsHandleProxy handleProxy => handleProxy.UnwrapTarget(this),
+            JsConstructorProxy ctorProxy => ctorProxy.UnwrapConstructor(this),
+            Task task => JsTaskPromiseInterop.ToPromise(this, task),
+            JsHostFunction hostFunction => _hostFunctionAdapters.GetValue(
+                hostFunction,
+                descriptor => new HostedCallbackFunctionObject(this, descriptor)),
+            Delegate callback => _hostDelegateAdapters.GetValue(
+                callback,
+                target => new HostedDelegateFunctionObject(this, target)),
+            _ => value,
+        };
+
+        return value switch
+        {
+            double => value,
+            float single => (double)single,
+            decimal number => (double)number,
+            sbyte or byte or short or ushort or int or uint or long or ulong
+                => Convert.ToDouble(value, CultureInfo.InvariantCulture),
+            char character => character.ToString(),
+            _ => value,
+        };
+    }
+
+    internal object[] NormalizeHostArguments(object?[]? arguments)
+    {
+        if (arguments == null || arguments.Length == 0)
+        {
+            return System.Array.Empty<object>();
+        }
+
+        var normalized = new object[arguments.Length];
+        for (var index = 0; index < arguments.Length; index++)
+        {
+            normalized[index] = NormalizeHostValue(arguments[index])!;
+        }
+
+        return normalized;
+    }
+
+    internal object? ProjectHostValue(object? value)
+        => JsDynamicValueProxy.Wrap(this, value);
+
+    internal object?[] ProjectHostArguments(object?[] arguments)
+    {
+        if (arguments.Length == 0)
+        {
+            return System.Array.Empty<object?>();
+        }
+
+        var projected = new object?[arguments.Length];
+        for (var index = 0; index < arguments.Length; index++)
+        {
+            projected[index] = ProjectHostValue(arguments[index]);
+        }
+
+        return projected;
     }
 
     private void ThreadMain(Assembly compiledAssembly, string moduleSpecifier)
@@ -271,7 +454,14 @@ internal sealed class JsRuntimeInstance : IDisposable
 
                 if (_queue.TryTake(out var item, waitMs, _shutdown.Token))
                 {
-                    item.Execute();
+                    try
+                    {
+                        item.Execute();
+                    }
+                    finally
+                    {
+                        _pendingWorkItems.TryRemove(item, out _);
+                    }
                     Engine.RunEventLoopUntilIdle(_eventLoop, waitForTimers: false);
                     continue;
                 }
@@ -292,6 +482,8 @@ internal sealed class JsRuntimeInstance : IDisposable
         }
         finally
         {
+            FailPendingOperations();
+
             if (_serviceProvider?.TryResolve<RuntimeExecutionContext>(out var runtimeContext) == true && runtimeContext != null)
             {
                 RuntimeServices.UnregisterModuleRequires(runtimeContext.RegisteredModuleRequires);
@@ -299,6 +491,9 @@ internal sealed class JsRuntimeInstance : IDisposable
 
             // Clear ambient global provider to avoid leaking thread-local state after thread exits.
             GlobalThis.ServiceProvider = null;
+            _exports = null;
+            _eventLoop = null;
+            _serviceProvider = null;
 
             // Mark thread termination before disposing shared resources.
             _terminated.TrySetResult();
@@ -316,6 +511,63 @@ internal sealed class JsRuntimeInstance : IDisposable
             throw new ObjectDisposedException(nameof(JsRuntimeInstance));
         }
     }
+
+    private void RegisterWorkItem(IWorkItem item)
+    {
+        if (!TryRegisterWorkItem(item))
+        {
+            throw CreateDisposedException();
+        }
+    }
+
+    private bool TryRegisterWorkItem(IWorkItem item)
+    {
+        if (Volatile.Read(ref _disposeSignaled) != 0)
+        {
+            item.FailIfNotStarted(CreateDisposedException());
+            return false;
+        }
+
+        if (!_pendingWorkItems.TryAdd(item, 0))
+        {
+            throw new InvalidOperationException("The work item is already registered.");
+        }
+
+        if (Volatile.Read(ref _disposeSignaled) == 0)
+        {
+            return true;
+        }
+
+        FailWorkItem(item);
+        return false;
+    }
+
+    private void FailWorkItem(IWorkItem item)
+    {
+        if (_pendingWorkItems.TryRemove(item, out _))
+        {
+            item.FailIfNotStarted(CreateDisposedException());
+        }
+    }
+
+    private void FailPendingOperations()
+    {
+        foreach (var item in _pendingWorkItems.Keys)
+        {
+            FailWorkItem(item);
+        }
+
+        foreach (var operation in _runtimeDependentOperations.Keys)
+        {
+            if (_runtimeDependentOperations.TryRemove(operation, out _))
+            {
+                operation.OnRuntimeDisposed(CreateDisposedException());
+            }
+        }
+    }
+
+    private static ObjectDisposedException CreateDisposedException()
+        => new(nameof(JsRuntimeInstance));
 
     private static string NormalizeLocalModuleSpecifier(string moduleId)
     {
@@ -335,12 +587,14 @@ internal sealed class JsRuntimeInstance : IDisposable
     private interface IWorkItem
     {
         void Execute();
+        void FailIfNotStarted(Exception exception);
     }
 
     private sealed class WorkItem<TResult> : IWorkItem
     {
         private readonly Func<TResult> _func;
         private readonly TaskCompletionSource<TResult> _tcs;
+        private int _state;
 
         public WorkItem(Func<TResult> func, TaskCompletionSource<TResult> tcs)
         {
@@ -350,6 +604,11 @@ internal sealed class JsRuntimeInstance : IDisposable
 
         public void Execute()
         {
+            if (Interlocked.CompareExchange(ref _state, 1, 0) != 0)
+            {
+                return;
+            }
+
             try
             {
                 var result = _func();
@@ -364,6 +623,54 @@ internal sealed class JsRuntimeInstance : IDisposable
             {
                 _tcs.TrySetException(ex);
             }
+            finally
+            {
+                Volatile.Write(ref _state, 2);
+            }
+        }
+
+        public void FailIfNotStarted(Exception exception)
+        {
+            if (Interlocked.CompareExchange(ref _state, 2, 0) == 0)
+            {
+                _tcs.TrySetException(exception);
+            }
         }
     }
+
+    private sealed class PostedWorkItem : IWorkItem
+    {
+        private readonly Action _action;
+        private int _state;
+
+        public PostedWorkItem(Action action)
+        {
+            _action = action;
+        }
+
+        public void Execute()
+        {
+            if (Interlocked.CompareExchange(ref _state, 1, 0) != 0)
+            {
+                return;
+            }
+
+            try
+            {
+                _action();
+            }
+            finally
+            {
+                Volatile.Write(ref _state, 2);
+            }
+        }
+
+        public void FailIfNotStarted(Exception exception)
+            => Interlocked.CompareExchange(ref _state, 2, 0);
+    }
+}
+
+internal interface IRuntimeDependentOperation
+{
+    void OnRuntimeDisposed(ObjectDisposedException exception);
 }

--- a/src/JavaScriptRuntime/Hosting/JsTaskPromiseInterop.cs
+++ b/src/JavaScriptRuntime/Hosting/JsTaskPromiseInterop.cs
@@ -1,0 +1,156 @@
+using System.Reflection;
+using JavaScriptRuntime;
+
+namespace Jroc.Runtime;
+
+internal static class JsTaskPromiseInterop
+{
+    internal static Promise ToPromise(JsRuntimeInstance runtime, Task task)
+    {
+        ArgumentNullException.ThrowIfNull(runtime);
+        ArgumentNullException.ThrowIfNull(task);
+
+        var deferred = Promise.withResolvers();
+        var bridge = new TaskPromiseBridge(runtime, deferred);
+        if (!runtime.TryRegisterRuntimeDependentOperation(bridge))
+        {
+            return deferred.promise;
+        }
+
+        _ = task.ContinueWith(
+            static (completedTask, state) =>
+                ((TaskPromiseBridge)state!).CompleteFromTask(completedTask),
+            bridge,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        return deferred.promise;
+    }
+
+    private static object? GetTaskResult(Task task)
+    {
+        for (var type = task.GetType(); type != null; type = type.BaseType)
+        {
+            if (!type.IsGenericType
+                || type.GetGenericTypeDefinition() != typeof(Task<>))
+            {
+                continue;
+            }
+
+            return type.GetProperty(
+                    nameof(Task<object>.Result),
+                    BindingFlags.Instance | BindingFlags.Public)
+                ?.GetValue(task);
+        }
+
+        return null;
+    }
+
+    private sealed class TaskPromiseBridge : IRuntimeDependentOperation
+    {
+        private readonly JsRuntimeInstance _runtime;
+        private readonly PromiseWithResolvers _deferred;
+        private int _state;
+
+        internal TaskPromiseBridge(
+            JsRuntimeInstance runtime,
+            PromiseWithResolvers deferred)
+        {
+            _runtime = runtime;
+            _deferred = deferred;
+        }
+
+        internal void CompleteFromTask(Task task)
+        {
+            if (Interlocked.CompareExchange(ref _state, 1, 0) != 0)
+            {
+                return;
+            }
+
+            object? result = null;
+            Exception? rejection = null;
+
+            if (task.IsCanceled)
+            {
+                rejection = new TaskCanceledException(task);
+            }
+            else if (task.IsFaulted)
+            {
+                var aggregate = task.Exception;
+                rejection = aggregate?.InnerExceptions.Count == 1
+                    ? aggregate.InnerException
+                    : aggregate;
+            }
+            else
+            {
+                try
+                {
+                    result = GetTaskResult(task);
+                }
+                catch (Exception exception)
+                {
+                    rejection = exception;
+                }
+            }
+
+            if (!_runtime.TryPost(() => Settle(result, rejection)))
+            {
+                CompleteWithoutSettlement();
+            }
+        }
+
+        public void OnRuntimeDisposed(ObjectDisposedException exception)
+            => CompleteWithoutSettlement();
+
+        private void Settle(object? result, Exception? rejection)
+        {
+            if (Interlocked.CompareExchange(ref _state, 2, 1) != 1)
+            {
+                return;
+            }
+
+            try
+            {
+                object callback;
+                object? value;
+                if (rejection == null)
+                {
+                    try
+                    {
+                        value = _runtime.NormalizeHostValue(result);
+                        callback = _deferred.resolve;
+                    }
+                    catch (Exception exception)
+                    {
+                        value = exception;
+                        callback = _deferred.reject;
+                    }
+                }
+                else
+                {
+                    value = rejection;
+                    callback = _deferred.reject;
+                }
+
+                _ = CallableOperations.Call1(
+                    callback,
+                    thisArgument: null,
+                    value);
+            }
+            finally
+            {
+                _runtime.UnregisterRuntimeDependentOperation(this);
+            }
+        }
+
+        private void CompleteWithoutSettlement()
+        {
+            var previousState = Interlocked.Exchange(ref _state, 2);
+            if (previousState != 2)
+            {
+                _runtime.UnregisterRuntimeDependentOperation(this);
+            }
+        }
+    }
+}

--- a/tests/Jroc.Tests/Hosting/JavaScript/Hosting_GeneratedFunctionInterop.js
+++ b/tests/Jroc.Tests/Hosting/JavaScript/Hosting_GeneratedFunctionInterop.js
@@ -1,0 +1,118 @@
+"use strict";
+
+function ordinary(left, right) {
+    return left + right;
+}
+
+ordinary.extra = "ordinary-property";
+
+function describe(prefix, suffix) {
+    return prefix + this.value + suffix;
+}
+
+function sumSeven(a, b, c, d, e, f, g) {
+    return a + b + c + d + e + f + g;
+}
+
+async function doubleAsync(value) {
+    return value * 2;
+}
+
+async function rejectAsync() {
+    throw new Error("async hosted boom");
+}
+
+function* sequence(start) {
+    yield start;
+    yield start + 1;
+    return start + 2;
+}
+
+function thrower() {
+    throw new Error("hosted callable boom");
+}
+
+function Person(name) {
+    this.name = name;
+}
+
+function NewTargetProbe() {
+    this.targetName = new.target.name;
+}
+
+const arrow = value => value + 1;
+const nested = { ordinary };
+
+function echo(value) {
+    return value;
+}
+
+function same(left, right) {
+    return left === right;
+}
+
+function inspectCallback(callback) {
+    callback.customProperty = "set-by-js";
+
+    let constructable = true;
+    try {
+        new callback();
+    } catch {
+        constructable = false;
+    }
+
+    return {
+        name: callback.name,
+        length: callback.length,
+        functionPrototype: Object.getPrototypeOf(callback) === Function.prototype,
+        customProperty: callback.customProperty,
+        constructable
+    };
+}
+
+function invokeCallback(callback, left, right) {
+    return callback(left, right);
+}
+
+function invokeCallbackVariadic(callback) {
+    return callback("first", 2, true);
+}
+
+async function awaitCallback(callback, first, second) {
+    return await callback(first, second);
+}
+
+function invokeCallbackWithReceiver(callback, value, prefix, suffix) {
+    return callback.call({ value }, prefix, suffix);
+}
+
+function constructCallback(callback, value) {
+    return new callback(value);
+}
+
+function readValue(value) {
+    return value.value;
+}
+
+module.exports = {
+    ordinary,
+    describe,
+    sumSeven,
+    doubleAsync,
+    rejectAsync,
+    sequence,
+    thrower,
+    Person,
+    NewTargetProbe,
+    arrow,
+    nested,
+    echo,
+    same,
+    inspectCallback,
+    invokeCallback,
+    invokeCallbackVariadic,
+    awaitCallback,
+    invokeCallbackWithReceiver,
+    constructCallback,
+    readValue
+};

--- a/tests/Jroc.Tests/Hosting/JavaScript/Hosting_PromiseTaskInterop.js
+++ b/tests/Jroc.Tests/Hosting/JavaScript/Hosting_PromiseTaskInterop.js
@@ -24,10 +24,15 @@ function timeoutReject(ms, reason) {
     });
 }
 
+function neverResolve() {
+    return new Promise(() => {});
+}
+
 module.exports = {
     immediateResolve,
     immediateReject,
     immediateRejectError,
     timeoutResolve,
-    timeoutReject
+    timeoutReject,
+    neverResolve
 };

--- a/tests/Jroc.Tests/Hosting/JavaScript/Hosting_RootFunctionExport.js
+++ b/tests/Jroc.Tests/Hosting/JavaScript/Hosting_RootFunctionExport.js
@@ -1,0 +1,8 @@
+"use strict";
+
+function rootIncrement(value) {
+    return value + 1;
+}
+
+rootIncrement.kind = "root-function";
+module.exports = rootIncrement;

--- a/tests/Jroc.Tests/Hosting/ModuleLoadTests.cs
+++ b/tests/Jroc.Tests/Hosting/ModuleLoadTests.cs
@@ -13,6 +13,10 @@ namespace Jroc.Tests.Hosting;
 public class ModuleLoadTests
 {
     private const string HostingJavaScriptResourcePrefix = "Jroc.Tests.Hosting.JavaScript.";
+    private delegate object? HostedSingleScopeDelegate(
+        PackedArgumentsHost scope,
+        object? newTarget,
+        object? addend);
 
     public interface IMathExports : IDisposable
     {
@@ -25,6 +29,37 @@ public class ModuleLoadTests
         object GetWindow();
         string GetTitle(object win);
         double GetHostValue(object win);
+    }
+
+    public interface IGeneratedCallableExports : IDisposable
+    {
+        JsCallable Ordinary { get; }
+        JsCallable Describe { get; }
+        JsCallable SumSeven { get; }
+        JsCallable DoubleAsync { get; }
+        JsCallable RejectAsync { get; }
+        JsCallable Sequence { get; }
+        JsCallable Thrower { get; }
+        JsCallable Person { get; }
+        JsCallable NewTargetProbe { get; }
+        JsCallable Arrow { get; }
+        object Nested { get; }
+        object Echo(object value);
+        bool Same(object left, object right);
+        object InspectCallback(object callback);
+        double InvokeCallback(object callback, double left, double right);
+        string InvokeCallbackVariadic(object callback);
+        Task<object?> AwaitCallback(
+            object callback,
+            object? first,
+            object? second);
+        string InvokeCallbackWithReceiver(
+            object callback,
+            string value,
+            string prefix,
+            string suffix);
+        object ConstructCallback(object callback, double value);
+        double ReadValue(object value);
     }
 
     private sealed class CompiledModuleAssembly : IDisposable
@@ -54,6 +89,62 @@ public class ModuleLoadTests
         }
     }
 
+    private sealed class PackedArgumentsHost
+    {
+        public double BaseValue { get; init; }
+
+        public string Pack(object[] arguments)
+            => $"{arguments.Length}:{arguments[0]}:{arguments[1]}:{arguments[2]}";
+
+        [JsCallableScopeAbi(
+            CallableScopeAbiKind.SingleScope,
+            SingleScopeType = typeof(PackedArgumentsHost))]
+        public object? AddWithScope(
+            PackedArgumentsHost scope,
+            object? newTarget,
+            object? addend)
+            => scope.BaseValue + Convert.ToDouble(addend);
+    }
+
+    [Fact]
+    public void JsEngine_LoadModule_NonGenericSignaturesRemainBinaryCompatible()
+    {
+        var loadModule = typeof(JsEngine)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method =>
+                method.Name == nameof(JsEngine.LoadModule)
+                && !method.IsGenericMethod
+                && method.GetParameters()
+                    .Select(parameter => parameter.ParameterType)
+                    .SequenceEqual(
+                        new[] { typeof(Assembly), typeof(string) }));
+        var loadModuleWithOptions = typeof(JsEngine)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method =>
+                method.Name == nameof(JsEngine.LoadModule)
+                && !method.IsGenericMethod
+                && method.GetParameters()
+                    .Select(parameter => parameter.ParameterType)
+                    .SequenceEqual(
+                        new[]
+                        {
+                            typeof(Assembly),
+                            typeof(string),
+                            typeof(JsModuleLoadOptions)
+                        }));
+        var loadDynamicModule = typeof(JsEngine).GetMethod(
+            nameof(JsEngine.LoadDynamicModule),
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: new[] { typeof(Assembly), typeof(string) },
+            modifiers: null);
+
+        Assert.NotNull(loadDynamicModule);
+        Assert.Equal(typeof(IDisposable), loadModule.ReturnType);
+        Assert.Equal(typeof(IDisposable), loadModuleWithOptions.ReturnType);
+        Assert.Equal(typeof(JsDynamicExports), loadDynamicModule.ReturnType);
+    }
+
     [Fact]
     public void JsEngine_LoadModule_AllowsCallingExports()
     {
@@ -69,7 +160,7 @@ public class ModuleLoadTests
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("math", "math.js");
 
-        using var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "math");
+        using var exportsObj = Jroc.Runtime.JsEngine.LoadDynamicModule(module.Assembly, "math");
         dynamic exports = exportsObj;
 
         Assert.Equal("1.0.0", (string)exports.version);
@@ -82,7 +173,7 @@ public class ModuleLoadTests
         using var module = CompileAndLoadModuleAssemblyFromResource("math", "math.js");
 
         using var exportsProxy = Assert.IsType<Jroc.Runtime.JsDynamicExports>(
-            Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "math"));
+            Jroc.Runtime.JsEngine.LoadDynamicModule(module.Assembly, "math"));
         var exports = Assert.IsType<JsObject>(exportsProxy.UnwrapExports());
 
         Assert.Equal("1.0.0", ExportMemberResolver.GetExportMember(exports, "version"));
@@ -104,7 +195,7 @@ public class ModuleLoadTests
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("mathEsm", "mathEsm.js");
 
-        using var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "mathEsm");
+        using var exportsObj = Jroc.Runtime.JsEngine.LoadDynamicModule(module.Assembly, "mathEsm");
         dynamic exports = exportsObj;
 
         Assert.Equal("2.0.0", (string)exports.version);
@@ -116,7 +207,7 @@ public class ModuleLoadTests
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("hostingMutable", "Hosting_TypedExports.js");
 
-        using var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "hostingMutable");
+        using var exportsObj = Jroc.Runtime.JsEngine.LoadDynamicModule(module.Assembly, "hostingMutable");
         dynamic exports = exportsObj;
 
         Assert.Equal(0.0, (double)exports.mutableValue);
@@ -218,7 +309,7 @@ public class ModuleLoadTests
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("immutableExports", "immutableExports.js");
 
-        using var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "immutableExports");
+        using var exportsObj = Jroc.Runtime.JsEngine.LoadDynamicModule(module.Assembly, "immutableExports");
         dynamic exports = exportsObj;
 
         var ex = Assert.Throws<JsInvocationException>(() =>
@@ -242,7 +333,7 @@ public class ModuleLoadTests
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("nestedReturn", "nestedReturn.js");
 
-        using var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "nestedReturn");
+        using var exportsObj = Jroc.Runtime.JsEngine.LoadDynamicModule(module.Assembly, "nestedReturn");
         dynamic exports = exportsObj;
 
         dynamic win = exports.getWindow();
@@ -281,7 +372,7 @@ public class ModuleLoadTests
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("nestedReturn", "nestedReturn.js");
 
-        using var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "nestedReturn");
+        using var exportsObj = Jroc.Runtime.JsEngine.LoadDynamicModule(module.Assembly, "nestedReturn");
         dynamic exports = exportsObj;
         dynamic win = exports.getWindow();
 
@@ -302,7 +393,7 @@ public class ModuleLoadTests
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("functionReturn", "functionReturn.js");
 
-        using var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "functionReturn");
+        using var exportsObj = Jroc.Runtime.JsEngine.LoadDynamicModule(module.Assembly, "functionReturn");
         dynamic exports = exportsObj;
 
         dynamic inc = exports.getIncrementer();
@@ -310,11 +401,393 @@ public class ModuleLoadTests
     }
 
     [Fact]
+    public void JsEngine_ProjectsGeneratedFunctions_WithStableIdentityAndProperties()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            "generatedFunctionInterop",
+            "Hosting_GeneratedFunctionInterop.js");
+        using var exports = JsEngine.LoadModule<IGeneratedCallableExports>(
+            module.Assembly,
+            "generatedFunctionInterop");
+
+        var ordinary = exports.Ordinary;
+
+        Assert.Same(ordinary, exports.Ordinary);
+        Assert.Same(ordinary, exports.Echo(ordinary));
+
+        dynamic nested = exports.Nested;
+        Assert.Same(ordinary, (object)nested.ordinary);
+
+        Assert.Equal("ordinary", ordinary.Name);
+        Assert.Equal(2.0, ordinary.Length);
+        Assert.Equal("ordinary-property", ordinary.GetProperty("extra"));
+
+        ordinary.SetProperty("hostProperty", 42);
+        Assert.Equal(42.0, ordinary.GetProperty("hostProperty"));
+        Assert.Equal(3.0, ordinary.Call(1, 2));
+        Assert.Equal(28.0, exports.SumSeven.Call(1, 2, 3, 4, 5, 6, 7));
+    }
+
+    [Fact]
+    public void JsCallable_PreservesReceiverErrorsAsyncGeneratorsAndConstruction()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            "generatedFunctionBehavior",
+            "Hosting_GeneratedFunctionInterop.js");
+        using var exports = JsEngine.LoadModule<IGeneratedCallableExports>(
+            module.Assembly,
+            "generatedFunctionBehavior");
+
+        dynamic receiver = new Dictionary<string, object?>
+        {
+            ["value"] = "middle"
+        };
+        Assert.Equal(
+            "<middle>",
+            exports.Describe.CallWithReceiver(receiver, "<", ">"));
+
+        var error = Assert.Throws<JsInvocationException>(
+            () => exports.Thrower.Call());
+        var jsError = Assert.IsType<JsErrorException>(error.InnerException);
+        Assert.Contains(
+            "hosted callable boom",
+            jsError.JsMessage ?? jsError.Message,
+            StringComparison.Ordinal);
+
+        dynamic iterator = exports.Sequence.Call(5)!;
+        dynamic first = iterator.next();
+        dynamic second = iterator.next();
+        dynamic completed = iterator.next();
+        Assert.Equal(5.0, (double)first.value);
+        Assert.False((bool)first.done);
+        Assert.Equal(6.0, (double)second.value);
+        Assert.Equal(7.0, (double)completed.value);
+        Assert.True((bool)completed.done);
+
+        Assert.True(exports.Person.IsConstructor);
+        dynamic person = exports.Person.Construct("Ada")!;
+        Assert.Equal("Ada", (string)person.name);
+        dynamic newTargetProbe = exports.NewTargetProbe.ConstructWithNewTarget(
+            exports.Ordinary)!;
+        Assert.Equal("ordinary", (string)newTargetProbe.targetName);
+
+        var arrowNewTargetError = Assert.Throws<JsInvocationException>(
+            () => exports.Person.ConstructWithNewTarget(
+                exports.Arrow,
+                "Ada"));
+        Assert.Equal(
+            "TypeError",
+            Assert.IsType<JsErrorException>(
+                arrowNewTargetError.InnerException).JsName);
+
+        var primitiveNewTargetError = Assert.Throws<JsInvocationException>(
+            () => exports.Person.ConstructWithNewTarget(42, "Ada"));
+        Assert.Equal(
+            "TypeError",
+            Assert.IsType<JsErrorException>(
+                primitiveNewTargetError.InnerException).JsName);
+
+        Assert.False(exports.Arrow.IsConstructor);
+        _ = Assert.Throws<JsInvocationException>(
+            () => exports.Arrow.Construct());
+    }
+
+    [Fact]
+    public async Task JsCallable_BridgesPromiseResultsToTask()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            "generatedFunctionAsync",
+            "Hosting_GeneratedFunctionInterop.js");
+        using var exports = JsEngine.LoadModule<IGeneratedCallableExports>(
+            module.Assembly,
+            "generatedFunctionAsync");
+
+        Assert.Equal(42.0, await exports.DoubleAsync.CallAsync<double>(21));
+
+        var error = await Assert.ThrowsAsync<JavaScriptRuntime.Error>(
+            () => exports.RejectAsync.CallAsync<object?>());
+        Assert.Contains(
+            "async hosted boom",
+            error.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsEngine_AdaptsHostDelegates_WithStableRoundTripIdentity()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            "hostDelegateInterop",
+            "Hosting_GeneratedFunctionInterop.js");
+        using var exports = JsEngine.LoadModule<IGeneratedCallableExports>(
+            module.Assembly,
+            "hostDelegateInterop");
+
+        Func<object, object, object?> add = (left, right) =>
+            Convert.ToDouble(left) + Convert.ToDouble(right);
+
+        Assert.True(exports.Same(add, add));
+        Assert.Equal(7.0, exports.InvokeCallback(add, 3, 4));
+
+        var returned = Assert.IsType<JsCallable>(exports.Echo(add));
+        Assert.Same(returned, exports.Echo(add));
+        Assert.True(exports.Same(returned, add));
+        Assert.Equal(11.0, returned.Call(5, 6));
+        Assert.False(returned.IsConstructor);
+
+        exports.Dispose();
+        _ = Assert.Throws<ObjectDisposedException>(
+            () => returned.Call(1, 2));
+    }
+
+    [Fact]
+    public void JsEngine_HostObjectArrayParametersReceivePackedJavaScriptArguments()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            "hostPackedArguments",
+            "Hosting_GeneratedFunctionInterop.js");
+        using var exports = JsEngine.LoadModule<IGeneratedCallableExports>(
+            module.Assembly,
+            "hostPackedArguments");
+
+        Func<object[], object?> packedDelegate = arguments =>
+            $"{arguments.Length}:{arguments[0]}:{arguments[1]}:{arguments[2]}";
+        Assert.Equal(
+            "3:first:2:True",
+            exports.InvokeCallbackVariadic(packedDelegate));
+
+        var hostFunction = new JsHostFunction(
+            (_, arguments) =>
+                $"{arguments.Length}:{arguments[0]}:{arguments[1]}:{arguments[2]}");
+        Assert.Equal(
+            "3:first:2:True",
+            exports.InvokeCallbackVariadic(hostFunction));
+
+        using var runtime = new JsRuntimeInstance(
+            module.Assembly,
+            "hostPackedArguments");
+        var host = new PackedArgumentsHost { BaseValue = 5 };
+        var method = typeof(PackedArgumentsHost).GetMethod(
+            nameof(PackedArgumentsHost.Pack))
+            ?? throw new InvalidOperationException("Expected Pack method.");
+        var adapter = runtime.GetOrCreateHostMethodAdapter(host, method);
+        var methodResult = runtime.Invoke(
+            () => CallableOperations.Call(
+                adapter,
+                null,
+                new object?[] { "first", 2d, true }));
+
+        Assert.Equal("3:first:2:True", methodResult);
+
+        HostedSingleScopeDelegate generatedDelegate = host.AddWithScope;
+        var generatedDelegateAdapter = Assert.IsAssignableFrom<JsFunctionObject>(
+            runtime.NormalizeHostValue(generatedDelegate));
+        var generatedDelegateResult = runtime.Invoke(
+            () => CallableOperations.Call(
+                generatedDelegateAdapter,
+                null,
+                new object?[] { 2d }));
+        Assert.Equal(7d, generatedDelegateResult);
+
+        var generatedMethod = typeof(PackedArgumentsHost).GetMethod(
+            nameof(PackedArgumentsHost.AddWithScope))
+            ?? throw new InvalidOperationException("Expected AddWithScope method.");
+        var generatedMethodAdapter = runtime.GetOrCreateHostMethodAdapter(
+            host,
+            generatedMethod);
+        var generatedMethodResult = runtime.Invoke(
+            () => CallableOperations.Call(
+                generatedMethodAdapter,
+                null,
+                new object?[] { 3d }));
+        Assert.Equal(8d, generatedMethodResult);
+    }
+
+    [Fact]
+    public async Task JsEngine_HostTasksBecomeJavaScriptPromises()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            "hostTaskInterop",
+            "Hosting_GeneratedFunctionInterop.js");
+        using var exports = JsEngine.LoadModule<IGeneratedCallableExports>(
+            module.Assembly,
+            "hostTaskInterop");
+
+        var delegateSource = new TaskCompletionSource<object?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        Func<object[], Task<object?>> delegateSuccess = arguments =>
+        {
+            Assert.Equal(3d, Convert.ToDouble(arguments[0]));
+            Assert.Equal(4d, Convert.ToDouble(arguments[1]));
+            return delegateSource.Task;
+        };
+        var delegatePending = exports.AwaitCallback(
+            delegateSuccess,
+            3,
+            4);
+        delegateSource.SetResult(7d);
+        Assert.Equal(
+            7d,
+            await delegatePending
+                .WaitAsync(TimeSpan.FromSeconds(2)));
+
+        var hostFunctionSuccess = new JsHostFunction(
+            (_, arguments) => Task.FromResult<object?>(
+                $"{arguments[0]}:{arguments[1]}"));
+        Assert.Equal(
+            "left:right",
+            await exports.AwaitCallback(
+                    hostFunctionSuccess,
+                    "left",
+                    "right")
+                .WaitAsync(TimeSpan.FromSeconds(2)));
+
+        Func<object[], Task<object?>> delegateFailure = _ =>
+            Task.FromException<object?>(
+                new InvalidOperationException("host task boom"));
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => exports.AwaitCallback(
+                    delegateFailure,
+                    null,
+                    null)
+                .WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.Equal("host task boom", failure.Message);
+
+        var hostFunctionCancellation = new JsHostFunction(
+            (_, _) => Task.FromCanceled<object?>(
+                new CancellationToken(canceled: true)));
+        _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => exports.AwaitCallback(
+                    hostFunctionCancellation,
+                    null,
+                    null)
+                .WaitAsync(TimeSpan.FromSeconds(2)));
+    }
+
+    [Fact]
+    public async Task JsEngine_DisposeFaultsPendingHostTaskPromiseBridge()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            "hostTaskDisposal",
+            "Hosting_GeneratedFunctionInterop.js");
+        var exports = JsEngine.LoadModule<IGeneratedCallableExports>(
+            module.Assembly,
+            "hostTaskDisposal");
+        var source = new TaskCompletionSource<object?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var hostFunction = new JsHostFunction(
+            (_, _) => source.Task);
+
+        var pending = exports.AwaitCallback(
+            hostFunction,
+            null,
+            null);
+        exports.Dispose();
+
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => pending.WaitAsync(TimeSpan.FromSeconds(2)));
+        source.TrySetResult("late");
+    }
+
+    [Fact]
+    public void JsEngine_AdaptsExplicitHostFunctions_WithMetadataReceiverAndConstruction()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            "explicitHostFunctionInterop",
+            "Hosting_GeneratedFunctionInterop.js");
+        using var exports = JsEngine.LoadModule<IGeneratedCallableExports>(
+            module.Assembly,
+            "explicitHostFunctionInterop");
+
+        var receiverAware = new JsHostFunction(
+            (receiver, arguments) =>
+            {
+                dynamic projectedReceiver = receiver
+                    ?? throw new InvalidOperationException("Expected a receiver.");
+                return $"{arguments[0]}{projectedReceiver.value}{arguments[1]}";
+            },
+            name: "receiverAware",
+            length: 2);
+
+        dynamic info = exports.InspectCallback(receiverAware);
+        Assert.Equal("receiverAware", (string)info.name);
+        Assert.Equal(2.0, (double)info.length);
+        Assert.True((bool)info.functionPrototype);
+        Assert.Equal("set-by-js", (string)info.customProperty);
+        Assert.False((bool)info.constructable);
+        var projected = Assert.IsType<JsCallable>(
+            exports.Echo(receiverAware));
+        Assert.Equal("receiverAware", projected.Name);
+        Assert.Equal(2.0, projected.Length);
+        Assert.Equal("set-by-js", projected.GetProperty("customProperty"));
+        Assert.Equal(
+            "<middle>",
+            exports.InvokeCallbackWithReceiver(
+                receiverAware,
+                "middle",
+                "<",
+                ">"));
+
+        var constructor = new JsHostFunction(
+            (_, _) => null,
+            name: "HostBox",
+            length: 1,
+            constructor: (arguments, _) =>
+                new Dictionary<string, object?>
+                {
+                    ["value"] = arguments.Length > 0 ? arguments[0] : null
+                });
+
+        dynamic constructorInfo = exports.InspectCallback(constructor);
+        Assert.True((bool)constructorInfo.constructable);
+        var instance = exports.ConstructCallback(constructor, 9);
+        Assert.Equal(9.0, exports.ReadValue(instance));
+    }
+
+    [Fact]
+    public void JsCallable_ThrowsAfterOwningRuntimeIsDisposed()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            "disposedCallableInterop",
+            "Hosting_GeneratedFunctionInterop.js");
+        var exports = JsEngine.LoadModule<IGeneratedCallableExports>(
+            module.Assembly,
+            "disposedCallableInterop");
+        var callable = exports.Ordinary;
+
+        exports.Dispose();
+
+        _ = Assert.Throws<ObjectDisposedException>(
+            () => callable.Call(1, 2));
+        _ = Assert.Throws<ObjectDisposedException>(
+            () => _ = callable.Name);
+    }
+
+    [Fact]
+    public void JsEngine_DynamicRootFunctionExport_UsesPublicCallableProjection()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            "rootFunctionExport",
+            "Hosting_RootFunctionExport.js");
+        using var exports = JsEngine.LoadDynamicModule(
+            module.Assembly,
+            "rootFunctionExport");
+
+        var callable = Assert.IsType<JsCallable>(exports.Value);
+        Assert.Same(callable, exports.Value);
+        Assert.Equal("rootIncrement", callable.Name);
+        Assert.Equal("root-function", callable.GetProperty("kind"));
+        Assert.Equal(3.0, callable.Call(2));
+
+        dynamic dynamicExports = exports;
+        Assert.Equal(4.0, (double)dynamicExports(3));
+    }
+
+    [Fact]
     public void JsEngine_LoadModule_Dynamic_NewOnValue_PadsMissingArgsWithUndefined()
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("ctorPadding", "ctorPadding.js");
 
-        using var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "ctorPadding");
+        using var exportsObj = Jroc.Runtime.JsEngine.LoadDynamicModule(module.Assembly, "ctorPadding");
         dynamic exports = exportsObj;
 
         Assert.True((bool)exports.undefinedWhenMissingArgs());
@@ -336,7 +809,7 @@ public class ModuleLoadTests
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("hostingMutable", "Hosting_TypedExports.js");
 
-        using var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "hostingMutable");
+        using var exportsObj = Jroc.Runtime.JsEngine.LoadDynamicModule(module.Assembly, "hostingMutable");
         dynamic exports = exportsObj;
 
         var result = await Task.Run(() =>
@@ -366,12 +839,54 @@ public class ModuleLoadTests
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("math", "math.js");
 
-        var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "math");
+        var exportsObj = Jroc.Runtime.JsEngine.LoadDynamicModule(module.Assembly, "math");
         var exports = Assert.IsType<Jroc.Runtime.JsDynamicExports>(exportsObj);
 
         exports.Dispose();
 
         Assert.True(exports.WaitForShutdown(TimeSpan.FromSeconds(2)));
+    }
+
+    [Fact]
+    public async Task JsRuntimeInstance_DisposeFaultsQueuedInvokeWithoutBlocking()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            "concurrentDispose",
+            "math.js");
+        using var runtime = new JsRuntimeInstance(
+            module.Assembly,
+            "concurrentDispose");
+        using var started = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+
+        var running = Task.Run(() => runtime.Invoke(() =>
+        {
+            started.Set();
+            if (!release.Wait(TimeSpan.FromSeconds(2)))
+            {
+                throw new TimeoutException("The test did not release the running invocation.");
+            }
+        }));
+
+        Assert.True(started.Wait(TimeSpan.FromSeconds(2)));
+        var queued = Task.Run(() => runtime.Invoke(() => 42));
+        Assert.True(SpinWait.SpinUntil(
+            () => runtime.PendingWorkItemCount >= 2,
+            TimeSpan.FromSeconds(2)));
+
+        var dispose = Task.Run(runtime.Dispose);
+        try
+        {
+            _ = await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => queued.WaitAsync(TimeSpan.FromSeconds(2)));
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running.WaitAsync(TimeSpan.FromSeconds(2));
+        await dispose.WaitAsync(TimeSpan.FromSeconds(2));
     }
 
     [Fact]
@@ -395,7 +910,8 @@ public class ModuleLoadTests
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("boom", "boom.js");
 
-        var ex = Assert.Throws<Jroc.Runtime.JsModuleLoadException>(() => Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "boom"));
+        var ex = Assert.Throws<Jroc.Runtime.JsModuleLoadException>(
+            () => Jroc.Runtime.JsEngine.LoadDynamicModule(module.Assembly, "boom"));
         Assert.Equal("boom", ex.ModuleId);
 
         var jsError = Assert.IsType<Jroc.Runtime.JsErrorException>(ex.InnerException);
@@ -500,7 +1016,9 @@ public class ModuleLoadTests
 
     private static void AssertHostedForkConfigurationError(CompiledModuleAssembly module)
     {
-        using var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "hostingForkUnsupported");
+        using var exportsObj = Jroc.Runtime.JsEngine.LoadDynamicModule(
+            module.Assembly,
+            "hostingForkUnsupported");
         dynamic exports = exportsObj;
 
         var ex = Assert.Throws<JsInvocationException>(() => exports.attemptFork());

--- a/tests/Jroc.Tests/Hosting/PromiseTaskInteropTests.cs
+++ b/tests/Jroc.Tests/Hosting/PromiseTaskInteropTests.cs
@@ -63,6 +63,18 @@ public class PromiseTaskInteropTests
         Assert.Equal("later", ex.Value);
     }
 
+    [Fact]
+    public async Task PromiseToTask_RuntimeDisposalFaultsPendingTask()
+    {
+        var exports = LoadExports(out _);
+        var pending = exports.NeverResolve();
+
+        exports.Dispose();
+
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => pending.WaitAsync(TimeSpan.FromSeconds(2)));
+    }
+
     private static IPromiseExports LoadExports(out string moduleId)
     {
         var assembly = CompileModule("Hosting_PromiseTaskInterop", out moduleId);
@@ -128,4 +140,6 @@ public interface IPromiseExports : IDisposable
     Task<int> TimeoutResolve(int ms, int value);
 
     Task<int> TimeoutReject(int ms, string reason);
+
+    Task NeverResolve();
 }

--- a/tests/Jroc.Tests/Runtime/CallableScopeAbiRuntimeTests.cs
+++ b/tests/Jroc.Tests/Runtime/CallableScopeAbiRuntimeTests.cs
@@ -57,22 +57,18 @@ public class CallableScopeAbiRuntimeTests
     }
 
     [Fact]
-    public void ExportMemberResolver_InvokeJsDelegate_UsesSingleScopeAttribute()
+    public void LegacyDelegateFunctionAdapter_UsesSingleScopeAttribute()
     {
         var host = new ScopedInstanceHost { BaseValue = 10 };
         InstanceSingleScopeDelegate del = host.Run;
+        var adapter = new LegacyDelegateFunctionAdapter(
+            del,
+            new object[] { host });
 
-        var result = ExportMemberResolver.InvokeJsDelegate(del, new object?[] { 5.0 });
-
-        Assert.Equal(15.0, Convert.ToDouble(result));
-    }
-
-    [Fact]
-    public void ExportMemberResolver_InvokeInstanceMethod_UsesSingleScopeAttribute()
-    {
-        var host = new ScopedInstanceHost { BaseValue = 10 };
-
-        var result = ExportMemberResolver.InvokeInstanceMethod(host, nameof(ScopedInstanceHost.Run), new object?[] { 5.0 });
+        var result = CallableOperations.Call(
+            adapter,
+            null,
+            new object?[] { 5.0 });
 
         Assert.Equal(15.0, Convert.ToDouble(result));
     }


### PR DESCRIPTION
## Summary

- expose exported generated functions through the public, runtime-owned `JsCallable` hosting contract with stable identity and thread marshalling
- add explicit `JsHostFunction` adapters for CLR delegates/methods, including metadata, receiver/argument handling, constructability, and Task-to-Promise conversion
- support callable root exports, dynamic and typed export projections, callback round trips, Promise-to-Task results, exceptions, and deterministic disposal
- preserve the existing `LoadModule` binary signatures, add `LoadDynamicModule`, and document intentional bootstrap delegate boundaries

## Testing

- `MSBUILDDISABLENODEREUSE=1 dotnet test --no-restore --verbosity minimal`
  - Jroc.Tests: 3,055 passed, 4 skipped
  - Jroc.Test262.Tests: 4,142 passed, 45 skipped

Closes #1720
